### PR TITLE
Render question images in the player client and unblock the admin field

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
-    <file url="PROJECT" libraries="{alpinejs, bulma, fontawesome-free}" />
+    <file url="PROJECT" libraries="{alpinejs, bulma}" />
   </component>
 </project>

--- a/.idea/topbanana.iml
+++ b/.idea/topbanana.iml
@@ -21,5 +21,7 @@
     <orderEntry type="library" name="bulma" level="application" />
     <orderEntry type="library" name="fontawesome-free" level="application" />
     <orderEntry type="library" name="alpinejs" level="application" />
+    <orderEntry type="library" name="bulma" level="application" />
+    <orderEntry type="library" name="alpinejs" level="application" />
   </component>
 </module>

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -14,11 +14,11 @@
             <h1 class="title">Top Banana!</h1>
 
             <div x-show="!gameId">
-                <h2 class="subtitle">Select a Quiz</h2>
                 <div class="field">
+                    <label class="label" for="quiz-select">Select a Quiz</label>
                     <div class="control">
                         <div class="select">
-                            <select x-model="selectedQuizId">
+                            <select id="quiz-select" x-model="selectedQuizId">
                                 <template x-for="quiz in quizzes" :key="quiz.id">
                                     <option :value="quiz.id" x-text="quiz.title"></option>
                                 </template>
@@ -34,6 +34,14 @@
                     <div>
                         <progress class="progress is-primary" :value="progress" max="100"></progress>
                         <h2 class="subtitle" x-text="question.text"></h2>
+
+                        <template x-if="question.imageUrl">
+                            <figure class="image">
+                                <img alt="" :src="question.imageUrl" :alt="question.text"
+                                     x-show="!imageError"
+                                     @error="imageError = true">
+                            </figure>
+                        </template>
 
                         <template x-if="feedback">
                             <div class="notification" :class="feedback.correct ? 'is-success' : 'is-danger'">

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -12,6 +12,11 @@ export class GameApp {
         this.feedback = null;
         this.progress = 100;
         this.timer = null;
+        // Reset per-question; the <img> element is reused across questions
+        // (Alpine doesn't recreate it when x-if stays truthy), so a stale
+        // display:none from a prior broken image would otherwise hide the
+        // next image too.
+        this.imageError = false;
     }
 
     async init() {
@@ -38,6 +43,7 @@ export class GameApp {
             this.results = await gameService.getResults(this.gameId);
             return;
         }
+        this.imageError = false;
         this.question = question;
         this.startCountdown();
     }
@@ -89,5 +95,6 @@ export class GameApp {
         this.results = null;
         this.feedback = null;
         this.progress = 100;
+        this.imageError = false;
     }
 }

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -198,6 +198,7 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 	type questionResponse struct {
 		ID        int64            `json:"id"`
 		Text      string           `json:"text"`
+		ImageURL  string           `json:"imageUrl"`
 		Options   []optionResponse `json:"options"`
 		StartedAt time.Time        `json:"startedAt"`
 		ExpiredAt time.Time        `json:"expiredAt"`
@@ -248,6 +249,7 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 		res := questionResponse{
 			ID:        gq.QuizQuestion.ID,
 			Text:      gq.QuizQuestion.Text,
+			ImageURL:  gq.QuizQuestion.ImageURL,
 			Options:   resOptions,
 			StartedAt: gq.StartedAt,
 			ExpiredAt: gq.ExpiredAt,

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -518,6 +518,46 @@ func TestHandleQuestionNext(t *testing.T) {
 			t.Errorf("status code = %v, want %v", got, want)
 		}
 	})
