### PR TITLE
Add anonymous player sessions and score-claiming on register

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -181,5 +181,9 @@ formatters:
 
 run:
   timeout: 5m
+  # Without this, files guarded by `//go:build integration` are silently
+  # excluded from every lint pass and accumulate violations unnoticed.
+  build-tags:
+    - integration
 severity:
   default: error

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -47,6 +48,15 @@ func HandleRegisterForm(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler
 // promoted to admin. Otherwise the role passed to the store is RolePlayer and
 // the store atomically promotes the very first password-bearing registrant to
 // admin — see CreatePlayer for the SQL that makes this concurrency-safe.
+//
+// Score-claiming flow: when the request already carries a valid session for
+// an anonymous player (a row created by EnsurePlayer with no password_hash),
+// the handler upgrades that existing row in place via ClaimPlayer instead of
+// inserting a new one. This means a visitor who plays a few games without an
+// account and then registers keeps their player_id, so their game history
+// follows them. If the anonymous row was concurrently claimed by another
+// request the handler falls back to CreatePlayer; the visitor ends up with a
+// fresh row but the registration still succeeds.
 func HandleRegisterSubmit(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
@@ -91,7 +101,7 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		player, err := players.CreatePlayer(r.Context(), input.Cleaned, hashed, role)
+		player, err := claimOrCreatePlayer(r, players, sessions, input.Cleaned, hashed, role)
 		if err != nil {
 			if errors.Is(err, ErrUsernameTaken) {
 				render.render(w, r, http.StatusConflict, formData{
@@ -111,6 +121,73 @@ func HandleRegisterSubmit(
 		sessions.Set(w, player.ID)
 		http.Redirect(w, r, adminLandingPath, http.StatusSeeOther)
 	})
+}
+
+// claimOrCreatePlayer is the storage-side branch of HandleRegisterSubmit. If
+// the request already has a session pointing at an anonymous (no
+// password_hash) row, it upgrades that row via ClaimPlayer so the visitor
+// keeps their player_id. Otherwise — no session, deleted row, or
+// already-claimed row — it falls back to CreatePlayer.
+//
+// The "already claimed" fallback handles a concurrent registration race
+// gracefully: by the time we call ClaimPlayer the row may have been claimed
+// by a different request that shared the same cookie. Falling back to
+// CreatePlayer means the user still completes registration, just without
+// their pre-claim history attached.
+//
+// Wrapped errors keep the underlying ErrUsernameTaken / ErrPlayerAlreadyClaimed
+// sentinel intact for [errors.Is] checks while satisfying wrapcheck.
+func claimOrCreatePlayer(
+	r *http.Request,
+	players PlayerStore,
+	sessions *session.Manager,
+	username, passwordHash, requestedRole string,
+) (*Player, error) {
+	playerID, ok := sessions.PlayerID(r)
+	if !ok {
+		return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+	}
+
+	existing, err := players.GetPlayerByID(r.Context(), playerID)
+	if err != nil {
+		if errors.Is(err, ErrPlayerNotFound) {
+			return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+		}
+
+		return nil, fmt.Errorf("get player by id for claim: %w", err)
+	}
+	if !existing.IsAnonymous() {
+		// Session already belongs to a credentialled account. Treat this as a
+		// fresh registration so the new account is created independently;
+		// the existing session is replaced when the caller resets the cookie.
+		return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+	}
+
+	claimed, err := players.ClaimPlayer(r.Context(), playerID, username, passwordHash, requestedRole)
+	if err != nil {
+		if errors.Is(err, ErrPlayerAlreadyClaimed) || errors.Is(err, ErrPlayerNotFound) {
+			return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+		}
+
+		return nil, fmt.Errorf("claim player: %w", err)
+	}
+
+	return claimed, nil
+}
+
+// createPlayerWrapped wraps PlayerStore.CreatePlayer's error so wrapcheck
+// is happy while preserving sentinel errors for [errors.Is].
+func createPlayerWrapped(
+	r *http.Request,
+	players PlayerStore,
+	username, passwordHash, requestedRole string,
+) (*Player, error) {
+	p, err := players.CreatePlayer(r.Context(), username, passwordHash, requestedRole)
+	if err != nil {
+		return nil, fmt.Errorf("create player: %w", err)
+	}
+
+	return p, nil
 }
 
 // HandleLoginForm returns a handler for GET /login that renders the login form.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -74,22 +74,7 @@ func (s *stubPlayerStore) CreatePlayer(
 		return nil, auth.ErrUsernameTaken
 	}
 
-	role := requestedRole
-	if role != auth.RoleAdmin {
-		hasPasswordBearer := false
-		for _, existing := range s.byID {
-			if existing.PasswordHash != "" {
-				hasPasswordBearer = true
-
-				break
-			}
-		}
-		if !hasPasswordBearer {
-			role = auth.RoleAdmin
-		} else {
-			role = auth.RolePlayer
-		}
-	}
+	role := s.resolveRoleLocked(requestedRole)
 
 	p := &auth.Player{
 		ID:           s.nextID,
@@ -102,6 +87,74 @@ func (s *stubPlayerStore) CreatePlayer(
 	s.byName[username] = p
 
 	return p, nil
+}
+
+// CreateAnonymousPlayer mirrors store.CreateAnonymousPlayer: insert a row
+// with the given username, no password_hash, role = "player".
+func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username string) (*auth.Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.byName[username]; exists {
+		return nil, auth.ErrUsernameTaken
+	}
+
+	p := &auth.Player{
+		ID:       s.nextID,
+		Username: username,
+		Role:     auth.RolePlayer,
+	}
+	s.nextID++
+	s.byID[p.ID] = p
+	s.byName[username] = p
+
+	return p, nil
+}
+
+// ClaimPlayer mirrors store.ClaimPlayer: upgrades an anonymous row in place
+// or fails with auth.ErrPlayerAlreadyClaimed / ErrPlayerNotFound /
+// ErrUsernameTaken.
+func (s *stubPlayerStore) ClaimPlayer(
+	_ context.Context,
+	playerID int64,
+	username, passwordHash, requestedRole string,
+) (*auth.Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.byID[playerID]
+	if !ok {
+		return nil, auth.ErrPlayerNotFound
+	}
+	if existing.PasswordHash != "" {
+		return nil, auth.ErrPlayerAlreadyClaimed
+	}
+	if other, exists := s.byName[username]; exists && other.ID != playerID {
+		return nil, auth.ErrUsernameTaken
+	}
+
+	delete(s.byName, existing.Username)
+	existing.Username = username
+	existing.PasswordHash = passwordHash
+	existing.Role = s.resolveRoleLocked(requestedRole)
+	s.byName[username] = existing
+
+	return existing, nil
+}
+
+// resolveRoleLocked applies the same "first password-bearing registrant
+// becomes admin" rule as the production SQL. Caller must hold s.mu.
+func (s *stubPlayerStore) resolveRoleLocked(requestedRole string) string {
+	if requestedRole == auth.RoleAdmin {
+		return auth.RoleAdmin
+	}
+	for _, existing := range s.byID {
+		if existing.PasswordHash != "" {
+			return auth.RolePlayer
+		}
+	}
+
+	return auth.RoleAdmin
 }
 
 func discardLogger() *slog.Logger {
@@ -278,6 +331,168 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	}
 	if got, want := rec.Body.String(), "already taken"; !strings.Contains(got, want) {
 		t.Errorf("body did not mention duplicate, got %q", got)
+	}
+}
+
+// TestHandleRegisterSubmit_ClaimsAnonymousSession verifies that registering
+// while already holding an anonymous session upgrades the existing row in
+// place rather than inserting a new one. This is the score-claiming flow:
+// the visitor's player_id stays stable so any games they played before
+// signing up still belong to them.
+func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-existing")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	sessions := session.New([]byte("k"))
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
+
+	// Build a request that already carries the anonymous session cookie.
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, anon.ID)
+	cookie := rec.Result().Cookies()[0]
+
+	form := url.Values{
+		"username": {"alice"},
+		"password": {"correctbattery"},
+	}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/register", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
+	}
+
+	// The same row was upgraded — no new row should appear, and the
+	// anonymous username should be gone.
+	upgraded, err := store.GetPlayerByUsername(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	if got, want := upgraded.ID, anon.ID; got != want {
+		t.Errorf("upgraded.ID = %d, want %d (player ID should be preserved)", got, want)
+	}
+	if upgraded.PasswordHash == "" {
+		t.Error("upgraded.PasswordHash is empty, want bcrypt hash from claim")
+	}
+	if _, err := store.GetPlayerByUsername(t.Context(), "anon-existing"); !errors.Is(err, auth.ErrPlayerNotFound) {
+		t.Errorf("anonymous row still resolvable by old username; err = %v, want ErrPlayerNotFound", err)
+	}
+}
+
+// TestHandleRegisterSubmit_ClaimWithTakenUsername returns 409 and leaves
+// the anonymous row untouched so the visitor can retry with a different
+// username. First-sign-in-wins semantics: the row that already owns the
+// requested username keeps it.
+func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	if _, err := store.CreatePlayer(t.Context(), "alice", "previousHash", auth.RolePlayer); err != nil {
+		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
+	}
+	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-claimer")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	sessions := session.New([]byte("k"))
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, anon.ID)
+	cookie := rec.Result().Cookies()[0]
+
+	form := url.Values{
+		"username": {"alice"}, // already taken by the seeded credentialled row
+		"password": {"correctbattery"},
+	}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/register", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusConflict; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	// Anonymous row was not mutated.
+	stillAnon, err := store.GetPlayerByID(t.Context(), anon.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := stillAnon.Username, "anon-claimer"; got != want {
+		t.Errorf("anonymous row Username = %q, want %q (should be unchanged)", got, want)
+	}
+	if !stillAnon.IsAnonymous() {
+		t.Error("anonymous row IsAnonymous() = false, want true (should still be unclaimed)")
+	}
+}
+
+// TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate covers the
+// concurrent-registration race: by the time the handler reaches ClaimPlayer
+// the anonymous row has already been claimed (e.g. another tab raced ahead).
+// The handler should fall through to CreatePlayer so the registration still
+// succeeds, just with a fresh row.
+func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-racer")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	// Simulate another tab claiming the row first.
+	if _, claimErr := store.ClaimPlayer(
+		t.Context(),
+		anon.ID,
+		"winner",
+		"winnerHash",
+		auth.RolePlayer,
+	); claimErr != nil {
+		t.Fatalf("ClaimPlayer err = %v, want nil", claimErr)
+	}
+
+	sessions := session.New([]byte("k"))
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, anon.ID) // cookie still points at the now-claimed row
+	cookie := rec.Result().Cookies()[0]
+
+	form := url.Values{
+		"username": {"latecomer"},
+		"password": {"correctbattery"},
+	}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/register", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
+	}
+	// A fresh row was created instead of clobbering the already-claimed one.
+	latecomer, err := store.GetPlayerByUsername(t.Context(), "latecomer")
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	if got, dontWant := latecomer.ID, anon.ID; got == dontWant {
+		t.Errorf("latecomer reused the racer's anonymous ID %d, want a fresh row", got)
 	}
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,9 +5,64 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/rs/xid"
+
 	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/session"
 )
