### PR TITLE
Add log out button and signed-in username to admin navbar

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gosimple/slug"
 
+	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/handlers"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/web/tmpl"
@@ -40,9 +41,31 @@ func NewTemplateRenderer(logger *slog.Logger, templatePath string) *TemplateRend
 
 // Render renders a template to the writer (w) giving a templatePath and data.
 // It does not return an error because the headers have already been written. So we can't render an error page anyway.
+//
+// The clone-and-override dance lets the navbar template call {{currentUser}}
+// without every handler having to thread the username into its data struct:
+// the placeholder registered in parseTemplate satisfies the parser, and here
+// we swap in a real implementation that reads the authenticated player from
+// the request context.
 func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, status int, data any) {
+	t, err := tr.t.Clone()
+	if err != nil {
+		tr.logger.ErrorContext(r.Context(), "error cloning template", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return
+	}
+
+	username := ""
+	if p, ok := auth.PlayerFromContext(r.Context()); ok {
+		username = p.Username
+	}
+	t = t.Funcs(template.FuncMap{
+		"currentUser": func() string { return username },
+	})
+
 	w.WriteHeader(status)
-	if err := tr.t.ExecuteTemplate(w, "base.gohtml", data); err != nil {
+	if err := t.ExecuteTemplate(w, "base.gohtml", data); err != nil {
 		tr.logger.ErrorContext(r.Context(), "error executing template", slog.Any("err", err))
 	}
 }
@@ -148,8 +171,18 @@ func optionDataFromOptions(options []*quiz.Option) []*OptionData {
 }
 
 // parseTemplate parses a template from the given path with layouts.
+//
+// A placeholder "currentUser" func is registered before parse so the navbar's
+// {{currentUser}} call resolves at parse time. TemplateRenderer.Render clones
+// the parsed tree and replaces this placeholder with one that reads the
+// authenticated player from the per-request context.
 func parseTemplate(path string) *template.Template {
-	layouts := template.Must(template.ParseFS(tmpl.FS, "admin/layouts/*.gohtml"))
+	funcs := template.FuncMap{
+		"currentUser": func() string { return "" },
+	}
+	layouts := template.Must(
+		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "admin/layouts/*.gohtml"),
+	)
 
 	return template.Must(template.Must(layouts.Clone()).ParseFS(tmpl.FS, path))
 }

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -244,10 +244,7 @@ func TestHandleQuizList_RendersNavbarLogout(t *testing.T) {
 	}
 	handler := HandleQuizList(logger, store)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest error: %v", err)
-	}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	// Unit tests don't go through RequireAdmin, so attach the player directly.
 	signedIn := &auth.Player{ID: 1, Username: "alice", Role: auth.RoleAdmin}
 	req = req.WithContext(auth.WithPlayer(req.Context(), signedIn))

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	. "github.com/starquake/topbanana/internal/admin"
+	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
@@ -230,6 +231,44 @@ func TestHandleQuizList(t *testing.T) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
 		}
 	})
+}
+
+func TestHandleQuizList_RendersNavbarLogout(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	store := stubQuizStore{
+		listQuizzes: func(_ context.Context) ([]*quiz.Quiz, error) {
+			return []*quiz.Quiz{}, nil
+		},
+	}
+	handler := HandleQuizList(logger, store)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest error: %v", err)
+	}
+	// Unit tests don't go through RequireAdmin, so attach the player directly.
+	signedIn := &auth.Player{ID: 1, Username: "alice", Role: auth.RoleAdmin}
+	req = req.WithContext(auth.WithPlayer(req.Context(), signedIn))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("status code = %v, want %v", got, want)
+	}
+
+	body := rr.Body.String()
+	if got, want := body, "alice"; !strings.Contains(got, want) {
+		t.Errorf("body should contain signed-in username %q, got %q", want, got)
+	}
+	if got, want := body, `action="/logout"`; !strings.Contains(got, want) {
+		t.Errorf("body should contain logout form action %q, got %q", want, got)
+	}
+	if got, want := body, "Log out"; !strings.Contains(got, want) {
+		t.Errorf("body should contain logout button label %q, got %q", want, got)
+	}
 }
 
 func TestHandleQuizList_ErrorHandling(t *testing.T) {

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,26 @@
+package auth
+
+import "context"
+
+// playerCtxKey is the unexported context-key type used for stashing the
+// authenticated player on a request context. It's a struct, not a string,
+// so external packages can't accidentally collide with it.
+type playerCtxKey struct{}
+
+// WithPlayer returns a copy of ctx that carries p. Use it in middleware to
+// expose the authenticated player to downstream handlers.
+func WithPlayer(ctx context.Context, p *Player) context.Context {
+	return context.WithValue(ctx, playerCtxKey{}, p)
+}
+
+// PlayerFromContext returns the player stored on ctx by WithPlayer, plus a
+// boolean reporting whether one was present. Returns (nil, false) for
+// contexts that have not been annotated.
+func PlayerFromContext(ctx context.Context) (*Player, bool) {
+	p, ok := ctx.Value(playerCtxKey{}).(*Player)
+	if !ok || p == nil {
+		return nil, false
+	}
+
+	return p, true
+}

--- a/internal/auth/context_test.go
+++ b/internal/auth/context_test.go
@@ -1,0 +1,35 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+func TestPlayerFromContext_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := &auth.Player{ID: 7, Username: "alice", Role: auth.RoleAdmin}
+	ctx := auth.WithPlayer(t.Context(), want)
+
+	got, ok := auth.PlayerFromContext(ctx)
+	if !ok {
+		t.Fatal("PlayerFromContext ok = false, want true")
+	}
+	if got != want {
+		t.Errorf("PlayerFromContext = %+v, want %+v", got, want)
+	}
+}
+
+func TestPlayerFromContext_Missing(t *testing.T) {
+	t.Parallel()
+
+	got, ok := auth.PlayerFromContext(context.Background())
+	if ok {
+		t.Error("PlayerFromContext ok = true, want false")
+	}
+	if got != nil {
+		t.Errorf("PlayerFromContext = %+v, want nil", got)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -47,6 +47,6 @@ func RequireAdmin(next http.Handler, players PlayerStore, sessions *session.Mana
 			return
 		}
 
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
 	})
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -20,8 +20,11 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	}
 
 	called := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var seenPlayer *auth.Player
