### PR TITLE
Track GitHub Actions and e2e npm deps with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Action versions pinned in .github/workflows/*.yml. Without this entry the
+  # pins drift silently — actions/checkout, actions/setup-go, etc. age out
+  # without a bump until something breaks.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Playwright + @types/node under test/e2e/. Keeps the browser deps moving
+  # forward in step with upstream releases (relevant for security advisories
+  # like the Playwright TLS-verification one we hit during #115).
+  - package-ecosystem: "npm"
+    directory: "/test/e2e"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Closes #17.
- `.github/dependabot.yml` gains weekly update blocks for `github-actions` (so pins in `.github/workflows/*.yml` don't drift) and `npm` rooted at `test/e2e/` (so Playwright security advisories like the TLS-verification one we hit during #115 surface as PRs).

## Test plan

- [x] `make lint-fix && make check` — clean (no Go code touched).
- [x] Valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)