### PR TITLE
Add CSRF protection to admin and auth POST routes

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosimple/slug"
 
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/handlers"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/web/tmpl"
@@ -27,14 +28,19 @@ type Validator interface {
 // TemplateRenderer renders templates using the given logger and template path.
 type TemplateRenderer struct {
 	logger *slog.Logger
+	csrf   *csrf.Manager
 	t      *template.Template
 }
 
-// NewTemplateRenderer creates a new TemplateRenderer with the given logger and template path.
-// It parses the template on creation.
-func NewTemplateRenderer(logger *slog.Logger, templatePath string) *TemplateRenderer {
+// NewTemplateRenderer creates a new TemplateRenderer with the given logger,
+// CSRF manager, and template path. It parses the template on creation.
+//
+// The CSRF manager may be nil for callers that render error pages without an
+// embedded form (the placeholder {{csrfToken}} func still resolves to "").
+func NewTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, templatePath string) *TemplateRenderer {
 	return &TemplateRenderer{
 		logger: logger,
+		csrf:   csrfMgr,
 		t:      parseTemplate(templatePath),
 	}
 }
@@ -47,6 +53,12 @@ func NewTemplateRenderer(logger *slog.Logger, templatePath string) *TemplateRend
 // the placeholder registered in parseTemplate satisfies the parser, and here
 // we swap in a real implementation that reads the authenticated player from
 // the request context.
+//
+// The same dance also wires up {{csrfToken}}: parseTemplate registers a
+// placeholder so templates parse cleanly; here we replace it with one that
+// asks the CSRF manager for the token, which sets a nonce cookie on the
+// response if needed. Calling Token before WriteHeader is required because
+// [http.SetCookie] is a header write.
 func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, status int, data any) {
 	t, err := tr.t.Clone()
 	if err != nil {
@@ -60,8 +72,15 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, statu
 	if p, ok := auth.PlayerFromContext(r.Context()); ok {
 		username = p.Username
 	}
+
+	csrfToken := ""
+	if tr.csrf != nil {
+		csrfToken = tr.csrf.Token(w, r)
+	}
+
 	t = t.Funcs(template.FuncMap{
 		"currentUser": func() string { return username },
+		"csrfToken":   func() string { return csrfToken },
 	})
 
 	w.WriteHeader(status)
@@ -172,13 +191,15 @@ func optionDataFromOptions(options []*quiz.Option) []*OptionData {
 
 // parseTemplate parses a template from the given path with layouts.
 //
-// A placeholder "currentUser" func is registered before parse so the navbar's
-// {{currentUser}} call resolves at parse time. TemplateRenderer.Render clones
-// the parsed tree and replaces this placeholder with one that reads the
-// authenticated player from the per-request context.
+// Placeholder "currentUser" and "csrfToken" funcs are registered before parse
+// so the navbar's {{currentUser}} call and any form's {{csrfToken}} call
+// resolve at parse time. TemplateRenderer.Render clones the parsed tree and
+// replaces these placeholders with implementations that read the request
+// context and CSRF manager, respectively.
 func parseTemplate(path string) *template.Template {
 	funcs := template.FuncMap{
 		"currentUser": func() string { return "" },
+		"csrfToken":   func() string { return "" },
 	}
 	layouts := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "admin/layouts/*.gohtml"),
@@ -189,8 +210,14 @@ func parseTemplate(path string) *template.Template {
 
 // render400 renders the 400 error page with the given message.
 // Should be used as the final handler in the chain and probably be followed by a return.
-func render400(w http.ResponseWriter, r *http.Request, logger *slog.Logger, msg string) {
-	render := &TemplateRenderer{logger: logger, t: parseTemplate("admin/errors/400.gohtml")}
+//
+// Error pages embed the navbar (which contains the logout form), so they need
+// a CSRF manager to render a working {{csrfToken}}. We accept it as a
+// parameter rather than re-derive it because error renderers are spawned ad
+// hoc deep in the call stack — passing it explicitly keeps the rendering path
+// honest about its dependencies.
+func render400(w http.ResponseWriter, r *http.Request, logger *slog.Logger, csrfMgr *csrf.Manager, msg string) {
+	render := &TemplateRenderer{logger: logger, csrf: csrfMgr, t: parseTemplate("admin/errors/400.gohtml")}
 	data := struct {
 		Title   string
 		Message string
@@ -203,15 +230,15 @@ func render400(w http.ResponseWriter, r *http.Request, logger *slog.Logger, msg 
 
 // render404 renders the 404 error page.
 // Should be used as the final handler in the chain and probably be followed by a return.
-func render404(w http.ResponseWriter, r *http.Request, logger *slog.Logger) {
-	render := &TemplateRenderer{logger: logger, t: parseTemplate("admin/errors/404.gohtml")}
+func render404(w http.ResponseWriter, r *http.Request, logger *slog.Logger, csrfMgr *csrf.Manager) {
+	render := &TemplateRenderer{logger: logger, csrf: csrfMgr, t: parseTemplate("admin/errors/404.gohtml")}
 	render.Render(w, r, http.StatusNotFound, nil)
 }
 
 // render500 renders the 500 error page.
 // Should be used as the final handler in the chain and probably be followed by a return.
-func render500(w http.ResponseWriter, r *http.Request, logger *slog.Logger) {
-	render := &TemplateRenderer{logger: logger, t: parseTemplate("admin/errors/500.gohtml")}
+func render500(w http.ResponseWriter, r *http.Request, logger *slog.Logger, csrfMgr *csrf.Manager) {
+	render := &TemplateRenderer{logger: logger, csrf: csrfMgr, t: parseTemplate("admin/errors/500.gohtml")}
 	render.Render(w, r, http.StatusInternalServerError, nil)
 }
 
@@ -221,6 +248,7 @@ func quizByID(
 	w http.ResponseWriter,
 	r *http.Request,
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	quizStore quiz.Store,
 	id int64,
 ) (*quiz.Quiz, bool) {
@@ -228,12 +256,12 @@ func quizByID(
 	if err != nil {
 		if errors.Is(err, quiz.ErrQuizNotFound) || errors.Is(err, quiz.ErrQuestionNotFound) {
 			logger.ErrorContext(r.Context(), "quiz not found", slog.Any("err", err))
-			render404(w, r, logger)
+			render404(w, r, logger, csrfMgr)
 
 			return nil, false
 		}
 		logger.ErrorContext(r.Context(), "error fetching data", slog.Any("err", err))
-		render500(w, r, logger)
+		render500(w, r, logger, csrfMgr)
 
 		return nil, false
 	}
@@ -247,6 +275,7 @@ func questionByID(
 	w http.ResponseWriter,
 	r *http.Request,
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	quizStore quiz.Store,
 	questionID int64,
 ) (*quiz.Question, bool) {
@@ -258,7 +287,7 @@ func questionByID(
 				fmt.Sprintf("question with ID %d not found", questionID),
 				slog.Any("err", err),
 			)
-			render404(w, r, logger)
+			render404(w, r, logger, csrfMgr)
 
 			return nil, false
 		}
@@ -267,7 +296,7 @@ func questionByID(
 			fmt.Sprintf("error fetching data for question with ID %d", questionID),
 			slog.Any("err", err),
 		)
-		render500(w, r, logger)
+		render500(w, r, logger, csrfMgr)
 
 		return nil, false
 	}
@@ -278,13 +307,19 @@ func questionByID(
 // fillQuizFromForm fills the quiz fields from the form values.
 // It renders an error page if the form is invalid.
 // It returns true if the form was valid and the quiz was filled successfully.
-func fillQuizFromForm(w http.ResponseWriter, r *http.Request, logger *slog.Logger, qz *quiz.Quiz) bool {
+func fillQuizFromForm(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	qz *quiz.Quiz,
+) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxFormSize)
 	err := r.ParseForm()
 	if err != nil {
 		msg := "error parsing form"
 		logger.ErrorContext(r.Context(), msg, slog.Any("err", err))
-		render400(w, r, logger, msg)
+		render400(w, r, logger, csrfMgr, msg)
 
 		return false
 	}
@@ -294,7 +329,7 @@ func fillQuizFromForm(w http.ResponseWriter, r *http.Request, logger *slog.Logge
 	if problems := qz.Valid(r.Context()); len(problems) > 0 {
 		msg := fmt.Sprintf("validation errors: %v", problems)
 		logger.ErrorContext(r.Context(), msg)
-		render400(w, r, logger, msg)
+		render400(w, r, logger, csrfMgr, msg)
 
 		return false
 	}
@@ -305,13 +340,19 @@ func fillQuizFromForm(w http.ResponseWriter, r *http.Request, logger *slog.Logge
 // fillQuestionFromForm fills the question fields from the form values.
 // It renders an error page if the form is invalid.
 // It returns true if the form was valid and the question was filled successfully.
-func fillQuestionFromForm(w http.ResponseWriter, r *http.Request, logger *slog.Logger, qs *quiz.Question) bool {
+func fillQuestionFromForm(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	qs *quiz.Question,
+) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxFormSize)
 	err := r.ParseForm()
 	if err != nil {
 		msg := "error parsing form"
 		logger.ErrorContext(r.Context(), msg, slog.Any("err", err))
-		render400(w, r, logger, msg)
+		render400(w, r, logger, csrfMgr, msg)
 
 		return false
 	}
@@ -321,7 +362,7 @@ func fillQuestionFromForm(w http.ResponseWriter, r *http.Request, logger *slog.L
 	if qs.Position, err = strconv.Atoi(r.PostFormValue("position")); err != nil {
 		msg := "error parsing position"
 		logger.ErrorContext(r.Context(), msg, slog.Any("err", err))
-		render400(w, r, logger, msg)
+		render400(w, r, logger, csrfMgr, msg)
 
 		return false
 	}
@@ -342,7 +383,7 @@ func fillQuestionFromForm(w http.ResponseWriter, r *http.Request, logger *slog.L
 			if err != nil {
 				msg := "error parsing optionID"
 				logger.ErrorContext(r.Context(), msg, slog.Any("err", err))
-				render400(w, r, logger, msg)
+				render400(w, r, logger, csrfMgr, msg)
 
 				return false
 			}
@@ -357,7 +398,7 @@ func fillQuestionFromForm(w http.ResponseWriter, r *http.Request, logger *slog.L
 	if problems := qs.Valid(r.Context()); len(problems) > 0 {
 		msg := fmt.Sprintf("validation errors: %v", problems)
 		logger.ErrorContext(r.Context(), msg)
-		render400(w, r, logger, msg)
+		render400(w, r, logger, csrfMgr, msg)
 
 		return false
 	}
@@ -369,6 +410,7 @@ func storeQuiz(
 	w http.ResponseWriter,
 	r *http.Request,
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	quizStore quiz.Store,
 	qz *quiz.Quiz,
 ) bool {
@@ -376,14 +418,14 @@ func storeQuiz(
 	if qz.ID == 0 {
 		if err = quizStore.CreateQuiz(r.Context(), qz); err != nil {
 			logger.ErrorContext(r.Context(), "error creating quiz", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return false
 		}
 	} else {
 		if err = quizStore.UpdateQuiz(r.Context(), qz); err != nil {
 			logger.ErrorContext(r.Context(), "error updating quiz", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return false
 		}
@@ -397,6 +439,7 @@ func storeQuestion(
 	w http.ResponseWriter,
 	r *http.Request,
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	quizStore quiz.Store,
 	qs *quiz.Question,
 ) bool {
@@ -405,7 +448,7 @@ func storeQuestion(
 		err = quizStore.CreateQuestion(r.Context(), qs)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error creating question", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return false
 		}
@@ -413,7 +456,7 @@ func storeQuestion(
 		err = quizStore.UpdateQuestion(r.Context(), qs)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error updating question", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return false
 		}
@@ -423,8 +466,8 @@ func storeQuestion(
 }
 
 // HandleIndex returns the index page.
-func HandleIndex(logger *slog.Logger) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/index.gohtml")
+func HandleIndex(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/index.gohtml")
 
 	type indexData struct {
 		Title string
@@ -440,8 +483,8 @@ func HandleIndex(logger *slog.Logger) http.Handler {
 }
 
 // HandleQuizList returns the quiz list page.
-func HandleQuizList(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/quizlist.gohtml")
+func HandleQuizList(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizlist.gohtml")
 
 	type quizListData struct {
 		Title   string
@@ -454,7 +497,7 @@ func HandleQuizList(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 		quizzes, err := quizStore.ListQuizzes(r.Context())
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error retrieving quizzes from store", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return
 		}
@@ -471,8 +514,8 @@ func HandleQuizList(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 }
 
 // HandleQuizView returns the quiz view page.
-func HandleQuizView(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/quizview.gohtml")
+func HandleQuizView(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizview.gohtml")
 
 	type quizViewData struct {
 		Title string
@@ -488,7 +531,7 @@ func HandleQuizView(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 		}
 
 		var qz *quiz.Quiz
-		if qz, ok = quizByID(w, r, logger, quizStore, id); !ok {
+		if qz, ok = quizByID(w, r, logger, csrfMgr, quizStore, id); !ok {
 			return
 		}
 
@@ -501,8 +544,8 @@ func HandleQuizView(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 }
 
 // HandleQuizCreate creates a quiz.
-func HandleQuizCreate(logger *slog.Logger) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/quizform.gohtml")
+func HandleQuizCreate(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizform.gohtml")
 
 	type quizCreateData struct {
 		Title string
@@ -519,8 +562,8 @@ func HandleQuizCreate(logger *slog.Logger) http.Handler {
 }
 
 // HandleQuizEdit handles the display of the quiz edit page in the admin dashboard.
-func HandleQuizEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/quizform.gohtml")
+func HandleQuizEdit(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizform.gohtml")
 
 	type quizEditData struct {
 		Title string
@@ -536,7 +579,7 @@ func HandleQuizEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 		}
 
 		var qz *quiz.Quiz
-		if qz, ok = quizByID(w, r, logger, quizStore, quizID); !ok {
+		if qz, ok = quizByID(w, r, logger, csrfMgr, quizStore, quizID); !ok {
 			return
 		}
 		data := quizEditData{
@@ -548,7 +591,7 @@ func HandleQuizEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 }
 
 // HandleQuizSave saves the quiz to the database.
-func HandleQuizSave(logger *slog.Logger, quizStore quiz.Store) http.Handler {
+func HandleQuizSave(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ok bool
 
@@ -562,16 +605,16 @@ func HandleQuizSave(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 		if newQuiz {
 			qz = &quiz.Quiz{}
 		} else {
-			if qz, ok = quizByID(w, r, logger, quizStore, quizID); !ok {
+			if qz, ok = quizByID(w, r, logger, csrfMgr, quizStore, quizID); !ok {
 				return
 			}
 		}
 
-		if !fillQuizFromForm(w, r, logger, qz) {
+		if !fillQuizFromForm(w, r, logger, csrfMgr, qz) {
 			return
 		}
 
-		if !storeQuiz(w, r, logger, quizStore, qz) {
+		if !storeQuiz(w, r, logger, csrfMgr, quizStore, qz) {
 			return
 		}
 
@@ -580,8 +623,8 @@ func HandleQuizSave(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 }
 
 // HandleQuestionCreate creates a question.
-func HandleQuestionCreate(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/questionform.gohtml")
+func HandleQuestionCreate(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/questionform.gohtml")
 
 	type questionCreateData struct {
 		Title    string
@@ -598,7 +641,7 @@ func HandleQuestionCreate(logger *slog.Logger, quizStore quiz.Store) http.Handle
 		}
 
 		var qz *quiz.Quiz
-		if qz, ok = quizByID(w, r, logger, quizStore, quizID); !ok {
+		if qz, ok = quizByID(w, r, logger, csrfMgr, quizStore, quizID); !ok {
 			return
 		}
 
@@ -612,8 +655,8 @@ func HandleQuestionCreate(logger *slog.Logger, quizStore quiz.Store) http.Handle
 }
 
 // HandleQuestionEdit handles the display of the question edit page in the admin dashboard.
-func HandleQuestionEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	render := NewTemplateRenderer(logger, "admin/pages/questionform.gohtml")
+func HandleQuestionEdit(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/questionform.gohtml")
 
 	type questionEditData struct {
 		Title    string
@@ -635,7 +678,7 @@ func HandleQuestionEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler 
 		}
 		newQuestion := questionID == 0
 
-		qz, ok := quizByID(w, r, logger, quizStore, quizID)
+		qz, ok := quizByID(w, r, logger, csrfMgr, quizStore, quizID)
 		if !ok {
 			return
 		}
@@ -647,7 +690,7 @@ func HandleQuestionEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler 
 				QuizID: quizID,
 			}
 		} else {
-			qs, ok = questionByID(w, r, logger, quizStore, questionID)
+			qs, ok = questionByID(w, r, logger, csrfMgr, quizStore, questionID)
 			if !ok {
 				return
 			}
@@ -663,7 +706,7 @@ func HandleQuestionEdit(logger *slog.Logger, quizStore quiz.Store) http.Handler 
 }
 
 // HandleQuizDelete deletes a quiz and all its questions and options.
-func HandleQuizDelete(logger *slog.Logger, quizStore quiz.Store) http.Handler {
+func HandleQuizDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ok bool
 
@@ -674,12 +717,12 @@ func HandleQuizDelete(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 
 		if err := quizStore.DeleteQuiz(r.Context(), quizID); err != nil {
 			if errors.Is(err, quiz.ErrDeletingQuizNoRowsAffected) {
-				render404(w, r, logger)
+				render404(w, r, logger, csrfMgr)
 
 				return
 			}
 			logger.ErrorContext(r.Context(), "error deleting quiz", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return
 		}
@@ -689,7 +732,7 @@ func HandleQuizDelete(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 }
 
 // HandleQuestionDelete deletes a question and all its options.
-func HandleQuestionDelete(logger *slog.Logger, quizStore quiz.Store) http.Handler {
+func HandleQuestionDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ok bool
 
@@ -705,12 +748,12 @@ func HandleQuestionDelete(logger *slog.Logger, quizStore quiz.Store) http.Handle
 
 		if err := quizStore.DeleteQuestion(r.Context(), questionID); err != nil {
 			if errors.Is(err, quiz.ErrDeletingQuestionNoRowsAffected) {
-				render404(w, r, logger)
+				render404(w, r, logger, csrfMgr)
 
 				return
 			}
 			logger.ErrorContext(r.Context(), "error deleting question", slog.Any("err", err))
-			render500(w, r, logger)
+			render500(w, r, logger, csrfMgr)
 
 			return
 		}
@@ -720,7 +763,7 @@ func HandleQuestionDelete(logger *slog.Logger, quizStore quiz.Store) http.Handle
 }
 
 // HandleQuestionSave saves a question.
-func HandleQuestionSave(logger *slog.Logger, quizStore quiz.Store) http.Handler {
+func HandleQuestionSave(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse quiz and question IDs from the URL
 		var ok bool
@@ -739,7 +782,7 @@ func HandleQuestionSave(logger *slog.Logger, quizStore quiz.Store) http.Handler 
 
 		// Retrieve quiz and question from the store
 		var qz *quiz.Quiz
-		if qz, ok = quizByID(w, r, logger, quizStore, quizID); !ok {
+		if qz, ok = quizByID(w, r, logger, csrfMgr, quizStore, quizID); !ok {
 			return
 		}
 
@@ -749,16 +792,16 @@ func HandleQuestionSave(logger *slog.Logger, quizStore quiz.Store) http.Handler 
 				QuizID: qz.ID,
 			}
 		} else {
-			if qs, ok = questionByID(w, r, logger, quizStore, questionID); !ok {
+			if qs, ok = questionByID(w, r, logger, csrfMgr, quizStore, questionID); !ok {
 				return
 			}
 		}
 
-		if !fillQuestionFromForm(w, r, logger, qs) {
+		if !fillQuestionFromForm(w, r, logger, csrfMgr, qs) {
 			return
 		}
 
-		if !storeQuestion(w, r, logger, quizStore, qs) {
+		if !storeQuestion(w, r, logger, csrfMgr, quizStore, qs) {
 			return
 		}
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -137,7 +138,7 @@ func TestTemplateRenderer_Render_LogsError(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	renderer := NewTemplateRenderer(logger, "admin/pages/quizview.gohtml")
+	renderer := NewTemplateRenderer(logger, nil, "admin/pages/quizview.gohtml")
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	if err != nil {
@@ -174,7 +175,7 @@ func TestHandleQuizList(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizList(logger, store)
+		handler := HandleQuizList(logger, nil, store)
 
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 		if err != nil {
@@ -209,7 +210,7 @@ func TestHandleQuizList(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizList(logger, store)
+		handler := HandleQuizList(logger, nil, store)
 
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 		if err != nil {
@@ -242,7 +243,7 @@ func TestHandleQuizList_RendersNavbarLogout(t *testing.T) {
 			return []*quiz.Quiz{}, nil
 		},
 	}
-	handler := HandleQuizList(logger, store)
+	handler := HandleQuizList(logger, nil, store)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	// Unit tests don't go through RequireAdmin, so attach the player directly.
@@ -285,7 +286,7 @@ func TestHandleQuizList_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizList(logger, store)
+		handler := HandleQuizList(logger, nil, store)
 
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 		if err != nil {
@@ -308,7 +309,7 @@ func TestHandleIndex(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.DiscardHandler)
-	handler := HandleIndex(logger)
+	handler := HandleIndex(logger, nil)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	if err != nil {
 		t.Fatalf("http.NewRequest error: %v", err)
@@ -358,7 +359,7 @@ func TestHandleQuizView(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -388,7 +389,7 @@ func TestHandleQuizView(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -418,7 +419,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizView(logger, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/abc", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -450,7 +451,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -475,7 +476,7 @@ func TestHandleQuizCreate(t *testing.T) {
 	buf := bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := HandleQuizCreate(logger)
+	handler := HandleQuizCreate(logger, nil)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/create", nil)
 	if err != nil {
 		t.Fatalf("http.NewRequest error: %v", err)
@@ -507,7 +508,7 @@ func TestHandleQuizEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizEdit(logger, quizStore)
+		handler := HandleQuizEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -537,7 +538,7 @@ func TestHandleQuizEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizEdit(logger, quizStore)
+		handler := HandleQuizEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -564,7 +565,7 @@ func TestHandleQuizEdit_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizEdit(logger, quizStore)
+		handler := HandleQuizEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/abc/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -596,7 +597,7 @@ func TestHandleQuizEdit_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizEdit(logger, quizStore)
+		handler := HandleQuizEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -635,7 +636,7 @@ func TestHandleQuizSave(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"title":       {testQuiz.Title},
@@ -710,7 +711,7 @@ func TestHandleQuizSave(t *testing.T) {
 			"description": {updatedQuiz.Description},
 		}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -753,7 +754,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, "/admin/quizzes/not-an-int/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -786,7 +787,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -812,7 +813,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		body := errReader{err: errors.New("simulated read error")}
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes", body)
 		if err != nil {
@@ -839,7 +840,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 
 		form := url.Values{}
 
@@ -887,7 +888,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 			"description": {testQuiz.Description},
 		}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -950,7 +951,7 @@ func TestHandleQuizSave_ErrorHandling(t *testing.T) {
 			"description": {updatedQuiz.Description},
 		}
 
-		handler := HandleQuizSave(logger, quizStore)
+		handler := HandleQuizSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -999,7 +1000,7 @@ func TestHandleQuestionCreate(t *testing.T) {
 		},
 	}
 
-	handler := HandleQuestionCreate(logger, quizStore)
+	handler := HandleQuestionCreate(logger, nil, quizStore)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1/questions/new", nil)
 	if err != nil {
@@ -1029,7 +1030,7 @@ func TestHandleQuestionCreate_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuestionCreate(logger, quizStore)
+		handler := HandleQuestionCreate(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, "/admin/quizzes/not-an-int/edit", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -1064,7 +1065,7 @@ func TestHandleQuestionCreate_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionCreate(logger, quizStore)
+		handler := HandleQuestionCreate(logger, nil, quizStore)
 
 		req, err := http.NewRequestWithContext(
 			t.Context(),
@@ -1111,7 +1112,7 @@ func TestHandleQuestionEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 
 		req, err := http.NewRequestWithContext(
 			t.Context(),
@@ -1167,7 +1168,7 @@ func TestHandleQuestionEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 
 		req, err := http.NewRequestWithContext(
 			t.Context(),
@@ -1201,7 +1202,7 @@ func TestHandleQuestionEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 
 		req, err := http.NewRequestWithContext(
 			t.Context(),
@@ -1248,7 +1249,7 @@ func TestHandleQuestionEdit(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 
 		req, err := http.NewRequestWithContext(
 			t.Context(),
@@ -1275,6 +1276,164 @@ func TestHandleQuestionEdit(t *testing.T) {
 	})
 }
 
+// TestQuestionEditSave_OptionIDsRoundTrip exercises the full edit-then-save
+// loop: render the edit form for a question with four options, scrape the
+// resulting <input> name/value pairs the way a browser would, POST them to
+// the save handler, and assert that every option's ID survives unchanged.
+//
+// This catches the class of bug where a form field name in the template
+// drifts away from what the handler reads — e.g. "option[2]id" without the
+// dot — because the round-trip silently drops those values and the save
+// handler then sees option C as an unsaved (ID=0) option.
+func TestQuestionEditSave_OptionIDsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	originalIDs := []int64{11, 22, 33, 44}
+	originalTexts := []string{"A", "B", "C", "D"}
+	originalCorrect := []bool{true, false, false, false}
+	original := quiz.Question{
+		ID: 5678, QuizID: 1234, Text: "Q?", Position: 1,
+		Options: []*quiz.Option{
+			{ID: originalIDs[0], Text: originalTexts[0], Correct: originalCorrect[0]},
+			{ID: originalIDs[1], Text: originalTexts[1], Correct: originalCorrect[1]},
+			{ID: originalIDs[2], Text: originalTexts[2], Correct: originalCorrect[2]},
+			{ID: originalIDs[3], Text: originalTexts[3], Correct: originalCorrect[3]},
+		},
+	}
+	q := quiz.Quiz{ID: 1234, Title: "Q1", Slug: "q-1", Questions: []*quiz.Question{&original}}
+
+	// Snapshot the option fields the handler sees at update-time. The handler
+	// mutates the loaded question's options in place, so we have to capture
+	// values rather than pointers.
+	type savedOption struct {
+		ID      int64
+		Text    string
+		Correct bool
+	}
+	var saved []savedOption
+	store := stubQuizStore{
+		getQuizByID:     func(_ context.Context, _ int64) (*quiz.Quiz, error) { return &q, nil },
+		getQuestionByID: func(_ context.Context, _ int64) (*quiz.Question, error) { return &original, nil },
+		updateQuestion: func(_ context.Context, qs *quiz.Question) error {
+			saved = make([]savedOption, len(qs.Options))
+			for i, o := range qs.Options {
+				saved[i] = savedOption{ID: o.ID, Text: o.Text, Correct: o.Correct}
+			}
+
+			return nil
+		},
+	}
+
+	// Step 1: render the edit form.
+	editReq := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", q.ID, original.ID),
+		nil,
+	)
+	editReq.SetPathValue("quizID", strconv.FormatInt(q.ID, 10))
+	editReq.SetPathValue("questionID", strconv.FormatInt(original.ID, 10))
+	editRec := httptest.NewRecorder()
+	HandleQuestionEdit(logger, nil, store).ServeHTTP(editRec, editReq)
+
+	if got, want := editRec.Code, http.StatusOK; got != want {
+		t.Fatalf("edit form status = %d, want %d", got, want)
+	}
+
+	// Step 2: scrape the rendered form's name=value pairs the way a browser
+	// would on submit, then POST them to the save handler.
+	formBody := scrapeFormFields(t, editRec.Body.String()).Encode()
+	saveReq := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("/admin/quizzes/%d/questions/%d", q.ID, original.ID),
+		strings.NewReader(formBody),
+	)
+	saveReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	saveReq.SetPathValue("quizID", strconv.FormatInt(q.ID, 10))
+	saveReq.SetPathValue("questionID", strconv.FormatInt(original.ID, 10))
+	saveRec := httptest.NewRecorder()
+	HandleQuestionSave(logger, nil, store).ServeHTTP(saveRec, saveReq)
+
+	if got, want := saveRec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("save status = %d, want %d (body=%q)", got, want, saveRec.Body.String())
+	}
+
+	// Step 3: assert every option field round-tripped. A typo on any
+	// option[N].<field> name would drop that field's value during the POST,
+	// so the saved value would not match the loaded one.
+	if saved == nil {
+		t.Fatal("UpdateQuestion was not called")
+	}
+	if got, want := len(saved), len(originalIDs); got != want {
+		t.Fatalf("saved %d options, want %d", got, want)
+	}
+	for i, opt := range saved {
+		if got, want := opt.ID, originalIDs[i]; got != want {
+			t.Errorf("option %d ID = %d, want %d (round-trip dropped the ID)", i, got, want)
+		}
+		if got, want := opt.Text, originalTexts[i]; got != want {
+			t.Errorf("option %d Text = %q, want %q (round-trip dropped the text)", i, got, want)
+		}
+		if got, want := opt.Correct, originalCorrect[i]; got != want {
+			t.Errorf("option %d Correct = %v, want %v (round-trip dropped the checkbox)", i, got, want)
+		}
+	}
+}
+
+// scrapeFormFields extracts (name, value) pairs from <input> elements in body
+// the way a browser would when submitting the surrounding form: disabled
+// inputs are skipped, and unchecked checkboxes are excluded.
+//
+// Limitation: every <input type="submit"> is included. A real browser only
+// sends the submit button that was actually clicked, so callers must ensure
+// the rendered form has at most one submit input — otherwise the resulting
+// POST will include both and the handler may not behave like production.
+var (
+	inputElementRe = regexp.MustCompile(`<input\b([^>]*)>`)
+	inputNameRe    = regexp.MustCompile(`\bname="([^"]+)"`)
+	inputValueRe   = regexp.MustCompile(`\bvalue="([^"]*)"`)
+	inputTypeRe    = regexp.MustCompile(`\btype="([^"]+)"`)
+	disabledAttrRe = regexp.MustCompile(`\bdisabled\b`)
+	checkedAttrRe  = regexp.MustCompile(`\bchecked\b`)
+)
+
+func scrapeFormFields(t *testing.T, body string) url.Values {
+	t.Helper()
+
+	values := url.Values{}
+	for _, match := range inputElementRe.FindAllStringSubmatch(body, -1) {
+		attrs := match[1]
+		// Browsers do not submit values from disabled fields.
+		if disabledAttrRe.MatchString(attrs) {
+			continue
+		}
+		nameMatch := inputNameRe.FindStringSubmatch(attrs)
+		if nameMatch == nil {
+			continue
+		}
+		name := nameMatch[1]
+
+		var value string
+		if v := inputValueRe.FindStringSubmatch(attrs); v != nil {
+			value = v[1]
+		}
+
+		// Checkboxes: only included when checked.
+		if typeMatch := inputTypeRe.FindStringSubmatch(attrs); typeMatch != nil && typeMatch[1] == "checkbox" {
+			if !checkedAttrRe.MatchString(attrs) {
+				continue
+			}
+		}
+
+		values.Add(name, value)
+	}
+
+	return values
+}
+
 func TestHandleQuestionEdit_HandleError(t *testing.T) {
 	t.Parallel()
 
@@ -1289,7 +1448,7 @@ func TestHandleQuestionEdit_HandleError(t *testing.T) {
 		quizID := "not-an-int"
 		questionID := "5678"
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodGet,
@@ -1323,7 +1482,7 @@ func TestHandleQuestionEdit_HandleError(t *testing.T) {
 		quizID := "1234"
 		questionID := "not-an-int"
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodGet,
@@ -1367,7 +1526,7 @@ func TestHandleQuestionEdit_HandleError(t *testing.T) {
 		quizID := "1234"
 		questionID := "5678"
 
-		handler := HandleQuestionEdit(logger, quizStore)
+		handler := HandleQuestionEdit(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodGet,
@@ -1475,7 +1634,7 @@ func TestHandleQuestionSave(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"text":      {testQuestion.Text},
@@ -1610,7 +1769,7 @@ func TestHandleQuestionSave(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"text":      {updatedQuestion.Text},
@@ -1674,7 +1833,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 
 		testQuizID := "not-an-int"
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -1709,7 +1868,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 		testQuizID := "1234"
 		testQuestionID := "not-an-int"
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -1746,7 +1905,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		body := errReader{err: errors.New("simulated read error")}
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1234/questions", body)
 		if err != nil {
@@ -1777,7 +1936,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"text":           {""},
@@ -1821,7 +1980,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"text":      {""},
@@ -1862,7 +2021,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 
 		form := url.Values{
 			"text":      {""},
@@ -1943,7 +2102,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			}
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2033,7 +2192,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			}
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2075,7 +2234,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1234/questions", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2110,7 +2269,7 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionSave(logger, quizStore)
+		handler := HandleQuestionSave(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2150,7 +2309,7 @@ func TestHandleQuizDelete(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizDelete(logger, quizStore)
+		handler := HandleQuizDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1/delete", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2181,7 +2340,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 		buf := bytes.Buffer{}
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-		handler := HandleQuizDelete(logger, stubQuizStore{})
+		handler := HandleQuizDelete(logger, nil, stubQuizStore{})
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/not-an-int/delete", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2208,7 +2367,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizDelete(logger, quizStore)
+		handler := HandleQuizDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/999/delete", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2237,7 +2396,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizDelete(logger, quizStore)
+		handler := HandleQuizDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1/delete", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2274,7 +2433,7 @@ func TestHandleQuestionDelete(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionDelete(logger, quizStore)
+		handler := HandleQuestionDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2311,7 +2470,7 @@ func TestHandleQuestionDelete_ErrorHandling(t *testing.T) {
 		buf := bytes.Buffer{}
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-		handler := HandleQuestionDelete(logger, stubQuizStore{})
+		handler := HandleQuestionDelete(logger, nil, stubQuizStore{})
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2338,7 +2497,7 @@ func TestHandleQuestionDelete_ErrorHandling(t *testing.T) {
 		buf := bytes.Buffer{}
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-		handler := HandleQuestionDelete(logger, stubQuizStore{})
+		handler := HandleQuestionDelete(logger, nil, stubQuizStore{})
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2371,7 +2530,7 @@ func TestHandleQuestionDelete_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionDelete(logger, quizStore)
+		handler := HandleQuestionDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,
@@ -2406,7 +2565,7 @@ func TestHandleQuestionDelete_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuestionDelete(logger, quizStore)
+		handler := HandleQuestionDelete(logger, nil, quizStore)
 		req, err := http.NewRequestWithContext(
 			t.Context(),
 			http.MethodPost,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/session"
 	"github.com/starquake/topbanana/internal/web/tmpl"
 )
@@ -30,8 +31,8 @@ type formData struct {
 
 // HandleRegisterForm returns a handler for GET /register that renders the
 // registration form.
-func HandleRegisterForm(logger *slog.Logger) http.Handler {
-	render := newTemplateRenderer(logger, "auth/pages/register.gohtml")
+func HandleRegisterForm(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/register.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		render.render(w, r, http.StatusOK, formData{Title: "Register"})
@@ -48,11 +49,12 @@ func HandleRegisterForm(logger *slog.Logger) http.Handler {
 // admin — see CreatePlayer for the SQL that makes this concurrency-safe.
 func HandleRegisterSubmit(
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	players PlayerStore,
 	sessions *session.Manager,
 	adminUsernames []string,
 ) http.Handler {
-	render := newTemplateRenderer(logger, "auth/pages/register.gohtml")
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/register.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -113,8 +115,8 @@ func HandleRegisterSubmit(
 
 // HandleLoginForm returns a handler for GET /login that renders the login form.
 // registrationEnabled controls whether the template shows the "No account? Register" link.
-func HandleLoginForm(logger *slog.Logger, registrationEnabled bool) http.Handler {
-	render := newTemplateRenderer(logger, "auth/pages/login.gohtml")
+func HandleLoginForm(logger *slog.Logger, csrfMgr *csrf.Manager, registrationEnabled bool) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		render.render(w, r, http.StatusOK, formData{Title: "Log in", ShowRegister: registrationEnabled})
@@ -126,11 +128,12 @@ func HandleLoginForm(logger *slog.Logger, registrationEnabled bool) http.Handler
 // registrationEnabled controls whether error renders show the "No account? Register" link.
 func HandleLoginSubmit(
 	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
 	players PlayerStore,
 	sessions *session.Manager,
 	registrationEnabled bool,
 ) http.Handler {
-	render := newTemplateRenderer(logger, "auth/pages/login.gohtml")
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
 
 	// dummyHash computes a bcrypt hash once on first use. The handler runs
 	// CheckPassword against it when the username does not exist so the
@@ -244,23 +247,53 @@ func renderInvalidCredentials(
 }
 
 // templateRenderer renders a template combined with the auth layouts.
+//
+// The CSRF manager wires the {{csrfToken}} template func: each render asks the
+// manager for the token, which sets a nonce cookie on the response when needed
+// and returns the HMAC-derived token for the form's hidden field. The
+// placeholder registered in newTemplateRenderer keeps templates parseable
+// without a manager (e.g. unit tests).
 type templateRenderer struct {
 	logger *slog.Logger
+	csrf   *csrf.Manager
 	t      *template.Template
 }
 
-func newTemplateRenderer(logger *slog.Logger, page string) *templateRenderer {
-	layouts := template.Must(template.ParseFS(tmpl.FS, "auth/layouts/*.gohtml"))
+func newTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, page string) *templateRenderer {
+	funcs := template.FuncMap{
+		"csrfToken": func() string { return "" },
+	}
+	layouts := template.Must(
+		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "auth/layouts/*.gohtml"),
+	)
 
 	return &templateRenderer{
 		logger: logger,
+		csrf:   csrfMgr,
 		t:      template.Must(template.Must(layouts.Clone()).ParseFS(tmpl.FS, page)),
 	}
 }
 
 func (tr *templateRenderer) render(w http.ResponseWriter, r *http.Request, status int, data any) {
+	t, err := tr.t.Clone()
+	if err != nil {
+		tr.logger.ErrorContext(r.Context(), "error cloning template", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return
+	}
+
+	csrfToken := ""
+	if tr.csrf != nil {
+		csrfToken = tr.csrf.Token(w, r)
+	}
+
+	t = t.Funcs(template.FuncMap{
+		"csrfToken": func() string { return csrfToken },
+	})
+
 	w.WriteHeader(status)
-	if err := tr.t.ExecuteTemplate(w, "base.gohtml", data); err != nil {
+	if err := t.ExecuteTemplate(w, "base.gohtml", data); err != nil {
 		tr.logger.ErrorContext(r.Context(), "error executing template", slog.Any("err", err))
 	}
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -122,7 +122,7 @@ func postForm(t *testing.T, handler http.Handler, path string, values url.Values
 func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleRegisterForm(discardLogger())
+	handler := auth.HandleRegisterForm(discardLogger(), nil)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/register", nil)
 	rec := httptest.NewRecorder()
@@ -140,7 +140,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -184,7 +184,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
 		"password": {"correctbattery"},
@@ -214,6 +214,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 
 	handler := auth.HandleRegisterSubmit(
 		discardLogger(),
+		nil,
 		store,
 		session.New([]byte("k")),
 		[]string{"alice", "carol"},
@@ -240,7 +241,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -266,7 +267,7 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -283,7 +284,7 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(discardLogger(), false)
+	handler := auth.HandleLoginForm(discardLogger(), nil, false)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
 	rec := httptest.NewRecorder()
@@ -300,7 +301,7 @@ func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(discardLogger(), false)
+	handler := auth.HandleLoginForm(discardLogger(), nil, false)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
 	rec := httptest.NewRecorder()
@@ -317,7 +318,7 @@ func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(discardLogger(), true)
+	handler := auth.HandleLoginForm(discardLogger(), nil, true)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
 	rec := httptest.NewRecorder()
@@ -343,7 +344,7 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -361,7 +362,7 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleLoginSubmit(discardLogger(), store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"ghost"},
@@ -388,7 +389,7 @@ func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"wrong-password-no"},
@@ -411,7 +412,7 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"legacy"},
 		"password": {"anything-goes-here-13"},
@@ -426,7 +427,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"   "},
@@ -449,7 +450,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
 
 	password := strings.Repeat("a", auth.MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/session"
 )
 
@@ -14,8 +15,17 @@ import (
 // redirected to /login with HTTP 303. Requests from a valid non-admin session
 // receive HTTP 403 with an "Access denied" page so the user understands the
 // rejection is about role, not authentication.
-func RequireAdmin(next http.Handler, players PlayerStore, sessions *session.Manager, logger *slog.Logger) http.Handler {
-	render := newTemplateRenderer(logger, "auth/pages/access_denied.gohtml")
+//
+// The csrfMgr is threaded through the access-denied renderer so the embedded
+// "Sign out and switch accounts" form has a working CSRF token.
+func RequireAdmin(
+	next http.Handler,
+	players PlayerStore,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+	logger *slog.Logger,
+) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/access_denied.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		playerID, ok := sessions.PlayerID(r)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -29,7 +29,7 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"))
-	mw := auth.RequireAdmin(next, store, sessions, discardLogger())
+	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID)
@@ -76,7 +76,7 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"))
-	mw := auth.RequireAdmin(next, store, sessions, discardLogger())
+	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID)
@@ -106,7 +106,7 @@ func TestRequireAdmin_NoCookie_RedirectsToLogin(t *testing.T) {
 		t.Error("next should not be called without cookie")
 	})
 
-	mw := auth.RequireAdmin(next, store, session.New([]byte("k")), discardLogger())
+	mw := auth.RequireAdmin(next, store, session.New([]byte("k")), nil, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -129,7 +129,7 @@ func TestRequireAdmin_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"))
-	mw := auth.RequireAdmin(next, store, sessions, discardLogger())
+	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, 9999)
@@ -160,7 +160,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"))
-	mw := auth.RequireAdmin(next, store, sessions, discardLogger())
+	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID)

--- a/internal/csrf/csrf.go
+++ b/internal/csrf/csrf.go
@@ -1,0 +1,192 @@
+// Package csrf provides CSRF protection for unsafe HTTP methods.
+//
+// The defence is the standard signed-double-submit pattern using stdlib
+// primitives only:
+//
+//  1. The first GET request to a form-rendering page receives a per-session
+//     nonce in the "tb_csrf_nonce" cookie.
+//  2. The same response embeds a hidden form field ("csrf_token") whose value
+//     is HMAC-SHA256(csrfKey, nonce), base64url-encoded.
+//  3. On a subsequent unsafe request the middleware reads the nonce cookie,
+//     recomputes the expected HMAC, and compares it to the submitted token in
+//     constant time. A mismatch results in 403.
+//
+// The CSRF signing key is derived from the application's SESSION_KEY via
+// HMAC-SHA256(sessionKey, "csrf-v1") so deployments do not need to manage a
+// second secret, and the two keys cannot be confused with each other.
+//
+// Cookies use Path=/, Secure, SameSite=Lax, and HttpOnly=true. The cookie
+// rides along automatically on same-origin form submits regardless of
+// HttpOnly, so making it readable from JavaScript would only add risk
+// without enabling any current flow.
+package csrf
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"net/http"
+)
+
+// CookieName is the name of the CSRF nonce cookie.
+const CookieName = "tb_csrf_nonce"
+
+// FormField is the name of the hidden form field carrying the CSRF token.
+const FormField = "csrf_token"
+
+// MaxAge is the lifetime of the CSRF nonce cookie in seconds (24h).
+const MaxAge = 24 * 60 * 60
+
+// nonceByteLength is the length of the random nonce written to the cookie.
+const nonceByteLength = 16
+
+// keyDerivationLabel is mixed into the SESSION_KEY to derive the CSRF signing
+// key. Versioned so we can rotate the derivation later without breaking
+// existing deployments.
+const keyDerivationLabel = "csrf-v1"
+
+// ErrInvalidToken is returned by Validate when the cookie or form token is
+// missing, malformed, or does not match. Callers (typically the middleware)
+// map it to HTTP 403.
+var ErrInvalidToken = errors.New("csrf: invalid or missing token")
+
+// Manager issues CSRF nonce cookies and validates tokens submitted with unsafe
+// requests. A single instance is safe for concurrent use.
+type Manager struct {
+	key []byte
+}
+
+// New returns a Manager whose signing key is derived from the given session
+// key using HMAC-SHA256. Passing the same SESSION_KEY produces the same CSRF
+// key so the manager survives process restarts without invalidating tokens.
+func New(sessionKey []byte) *Manager {
+	h := hmac.New(sha256.New, sessionKey)
+	// hash.Hash.Write never returns an error.
+	_, _ = h.Write([]byte(keyDerivationLabel))
+
+	return &Manager{key: h.Sum(nil)}
+}
+
+// Token returns a CSRF token for the current request, ensuring a nonce cookie
+// is set on the response when one is not already present. Call at most once
+// per response: a second call without a pre-existing cookie would issue a new
+// nonce, overwrite the previous Set-Cookie, and produce a token that no
+// longer matches the form rendered from the first call.
+//
+// Callers that already wrote a response status should still call Token before
+// flushing the body — [http.SetCookie] writes a header, which only takes effect
+// before WriteHeader.
+func (m *Manager) Token(w http.ResponseWriter, r *http.Request) string {
+	if c, err := r.Cookie(CookieName); err == nil && c.Value != "" {
+		return tokenFromNonce(m.key, c.Value)
+	}
+
+	nonce := newNonce()
+	http.SetCookie(w, newCookie(nonce))
+
+	return tokenFromNonce(m.key, nonce)
+}
+
+// Validate reads the nonce cookie and the form's csrf_token field, recomputes
+// the expected HMAC, and compares it to the submitted token in constant time.
+// It returns ErrInvalidToken on any mismatch, missing data, or parse error.
+//
+// Validate calls r.ParseForm if the form has not yet been parsed. Callers can
+// safely call r.PostFormValue or r.ParseForm again afterward.
+func (m *Manager) Validate(r *http.Request) error {
+	c, err := r.Cookie(CookieName)
+	if err != nil || c.Value == "" {
+		return ErrInvalidToken
+	}
+
+	if parseErr := r.ParseForm(); parseErr != nil {
+		return ErrInvalidToken
+	}
+
+	submitted := r.PostFormValue(FormField)
+	if submitted == "" {
+		return ErrInvalidToken
+	}
+
+	expected := tokenFromNonce(m.key, c.Value)
+
+	gotBytes, err := base64.RawURLEncoding.DecodeString(submitted)
+	if err != nil {
+		return ErrInvalidToken
+	}
+	wantBytes, err := base64.RawURLEncoding.DecodeString(expected)
+	if err != nil {
+		return ErrInvalidToken
+	}
+
+	if subtle.ConstantTimeCompare(gotBytes, wantBytes) != 1 {
+		return ErrInvalidToken
+	}
+
+	return nil
+}
+
+// Middleware enforces CSRF protection on unsafe HTTP methods. Safe methods
+// (GET, HEAD, OPTIONS) pass through unchanged so renderers can still set the
+// nonce cookie on the response. POST, PUT, PATCH, and DELETE must carry a
+// matching token; otherwise the request is short-circuited with 403.
+func (m *Manager) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isSafeMethod(r.Method) {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+		if err := m.Validate(r); err != nil {
+			http.Error(w, "forbidden: invalid CSRF token", http.StatusForbidden)
+
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isSafeMethod reports whether the given HTTP method is "safe" per RFC 9110
+// (no state change). Safe methods bypass CSRF validation.
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+// tokenFromNonce returns the base64url-encoded HMAC-SHA256 of the nonce.
+func tokenFromNonce(key []byte, nonce string) string {
+	h := hmac.New(sha256.New, key)
+	// hash.Hash.Write never returns an error.
+	_, _ = h.Write([]byte(nonce))
+
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+// newNonce returns a fresh random nonce, base64url-encoded.
+func newNonce() string {
+	b := make([]byte, nonceByteLength)
+	// crypto/rand.Read in Go 1.24+ never returns an error.
+	_, _ = rand.Read(b)
+
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// newCookie returns a fresh CSRF nonce cookie with the safe defaults applied.
+func newCookie(value string) *http.Cookie {
+	return &http.Cookie{
+		Name:     CookieName,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   MaxAge,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/internal/csrf/csrf_test.go
+++ b/internal/csrf/csrf_test.go
@@ -1,0 +1,318 @@
+package csrf_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/csrf"
+)
+
+// newGetRequest builds a GET request with the test context attached so
+// httptest plays nicely with t.Cleanup.
+func newGetRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+
+	return httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+}
+
+// newPostFormRequest builds a POST request with form data and the test context.
+// All tests in this file post to the same path; the choice is arbitrary
+// because the middleware is path-agnostic.
+func newPostFormRequest(t *testing.T, values url.Values) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		"/admin/quizzes",
+		strings.NewReader(values.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+// nonceCookieFromResponse returns the value of the CSRF nonce cookie set on
+// the response, or an empty string if no such cookie was set.
+func nonceCookieFromResponse(rec *httptest.ResponseRecorder) string {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == csrf.CookieName {
+			return c.Value
+		}
+	}
+
+	return ""
+}
+
+func TestToken_SetsCookieWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+
+	tok := m.Token(rec, req)
+	if got := tok; got == "" {
+		t.Fatal("Token returned empty string, want non-empty")
+	}
+
+	nonce := nonceCookieFromResponse(rec)
+	if nonce == "" {
+		t.Fatalf("expected %q cookie to be set, got none", csrf.CookieName)
+	}
+}
+
+func TestToken_ReusesExistingCookie(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	// Issue a nonce first so we have a stable cookie value.
+	rec1 := httptest.NewRecorder()
+	req1 := newGetRequest(t, "/login")
+	tok1 := m.Token(rec1, req1)
+
+	nonce := nonceCookieFromResponse(rec1)
+	if nonce == "" {
+		t.Fatalf("expected %q cookie to be set on first call", csrf.CookieName)
+	}
+
+	// Second request with the cookie attached should reuse it.
+	rec2 := httptest.NewRecorder()
+	req2 := newGetRequest(t, "/login")
+	req2.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: nonce})
+
+	tok2 := m.Token(rec2, req2)
+
+	if got, want := tok2, tok1; got != want {
+		t.Errorf("Token = %q, want %q (should be deterministic for same nonce)", got, want)
+	}
+	if got := nonceCookieFromResponse(rec2); got != "" {
+		t.Errorf("expected no new Set-Cookie when nonce already present, got %q", got)
+	}
+}
+
+func TestToken_DeterministicForSameNonce(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "fixed-nonce-value"})
+
+	t1 := m.Token(rec, req)
+	t2 := m.Token(rec, req)
+
+	if got, want := t2, t1; got != want {
+		t.Errorf("Token = %q, want %q (should be deterministic for same nonce)", got, want)
+	}
+}
+
+func TestValidate_NoCookie(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+	req := newPostFormRequest(t, url.Values{csrf.FormField: {"anything"}})
+
+	if got, want := m.Validate(req), csrf.ErrInvalidToken; !errors.Is(got, want) {
+		t.Errorf("Validate err = %v, want %v", got, want)
+	}
+}
+
+func TestValidate_NoFormField(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+	req := newPostFormRequest(t, url.Values{})
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "some-nonce"})
+
+	if got, want := m.Validate(req), csrf.ErrInvalidToken; !errors.Is(got, want) {
+		t.Errorf("Validate err = %v, want %v", got, want)
+	}
+}
+
+func TestValidate_TamperedToken(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	// Get a valid token.
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "real-nonce"})
+	valid := m.Token(rec, req)
+
+	// Flip the last character to produce something that is still
+	// base64url-decodable but does not match the HMAC.
+	last := valid[len(valid)-1]
+	flipped := byte('A')
+	if last == 'A' {
+		flipped = 'B'
+	}
+	tampered := valid[:len(valid)-1] + string(flipped)
+
+	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tampered}})
+	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "real-nonce"})
+
+	if got, want := m.Validate(postReq), csrf.ErrInvalidToken; !errors.Is(got, want) {
+		t.Errorf("Validate err = %v, want %v", got, want)
+	}
+}
+
+func TestValidate_DifferentKey(t *testing.T) {
+	t.Parallel()
+
+	managerA := csrf.New([]byte("key-a"))
+	managerB := csrf.New([]byte("key-b"))
+
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "shared-nonce"})
+	tokenFromA := managerA.Token(rec, req)
+
+	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tokenFromA}})
+	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "shared-nonce"})
+
+	if got, want := managerB.Validate(postReq), csrf.ErrInvalidToken; !errors.Is(got, want) {
+		t.Errorf("Validate err = %v, want %v", got, want)
+	}
+}
+
+func TestValidate_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "happy-path-nonce"})
+	tok := m.Token(rec, req)
+
+	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tok}})
+	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "happy-path-nonce"})
+
+	if err := m.Validate(postReq); err != nil {
+		t.Errorf("Validate err = %v, want nil", err)
+	}
+}
+
+func TestMiddleware_GET_PassesThrough(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	called := false
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	})
+	handler := m.Middleware(next)
+
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/admin/quizzes")
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("next handler was not invoked for GET request")
+	}
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestMiddleware_POST_NoToken_403(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	called := false
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	})
+	handler := m.Middleware(next)
+
+	rec := httptest.NewRecorder()
+	req := newPostFormRequest(t, url.Values{})
+	handler.ServeHTTP(rec, req)
+
+	if called {
+		t.Error("next handler was invoked despite missing CSRF token")
+	}
+	if got, want := rec.Code, http.StatusForbidden; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	// Issue a token first so we know the nonce/token pair is valid.
+	rec := httptest.NewRecorder()
+	req := newGetRequest(t, "/login")
+	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "post-nonce"})
+	tok := m.Token(rec, req)
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := m.Middleware(next)
+
+	postRec := httptest.NewRecorder()
+	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tok}})
+	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "post-nonce"})
+	handler.ServeHTTP(postRec, postReq)
+
+	if !called {
+		t.Error("next handler was not invoked despite valid CSRF token")
+	}
+	if got, want := postRec.Code, http.StatusNoContent; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestMiddleware_UnsafeMethods_AreValidated(t *testing.T) {
+	t.Parallel()
+
+	m := csrf.New([]byte("test-key"))
+
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{name: "POST", method: http.MethodPost},
+		{name: "PUT", method: http.MethodPut},
+		{name: "PATCH", method: http.MethodPatch},
+		{name: "DELETE", method: http.MethodDelete},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := false
+			handler := m.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				called = true
+			}))
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, "/admin/quizzes", nil)
+			handler.ServeHTTP(rec, req)
+
+			if called {
+				t.Errorf("%s: next handler was invoked despite missing CSRF token", tc.method)
+			}
+			if got, want := rec.Code, http.StatusForbidden; got != want {
+				t.Errorf("%s: status = %d, want %d", tc.method, got, want)
+			}
+		})
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/starquake/topbanana/internal/client"
 	"github.com/starquake/topbanana/internal/clientapi"
 	"github.com/starquake/topbanana/internal/config"
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/health"
 	"github.com/starquake/topbanana/internal/session"
@@ -23,66 +24,11 @@ func addRoutes(
 	cfg *config.Config,
 ) {
 	sessions := session.New([]byte(cfg.SessionKey))
+	csrfMgr := csrf.New([]byte(cfg.SessionKey))
 
-	// Auth routes (HTML, no admin check). Registration routes are only registered when
-	// REGISTRATION_ENABLED is true; when disabled, /register naturally 404s from the mux,
-	// which is the desired UX (don't reveal the route exists).
-	if cfg.RegistrationEnabled {
-		mux.Handle("GET /register", auth.HandleRegisterForm(logger))
-		mux.Handle(
-			"POST /register",
-			auth.HandleRegisterSubmit(logger, stores.Players, sessions, cfg.AdminUsernames),
-		)
-	}
-	mux.Handle("GET /login", auth.HandleLoginForm(logger, cfg.RegistrationEnabled))
-	mux.Handle("POST /login", auth.HandleLoginSubmit(logger, stores.Players, sessions, cfg.RegistrationEnabled))
-	mux.Handle("POST /logout", auth.HandleLogout(sessions))
-
-	// Admin interface routes (require admin role)
-	requireAdmin := func(h http.Handler) http.Handler {
-		return auth.RequireAdmin(h, stores.Players, sessions, logger)
-	}
-
-	mux.Handle("GET /admin", requireAdmin(admin.HandleIndex(logger)))
-	mux.Handle("GET /admin/quizzes", requireAdmin(admin.HandleQuizList(logger, stores.Quizzes)))
-	mux.Handle("GET /admin/quizzes/{quizID}", requireAdmin(admin.HandleQuizView(logger, stores.Quizzes)))
-	mux.Handle("GET /admin/quizzes/new", requireAdmin(admin.HandleQuizCreate(logger)))
-	mux.Handle("POST /admin/quizzes", requireAdmin(admin.HandleQuizSave(logger, stores.Quizzes)))
-	mux.Handle("GET /admin/quizzes/{quizID}/edit", requireAdmin(admin.HandleQuizEdit(logger, stores.Quizzes)))
-	mux.Handle("POST /admin/quizzes/{quizID}", requireAdmin(admin.HandleQuizSave(logger, stores.Quizzes)))
-	mux.Handle("POST /admin/quizzes/{quizID}/delete", requireAdmin(admin.HandleQuizDelete(logger, stores.Quizzes)))
-
-	mux.Handle(
-		"GET /admin/quizzes/{quizID}/questions/new",
-		requireAdmin(admin.HandleQuestionCreate(logger, stores.Quizzes)),
-	)
-	mux.Handle(
-		"POST /admin/quizzes/{quizID}/questions",
-		requireAdmin(admin.HandleQuestionSave(logger, stores.Quizzes)),
-	)
-	mux.Handle(
-		"GET /admin/quizzes/{quizID}/questions/{questionID}/edit",
-		requireAdmin(admin.HandleQuestionEdit(logger, stores.Quizzes)),
-	)
-	mux.Handle(
-		"POST /admin/quizzes/{quizID}/questions/{questionID}",
-		requireAdmin(admin.HandleQuestionSave(logger, stores.Quizzes)),
-	)
-	mux.Handle(
-		"POST /admin/quizzes/{quizID}/questions/{questionID}/delete",
-		requireAdmin(admin.HandleQuestionDelete(logger, stores.Quizzes)),
-	)
-
-	// API
-	mux.Handle("GET /api/quizzes", clientapi.HandleQuizList(logger, stores.Quizzes))
-	mux.Handle("GET /api/quizzes/{slugID}", clientapi.HandleQuizGet(logger, stores.Quizzes))
-	mux.Handle("POST /api/games", clientapi.HandleCreateGame(logger, gameService))
-	mux.Handle("GET /api/games/{gameID}/questions/next", clientapi.HandleQuestionNext(logger, gameService))
-	mux.Handle(
-		"POST /api/games/{gameID}/questions/{questionID}/answers",
-		clientapi.HandleAnswerPost(logger, gameService),
-	)
-	mux.Handle("GET /api/games/{gameID}/results", clientapi.HandleGameResults(logger, gameService))
+	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
+	addAdminRoutes(mux, logger, stores, sessions, csrfMgr)
+	addAPIRoutes(mux, logger, stores, gameService)
 
 	// Client
 	mux.Handle("/client/", client.Handler(cfg))
@@ -92,4 +38,111 @@ func addRoutes(
 
 	// Not found
 	mux.Handle("/", http.NotFoundHandler())
+}
+
+// addAuthRoutes registers the unauthenticated auth-flow routes. Registration
+// is only registered when REGISTRATION_ENABLED is true; when disabled,
+// /register naturally 404s from the mux, which is the desired UX.
+//
+// The CSRF middleware guards every unsafe method; safe methods pass through so
+// the GET form renderer can still set the nonce cookie.
+func addAuthRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+	cfg *config.Config,
+) {
+	csrfMW := csrfMgr.Middleware
+
+	if cfg.RegistrationEnabled {
+		mux.Handle("GET /register", auth.HandleRegisterForm(logger, csrfMgr))
+		mux.Handle(
+			"POST /register",
+			csrfMW(auth.HandleRegisterSubmit(logger, csrfMgr, stores.Players, sessions, cfg.AdminUsernames)),
+		)
+	}
+	mux.Handle("GET /login", auth.HandleLoginForm(logger, csrfMgr, cfg.RegistrationEnabled))
+	mux.Handle(
+		"POST /login",
+		csrfMW(auth.HandleLoginSubmit(logger, csrfMgr, stores.Players, sessions, cfg.RegistrationEnabled)),
+	)
+	mux.Handle("POST /logout", csrfMW(auth.HandleLogout(sessions)))
+}
+
+// addAdminRoutes registers every /admin/* route. Each unsafe (POST/PUT/...)
+// route is wrapped as csrfMW(requireAdmin(handler)): the CSRF middleware runs
+// first so an unauthenticated request without a valid token is rejected with
+// 403 before any auth-state-leaking 303 to /login.
+func addAdminRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+) {
+	csrfMW := csrfMgr.Middleware
+	requireAdmin := func(h http.Handler) http.Handler {
+		return auth.RequireAdmin(h, stores.Players, sessions, csrfMgr, logger)
+	}
+
+	mux.Handle("GET /admin", requireAdmin(admin.HandleIndex(logger, csrfMgr)))
+	mux.Handle("GET /admin/quizzes", requireAdmin(admin.HandleQuizList(logger, csrfMgr, stores.Quizzes)))
+	mux.Handle("GET /admin/quizzes/{quizID}", requireAdmin(admin.HandleQuizView(logger, csrfMgr, stores.Quizzes)))
+	mux.Handle("GET /admin/quizzes/new", requireAdmin(admin.HandleQuizCreate(logger, csrfMgr)))
+	mux.Handle("POST /admin/quizzes", csrfMW(requireAdmin(admin.HandleQuizSave(logger, csrfMgr, stores.Quizzes))))
+	mux.Handle(
+		"GET /admin/quizzes/{quizID}/edit",
+		requireAdmin(admin.HandleQuizEdit(logger, csrfMgr, stores.Quizzes)),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}",
+		csrfMW(requireAdmin(admin.HandleQuizSave(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/delete",
+		csrfMW(requireAdmin(admin.HandleQuizDelete(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
+		"GET /admin/quizzes/{quizID}/questions/new",
+		requireAdmin(admin.HandleQuestionCreate(logger, csrfMgr, stores.Quizzes)),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/questions",
+		csrfMW(requireAdmin(admin.HandleQuestionSave(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
+		"GET /admin/quizzes/{quizID}/questions/{questionID}/edit",
+		requireAdmin(admin.HandleQuestionEdit(logger, csrfMgr, stores.Quizzes)),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/questions/{questionID}",
+		csrfMW(requireAdmin(admin.HandleQuestionSave(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/questions/{questionID}/delete",
+		csrfMW(requireAdmin(admin.HandleQuestionDelete(logger, csrfMgr, stores.Quizzes))),
+	)
+}
+
+// addAPIRoutes registers the JSON API routes consumed by the game client.
+// These do not need CSRF protection: they expect application/json bodies and
+// do not rely on cookie auth, so the classic browser-form CSRF threat does
+// not apply.
+func addAPIRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	gameService *game.Service,
+) {
+	mux.Handle("GET /api/quizzes", clientapi.HandleQuizList(logger, stores.Quizzes))
+	mux.Handle("GET /api/quizzes/{slugID}", clientapi.HandleQuizGet(logger, stores.Quizzes))
+	mux.Handle("POST /api/games", clientapi.HandleCreateGame(logger, gameService))
+	mux.Handle("GET /api/games/{gameID}/questions/next", clientapi.HandleQuestionNext(logger, gameService))
+	mux.Handle(
+		"POST /api/games/{gameID}/questions/{questionID}/answers",
+		clientapi.HandleAnswerPost(logger, gameService),
+	)
+	mux.Handle("GET /api/games/{gameID}/results", clientapi.HandleGameResults(logger, gameService))
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -6,10 +6,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/config"
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/quiz"
 	. "github.com/starquake/topbanana/internal/server"
@@ -238,6 +242,97 @@ func TestAddRoutes_UnknownRouteReturns404(t *testing.T) {
 	}
 }
 
+// csrfFormPattern extracts the value of the hidden csrf_token form field from
+// a rendered HTML form.
+var csrfFormPattern = regexp.MustCompile(`name="csrf_token" value="([^"]+)"`)
+
+// TestAddRoutes_LoginPOST_RejectsMissingCSRF verifies the CSRF middleware
+// short-circuits an unsafe request that does not carry a token, and accepts
+// the same request once the token is provided. /login is convenient here
+// because it does not require an admin session — only the CSRF middleware
+// stands between the request and the handler.
+func TestAddRoutes_LoginPOST_RejectsMissingCSRF(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	stores := &store.Stores{
+		Quizzes: stubQuizStore{},
+		Players: stubPlayerStore{},
+	}
+	mux := http.NewServeMux()
+	cfg := &config.Config{SessionKey: "test-session-key"}
+	ExportAddRoutes(mux, logger, stores, game.NewService(stubGameStore{}, stubQuizStore{}, logger), cfg)
+
+	t.Run("missing token returns 403", func(t *testing.T) {
+		t.Parallel()
+
+		body := url.Values{
+			"username": {"any"},
+			"password": {"any"},
+		}.Encode()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/login", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+
+		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusForbidden; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("valid token reaches handler", func(t *testing.T) {
+		t.Parallel()
+
+		// Step 1: GET /login to receive the nonce cookie and the matching
+		// hidden token rendered in the form.
+		getReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
+		getRec := httptest.NewRecorder()
+		mux.ServeHTTP(getRec, getReq)
+
+		if got, want := getRec.Code, http.StatusOK; got != want {
+			t.Fatalf("GET /login status = %d, want %d", got, want)
+		}
+
+		match := csrfFormPattern.FindStringSubmatch(getRec.Body.String())
+		if match == nil {
+			t.Fatalf("no csrf_token field found in /login HTML, body=%q", getRec.Body.String())
+		}
+		token := match[1]
+
+		var nonce *http.Cookie
+		for _, c := range getRec.Result().Cookies() {
+			if c.Name == csrf.CookieName {
+				nonce = c
+
+				break
+			}
+		}
+		if nonce == nil {
+			t.Fatalf("no %q cookie found on GET /login", csrf.CookieName)
+		}
+
+		// Step 2: POST /login with the token in the form and the cookie on
+		// the request. The POST should pass CSRF validation and reach the
+		// handler, which in turn returns 401 for the unknown user — that's
+		// fine, the assertion here is "not 403".
+		body := url.Values{
+			"username":   {"ghost"},
+			"password":   {"correctbatterystaple"},
+			"csrf_token": {token},
+		}.Encode()
+		postReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/login", strings.NewReader(body))
+		postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		postReq.AddCookie(nonce)
+		postRec := httptest.NewRecorder()
+		mux.ServeHTTP(postRec, postReq)
+
+		if got := postRec.Code; got == http.StatusForbidden {
+			t.Errorf("status = %d (forbidden); CSRF should have passed with a valid token", got)
+		}
+	})
+}
+
 func TestAddRoutes_AdminRouteWithoutSession_RedirectsToLogin(t *testing.T) {
 	t.Parallel()
 
@@ -258,5 +353,33 @@ func TestAddRoutes_AdminRouteWithoutSession_RedirectsToLogin(t *testing.T) {
 	}
 	if got, want := rec.Header().Get("Location"), "/login"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+// TestAddRoutes_AdminPOSTWithoutCSRF_Returns403_NotAuthRedirect locks in the
+// middleware order on admin POST routes: csrfMW(requireAdmin(...)). An
+// anonymous POST without a CSRF token should be rejected with 403 from the
+// CSRF layer rather than 303-redirected to /login by the auth layer, so we
+// don't leak whether a session would have been honoured.
+func TestAddRoutes_AdminPOSTWithoutCSRF_Returns403_NotAuthRedirect(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	stores := &store.Stores{
+		Quizzes: stubQuizStore{},
+		Players: stubPlayerStore{},
+	}
+	mux := http.NewServeMux()
+	cfg := &config.Config{SessionKey: "test-session-key"}
+	ExportAddRoutes(mux, logger, stores, game.NewService(stubGameStore{}, stubQuizStore{}, logger), cfg)
+
+	body := strings.NewReader(url.Values{}.Encode())
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1/delete", body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusForbidden; got != want {
+		t.Errorf("status = %d, want %d (CSRF must reject before the auth layer redirects)", got, want)
 	}
 }

--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -54,6 +54,7 @@
                 </div>
                 <div class="navbar-item">
                     <form action="/logout" method="POST">
+                        <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                         <button type="submit" class="button is-light">
                             Log out
                         </button>

--- a/internal/web/tmpl/admin/pages/questionform.gohtml
+++ b/internal/web/tmpl/admin/pages/questionform.gohtml
@@ -10,6 +10,7 @@
                     action="/admin/quizzes/{{.Quiz.ID}}/questions"
                 {{end}}
                 method="POST">
+            <input type="hidden" name="csrf_token" value="{{csrfToken}}">
 
             <input type="hidden" name="id" value="{{.Question.ID}}">
             <div class="field">
@@ -40,7 +41,7 @@
                 <div class="grid ">
                     <div class="cell">
                         <div class="field">
-                            <label class="label">Option A</label>
+                            <label class="label" for="option[0].text">Option A</label>
                             <div class="field is-grouped">
                                 <div class="control is-expanded">
                                     <input type="hidden" name="option[0].id"
@@ -58,7 +59,7 @@
                     </div>
                     <div class="cell">
                         <div class="field">
-                            <label class="label">Option B</label>
+                            <label class="label" for="option[1].text">Option B</label>
                             <div class="field is-grouped">
                                 <div class="control is-expanded">
                                     <input type="hidden" name="option[1].id"
@@ -76,10 +77,10 @@
                     </div>
                     <div class="cell">
                         <div class="field">
-                            <label class="label">Option C</label>
+                            <label class="label" for="option[2].text">Option C</label>
                             <div class="field is-grouped">
                                 <div class="control is-expanded">
-                                    <input type="hidden" name="option[2]id"
+                                    <input type="hidden" name="option[2].id"
                                            value="{{if gt (len .Question.Options) 2}}{{(index .Question.Options 2).ID}}{{end}}">
                                     <input id="option[2].text" name="option[2].text" class="input" type="text"
                                            value="{{if gt (len .Question.Options) 2}}{{(index .Question.Options 2).Text}}{{end}}">
@@ -94,7 +95,7 @@
                     </div>
                     <div class="cell">
                         <div class="field">
-                            <label class="label">Option D</label>
+                            <label class="label" for="option[3].text">Option D</label>
                             <div class="field is-grouped">
                                 <div class="control is-expanded">
                                     <input type="hidden" name="option[3].id"

--- a/internal/web/tmpl/admin/pages/quizform.gohtml
+++ b/internal/web/tmpl/admin/pages/quizform.gohtml
@@ -10,6 +10,7 @@
                     action="/admin/quizzes"
                 {{end}}
                 method="POST">
+            <input type="hidden" name="csrf_token" value="{{csrfToken}}">
 
             <div class="field">
                 <label class="label" for="title">Title</label>

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -63,6 +63,7 @@
                         <footer class="modal-card-foot">
                             <div class="buttons">
                                 <form method="post" action="/admin/quizzes/{{.ID}}/delete">
+                                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                                     <button class="button is-danger" type="submit">Delete</button>
                                 </form>
                                 <button class="button" onclick="closeModal('modal-delete-quiz-{{.ID}}')">Cancel</button>

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -43,6 +43,7 @@
                     <footer class="modal-card-foot">
                         <div class="buttons">
                             <form method="post" action="/admin/quizzes/{{.Quiz.ID}}/delete">
+                                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                                 <button class="button is-danger" type="submit">Delete</button>
                             </form>
                             <button class="button" onclick="closeModal('modal-delete-quiz-{{.Quiz.ID}}')">Cancel</button>
@@ -118,6 +119,7 @@
                             <footer class="modal-card-foot">
                                 <div class="buttons">
                                     <form method="post" action="/admin/quizzes/{{.QuizID}}/questions/{{.ID}}/delete">
+                                        <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                                         <button class="button is-danger" type="submit">Delete</button>
                                     </form>
                                     <button class="button" onclick="closeModal('modal-delete-question-{{.ID}}')">Cancel</button>

--- a/internal/web/tmpl/auth/pages/access_denied.gohtml
+++ b/internal/web/tmpl/auth/pages/access_denied.gohtml
@@ -10,6 +10,7 @@
             </p>
 
             <form action="/logout" method="POST">
+                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <div class="field">
                     <div class="control">
                         <button class="button is-primary" type="submit">Sign out and switch accounts</button>

--- a/internal/web/tmpl/auth/pages/login.gohtml
+++ b/internal/web/tmpl/auth/pages/login.gohtml
@@ -8,6 +8,7 @@
             {{end}}
 
             <form action="/login" method="POST">
+                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <div class="field">
                     <label class="label" for="username">Username</label>
                     <div class="control">

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -8,6 +8,7 @@
             {{end}}
 
             <form action="/register" method="POST">
+                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <div class="field">
                     <label class="label" for="username">Username</label>
                     <div class="control">

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -18,9 +19,52 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/starquake/topbanana/cmd/server/app"
+	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/testutil"
 )
+
+// csrfTokenPattern extracts the value of the hidden CSRF form field a
+// renderer embeds on every form. The browser does this implicitly when
+// submitting a form; the test client has to scrape it out of the GET response.
+// Built from csrf.FormField so a rename of the constant fails the integration
+// test loudly instead of silently producing empty matches.
+var csrfTokenPattern = regexp.MustCompile(
+	fmt.Sprintf(`name="%s" value="([^"]+)"`, regexp.QuoteMeta(csrf.FormField)),
+)
+
+// fetchCSRFToken issues a GET to the given URL using the supplied client,
+// extracts the first csrf_token form value from the response body, and
+// returns it. The client's cookie jar picks up the nonce cookie as a side
+// effect, so subsequent POSTs from the same client carry the matching pair.
+func fetchCSRFToken(ctx context.Context, t *testing.T, client *http.Client, url string) string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("failed to create CSRF GET request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("failed to GET %s: %v", url, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body of %s: %v", url, err)
+	}
+	m := csrfTokenPattern.FindStringSubmatch(string(body))
+	if m == nil {
+		t.Fatalf("no csrf_token found in response from %s; body=%q", url, body)
+	}
+
+	return m[1]
+}
 
 func TestAdmin_Integration(t *testing.T) {
 	t.Parallel()
@@ -69,10 +113,6 @@ func TestAdmin_Integration(t *testing.T) {
 	quizTitle := "Integration Test Quiz"
 	quizDesc := "A quiz created by integration test"
 
-	quizForm := url.Values{}
-	quizForm.Add("title", quizTitle)
-	quizForm.Add("description", quizDesc)
-
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("failed to create cookie jar: %v", err)
@@ -85,9 +125,14 @@ func TestAdmin_Integration(t *testing.T) {
 	}
 
 	// Register the first user (becomes admin) so subsequent /admin/* requests succeed.
+	// Fetching the GET form first sets the CSRF nonce cookie on the jar and
+	// returns the hidden token, both of which the POST then carries.
+	registerToken := fetchCSRFToken(ctx, t, client, fmt.Sprintf("http://%s/register", serverAddr))
+
 	registerForm := url.Values{}
 	registerForm.Add("username", "integration-admin")
 	registerForm.Add("password", "integration-pass-123")
+	registerForm.Add("csrf_token", registerToken)
 
 	registerReq, err := http.NewRequestWithContext(
 		ctx,
@@ -109,6 +154,15 @@ func TestAdmin_Integration(t *testing.T) {
 	if err := registerResp.Body.Close(); err != nil {
 		t.Errorf("failed to close register body: %v", err)
 	}
+
+	// Visit the quiz-create form GET so we can pull a fresh CSRF token tied
+	// to the now-authenticated session jar.
+	quizCreateToken := fetchCSRFToken(ctx, t, client, fmt.Sprintf("http://%s/admin/quizzes/new", serverAddr))
+
+	quizForm := url.Values{}
+	quizForm.Add("title", quizTitle)
+	quizForm.Add("description", quizDesc)
+	quizForm.Add("csrf_token", quizCreateToken)
 
 	var req *http.Request
 	req, err = http.NewRequestWithContext(
@@ -212,6 +266,13 @@ func TestAdmin_Integration(t *testing.T) {
 	questionOption3 := "Tolls"
 	questionOption4 := "Kirby"
 
+	questionToken := fetchCSRFToken(
+		ctx,
+		t,
+		client,
+		fmt.Sprintf("http://%s%s/questions/new", serverAddr, quizLocation),
+	)
+
 	questionForm := url.Values{}
 	questionForm.Add("text", questionText)
 	questionForm.Add("position", "10")
@@ -220,6 +281,7 @@ func TestAdmin_Integration(t *testing.T) {
 	questionForm.Add("option[1].correct", "on")
 	questionForm.Add("option[2].text", questionOption3)
 	questionForm.Add("option[3].text", questionOption4)
+	questionForm.Add("csrf_token", questionToken)
 
 	// Add question to quiz
 	req, err = http.NewRequestWithContext(


### PR DESCRIPTION
## Summary

- Closes #107.
- New `internal/csrf` package — stdlib-only signed double-submit. Per-browser nonce in `tb_csrf_nonce` (HttpOnly, Secure, SameSite=Lax, 24h); form token is `base64url(HMAC-SHA256(csrfKey, nonce))`. `csrfKey` is derived from `SESSION_KEY` via `HMAC(sessionKey, "csrf-v1")`.
- Middleware enforces on POST/PUT/PATCH/DELETE; safe methods pass through. Wired as `csrfMW(requireAdmin(...))` on admin POSTs and `csrfMW(...)` on auth POSTs (register/login/logout) so anonymous attackers see 403, not an auth 303.
- Renderers in `internal/admin` and `internal/auth` expose `{{csrfToken}}` via the same clone-and-override pattern already used for `{{currentUser}}`. Every form template now embeds the hidden field.
- While in `questionform.gohtml`: fixed accessibility (added `for` attributes on the four Option labels) and a long-standing bug where Option C's hidden ID input was named `option[2]id` (no dot). The handler reads `option[2].id`, so saving an existing question silently treated Option C as new on every save.

## Tests

- `internal/csrf/csrf_test.go` — Token / Validate / Middleware coverage (12 tests).
- `internal/server/routes_test.go` — full-mux CSRF positive+negative on `/login`, plus an admin-POST-without-CSRF test that locks in the `csrfMW(requireAdmin(...))` ordering.
- `internal/admin/admin_test.go` — new `TestQuestionEditSave_OptionIDsRoundTrip` renders the edit form, scrapes its `<input>` name/value pairs, POSTs them through `HandleQuestionSave`, and asserts every option's ID, Text, and Correct value round-trips. This catches the `option[2]id` bug class plus any future template ↔ handler field-name drift. Helper `scrapeFormFields` lives in the same file.
- `test/integration/admin_test.go` — `fetchCSRFToken` helper added; flow now scrapes the rendered hidden token and submits it. Regex is built from `csrf.FormField` so a constant rename trips the test.
- `test/e2e/tests/auth.spec.ts` — unchanged; real browser handles tokens automatically.

## Test plan

- [x] `make lint-fix` — clean.
- [x] `make check` — unit + integration green; coverage 86.6%.
- [x] `make test-e2e` — Chromium and Firefox both pass with the CSRF-protected forms.
- [x] Verified `TestQuestionEditSave_OptionIDsRoundTrip` fails on the original bug and on equivalent text/correct field-name drift, then passes after the fix.
- [x] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)