### PR TITLE
Add a --check startup flag and a make smoke target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ make check            # lint + sql-lint + build + all tests — run before every
 make test             # unit tests only
 make test-integration # integration tests (-tags=integration)
 make test-e2e         # end-to-end browser tests (Playwright; requires Node.js)
+make smoke            # validate startup against the existing dev DB (no HTTP listener)
 ```
 
 ## Commits
@@ -15,8 +16,8 @@ Never create commits yourself. When work is ready to commit, suggest a one-line 
 
 ## Testing
 
-Every change or new feature must have tests. Run `make lint-fix`, `make check`, and `make test-e2e` before marking work done.
-After changes, also boot the server against the existing dev DB (`go run ./cmd/server/`) and confirm it starts cleanly before reporting done — `make check` only exercises a fresh DB, so migration or startup issues that only surface against populated data otherwise slip through.
+Every change or new feature must have tests. Run `make lint-fix`, `make check`, `make test-e2e`, and `make smoke` before marking work done.
+`make check` only exercises a fresh DB, so migration or startup issues that only surface against populated data otherwise slip through. `make smoke` runs `go run ./cmd/server/ -check` to parse config, open the dev DB, run migrations, and exit — no port juggling, no leftover process.
 
 ## Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,17 @@ test-coverage-html: test-coverage
 test-e2e:
 	cd test/e2e && npm ci && npx playwright install chromium firefox && npm test
 
+# Smoke-test the binary against the existing dev DB: parses config, opens
+# the DB, runs migrations, and exits 0. Catches startup / migration / config
+# regressions that `make check` (fresh DB only) wouldn't surface.
+#
+# On a fresh checkout the dev DB doesn't exist; SQLite creates it and goose
+# applies every migration, so the first `make smoke` run also seeds an empty
+# topbanana.sqlite in the working directory. Subsequent runs reuse it.
+.PHONY: smoke
+smoke:
+	go run ./cmd/server/ -check
+
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)

--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -30,6 +30,37 @@ const (
 	shutdownTimeout   = 5 * time.Second
 )
 
+// Check validates that the server can start: it parses config, opens the
+// database, and runs migrations, then closes the connection and returns. No
+// TCP listener is bound. Used by the `make smoke` target so a contributor
+// can confirm the binary boots cleanly against the existing dev DB without
+// process juggling.
+func Check(ctx context.Context, getenv func(string) string, stdout io.Writer) error {
+	logger := slog.New(slog.NewTextHandler(stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg, err := config.Parse(getenv)
+	if err != nil {
+		msg := "error parsing config"
+		logger.ErrorContext(ctx, msg, slog.Any("err", err))
+
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+
+	conn, err := setupDB(ctx, cfg, logger)
+	if err != nil {
+		return err
+	}
+	if cerr := conn.Close(); cerr != nil {
+		logger.ErrorContext(ctx, "error closing database connection", slog.Any("err", cerr))
+
+		return fmt.Errorf("error closing database connection: %w", cerr)
+	}
+
+	logger.InfoContext(ctx, "startup ok")
+
+	return nil
+}
+
 // Run starts the application server, connects to the database, runs migrations, and listens for incoming requests.
 func Run(
 	ctx context.Context,

--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -1,0 +1,54 @@
+package app_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/starquake/topbanana/cmd/server/app"
+	"github.com/starquake/topbanana/internal/database"
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// TestMain wires goose's global state up once for the package — calling
+// SetupGoose from parallel tests races on the goose package-level fields.
+func TestMain(m *testing.M) {
+	database.SetupGoose()
+	m.Run()
+}
+
+func TestCheck_FreshDB_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	getenv := func(key string) string {
+		return map[string]string{"DB_URI": dbURI, "PORT": "0"}[key]
+	}
+
+	var stdout bytes.Buffer
+	if err := app.Check(t.Context(), getenv, &stdout); err != nil {
+		t.Fatalf("Check err = %v, want nil", err)
+	}
+	if got, want := stdout.String(), "startup ok"; !strings.Contains(got, want) {
+		t.Errorf("stdout should contain %q, got %q", want, got)
+	}
+}
+
+func TestCheck_BadDBURI_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	getenv := func(key string) string {
+		// A path under a nonexistent directory: SQLite will fail to open it.
+		return map[string]string{"DB_URI": "file:/nonexistent-dir/topbanana.sqlite", "PORT": "0"}[key]
+	}
+
+	var stdout bytes.Buffer
+	err := app.Check(t.Context(), getenv, &stdout)
+	if err == nil {
+		t.Fatal("Check err = nil, want non-nil for unreachable DB_URI")
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 
@@ -13,11 +14,25 @@ import (
 )
 
 func main() {
+	checkOnly := flag.Bool(
+		"check",
+		false,
+		"validate startup (parse config, open DB, run migrations) and exit without serving HTTP",
+	)
+	flag.Parse()
+
 	ctx := context.Background()
 
 	database.SetupGoose()
 
-	if err := app.Run(ctx, os.Getenv, os.Stdout, nil); err != nil {
+	var err error
+	if *checkOnly {
+		err = app.Check(ctx, os.Getenv, os.Stdout)
+	} else {
+		err = app.Run(ctx, os.Getenv, os.Stdout, nil)
+	}
+
+	if err != nil {
 		if _, err2 := fmt.Fprintf(os.Stderr, "error: %v\n", err); err2 != nil {
 			panic(err2)
 		}


### PR DESCRIPTION
## Summary

- Closes #120.
- New `app.Check(ctx, getenv, stdout)` validates startup (parse config → open DB → run migrations → close) without binding a listener. Reuses the existing `setupDB` helper so the migration code path is byte-identical to a real boot.
- `cmd/server` accepts `-check`. Default false; non-breaking.
- New `make smoke` target wraps `go run ./cmd/server/ -check`.
- `CLAUDE.md` replaces the bare `go run ./cmd/server/` instruction with `make smoke` in both the commands list and the testing rules.
- Two unit tests for `Check`; `TestMain` calls `database.SetupGoose` once to avoid the package-level race we hit during development.

## Test plan

- [x] `make lint-fix && make check` — clean.
- [x] `make smoke` — boots, runs migrations, exits 0 with `"startup ok"`.
- [x] `make test-e2e` — 6/6 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)