+
+	t.Run("returns the question with imageUrl when set", func(t *testing.T) {
+		t.Parallel()
+
+		const imageURL = "https://example.com/picture.png"
+		svc := newService(
+			stubGameStore{
+				getGame: func(_ context.Context, id string) (*game.Game, error) {
+					return &game.Game{ID: id, QuizID: 1}, nil
+				},
+				createQuestion: func(_ context.Context, _ *game.Question) error { return nil },
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, qid int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{
+						ID: qid,
+						Questions: []*quiz.Question{
+							{ID: 42, Text: "Q1", ImageURL: imageURL, Options: []*quiz.Option{{ID: 1, Text: "A"}}},
+						},
+					}, nil
+				},
+			},
+		)
+
+		mux := http.NewServeMux()
+		mux.Handle("GET /api/games/{gameID}/questions/next", HandleQuestionNext(logger, svc))
+
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/api/games/game-1/questions/next", nil,
+		)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusOK; got != want {
+			t.Fatalf("status code = %v, want %v", got, want)
+		}
+		if got, want := rec.Body.String(), `"imageUrl":"`+imageURL+`"`; !strings.Contains(got, want) {
+			t.Errorf("body should contain %q, got %q", want, got)
+		}
+	})
 }
 
 func TestHandleAnswerPost(t *testing.T) {

--- a/internal/web/tmpl/admin/pages/questionform.gohtml
+++ b/internal/web/tmpl/admin/pages/questionform.gohtml
@@ -21,10 +21,11 @@
             </div>
 
             <div class="field">
-                <label class="label" for="imageURL">Image URL</label>
+                <label class="label" for="image_url">Image URL</label>
                 <div class="control">
-                    <input id="imageURL" name="imageURL" class="input" type="text" value="{{.Question.ImageURL}}"
-                           disabled>
+                    <input id="image_url" name="image_url" class="input" type="text"
+                           placeholder="https://example.com/picture.png"
+                           value="{{.Question.ImageURL}}">
                 </div>
             </div>
 

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -7,16 +7,43 @@ export type QuestionSpec = {
   text: string;
   options: [string, string, string, string];
   correctIndices: readonly number[];
+  // Optional question image. When set, the player client renders <figure
+  // class="image"><img>; the admin form persists the URL.
+  imageUrl?: string;
+  // Optional E2E expectation: did this question's image render (true) or did
+  // it fail to load and get hidden by @error (false)? Undefined means the
+  // question has no image and no <figure> is rendered at all.
+  expectImageVisible?: boolean;
 };
 
+// 1x1 transparent PNG inlined as a data URL so the working-image case works
+// without network access.
+const TRANSPARENT_PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+
 // Four question variants exercised by both the admin and player E2E flows.
-// Variant 1 keeps the original "one correct answer" case; variants 2-4 add
-// "no correct answers", "all correct answers", and "3 of 4 correct".
+// Variant 1 has a deliberately-broken image; variant 2 has a working image
+// rendered immediately afterwards. Together they prove the imageError state
+// resets between consecutive image-bearing questions (the <img> element is
+// reused across them, so a stale display:none would otherwise hide the
+// second image too).
 export const QUIZ_QUESTIONS: readonly QuestionSpec[] = [
-  { text: 'What is 2+2?',                options: ['3', '4', '5', '6'],                       correctIndices: [1] },
-  { text: 'Which animals are mammals?',  options: ['cat', 'salmon', 'sparrow', 'lizard'],     correctIndices: [] },
-  { text: 'Pick a colour.',              options: ['red', 'blue', 'green', 'yellow'],         correctIndices: [0, 1, 2, 3] },
-  { text: 'Which are prime?',            options: ['2', '3', '5', '9'],                       correctIndices: [0, 1, 2] },
+  {
+    text: 'What is 2+2?',
+    options: ['3', '4', '5', '6'],
+    correctIndices: [1],
+    imageUrl: '/this-image-does-not-exist.png',
+    expectImageVisible: false,
+  },
+  {
+    text: 'Which animals are mammals?',
+    options: ['cat', 'salmon', 'sparrow', 'lizard'],
+    correctIndices: [],
+    imageUrl: TRANSPARENT_PNG_DATA_URL,
+    expectImageVisible: true,
+  },
+  { text: 'Pick a colour.',   options: ['red', 'blue', 'green', 'yellow'], correctIndices: [0, 1, 2, 3] },
+  { text: 'Which are prime?', options: ['2', '3', '5', '9'],               correctIndices: [0, 1, 2] },
 ];
 
 export async function registerAdmin(page: Page, username: string): Promise<void> {
@@ -46,6 +73,9 @@ export async function createQuizWithQuestions(
 
     await page.locator('input[name=text]').fill(q.text);
     await page.locator('input[name=position]').fill(String(index + 1));
+    if (q.imageUrl !== undefined) {
+      await page.locator('input[name=image_url]').fill(q.imageUrl);
+    }
     for (let i = 0; i < q.options.length; i++) {
       await page.locator(`input[name="option[${i}].text"]`).fill(q.options[i]);
       if (q.correctIndices.includes(i)) {

--- a/test/e2e/tests/player.spec.ts
+++ b/test/e2e/tests/player.spec.ts
@@ -37,10 +37,23 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
   // Walk every question. We always click the first option; whether that picks
   // a correct answer is determined by the spec (correctIndices includes 0).
   let expectedSuccesses = 0;
+  const figureImg = page.locator('figure.image img');
   for (const q of QUIZ_QUESTIONS) {
     const choice = q.options[0];
     const wasCorrect = q.correctIndices.includes(0);
-    await page.getByRole('button', { name: choice }).click();
+
+    // Wait for the new question to be live before asserting on its image so
+    // we don't read state from the previous question's render.
+    const optionButton = page.getByRole('button', { name: choice });
+    await expect(optionButton).toBeVisible();
+
+    if (q.expectImageVisible === true) {
+      await expect(figureImg).toBeVisible();
+    } else if (q.expectImageVisible === false) {
+      await expect(figureImg).toBeHidden();
+    }
+
+    await optionButton.click();
 
     if (wasCorrect) {
       await expect(page.locator('.notification.is-success')).toBeVisible();


### PR DESCRIPTION
## Summary

- Closes #100.
- Player client renders `<figure class="image"><img>` when `question.imageUrl` is set, with `@error` hiding broken images so a bad URL doesn't break the quiz flow.
- Per-question `imageError` state on `GameApp` is reset on each new question, so a broken image in question N doesn't leave the next question's image hidden.
- API: next-question response now includes `imageUrl`.
- Admin: enabled the previously-`disabled` image-URL input, and renamed it from `imageURL` to `image_url` so its name matches what `HandleQuestionSave` already reads (a long-standing bug — the field never round-tripped before).
- Accessibility cleanups while in the file: `<select>` for quiz pick now has a real `<label for="…">`; `<img>` carries a static `alt=""` fallback so HTML validators see it (Alpine's `:alt="question.text"` binding overwrites at runtime).

## Test plan

- [x] `make lint-fix` — clean.
- [x] `make check` — unit + integration green; new clientapi sub-test asserts `imageUrl` flows through `/questions/next`.
- [x] `make test-e2e` — Chromium + Firefox both pass. `helpers.ts` ships a deliberately-broken `imageUrl` on Q1 and a 1×1 transparent data-URL on Q2; the player loop asserts the broken image is hidden, then the working image is visible — pinning down the cross-question reset.
- [x] Forced regression: removing `this.imageError = false` from `nextQuestion()` makes the player spec fail at Q2's `figure.image img toBeVisible` assertion in both browsers. Reverted.
- [x] Server boot smoke (`PORT=8090 go run ./cmd/server/`) — `/healthz` 200.
- [x] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)