+
+// anonymousUsernamePrefix is prepended to the random xid used as the username
+// for an EnsurePlayer-created row. Keeping a recognisable prefix means an
+// admin scrolling through the players table can tell a never-claimed visitor
+// apart from a real registration without inspecting password_hash.
+const anonymousUsernamePrefix = "anon-"
+
+// EnsurePlayer guarantees the request carries a session that points at an
+// existing players row. If the request has no session, an invalid one, or a
+// session whose player has been deleted, the middleware creates a fresh
+// anonymous players row, writes a session cookie for it, and stashes the
+// loaded *Player on the request context so downstream handlers can read it
+// via PlayerFromContext.
+//
+// Wrap every /api/* route that needs to attribute work to a player (creating
+// games, submitting answers). Static client assets are deliberately not
+// wrapped so loading index.html and JS bundles does not create a row — the
+// row is only created on the first /api/ call.
+//
+// On failure to create a row the request is rejected with 500: proceeding
+// without a session would leave the handler unable to attribute writes.
+func EnsurePlayer(next http.Handler, players PlayerStore, sessions *session.Manager, logger *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if playerID, ok := sessions.PlayerID(r); ok {
+			player, err := players.GetPlayerByID(r.Context(), playerID)
+			if err == nil {
+				next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
+
+				return
+			}
+			if !errors.Is(err, ErrPlayerNotFound) {
+				logger.ErrorContext(r.Context(), "error loading player for ensure", slog.Any("err", err))
+				http.Error(w, "internal error", http.StatusInternalServerError)
+
+				return
+			}
+			// Fall through: the cookie referenced a deleted row, mint a new
+			// anonymous player and replace the cookie.
+		}
+
+		username := anonymousUsernamePrefix + xid.New().String()
+		player, err := players.CreateAnonymousPlayer(r.Context(), username)
+		if err != nil {
+			logger.ErrorContext(r.Context(), "error creating anonymous player", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		sessions.Set(w, player.ID)
+		next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
+	})
+}
 
 // RequireAdmin wraps the next handler so only admins can reach it.
 //

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/starquake/topbanana/internal/session"
 )
 
+// findCookie returns the first response cookie with the given name and a
+// boolean reporting whether it was found. Used by the EnsurePlayer tests to
+// assert that a fresh session cookie is set on the response.
+func findCookie(rec *httptest.ResponseRecorder, name string) (*http.Cookie, bool) {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			return c, true
+		}
+	}
+
+	return nil, false
+}
+
 func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	t.Parallel()
 
@@ -173,5 +186,186 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 
 	if got, want := rec.Code, http.StatusInternalServerError; got != want {
 		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	sessions := session.New([]byte("k"))
+
+	var seenPlayer *auth.Player
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("next handler was not called")
+	}
+	if got, want := rec.Code, http.StatusTeapot; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; middleware should have populated one")
+	}
+	if !seenPlayer.IsAnonymous() {
+		t.Errorf("seenPlayer.IsAnonymous() = false, want true (PasswordHash = %q)", seenPlayer.PasswordHash)
+	}
+	if got, want := seenPlayer.Username[:5], "anon-"; got != want {
+		t.Errorf("seenPlayer.Username prefix = %q, want %q", got, want)
+	}
+	cookie, ok := findCookie(rec, session.CookieName)
+	if !ok {
+		t.Fatal("session cookie was not set on the response")
+	}
+	if cookie.Value == "" {
+		t.Error("session cookie value is empty")
+	}
+}
+
+func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	existing, err := store.CreateAnonymousPlayer(t.Context(), "anon-existing")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	sessions := session.New([]byte("k"))
+
+	var seenPlayer *auth.Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, existing.ID)
+	cookie := rec.Result().Cookies()[0]
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; middleware should have loaded the existing row")
+	}
+	if got, want := seenPlayer.ID, existing.ID; got != want {
+		t.Errorf("seenPlayer.ID = %d, want %d (existing row)", got, want)
+	}
+	if _, ok := findCookie(rec, session.CookieName); ok {
+		t.Error("session cookie should not be re-set when the cookie is valid")
+	}
+}
+
+func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	sessions := session.New([]byte("k"))
+
+	var seenPlayer *auth.Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	// Issue a cookie pointing at an ID that does not exist in the store.
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, 9999)
+	cookie := rec.Result().Cookies()[0]
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; middleware should have minted a new anonymous row")
+	}
+	if got, dontWant := seenPlayer.ID, int64(9999); got == dontWant {
+		t.Errorf("seenPlayer.ID = %d, should not equal the deleted ID %d", got, dontWant)
+	}
+	if !seenPlayer.IsAnonymous() {
+		t.Error("seenPlayer.IsAnonymous() = false, want true")
+	}
+	if _, ok := findCookie(rec, session.CookieName); !ok {
+		t.Error("session cookie should have been re-issued when the cookie referenced a deleted row")
+	}
+}
+
+func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	sessions := session.New([]byte("k"))
+
+	var seenIDs []int64
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		p, _ := auth.PlayerFromContext(r.Context())
+		seenIDs = append(seenIDs, p.ID)
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	for range 2 {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+		mw.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	if got, want := len(seenIDs), 2; got != want {
+		t.Fatalf("len(seenIDs) = %d, want %d", got, want)
+	}
+	if seenIDs[0] == seenIDs[1] {
+		t.Errorf("two cookieless requests produced the same player ID %d, want distinct", seenIDs[0])
+	}
+}
+
+func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	existing, err := store.CreateAnonymousPlayer(t.Context(), "anon-x")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	store.failGet = true
+
+	sessions := session.New([]byte("k"))
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("next should not be called on store error")
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, existing.ID)
+	cookie := rec.Result().Cookies()[0]
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), "internal error"; !strings.Contains(got, want) {
+		t.Errorf("body = %q, should contain %q", got, want)
 	}
 }

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -12,6 +12,10 @@ var ErrPlayerNotFound = errors.New("player not found")
 // ErrUsernameTaken is returned when a username is already in use.
 var ErrUsernameTaken = errors.New("username taken")
 
