### PR TITLE
Populate quiz question count in the admin list

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -552,6 +552,9 @@ func HandleQuizList(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.S
 		// Counts come from a separate aggregate query so the Quiz domain
 		// type doesn't have to carry a list-only field. A quiz with no
 		// questions is absent from the map; the lookup yields 0.
+		// A question added or deleted between this call and ListQuizzes
+		// above can produce a count that's off by one for a single render
+		// — acceptable for a read view; eventual consistency is fine.
 		counts, err := quizStore.QuestionCountsByQuiz(r.Context())
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error retrieving question counts from store", slog.Any("err", err))

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -92,12 +92,13 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, statu
 
 // QuizData is the data for the quiz list page, it shows multiple quizzes when available.
 type QuizData struct {
-	ID          int64
-	Title       string
-	Slug        string
-	Description string
-	UpdatedAt   time.Time
-	Questions   []*QuestionData
+	ID            int64
+	Title         string
+	Slug          string
+	Description   string
+	UpdatedAt     time.Time
+	QuestionCount int
+	Questions     []*QuestionData
 }
 
 // QuestionData is the data for a question.
@@ -125,13 +126,17 @@ const (
 )
 
 func quizDataFromQuiz(qz *quiz.Quiz) *QuizData {
+	// QuestionCount defaults to len(Questions); the list handler overrides
+	// it from a separate count query because ListQuizzes doesn't load the
+	// question tree.
 	return &QuizData{
-		ID:          qz.ID,
-		Title:       qz.Title,
-		Slug:        qz.Slug,
-		Description: qz.Description,
-		UpdatedAt:   qz.UpdatedAt,
-		Questions:   questionDataFromQuestions(qz.Questions),
+		ID:            qz.ID,
+		Title:         qz.Title,
+		Slug:          qz.Slug,
+		Description:   qz.Description,
+		UpdatedAt:     qz.UpdatedAt,
+		QuestionCount: len(qz.Questions),
+		Questions:     questionDataFromQuestions(qz.Questions),
 	}
 }
 
@@ -544,7 +549,21 @@ func HandleQuizList(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.S
 			return
 		}
 
+		// Counts come from a separate aggregate query so the Quiz domain
+		// type doesn't have to carry a list-only field. A quiz with no
+		// questions is absent from the map; the lookup yields 0.
+		counts, err := quizStore.QuestionCountsByQuiz(r.Context())
+		if err != nil {
+			logger.ErrorContext(r.Context(), "error retrieving question counts from store", slog.Any("err", err))
+			render500(w, r, logger, csrfMgr)
+
+			return
+		}
+
 		qzd := quizDataFromQuizzes(quizzes)
+		for _, qd := range qzd {
+			qd.QuestionCount = counts[qd.ID]
+		}
 
 		data := quizListData{
 			Title:   "Admin Dashboard - Quiz List",

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -234,6 +234,67 @@ func TestHandleQuizList(t *testing.T) {
 		}
 	})
 
