### PR TITLE
Enable registration and whitelist admin in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
+      - REGISTRATION_ENABLED=true
+      - ADMIN_USERNAMES=admin
     volumes:
       - topbanana_data:/home/nonroot/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds two env vars to `docker-compose.yml`:

- `REGISTRATION_ENABLED=true` — opens up `/register` so the operator can create the first user from the running container.
- `ADMIN_USERNAMES=admin` — promotes whoever registers with username `admin` to the admin role.

Lets a fresh `docker compose up` reach a usable admin without manual SQL.

## Test plan

- [x] `make lint-fix && make check` — clean (no Go code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)