+// ErrPlayerAlreadyClaimed is returned by ClaimPlayer when the target row
+// already has a password_hash set, so it cannot be upgraded again.
+var ErrPlayerAlreadyClaimed = errors.New("player already claimed")
+
 // Player represents an authenticated user (admin or player).
 type Player struct {
 	ID           int64
@@ -20,6 +24,18 @@ type Player struct {
 	PasswordHash string
 	Role         string
 	CreatedAt    time.Time
+}
+
+// IsAnonymous reports whether the player has no credentials set yet (no
+// password_hash) AND is not an admin. Anonymous rows are created by
+// EnsurePlayer for visitors who arrive without a session and may later be
+// upgraded by ClaimPlayer.
+//
+// The admin-role exclusion guards the seeded admin row (id=1), which also
+// has a NULL password_hash but must never be treated as a claimable
+// anonymous row by HandleRegisterSubmit's claim path.
+func (p *Player) IsAnonymous() bool {
+	return p.PasswordHash == "" && p.Role != RoleAdmin
 }
 
 // PlayerStore is the persistence interface used by the auth package.
@@ -37,4 +53,20 @@ type PlayerStore interface {
 	// against concurrent registrations.
 	// Returns ErrUsernameTaken when the username is already in use.
 	CreatePlayer(ctx context.Context, username, passwordHash, requestedRole string) (*Player, error)
+	// CreateAnonymousPlayer creates a row with the given username, no email,
+	// no password_hash, and role = "player". Used by EnsurePlayer to back a
+	// brand-new visitor with a real row before they can play. The caller
+	// generates the username (typically "anon-<xid>") so the store stays
+	// agnostic about the format.
+	// Returns ErrUsernameTaken on the (effectively impossible) collision.
+	CreateAnonymousPlayer(ctx context.Context, username string) (*Player, error)
+	// ClaimPlayer upgrades an anonymous row (password_hash IS NULL) in place
+	// with the supplied credentials and requested role. The store mirrors the
+	// "first password-bearing registrant becomes admin" promotion logic of
+	// CreatePlayer so the rule still triggers when a visitor's very first
+	// sign-up flows through the claim path.
+	// Returns ErrPlayerAlreadyClaimed when the target row already has a
+	// password_hash, ErrUsernameTaken when the requested username collides
+	// with another row, and ErrPlayerNotFound when the id does not exist.
+	ClaimPlayer(ctx context.Context, playerID int64, username, passwordHash, requestedRole string) (*Player, error)
 }

--- a/internal/auth/player_test.go
+++ b/internal/auth/player_test.go
@@ -1,0 +1,47 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+func TestPlayer_IsAnonymous(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    auth.Player
+		want bool
+	}{
+		{
+			name: "anonymous player (empty hash, player role)",
+			p:    auth.Player{PasswordHash: "", Role: auth.RolePlayer},
+			want: true,
+		},
+		{
+			name: "credentialled player",
+			p:    auth.Player{PasswordHash: "$2a$bcrypted", Role: auth.RolePlayer},
+			want: false,
+		},
+		{
+			name: "seeded admin row (empty hash but admin role) is not anonymous",
+			p:    auth.Player{PasswordHash: "", Role: auth.RoleAdmin},
+			want: false,
+		},
+		{
+			name: "credentialled admin",
+			p:    auth.Player{PasswordHash: "$2a$bcrypted", Role: auth.RoleAdmin},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := tc.p.IsAnonymous(), tc.want; got != want {
+				t.Errorf("IsAnonymous() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/handlers"
 	"github.com/starquake/topbanana/internal/quiz"
@@ -162,8 +163,17 @@ func HandleCreateGame(logger *slog.Logger, service *game.Service) http.Handler {
 			return
 		}
 
-		// TODO: Replace with real PlayerID
-		g, err := service.CreateGame(ctx, req.QuizID, 1)
+		player, ok := auth.PlayerFromContext(ctx)
+		if !ok {
+			// EnsurePlayer middleware should have populated this; reaching
+			// here means the route was wired without it.
+			logger.ErrorContext(ctx, "missing player on context for create game")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		g, err := service.CreateGame(ctx, req.QuizID, player.ID)
 		if err != nil {
 			if errors.Is(err, quiz.ErrQuizNotFound) {
 				http.NotFound(w, r)
@@ -298,8 +308,15 @@ func HandleAnswerPost(logger *slog.Logger, service *game.Service) http.Handler {
 			return
 		}
 
-		// TODO: Replace with real PlayerID
-		a, err := service.SubmitAnswer(r.Context(), gameID, 1, questionID, req.OptionID)
+		player, ok := auth.PlayerFromContext(r.Context())
+		if !ok {
+			logger.ErrorContext(r.Context(), "missing player on context for submit answer")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		a, err := service.SubmitAnswer(r.Context(), gameID, player.ID, questionID, req.OptionID)
 		if err != nil {
 			if errors.Is(err, game.ErrGameNotFound) || errors.Is(err, game.ErrQuestionNotInGame) {
 				http.Error(w, err.Error(), http.StatusNotFound)

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -11,10 +11,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/starquake/topbanana/internal/auth"
 	. "github.com/starquake/topbanana/internal/clientapi"
 	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/quiz"
 )
+
+// withPlayer returns ctx annotated with a stub authenticated player. Use it
+// when the test exercises a handler that pulls the player off the context
+// (typically because EnsurePlayer would do so in production).
+func withPlayer(ctx context.Context, id int64) context.Context {
+	return auth.WithPlayer(ctx, &auth.Player{ID: id, Username: "stub", Role: auth.RolePlayer})
+}
 
 var errStub = errors.New("stub error")
 
@@ -342,7 +350,7 @@ func TestHandleCreateGame(t *testing.T) {
 		handler := HandleCreateGame(logger, svc)
 
 		req := httptest.NewRequestWithContext(
-			context.Background(), http.MethodPost, "/api/games",
+			withPlayer(t.Context(), 7), http.MethodPost, "/api/games",
 			strings.NewReader(`{"quizId": 1}`),
 		)
 		rec := httptest.NewRecorder()
@@ -371,7 +379,69 @@ func TestHandleCreateGame(t *testing.T) {
 		handler := HandleCreateGame(logger, svc)
 
 		req := httptest.NewRequestWithContext(
-			context.Background(), http.MethodPost, "/api/games",
+			withPlayer(t.Context(), 7), http.MethodPost, "/api/games",
+			strings.NewReader(`{"quizId": 1}`),
+		)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("uses player ID from context", func(t *testing.T) {
+		t.Parallel()
+
+		const wantPlayerID = int64(42)
+		var seenPlayerID int64
+		svc := newService(
+			stubGameStore{
+				createGame: func(_ context.Context, _ *game.Game) error { return nil },
+				createParticipant: func(_ context.Context, p *game.Participant) error {
+					seenPlayerID = p.PlayerID
+
+					return nil
+				},
+				startGame: func(_ context.Context, _ string) error { return nil },
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id, Title: "Q"}, nil
+				},
+			},
+		)
+		handler := HandleCreateGame(logger, svc)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), wantPlayerID), http.MethodPost, "/api/games",
+			strings.NewReader(`{"quizId": 1}`),
+		)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusCreated; got != want {
+			t.Fatalf("status code = %v, want %v (body=%q)", got, want, rec.Body.String())
+		}
+		if got, want := seenPlayerID, wantPlayerID; got != want {
+			t.Errorf("CreateParticipant PlayerID = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("returns 500 when player missing on context", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(stubGameStore{}, stubQuizStore{
+			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Q"}, nil
+			},
+		})
+		handler := HandleCreateGame(logger, svc)
+
+		// No player on the context — handler should refuse rather than
+		// silently fall back to a hardcoded ID.
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "/api/games",
 			strings.NewReader(`{"quizId": 1}`),
 		)
 		rec := httptest.NewRecorder()
@@ -639,7 +709,7 @@ func TestHandleAnswerPost(t *testing.T) {
 		)
 
 		req := httptest.NewRequestWithContext(
-			context.Background(), http.MethodPost,
+			withPlayer(t.Context(), 7), http.MethodPost,
 			"/api/games/missing/questions/1/answers",
 			strings.NewReader(`{"optionId": 1}`),
 		)
@@ -667,7 +737,7 @@ func TestHandleAnswerPost(t *testing.T) {
 		)
 
 		req := httptest.NewRequestWithContext(
-			context.Background(), http.MethodPost,
+			withPlayer(t.Context(), 7), http.MethodPost,
 			"/api/games/game-1/questions/99/answers",
 			strings.NewReader(`{"optionId": 1}`),
 		)
@@ -714,7 +784,7 @@ func TestHandleAnswerPost(t *testing.T) {
 		)
 
 		req := httptest.NewRequestWithContext(
-			context.Background(), http.MethodPost,
+			withPlayer(t.Context(), 7), http.MethodPost,
 			"/api/games/game-1/questions/10/answers",
 			strings.NewReader(`{"optionId": 200}`),
 		)
@@ -722,6 +792,43 @@ func TestHandleAnswerPost(t *testing.T) {
 		mux.ServeHTTP(rec, req)
 
 		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 500 when player missing on context", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(
+			stubGameStore{
+				getGame: func(_ context.Context, id string) (*game.Game, error) {
+					return &game.Game{
+						ID:     id,
+						QuizID: 1,
+						Questions: []*game.Question{
+							{ID: 1, GameID: id, QuestionID: 10},
+						},
+					}, nil
+				},
+			},
+			stubQuizStore{},
+		)
+
+		mux := http.NewServeMux()
+		mux.Handle(
+			"POST /api/games/{gameID}/questions/{questionID}/answers",
+			HandleAnswerPost(logger, svc),
+		)
+
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/api/games/game-1/questions/10/answers",
+			strings.NewReader(`{"optionId": 200}`),
+		)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
 			t.Errorf("status code = %v, want %v", got, want)
 		}
 	})

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -10,6 +10,83 @@ import (
 	"database/sql"
 )
 
+const claimPlayer = `-- name: ClaimPlayer :one
+UPDATE players
+SET username = ?1,
+    password_hash = ?2,
+    role = CASE
+        WHEN CAST(?3 AS TEXT) = 'admin' THEN 'admin'
+        WHEN (SELECT COUNT(*) FROM players AS pp WHERE pp.password_hash IS NOT NULL) = 0 THEN 'admin'
+        ELSE 'player'
+    END
+WHERE players.id = ?4
+  AND players.password_hash IS NULL
+RETURNING id, username, email, password_hash, role, created_at
+`
+
+type ClaimPlayerParams struct {
+	Username      string
+	PasswordHash  sql.NullString
+	RequestedRole string
+	ID            int64
+}
+
+// Upgrades an anonymous (password_hash IS NULL) row in place so that an
+// already-playing visitor keeps their player_id when they sign up. The
+// WHERE password_hash IS NULL guard makes this idempotent: a second claim
+// attempt against an already-credentialled row returns no rows, which the
+// store maps to ErrPlayerAlreadyClaimed.
+//
+// The role CASE mirrors CreatePlayerWithCredentials so the "first
+// password-bearing registrant becomes admin" rule still triggers when the
+// very first sign-up happens through the claim path (i.e. the registrant
+// played anonymously first). The subquery aliases the players table as pp
+// so the column reference in the WHERE is unambiguous against the row
+// being updated.
+func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Player, error) {
+	row := q.db.QueryRowContext(ctx, claimPlayer,
+		arg.Username,
+		arg.PasswordHash,
+		arg.RequestedRole,
+		arg.ID,
+	)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.Email,
+		&i.PasswordHash,
+		&i.Role,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const createAnonymousPlayer = `-- name: CreateAnonymousPlayer :one
+INSERT INTO players (username, role)
+VALUES (?1, 'player')
+RETURNING id, username, email, password_hash, role, created_at
+`
+
+// Used by the EnsurePlayer middleware to back a fresh visitor with a real
+// players row before they can play. email and password_hash are NULL; role
+// is fixed to 'player' because the "first password-bearing registrant
+// becomes admin" SQL above filters by password_hash IS NOT NULL, so an
+// anonymous row never qualifies for promotion.
+func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (Player, error) {
+	row := q.db.QueryRowContext(ctx, createAnonymousPlayer, username)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.Email,
+		&i.PasswordHash,
+		&i.Role,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const createPlayerWithCredentials = `-- name: CreatePlayerWithCredentials :one
 INSERT INTO players (username, password_hash, role)
 VALUES (

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -26,3 +26,38 @@ VALUES (
     END
 )
 RETURNING *;
+
+-- name: CreateAnonymousPlayer :one
+-- Used by the EnsurePlayer middleware to back a fresh visitor with a real
+-- players row before they can play. email and password_hash are NULL; role
+-- is fixed to 'player' because the "first password-bearing registrant
+-- becomes admin" SQL above filters by password_hash IS NOT NULL, so an
+-- anonymous row never qualifies for promotion.
+INSERT INTO players (username, role)
+VALUES (sqlc.arg('username'), 'player')
+RETURNING *;
+
+-- name: ClaimPlayer :one
+-- Upgrades an anonymous (password_hash IS NULL) row in place so that an
+-- already-playing visitor keeps their player_id when they sign up. The
+-- WHERE password_hash IS NULL guard makes this idempotent: a second claim
+-- attempt against an already-credentialled row returns no rows, which the
+-- store maps to ErrPlayerAlreadyClaimed.
+--
+-- The role CASE mirrors CreatePlayerWithCredentials so the "first
+-- password-bearing registrant becomes admin" rule still triggers when the
+-- very first sign-up happens through the claim path (i.e. the registrant
+-- played anonymously first). The subquery aliases the players table as pp
+-- so the column reference in the WHERE is unambiguous against the row
+-- being updated.
+UPDATE players
+SET username = sqlc.arg('username'),
+    password_hash = sqlc.arg('password_hash'),
+    role = CASE
+        WHEN CAST(sqlc.arg('requested_role') AS TEXT) = 'admin' THEN 'admin'
+        WHEN (SELECT COUNT(*) FROM players AS pp WHERE pp.password_hash IS NOT NULL) = 0 THEN 'admin'
+        ELSE 'player'
+    END
+WHERE players.id = sqlc.arg('id')
+  AND players.password_hash IS NULL
+RETURNING *;

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -28,7 +28,7 @@ func addRoutes(
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
 	addAdminRoutes(mux, logger, stores, sessions, csrfMgr)
-	addAPIRoutes(mux, logger, stores, gameService)
+	addAPIRoutes(mux, logger, stores, gameService, sessions)
 
 	// Client
 	mux.Handle("/client/", client.Handler(cfg))
@@ -130,19 +130,34 @@ func addAdminRoutes(
 // These do not need CSRF protection: they expect application/json bodies and
 // do not rely on cookie auth, so the classic browser-form CSRF threat does
 // not apply.
+//
+// Every route is wrapped in EnsurePlayer so a cookieless visitor is silently
+// upgraded to an anonymous players row before the handler runs. This means
+// HandleCreateGame and HandleAnswerPost can safely read the player off the
+// request context. The static /client/* assets are intentionally not wrapped
+// — loading the SPA shell should not create a row; the first /api/ call
+// does.
 func addAPIRoutes(
 	mux *http.ServeMux,
 	logger *slog.Logger,
 	stores *store.Stores,
 	gameService *game.Service,
+	sessions *session.Manager,
 ) {
-	mux.Handle("GET /api/quizzes", clientapi.HandleQuizList(logger, stores.Quizzes))
-	mux.Handle("GET /api/quizzes/{slugID}", clientapi.HandleQuizGet(logger, stores.Quizzes))
-	mux.Handle("POST /api/games", clientapi.HandleCreateGame(logger, gameService))
-	mux.Handle("GET /api/games/{gameID}/questions/next", clientapi.HandleQuestionNext(logger, gameService))
+	ensurePlayer := func(h http.Handler) http.Handler {
+		return auth.EnsurePlayer(h, stores.Players, sessions, logger)
+	}
+
+	mux.Handle("GET /api/quizzes", ensurePlayer(clientapi.HandleQuizList(logger, stores.Quizzes)))
+	mux.Handle("GET /api/quizzes/{slugID}", ensurePlayer(clientapi.HandleQuizGet(logger, stores.Quizzes)))
+	mux.Handle("POST /api/games", ensurePlayer(clientapi.HandleCreateGame(logger, gameService)))
+	mux.Handle(
+		"GET /api/games/{gameID}/questions/next",
+		ensurePlayer(clientapi.HandleQuestionNext(logger, gameService)),
+	)
 	mux.Handle(
 		"POST /api/games/{gameID}/questions/{questionID}/answers",
-		clientapi.HandleAnswerPost(logger, gameService),
+		ensurePlayer(clientapi.HandleAnswerPost(logger, gameService)),
 	)
-	mux.Handle("GET /api/games/{gameID}/results", clientapi.HandleGameResults(logger, gameService))
+	mux.Handle("GET /api/games/{gameID}/results", ensurePlayer(clientapi.HandleGameResults(logger, gameService)))
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -34,6 +34,14 @@ func (stubPlayerStore) CreatePlayer(_ context.Context, _, _, _ string) (*auth.Pl
 	return nil, errRouteStub
 }
 
+func (stubPlayerStore) CreateAnonymousPlayer(_ context.Context, _ string) (*auth.Player, error) {
+	return nil, errRouteStub
+}
+
+func (stubPlayerStore) ClaimPlayer(_ context.Context, _ int64, _, _, _ string) (*auth.Player, error) {
+	return nil, errRouteStub
+}
+
 var errRouteStub = errors.New("stub")
 
 type stubQuizStore struct{}

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -99,6 +99,76 @@ func (s *PlayerStore) CreatePlayer(
 	return playerFromRow(row), nil
 }
 
+// CreateAnonymousPlayer inserts a row with the given username, no email, no
+// password_hash, role = 'player'. Callers (EnsurePlayer) generate a random
+// "anon-<xid>" username so collisions on the unique index are not a concern;
+// if one happens anyway it surfaces as auth.ErrUsernameTaken.
+func (s *PlayerStore) CreateAnonymousPlayer(ctx context.Context, username string) (*auth.Player, error) {
+	row, err := s.q.CreateAnonymousPlayer(ctx, strings.TrimSpace(username))
+	if err != nil {
+		var sqliteErr *sqlite.Error
+		if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
+			return nil, auth.ErrUsernameTaken
+		}
+
+		return nil, fmt.Errorf("failed to create anonymous player: %w", err)
+	}
+
+	return playerFromRow(row), nil
+}
+
+// ClaimPlayer upgrades an anonymous (password_hash IS NULL) row to a
+// credentialled player. The underlying SQL uses the same "first
+// password-bearing registrant becomes admin" CASE as CreatePlayer so a first
+// sign-up that flows through the claim path still triggers the promotion
+// atomically.
+//
+// Returns auth.ErrUsernameTaken when the new username collides with another
+// row, auth.ErrPlayerAlreadyClaimed when the row already has credentials
+// (the WHERE password_hash IS NULL guard filters it out and the UPDATE
+// returns no rows), and auth.ErrPlayerNotFound when no row matches the id.
+func (s *PlayerStore) ClaimPlayer(
+	ctx context.Context,
+	playerID int64,
+	username, passwordHash, requestedRole string,
+) (*auth.Player, error) {
+	row, err := s.q.ClaimPlayer(ctx, db.ClaimPlayerParams{
+		Username:      strings.TrimSpace(username),
+		PasswordHash:  sql.NullString{String: passwordHash, Valid: true},
+		RequestedRole: requestedRole,
+		ID:            playerID,
+	})
+	if err != nil {
+		return nil, s.classifyClaimErr(ctx, playerID, err)
+	}
+
+	return playerFromRow(row), nil
+}
+
+// classifyClaimErr maps a ClaimPlayer storage error onto the auth-package
+// sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous (the id might
+// not exist OR the row has already been claimed), so it re-queries by id
+// to disambiguate.
+func (s *PlayerStore) classifyClaimErr(ctx context.Context, playerID int64, err error) error {
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
+		return auth.ErrUsernameTaken
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("failed to claim player: %w", err)
+	}
+
+	if _, getErr := s.q.GetPlayer(ctx, playerID); getErr != nil {
+		if errors.Is(getErr, sql.ErrNoRows) {
+			return auth.ErrPlayerNotFound
+		}
+
+		return fmt.Errorf("failed to verify player after claim: %w", getErr)
+	}
+
+	return auth.ErrPlayerAlreadyClaimed
+}
+
 func playerFromRow(row db.Player) *auth.Player {
 	p := &auth.Player{
 		ID:        row.ID,

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -179,3 +179,140 @@ func TestPlayerStore_CreatePlayer_DuplicateUsername(t *testing.T) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }
+
+func TestPlayerStore_CreateAnonymousPlayer(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	created, err := ps.CreateAnonymousPlayer(t.Context(), "anon-foo")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	if got, want := created.Username, "anon-foo"; got != want {
+		t.Errorf("Username = %q, want %q", got, want)
+	}
+	if got, want := created.PasswordHash, ""; got != want {
+		t.Errorf("PasswordHash = %q, want %q (anonymous row should have NULL hash)", got, want)
+	}
+	if got, want := created.Role, auth.RolePlayer; got != want {
+		t.Errorf("Role = %q, want %q (anonymous row never auto-promotes to admin)", got, want)
+	}
+	if !created.IsAnonymous() {
+		t.Error("IsAnonymous() = false, want true")
+	}
+}
+
+func TestPlayerStore_CreateAnonymousPlayer_DoesNotBlockFirstAdmin(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	// Seed an anonymous row first; the next CreatePlayer call should still
+	// trigger the "first password-bearing registrant becomes admin" rule
+	// because the SQL CASE filters by password_hash IS NOT NULL.
+	if _, err := ps.CreateAnonymousPlayer(t.Context(), "anon-first"); err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	created, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	if got, want := created.Role, auth.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q (first credentialled player should still become admin)", got, want)
+	}
+}
+
+func TestPlayerStore_ClaimPlayer_UpgradesAnonymousRow(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-claim")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	claimed, err := ps.ClaimPlayer(t.Context(), anon.ID, "alice", "hash", auth.RolePlayer)
+	if err != nil {
+		t.Fatalf("ClaimPlayer err = %v, want nil", err)
+	}
+	if got, want := claimed.ID, anon.ID; got != want {
+		t.Errorf("claimed.ID = %d, want %d (claim must preserve player ID)", got, want)
+	}
+	if got, want := claimed.Username, "alice"; got != want {
+		t.Errorf("claimed.Username = %q, want %q", got, want)
+	}
+	if got, want := claimed.PasswordHash, "hash"; got != want {
+		t.Errorf("claimed.PasswordHash = %q, want %q", got, want)
+	}
+	// First password-bearing registrant — even via the claim path — becomes admin.
+	if got, want := claimed.Role, auth.RoleAdmin; got != want {
+		t.Errorf("claimed.Role = %q, want %q", got, want)
+	}
+}
+
+func TestPlayerStore_ClaimPlayer_AlreadyClaimed_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-twice")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	if _, claimErr := ps.ClaimPlayer(t.Context(), anon.ID, "alice", "hash", auth.RolePlayer); claimErr != nil {
+		t.Fatalf("first ClaimPlayer err = %v, want nil", claimErr)
+	}
+
+	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "bob", "other", auth.RolePlayer)
+	if got, want := err, auth.ErrPlayerAlreadyClaimed; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+
+	// Make sure the original claim was not clobbered by the second attempt.
+	stored, err := ps.GetPlayerByUsername(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	if got, want := stored.ID, anon.ID; got != want {
+		t.Errorf("stored.ID = %d, want %d (first claim should win)", got, want)
+	}
+}
+
+func TestPlayerStore_ClaimPlayer_UnknownPlayerID_ReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	_, err := ps.ClaimPlayer(t.Context(), 9999, "ghost", "hash", auth.RolePlayer)
+	if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "h", auth.RolePlayer); err != nil {
+		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
+	}
+	anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-rival")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "alice", "h", auth.RolePlayer)
+	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -79,7 +79,13 @@ export async function createQuizWithQuestions(
     for (let i = 0; i < q.options.length; i++) {
       await page.locator(`input[name="option[${i}].text"]`).fill(q.options[i]);
       if (q.correctIndices.includes(i)) {
-        await page.locator(`input[name="option[${i}].correct"]`).check();
+        // scrollIntoViewIfNeeded gives Firefox a frame to settle before the
+        // click — without it CI occasionally surfaces "Clicking the checkbox
+        // did not change its state" when the form's still styling under
+        // CDN-loaded Bulma CSS.
+        const checkbox = page.locator(`input[name="option[${i}].correct"]`);
+        await checkbox.scrollIntoViewIfNeeded();
+        await checkbox.check();
       }
     }
     await page.getByRole('button', { name: 'Save' }).click();

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -37,30 +37,30 @@ var csrfTokenPattern = regexp.MustCompile(
 // extracts the first csrf_token form value from the response body, and
 // returns it. The client's cookie jar picks up the nonce cookie as a side
 // effect, so subsequent POSTs from the same client carry the matching pair.
-func fetchCSRFToken(ctx context.Context, t *testing.T, client *http.Client, url string) string {
+func fetchCSRFToken(ctx context.Context, t *testing.T, client *http.Client, formURL string) string {
 	t.Helper()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, formURL, nil)
 	if err != nil {
 		t.Fatalf("failed to create CSRF GET request: %v", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		t.Fatalf("failed to GET %s: %v", url, err)
+		t.Fatalf("failed to GET %s: %v", formURL, err)
 	}
 	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			t.Errorf("failed to close response body: %v", err)
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("failed to close response body: %v", cerr)
 		}
 	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("failed to read body of %s: %v", url, err)
+		t.Fatalf("failed to read body of %s: %v", formURL, err)
 	}
 	m := csrfTokenPattern.FindStringSubmatch(string(body))
 	if m == nil {
-		t.Fatalf("no csrf_token found in response from %s; body=%q", url, body)
+		t.Fatalf("no csrf_token found in response from %s; body=%q", formURL, body)
 	}
 
 	return m[1]
@@ -151,8 +151,8 @@ func TestAdmin_Integration(t *testing.T) {
 	if got, want := registerResp.StatusCode, http.StatusSeeOther; got != want {
 		t.Fatalf("register status = %d, want %d", got, want)
 	}
-	if err := registerResp.Body.Close(); err != nil {
-		t.Errorf("failed to close register body: %v", err)
+	if cerr := registerResp.Body.Close(); cerr != nil {
+		t.Errorf("failed to close register body: %v", cerr)
 	}
 
 	// Visit the quiz-create form GET so we can pull a fresh CSRF token tied
@@ -307,8 +307,8 @@ func TestAdmin_Integration(t *testing.T) {
 	}()
 	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
 		t.Errorf("expected status %d, got %d", want, got)
-		body, _ := io.ReadAll(resp.Body)
-		t.Logf("Response body: %s", string(body))
+		errBody, _ := io.ReadAll(resp.Body)
+		t.Logf("Response body: %s", string(errBody))
 	}
 
 	questionLocation := resp.Header.Get("Location")

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/starquake/topbanana/cmd/server/app"
+	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/quiz"
+	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
+	"github.com/starquake/topbanana/internal/testutil"
+)
+
+// TestAnonymous_Integration exercises the score-claiming acceptance criteria:
+//   - First /api/games request without a cookie creates a players row and
+//     sets a session cookie on the response.
+//   - Repeating that request from the same client reuses the row.
+//   - Two distinct cookie jars produce two distinct anonymous players.
+func TestAnonymous_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, stop := testutil.SignalCtx(t)
+
+	stdout := testutil.NewTestWriter(t)
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	getenv := func(key string) string {
+		env := map[string]string{
+			"HOST":   "localhost",
+			"PORT":   "0",
+			"DB_URI": dbURI,
+		}
+
+		return env[key]
+	}
+
+	listenConfig := &net.ListenConfig{}
+	ln, err := listenConfig.Listen(ctx, "tcp", net.JoinHostPort(getenv("HOST"), getenv("PORT")))
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run(ctx, getenv, stdout, ln)
+	}()
+
+	serverAddr := ln.Addr().String()
+	baseURL := "http://" + serverAddr
+	if readyErr := testutil.WaitForReady(ctx, t, 10*time.Second, baseURL+"/healthz"); readyErr != nil {
+		t.Fatalf("error waiting for server to be ready: %v", readyErr)
+	}
+
+	// Seed a quiz directly via the DB so we can ask the API to start a
+	// game against it. Using the store keeps this independent of the admin
+	// HTTP flow exercised in admin_test.go.
+	dbConn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() {
+		if cerr := dbConn.Close(); cerr != nil {
+			t.Errorf("dbConn.Close err = %v, want nil", cerr)
+		}
+	})
+
+	qz := &quiz.Quiz{
+		Title:       "Anonymous Quiz",
+		Slug:        "anonymous-quiz",
+		Description: "for the anonymous integration test",
+		Questions: []*quiz.Question{
+			{
+				Text:     "Q1",
+				Position: 1,
+				Options: []*quiz.Option{
+					{Text: "A", Correct: true},
+					{Text: "B"},
+				},
+			},
+		},
+	}
+	stores := store.New(dbConn, slog.Default())
+	if createErr := stores.Quizzes.CreateQuiz(ctx, qz); createErr != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", createErr)
+	}
+
+	// Three scenarios run sequentially in this body (rather than as t.Run
+	// subtests) because they share dbConn and the EnsurePlayer-managed
+	// players-row count — paralleltest would force subtests to be parallel,
+	// which would race the count-delta assertions below.
+
+	// Scenario 1: first request without cookie creates an anonymous player
+	// AND sets a session cookie on the response (otherwise repeat requests
+	// can't reuse the row).
+	jar1, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New err = %v, want nil", err)
+	}
+	client1 := &http.Client{Jar: jar1}
+
+	startCount := countAnonymousPlayers(ctx, t, dbConn)
+	gameID, setCookie := postCreateGame(ctx, t, client1, baseURL, qz.ID)
+	if gameID == "" {
+		t.Fatal("expected non-empty game ID")
+	}
+	if !setCookie {
+		t.Fatal("expected Set-Cookie on first /api/games response")
+	}
+	if got, want := countAnonymousPlayers(ctx, t, dbConn)-startCount, 1; got != want {
+		t.Errorf("[scenario 1] anonymous players added = %d, want %d", got, want)
+	}
+
+	// Scenario 2: second request from same client reuses the existing row.
+	jar2, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New err = %v, want nil", err)
+	}
+	client2 := &http.Client{Jar: jar2}
+
+	startCount = countAnonymousPlayers(ctx, t, dbConn)
+	_, _ = postCreateGame(ctx, t, client2, baseURL, qz.ID)
+	_, _ = postCreateGame(ctx, t, client2, baseURL, qz.ID)
+	if got, want := countAnonymousPlayers(ctx, t, dbConn)-startCount, 1; got != want {
+		t.Errorf("[scenario 2] anonymous players added = %d, want %d (jar should reuse row)", got, want)
+	}
+
+	// Scenario 3: two cookie jars mint two distinct anonymous players.
+	jarA, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New err = %v, want nil", err)
+	}
+	jarB, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New err = %v, want nil", err)
+	}
+	clientA := &http.Client{Jar: jarA}
+	clientB := &http.Client{Jar: jarB}
+
+	startCount = countAnonymousPlayers(ctx, t, dbConn)
+	_, _ = postCreateGame(ctx, t, clientA, baseURL, qz.ID)
+	_, _ = postCreateGame(ctx, t, clientB, baseURL, qz.ID)
+	if got, want := countAnonymousPlayers(ctx, t, dbConn)-startCount, 2; got != want {
+		t.Errorf("[scenario 3] anonymous players added = %d, want %d (two jars → two rows)", got, want)
+	}
+
+	stop()
+	select {
+	case err = <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("run() returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("server failed to shutdown in time")
+	}
+}
+
+// postCreateGame issues POST /api/games and returns the new game ID plus
+// whether the response set the session cookie. Failures are reported as
+// fatal because every assertion downstream needs a healthy game.
+func postCreateGame(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL string, quizID int64,
+) (string, bool) {
+	t.Helper()
+
+	body := fmt.Sprintf(`{"quizId": %d}`, quizID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/games", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", err)
+		}
+	}()
+
+	if got, want := resp.StatusCode, http.StatusCreated; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("json.Decode err = %v, want nil", err)
+	}
+
+	hadSessionCookie := false
+	for _, c := range resp.Cookies() {
+		if c.Name == session.CookieName {
+			hadSessionCookie = true
+		}
+	}
+
+	return out.ID, hadSessionCookie
+}
+
+// countAnonymousPlayers returns the number of rows with NULL password_hash.
+// The EnsurePlayer middleware is the only path that creates such rows, so
+// the value is a direct proxy for "how many anonymous visitors the server
+// has minted so far".
+func countAnonymousPlayers(ctx context.Context, t *testing.T, dbConn *sql.DB) int {
+	t.Helper()
+
+	var n int
+	err := dbConn.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM players WHERE password_hash IS NULL`,
+	).Scan(&n)
+	if err != nil {
+		t.Fatalf("QueryRow err = %v, want nil", err)
+	}
+
+	return n
+}

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +26,77 @@ import (
 	"github.com/starquake/topbanana/internal/testutil"
 )
 
-func setupIntegration(t *testing.T) (context.Context, context.CancelFunc, chan error, string, *store.Stores, error) {
+// httpGet issues a GET with a request-scoped context so the noctx linter is
+// happy and the request gets cancelled when the test ends.
+func httpGet(ctx context.Context, t *testing.T, client *http.Client, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+
+	return resp
+}
+
+// httpPostJSON issues a POST with a JSON body and a request-scoped context.
+func httpPostJSON(ctx context.Context, t *testing.T, client *http.Client, url, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+
+	return resp
+}
+
+// nextQuestionOption mirrors one option in the GET /api/games/.../next
+// response. Pulled out so the parent decode target isn't a nested struct
+// (revive's nested-structs rule).
+type nextQuestionOption struct {
+	ID   int64  `json:"id"`
+	Text string `json:"text"`
+}
+
+// nextQuestionRes is the decode target for GET /api/games/.../next.
+type nextQuestionRes struct {
+	ID      int64                `json:"id"`
+	Text    string               `json:"text"`
+	Options []nextQuestionOption `json:"options"`
+}
+
+// playerScoreRes mirrors one player_scores entry in the GET .../results
+// response. Pulled out for the same nested-structs reason.
+type playerScoreRes struct {
+	PlayerID int64 `json:"playerId"`
+	Score    int   `json:"score"`
+}
+
+// resultsRes is the decode target for GET /api/games/.../results.
+type resultsRes struct {
+	GameID       string           `json:"gameId"`
+	PlayerScores []playerScoreRes `json:"playerScores"`
+}
+
+// integrationSetup bundles the artefacts a gameplay-style integration test
+// needs. Context is intentionally returned separately from the struct (passed
+// out of setupIntegration as the first return value) to avoid containedctx.
+type integrationSetup struct {
+	Stop    context.CancelFunc
+	ErrCh   chan error
+	BaseURL string
+	Stores  *store.Stores
+}
+
+func setupIntegration(t *testing.T) (context.Context, integrationSetup) {
 	t.Helper()
 
 	var err error
@@ -62,8 +133,8 @@ func setupIntegration(t *testing.T) (context.Context, context.CancelFunc, chan e
 	}()
 
 	serverAddr := ln.Addr().String()
-	baseURL := fmt.Sprintf("http://%s", serverAddr)
-	err = testutil.WaitForReady(ctx, t, 10*time.Second, fmt.Sprintf("%s/healthz", baseURL))
+	baseURL := "http://" + serverAddr
+	err = testutil.WaitForReady(ctx, t, 10*time.Second, baseURL+"/healthz")
 	if err != nil {
 		t.Fatalf("error waiting for server to be ready: %v", err)
 	}
@@ -74,19 +145,29 @@ func setupIntegration(t *testing.T) (context.Context, context.CancelFunc, chan e
 		t.Fatalf("failed to open db: %v", err)
 	}
 	t.Cleanup(func() {
-		db.Close()
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
 	})
 
 	stores := store.New(db, slog.Default())
-	return ctx, stop, errCh, baseURL, stores, err
+
+	return ctx, integrationSetup{
+		Stop:    stop,
+		ErrCh:   errCh,
+		BaseURL: baseURL,
+		Stores:  stores,
+	}
 }
 
 func TestGameplay_Integration(t *testing.T) {
 	t.Parallel()
 
-	var err error
-
-	ctx, stop, errCh, baseURL, stores, err := setupIntegration(t)
+	ctx, setup := setupIntegration(t)
+	stop := setup.Stop
+	errCh := setup.ErrCh
+	baseURL := setup.BaseURL
+	stores := setup.Stores
 
 	qz := &quiz.Quiz{
 		Title:       "Integration Quiz",
@@ -120,21 +201,23 @@ func TestGameplay_Integration(t *testing.T) {
 		},
 	}
 
-	err = stores.Quizzes.CreateQuiz(ctx, qz)
-	if err != nil {
+	if err := stores.Quizzes.CreateQuiz(ctx, qz); err != nil {
 		t.Fatalf("failed to create quiz: %v", err)
 	}
 
-	// Start of the integration test
-	client := &http.Client{}
+	// Start of the integration test. The cookie jar carries the anonymous
+	// session cookie that EnsurePlayer issues on the first request, so
+	// every subsequent request is attributed to the same player row.
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create cookie jar: %v", err)
+	}
+	client := &http.Client{Jar: jar}
 
 	var resp *http.Response
 
 	// Get a list of quizzes
-	resp, err = client.Get(baseURL + "/api/quizzes")
-	if err != nil {
-		t.Fatalf("failed to get quizzes: %v", err)
-	}
+	resp = httpGet(ctx, t, client, baseURL+"/api/quizzes")
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
 	}
@@ -144,7 +227,9 @@ func TestGameplay_Integration(t *testing.T) {
 		Description string `json:"description"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&quizzesRes)
-	resp.Body.Close()
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
 	if err != nil {
 		t.Fatalf("failed to decode quizzes response: %v", err)
 	}
@@ -160,10 +245,7 @@ func TestGameplay_Integration(t *testing.T) {
 
 	// Create Game
 	createGameReq := fmt.Sprintf(`{"quizId": %d}`, qz.ID)
-	resp, err = client.Post(baseURL+"/api/games", "application/json", strings.NewReader(createGameReq))
-	if err != nil {
-		t.Fatalf("failed to create game: %v", err)
-	}
+	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("expected status 201, got %d", resp.StatusCode)
 	}
@@ -172,7 +254,9 @@ func TestGameplay_Integration(t *testing.T) {
 		ID string `json:"id"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&createGameRes)
-	resp.Body.Close()
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
 	if err != nil {
 		t.Fatalf("failed to decode create game response: %v", err)
 	}
@@ -180,26 +264,18 @@ func TestGameplay_Integration(t *testing.T) {
 
 	runningScore := 0
 	// Walk through questions
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		// Get Next Question
-		resp, err = client.Get(fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
-		if err != nil {
-			t.Fatalf("failed to get next question: %v", err)
-		}
+		resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected status 200, got %d", resp.StatusCode)
 		}
 
-		var nextQsRes struct {
-			ID      int64  `json:"id"`
-			Text    string `json:"text"`
-			Options []struct {
-				ID   int64  `json:"id"`
-				Text string `json:"text"`
-			} `json:"options"`
-		}
+		var nextQsRes nextQuestionRes
 		err = json.NewDecoder(resp.Body).Decode(&nextQsRes)
-		resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
 		if err != nil {
 			t.Fatalf("failed to decode next question response: %v", err)
 		}
@@ -219,6 +295,7 @@ func TestGameplay_Integration(t *testing.T) {
 					if o.Correct == targetCorrect {
 						optionID = o.ID
 						found = true
+
 						break
 					}
 				}
@@ -235,10 +312,7 @@ func TestGameplay_Integration(t *testing.T) {
 		// Submit Answer
 		answerReq := fmt.Sprintf(`{"optionId": %d}`, optionID)
 		answerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, gameID, nextQsRes.ID)
-		resp, err = client.Post(answerURL, "application/json", strings.NewReader(answerReq))
-		if err != nil {
-			t.Fatalf("failed to submit answer: %v", err)
-		}
+		resp = httpPostJSON(ctx, t, client, answerURL, answerReq)
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected status 200, got %d", resp.StatusCode)
 		}
@@ -247,7 +321,11 @@ func TestGameplay_Integration(t *testing.T) {
 			Correct bool `json:"correct"`
 			Score   int  `json:"score"`
 		}
-		if err = json.NewDecoder(resp.Body).Decode(&answerRes); err != nil {
+		err = json.NewDecoder(resp.Body).Decode(&answerRes)
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if err != nil {
 			t.Fatalf("failed to decode results response: %v", err)
 		}
 		if got, want := answerRes.Correct, targetCorrect; got != want {
@@ -257,51 +335,44 @@ func TestGameplay_Integration(t *testing.T) {
 	}
 
 	// Get Results
-	resp, err = client.Get(fmt.Sprintf("%s/api/games/%s/results", baseURL, gameID))
-	if err != nil {
-		t.Fatalf("failed to get results: %v", err)
-	}
+	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/results", baseURL, gameID))
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
 	}
 
-	var resultsRes struct {
-		GameID       string `json:"gameId"`
-		PlayerScores []struct {
-			PlayerID int64 `json:"playerId"`
-			Score    int   `json:"score"`
-		} `json:"playerScores"`
+	var results resultsRes
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
 	}
-	err = json.NewDecoder(resp.Body).Decode(&resultsRes)
-	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("failed to decode results response: %v", err)
 	}
 
-	if got, want := resultsRes.GameID, gameID; got != want {
+	if got, want := results.GameID, gameID; got != want {
 		t.Fatalf("got game ID %q, want %q", got, want)
 	}
-	if got, want := len(resultsRes.PlayerScores), 1; got != want {
+	if got, want := len(results.PlayerScores), 1; got != want {
 		t.Fatalf("got %d player scores, want %d", got, want)
 	}
 
-	// TODO: Update when player ID is generated by server
-	if got, want := resultsRes.PlayerScores[0].PlayerID, int64(1); got != want {
-		t.Fatalf("got player ID %q, want %q", got, want)
+	// The server picks the player ID for an anonymous session, so we
+	// don't assert a specific value — just that it is a real row.
+	if got := results.PlayerScores[0].PlayerID; got <= 0 {
+		t.Fatalf("got player ID %d, want > 0", got)
 	}
-	if got, want := resultsRes.PlayerScores[0].Score, runningScore; got != want {
+	if got, want := results.PlayerScores[0].Score, runningScore; got != want {
 		t.Fatalf("got score %d, want %d", got, want)
 	}
 
 	// Verify no more questions
-	resp, err = client.Get(fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
-	if err != nil {
-		t.Fatalf("failed to get next question (final): %v", err)
-	}
+	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected status 404, got %d", resp.StatusCode)
 	}
-	resp.Body.Close()
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
 
 	// Shutdown server
 	stop()


### PR DESCRIPTION
## Summary

- Closes #102.
- New `EnsurePlayer` middleware mints an `anon-<xid>` row on the first cookieless `/api/*` request, sets a session cookie, and stashes the loaded `*Player` on the request context. Subsequent requests reuse the row.
- `clientapi` `HandleCreateGame` and `HandleAnswerPost` read the player from context — both `playerID = 1` TODOs are gone.
- `HandleRegisterSubmit` upgrades an existing anonymous row in place via the new `ClaimPlayer` SQL when a session is present, falling back to `CreatePlayer` for no-session / deleted-player / already-claimed / non-anonymous-existing cases. `Player.IsAnonymous()` excludes the seeded admin (NULL hash but role=admin) so it can never be claimed.
- New SQL: `CreateAnonymousPlayer` and `ClaimPlayer` (with `WHERE password_hash IS NULL` idempotency guard and the same admin-promotion CASE as `CreatePlayerWithCredentials`).
- Lint hardening: `golangci-lint` now sees the `//go:build integration` files (config gained `build-tags: [integration]`) and errcheck runs on tests too. All resulting violations fixed.
- Stabilised the admin-form E2E helper with `scrollIntoViewIfNeeded()` before each correct-checkbox `.check()` — CI flake on Firefox tracked back to Bulma styling not yet settled when Playwright clicked.

## Test plan

- [x] `make lint-fix` — clean (incl. integration files now linted).
- [x] `make check` — unit + integration green; new sub-tests for `EnsurePlayer`, `ClaimPlayer`, register claim flow, `IsAnonymous`, and clientapi-from-context.
- [x] `make test-e2e` — 6/6 (chromium + firefox).
- [x] Smoke: `PORT=8090 go run ./cmd/server/` boots cleanly, `/healthz` 200, first `/api/quizzes` mints `Set-Cookie`, second reuses the row.
- [x] Forced regression checks (covered in review): removing `imageError` reset trips player spec; removing `EnsurePlayer` wrap on a route trips integration; integration counts go up by 1 / 1 / 2 in the three scenarios.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)