+	t.Run("renders question counts merged from QuestionCountsByQuiz", func(t *testing.T) {
+		t.Parallel()
+
+		// Two quizzes; only Quiz One is in the counts map. Quiz Two is
+		// absent (zero questions) and should render as "0", proving the
+		// missing-key contract holds at the rendering boundary.
+		store := stubQuizStore{
+			listQuizzes: func(_ context.Context) ([]*quiz.Quiz, error) {
+				return []*quiz.Quiz{
+					{ID: 1, Title: "Quiz With Five", Slug: "quiz-1", Description: "x"},
+					{ID: 2, Title: "Empty Quiz", Slug: "quiz-2", Description: "y"},
+				}, nil
+			},
+			questionCountsByQuiz: func(_ context.Context) (map[int64]int, error) {
+				return map[int64]int{1: 5}, nil
+			},
+		}
+
+		handler := HandleQuizList(logger, nil, store)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+
+		body := rr.Body.String()
+		// The count for Quiz One (id=1) should appear inside its row's
+		// linked count cell. Anchor on the href so we don't accidentally
+		// match unrelated digits elsewhere on the page.
+		if got, want := body, `href="/admin/quizzes/1">5</a>`; !strings.Contains(got, want) {
+			t.Errorf("body should contain count cell %q, got %q", want, got)
+		}
+		if got, want := body, `href="/admin/quizzes/2">0</a>`; !strings.Contains(got, want) {
+			t.Errorf("body should contain zero-count cell %q (missing key → 0), got %q", want, got)
+		}
+	})
+
+	t.Run("returns 500 when QuestionCountsByQuiz fails", func(t *testing.T) {
+		t.Parallel()
+
+		store := stubQuizStore{
+			listQuizzes: func(_ context.Context) ([]*quiz.Quiz, error) {
+				return []*quiz.Quiz{{ID: 1, Title: "Q", Slug: "q", Description: ""}}, nil
+			},
+			questionCountsByQuiz: func(_ context.Context) (map[int64]int, error) {
+				return nil, errors.New("count boom")
+			},
+		}
+
+		handler := HandleQuizList(logger, nil, store)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
 	t.Run("no quizzes", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -29,16 +29,17 @@ func (e errReader) Read(_ []byte) (int, error) { return 0, e.err }
 func (errReader) Close() error                 { return nil }
 
 type stubQuizStore struct {
-	listQuizzes     func(ctx context.Context) ([]*quiz.Quiz, error)
-	getQuizByID     func(ctx context.Context, id int64) (*quiz.Quiz, error)
-	createQuiz      func(ctx context.Context, qz *quiz.Quiz) error
-	updateQuiz      func(ctx context.Context, qz *quiz.Quiz) error
-	deleteQuiz      func(ctx context.Context, id int64) error
-	getQuestionByID func(ctx context.Context, id int64) (*quiz.Question, error)
-	createQuestion  func(ctx context.Context, qs *quiz.Question) error
-	updateQuestion  func(ctx context.Context, qs *quiz.Question) error
-	deleteQuestion  func(ctx context.Context, id int64) error
-	listQuestions   func(ctx context.Context, quizID int64) ([]*quiz.Question, error)
+	listQuizzes          func(ctx context.Context) ([]*quiz.Quiz, error)
+	questionCountsByQuiz func(ctx context.Context) (map[int64]int, error)
+	getQuizByID          func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	createQuiz           func(ctx context.Context, qz *quiz.Quiz) error
+	updateQuiz           func(ctx context.Context, qz *quiz.Quiz) error
+	deleteQuiz           func(ctx context.Context, id int64) error
+	getQuestionByID      func(ctx context.Context, id int64) (*quiz.Question, error)
+	createQuestion       func(ctx context.Context, qs *quiz.Question) error
+	updateQuestion       func(ctx context.Context, qs *quiz.Question) error
+	deleteQuestion       func(ctx context.Context, id int64) error
+	listQuestions        func(ctx context.Context, quizID int64) ([]*quiz.Question, error)
 }
 
 func (stubQuizStore) Ping(_ context.Context) error {
@@ -67,6 +68,14 @@ func (s stubQuizStore) ListQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 	}
 
 	return s.listQuizzes(ctx)
+}
+
+func (s stubQuizStore) QuestionCountsByQuiz(ctx context.Context) (map[int64]int, error) {
+	if s.questionCountsByQuiz == nil {
+		return map[int64]int{}, nil
+	}
+
+	return s.questionCountsByQuiz(ctx)
 }
 
 func (s stubQuizStore) CreateQuiz(ctx context.Context, qz *quiz.Quiz) error {

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -42,6 +42,10 @@ func (s stubQuizStore) ListQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 	return s.listQuizzes(ctx)
 }
 
+func (stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, error) {
+	return map[int64]int{}, nil
+}
+
 func (s stubQuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
 	if s.getQuiz == nil {
 		return nil, errStub

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -389,6 +389,44 @@ func (q *Queries) ListQuizzes(ctx context.Context) ([]Quiz, error) {
 	return items, nil
 }
 
+const questionCountsByQuiz = `-- name: QuestionCountsByQuiz :many
+SELECT quiz_id, COUNT(*) AS question_count
+FROM questions
+GROUP BY quiz_id
+`
+
+type QuestionCountsByQuizRow struct {
+	QuizID        int64
+	QuestionCount int64
+}
+
+// Returns one row per quiz that has at least one question. Quizzes with
+// zero questions are absent; callers should treat a missing entry as 0.
+// Used by the admin list to render "{N} questions" alongside ListQuizzes
+// without coupling the count into the Quiz domain type.
+func (q *Queries) QuestionCountsByQuiz(ctx context.Context) ([]QuestionCountsByQuizRow, error) {
+	rows, err := q.db.QueryContext(ctx, questionCountsByQuiz)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []QuestionCountsByQuizRow
+	for rows.Next() {
+		var i QuestionCountsByQuizRow
+		if err := rows.Scan(&i.QuizID, &i.QuestionCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateOption = `-- name: UpdateOption :execresult
 UPDATE options
 SET text = ?,

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -22,6 +22,10 @@ type stubQuizStore struct {
 
 func (s *stubQuizStore) Ping(_ context.Context) error                      { return s.pingErr }
 func (*stubQuizStore) ListQuizzes(_ context.Context) ([]*quiz.Quiz, error) { return nil, nil }
+func (*stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, error) {
+	return map[int64]int{}, nil
+}
+
 func (*stubQuizStore) GetQuiz(_ context.Context, _ int64) (*quiz.Quiz, error) {
 	return nil, errors.ErrUnsupported
 }

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -3,6 +3,15 @@ SELECT *
 FROM quizzes
 ORDER BY updated_at DESC, id DESC;
 
+-- name: QuestionCountsByQuiz :many
+-- Returns one row per quiz that has at least one question. Quizzes with
+-- zero questions are absent; callers should treat a missing entry as 0.
+-- Used by the admin list to render "{N} questions" alongside ListQuizzes
+-- without coupling the count into the Quiz domain type.
+SELECT quiz_id, COUNT(*) AS question_count
+FROM questions
+GROUP BY quiz_id;
+
 -- name: GetQuiz :one
 SELECT *
 FROM quizzes

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -16,6 +16,11 @@ type Store interface {
 	Ping(ctx context.Context) error
 	// ListQuizzes returns all quizzes.
 	ListQuizzes(ctx context.Context) ([]*Quiz, error)
+	// QuestionCountsByQuiz returns the number of questions per quiz, keyed by
+	// quiz ID. Quizzes with no questions are absent from the map; callers
+	// should treat a missing entry as 0. Used alongside ListQuizzes by the
+	// admin list to render counts without loading every quiz's full tree.
+	QuestionCountsByQuiz(ctx context.Context) (map[int64]int, error)
 	// GetQuiz returns a quiz including related questions and options by its ID.
 	// Returns ErrQuizNotFound if the quiz is not found.
 	GetQuiz(ctx context.Context, id int64) (*Quiz, error)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -77,6 +77,10 @@ func (stubQuizStore) ListQuizzes(_ context.Context) ([]*quiz.Quiz, error) {
 	}, nil
 }
 
+func (stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, error) {
+	return map[int64]int{}, nil
+}
+
 func (stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error {
 	return nil
 }

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -56,6 +56,25 @@ func (s *QuizStore) ListQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 	return quizzes, nil
 }
 
+// QuestionCountsByQuiz returns the number of questions per quiz, keyed by
+// quiz ID. Quizzes with zero questions are absent from the map; callers
+// should treat a missing entry as 0. Pair with [QuizStore.ListQuizzes] when
+// the list view needs to render counts without loading every quiz's full
+// question + option tree.
+func (s *QuizStore) QuestionCountsByQuiz(ctx context.Context) (map[int64]int, error) {
+	rows, err := s.q.QuestionCountsByQuiz(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count questions by quiz: %w", err)
+	}
+
+	counts := make(map[int64]int, len(rows))
+	for _, r := range rows {
+		counts[r.QuizID] = int(r.QuestionCount)
+	}
+
+	return counts, nil
+}
+
 // GetQuiz returns a quiz by its ID.
 func (s *QuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
 	var err error

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -242,6 +242,46 @@ func TestQuizStore_ListQuizzes(t *testing.T) {
 	}
 }
 
+func TestQuizStore_QuestionCountsByQuiz(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+
+	// Two quizzes with different question counts; one with no questions
+	// at all so we can assert it's absent from the map.
+	withQuestions := &quiz.Quiz{
+		Title: "With questions", Slug: "with-questions", Description: "x",
+		Questions: []*quiz.Question{
+			{Text: "Q1", Options: []*quiz.Option{{Text: "a", Correct: true}}},
+			{Text: "Q2", Options: []*quiz.Option{{Text: "b"}}},
+			{Text: "Q3", Options: []*quiz.Option{{Text: "c"}}},
+		},
+	}
+	if err := quizStore.CreateQuiz(t.Context(), withQuestions); err != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", err)
+	}
+
+	empty := &quiz.Quiz{Title: "Empty", Slug: "empty", Description: "y"}
+	if err := quizStore.CreateQuiz(t.Context(), empty); err != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", err)
+	}
+
+	counts, err := quizStore.QuestionCountsByQuiz(t.Context())
+	if err != nil {
+		t.Fatalf("QuestionCountsByQuiz err = %v, want nil", err)
+	}
+
+	if got, want := counts[withQuestions.ID], 3; got != want {
+		t.Errorf("counts[%d] = %d, want %d", withQuestions.ID, got, want)
+	}
+	if _, present := counts[empty.ID]; present {
+		// A quiz with zero questions should not appear in the map at all;
+		// callers treat the missing entry as 0.
+		t.Errorf("empty quiz id %d should be absent from counts, got %d", empty.ID, counts[empty.ID])
+	}
+}
+
 func TestQuizStore_ListQuizzes_ErrorHandling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -30,7 +30,7 @@
                         <td>{{.Slug}}</td>
                         <td>{{.Description}}</td>
                         <td title="{{.UpdatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .UpdatedAt}}</td>
-                        <td><a href="/admin/quizzes/{{.ID}}">{{len .Questions}}</a></td>
+                        <td><a href="/admin/quizzes/{{.ID}}">{{.QuestionCount}}</a></td>
                         <td>
                             <a href="/admin/quizzes/{{.ID}}/edit">
                                 <span class="icon-text">


### PR DESCRIPTION
## Summary

- Closes #133.
- The admin quiz list was always rendering `0` in the "Questions" column because `ListQuizzes` is a summary path that doesn't load the question tree, and the template was reading `len .Questions`.
- New `QuestionCountsByQuiz` SQL query and store method return `map[int64]int` of counts. Quizzes with zero questions are absent (caller treats missing key as 0).
- `HandleQuizList` calls both `ListQuizzes` and `QuestionCountsByQuiz` and merges the count into `QuizData.QuestionCount` before rendering.
- `quiz.Quiz` domain stays clean — no list-only field. `quizDataFromQuiz` defaults the count from `len(Questions)` for non-list paths (`GetQuiz`, the form-render handlers).
- Picked Option D' from the design discussion: domain-pure, single struct, two queries.

## Test plan

- [x] `make lint-fix && make check` — clean.
- [x] `make test-e2e` — 6/6 (chromium + firefox).
- [x] `make smoke` — startup ok against the dev DB.
- [x] New tests:
  - `TestQuizStore_QuestionCountsByQuiz` — populated case + empty case (asserts the missing-key contract).
  - `TestHandleQuizList/renders_question_counts_merged_from_QuestionCountsByQuiz` — locks in the handler-level merge.
  - `TestHandleQuizList/returns_500_when_QuestionCountsByQuiz_fails` — error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)