+	var seenOK bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
+		seenPlayer, seenOK = auth.PlayerFromContext(r.Context())
 		w.WriteHeader(http.StatusTeapot)
 	})
 
@@ -42,6 +45,15 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	}
 	if got, want := rec.Code, http.StatusTeapot; got != want {
 		t.Errorf("status = %d, want %d", got, want)
+	}
+	if !seenOK {
+		t.Fatal("PlayerFromContext ok = false, want true (admin should be on context)")
+	}
+	if got, want := seenPlayer.ID, admin.ID; got != want {
+		t.Errorf("player.ID on context = %d, want %d", got, want)
+	}
+	if got, want := seenPlayer.Username, "alice"; got != want {
+		t.Errorf("player.Username on context = %q, want %q", got, want)
 	}
 }
 

--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -50,14 +50,14 @@
 
             <div class="navbar-end">
                 <div class="navbar-item">
-                    <div class="buttons">
-                        <a class="button is-primary">
-                            <strong>Sign up</strong>
-                        </a>
-                        <a class="button is-light">
-                            Log in
-                        </a>
-                    </div>
+                    Signed in as <strong>&nbsp;{{currentUser}}</strong>
+                </div>
+                <div class="navbar-item">
+                    <form action="/logout" method="POST">
+                        <button type="submit" class="button is-light">
+                            Log out
+                        </button>
+                    </form>
                 </div>
             </div>
         </div>

--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -50,7 +50,7 @@
 
             <div class="navbar-end">
                 <div class="navbar-item">
-                    Signed in as <strong>&nbsp;{{currentUser}}</strong>
+                    Signed in as&nbsp;<strong>{{currentUser}}</strong>
                 </div>
                 <div class="navbar-item">
                     <form action="/logout" method="POST">

--- a/test/e2e/tests/auth.spec.ts
+++ b/test/e2e/tests/auth.spec.ts
@@ -17,12 +17,11 @@ test('register, log out, log back in, and reach the admin dashboard', async ({ p
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
   await expect(page.locator('h1.title')).toContainText('Admin Dashboard');
 
-  // Log out via POST /logout. There is no logout button in the admin UI yet
-  // (tracked by #113); for now we drive the endpoint directly using the page's
-  // request context so cookies are shared.
-  const logoutResp = await page.request.post('/logout', { maxRedirects: 0 });
-  expect(logoutResp.status()).toBe(303);
-  expect(logoutResp.headers()['location']).toBe('/login');
+  // Log out via the navbar button. The form posts to /logout, the server
+  // clears the cookie and 303s to /login, and the browser follows the redirect.
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.locator('h1.title')).toContainText('Log in');
 
   // After logout, /admin/quizzes redirects to /login (303). Navigating with the
   // browser follows the redirect; assert on the final URL.


### PR DESCRIPTION
## Summary

- Closes #113.
- New `auth.WithPlayer` / `auth.PlayerFromContext` helpers; `RequireAdmin` puts the loaded admin on the request context.
- The admin `TemplateRenderer` exposes a `currentUser` template func via a clone-and-override pattern, so no admin handler had to thread the username through its data struct.
- The navbar's `.navbar-end` placeholder "Sign up / Log in" buttons are gone; replaced with "Signed in as <username>" plus a real `POST /logout` form button.
- E2E auth spec now clicks the new button instead of POSTing `/logout` directly.

## Test plan

- [x] `make lint-fix` — clean.
- [x] `make check` — unit + integration green; new tests for context helpers, middleware-puts-player-on-context, and the rendered navbar markup.
- [x] `make test-e2e` — Chromium and Firefox both pass with the button-click logout.
- [x] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)