### PR TITLE
Enable registration and whitelist admin in staging compose

### DIFF
--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -7,6 +7,8 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
+      - REGISTRATION_ENABLED=true
+      - ADMIN_USERNAMES=admin
     volumes:
       - topbanana_staging_data:/home/nonroot/data
     networks:


### PR DESCRIPTION
## Summary

Mirrors PR #135 for the staging compose file: `deployments/demo/docker-compose.staging.yml` now sets

- `REGISTRATION_ENABLED=true` — so a fresh staging instance can register the first admin without a manual SQL bootstrap.
- `ADMIN_USERNAMES=admin` — promotes the user registered as `admin` to the admin role.

## Test plan

- [x] `make lint-fix && make check` — clean (no Go code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)