### PR TITLE
Show access-denied page when a non-admin session hits an admin route

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -10,9 +10,13 @@ import (
 
 // RequireAdmin wraps the next handler so only admins can reach it.
 //
-// If the request has no valid session cookie, the player cannot be found, or the
-// player's role is not admin, the request is redirected to /login with HTTP 303.
+// Unauthenticated requests (no cookie, invalid cookie, or unknown player ID) are
+// redirected to /login with HTTP 303. Requests from a valid non-admin session
+// receive HTTP 403 with an "Access denied" page so the user understands the
+// rejection is about role, not authentication.
 func RequireAdmin(next http.Handler, players PlayerStore, sessions *session.Manager, logger *slog.Logger) http.Handler {
+	render := newTemplateRenderer(logger, "auth/pages/access_denied.gohtml")
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		playerID, ok := sessions.PlayerID(r)
 		if !ok {
@@ -35,7 +39,10 @@ func RequireAdmin(next http.Handler, players PlayerStore, sessions *session.Mana
 		}
 
 		if player.Role != RoleAdmin {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			render.render(w, r, http.StatusForbidden, formData{
+				Title:    "Access denied",
+				Username: player.Username,
+			})
 
 			return
 		}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/starquake/topbanana/internal/auth"
@@ -74,11 +75,14 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	rec = httptest.NewRecorder()
 	mw.ServeHTTP(rec, req)
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
+	if got, want := rec.Code, http.StatusForbidden; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	if got, want := rec.Header().Get("Location"), "/login"; got != want {
-		t.Errorf("Location = %q, want %q", got, want)
+	if got, want := rec.Body.String(), "Access denied"; !strings.Contains(got, want) {
+		t.Errorf("body should contain %q, got %q", want, got)
+	}
+	if got, want := rec.Body.String(), "bob"; !strings.Contains(got, want) {
+		t.Errorf("body should contain signed-in username %q, got %q", want, got)
 	}
 }
 

--- a/internal/web/tmpl/auth/pages/access_denied.gohtml
+++ b/internal/web/tmpl/auth/pages/access_denied.gohtml
@@ -1,0 +1,21 @@
+{{define "content"}}
+    <div class="columns is-centered">
+        <div class="column is-half">
+            <h1 class="title">Access denied</h1>
+            <p class="subtitle">This area requires an admin account.</p>
+
+            <p class="block">
+                You are signed in as <strong>{{.Username}}</strong>, but the page you tried to open is
+                only available to admins.
+            </p>
+
+            <form action="/logout" method="POST">
+                <div class="field">
+                    <div class="control">
+                        <button class="button is-primary" type="submit">Sign out and switch accounts</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{{end}}


### PR DESCRIPTION
## Summary

- Closes #110.
- Non-admin sessions hitting `/admin/*` now get HTTP 403 with a Bulma-styled "Access denied" page instead of being silently 303'd to `/login`.
- Unauthenticated requests still 303 to `/login`; the unknown-player and store-error branches are unchanged.
- New page (`internal/web/tmpl/auth/pages/access_denied.gohtml`) shows the signed-in username and a `POST /logout` button so the player can switch accounts.

## Test plan

- [x] `make lint-fix && make check` — unit + integration green.
- [x] Booted server against the dev DB; `/healthz` 200.
- [x] Manual: log in as a non-admin player, hit `/admin/quizzes` → 403 + access-denied page; logout button clears session and lands on `/login`.
- [x] Manual: log out → `/admin/quizzes` still 303s to `/login`.
- [x] Manual: log in as admin → admin pages still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)