### PR TITLE
Show a global leaderboard at the end of a quiz

### DIFF
--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -64,26 +64,31 @@
 
             <div x-show="finished">
                 <h2 class="subtitle">Game Finished!</h2>
-                <template x-if="results">
+                <template x-if="leaderboard">
                     <div class="content">
-                        <h3>Results</h3>
+                        <h3>Leaderboard</h3>
                         <table class="table is-striped is-fullwidth">
                             <thead>
                                 <tr>
-                                    <th>Player ID</th>
+                                    <th>Rank</th>
+                                    <th>Player</th>
                                     <th>Score</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <template x-for="playerScore in results.playerScores" :key="playerScore.playerId">
-                                    <tr>
-                                        <td x-text="playerScore.playerId"></td>
-                                        <td x-text="playerScore.score"></td>
+                                <template x-for="(entry, index) in leaderboard.entries" :key="entry.playerId">
+                                    <tr :class="entry.isCurrentPlayer ? 'is-selected' : ''">
+                                        <td x-text="index + 1"></td>
+                                        <td x-text="entry.username"></td>
+                                        <td x-text="entry.score"></td>
                                     </tr>
                                 </template>
                             </tbody>
                         </table>
                     </div>
+                </template>
+                <template x-if="!leaderboard">
+                    <p>Loading leaderboard...</p>
                 </template>
                 <button class="button is-link" @click="reset()">Play Again</button>
             </div>

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -8,7 +8,8 @@ export class GameApp {
         this.gameId = null;
         this.question = null;
         this.finished = false;
-        this.results = null;
+        this.leaderboard = null;
+        this.quizSlugId = null;
         this.feedback = null;
         this.progress = 100;
         this.timer = null;
@@ -27,6 +28,9 @@ export class GameApp {
     }
 
     async startGame() {
+        const quiz = this.quizzes.find(q => q.id === parseInt(this.selectedQuizId));
+        if (!quiz) return;
+        this.quizSlugId = `${quiz.slug}-${quiz.id}`;
         const data = await gameService.startGame(this.selectedQuizId);
         this.gameId = data.id;
         await this.nextQuestion();
@@ -40,7 +44,7 @@ export class GameApp {
         const question = await gameService.getNextQuestion(this.gameId);
         if (!question) {
             this.finished = true;
-            this.results = await gameService.getResults(this.gameId);
+            this.leaderboard = await gameService.getQuizLeaderboard(this.quizSlugId);
             return;
         }
         this.imageError = false;
@@ -92,7 +96,8 @@ export class GameApp {
         this.gameId = null;
         this.question = null;
         this.finished = false;
-        this.results = null;
+        this.leaderboard = null;
+        this.quizSlugId = null;
         this.feedback = null;
         this.progress = 100;
         this.imageError = false;

--- a/internal/client/static/js/services/GameService.js
+++ b/internal/client/static/js/services/GameService.js
@@ -29,6 +29,11 @@ export class GameService {
         const response = await fetch(`/api/games/${gameId}/results`);
         return await response.json();
     }
+
+    async getQuizLeaderboard(slugId) {
+        const response = await fetch(`/api/quizzes/${slugId}/leaderboard`);
+        return await response.json();
+    }
 }
 
 export const gameService = new GameService();

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -135,6 +135,77 @@ func HandleQuizGet(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 	})
 }
 
+// HandleQuizLeaderboard returns the top scoring players for the given quiz.
+// Each player appears at most once, with their total score for the quiz; ties
+// are broken by ascending username for a stable order. IsCurrentPlayer is set
+// on the entry that matches the authenticated player on the request context
+// so the client can highlight that row.
+func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Handler {
+	const leaderboardLimit = 10
+
+	type entryResponse struct {
+		PlayerID        int64  `json:"playerId"`
+		Username        string `json:"username"`
+		Score           int    `json:"score"`
+		IsCurrentPlayer bool   `json:"isCurrentPlayer"`
+	}
+
+	type leaderboardResponse struct {
+		QuizID  int64           `json:"quizId"`
+		Entries []entryResponse `json:"entries"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		quizID, ok := handlers.ParseIDFromSlugPath(w, r, logger, "slugID")
+		if !ok {
+			return
+		}
+
+		player, ok := auth.PlayerFromContext(ctx)
+		if !ok {
+			// EnsurePlayer middleware should have populated this; reaching
+			// here means the route was wired without it.
+			logger.ErrorContext(ctx, "missing player on context for quiz leaderboard")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		entries, err := service.GetQuizLeaderboard(ctx, quizID, player.ID, leaderboardLimit)
+		if err != nil {
+			if errors.Is(err, quiz.ErrQuizNotFound) {
+				http.NotFound(w, r)
+
+				return
+			}
+			logger.ErrorContext(ctx, "error retrieving quiz leaderboard", slog.Any("err", err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		respEntries := make([]entryResponse, 0, len(entries))
+		for _, e := range entries {
+			respEntries = append(respEntries, entryResponse{
+				PlayerID:        e.PlayerID,
+				Username:        e.Username,
+				Score:           e.Score,
+				IsCurrentPlayer: e.IsCurrentPlayer,
+			})
+		}
+
+		res := leaderboardResponse{QuizID: quizID, Entries: respEntries}
+
+		if err = handlers.EncodeJSON(w, http.StatusOK, res); err != nil {
+			logger.ErrorContext(ctx, "error encoding leaderboardResponse", slog.Any("err", err))
+
+			return
+		}
+	})
+}
+
 // HandleCreateGame creates a new game.
 // It first checks if the quiz exists, then creates the game and participant, and finally starts the game.
 // Returns the ID of the created game.

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -82,12 +82,13 @@ func (stubQuizStore) GetOptionsByIDs(_ context.Context, _ []int64) ([]*quiz.Opti
 }
 
 type stubGameStore struct {
-	getGame           func(ctx context.Context, id string) (*game.Game, error)
-	createGame        func(ctx context.Context, g *game.Game) error
-	startGame         func(ctx context.Context, id string) error
-	createParticipant func(ctx context.Context, p *game.Participant) error
-	createQuestion    func(ctx context.Context, gq *game.Question) error
-	createAnswer      func(ctx context.Context, a *game.Answer) error
+	getGame                       func(ctx context.Context, id string) (*game.Game, error)
+	createGame                    func(ctx context.Context, g *game.Game) error
+	startGame                     func(ctx context.Context, id string) error
+	createParticipant             func(ctx context.Context, p *game.Participant) error
+	createQuestion                func(ctx context.Context, gq *game.Question) error
+	createAnswer                  func(ctx context.Context, a *game.Answer) error
+	listAnswersForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*game.LeaderboardAnswer, error)
 }
 
 func (stubGameStore) Ping(_ context.Context) error { return nil }
@@ -138,6 +139,16 @@ func (s stubGameStore) CreateAnswer(ctx context.Context, a *game.Answer) error {
 	}
 
 	return s.createAnswer(ctx, a)
+}
+
+func (s stubGameStore) ListAnswersForQuizLeaderboard(
+	ctx context.Context, quizID int64,
+) ([]*game.LeaderboardAnswer, error) {
+	if s.listAnswersForQuizLeaderboard == nil {
+		return nil, errStub
+	}
+
+	return s.listAnswersForQuizLeaderboard(ctx, quizID)
 }
 
 func newService(gs stubGameStore, qs stubQuizStore) *game.Service {
@@ -925,6 +936,173 @@ func TestHandleGameResults(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+}
+
+// leaderboardTestEntry mirrors one entry in the JSON leaderboard response;
+// pulled out of the surrounding test fn so the parent decode target stays
+// flat (revive's nested-structs rule).
+type leaderboardTestEntry struct {
+	PlayerID        int64  `json:"playerId"`
+	Username        string `json:"username"`
+	Score           int    `json:"score"`
+	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
+}
+
+// leaderboardTestResponse is the decode target for the leaderboard endpoint.
+type leaderboardTestResponse struct {
+	QuizID  int64                  `json:"quizId"`
+	Entries []leaderboardTestEntry `json:"entries"`
+}
+
+func TestHandleQuizLeaderboard(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	// makeAnswer mirrors the helper in internal/game; replicated here so the
+	// black-box test does not need an exported builder. The 10s window with
+	// answeredOffset=0 yields a 1000-point CalculateScore for a correct
+	// answer and 0 for a wrong one.
+	makeAnswer := func(playerID int64, username string, correct bool) *game.LeaderboardAnswer {
+		const window = 10 * time.Second
+		start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+		return &game.LeaderboardAnswer{
+			PlayerID:          playerID,
+			Username:          username,
+			QuestionStartedAt: start,
+			QuestionExpiredAt: start.Add(window),
+			AnsweredAt:        start,
+			Correct:           correct,
+		}
+	}
+
+	t.Run("returns leaderboard with isCurrentPlayer set", func(t *testing.T) {
+		t.Parallel()
+
+		gs := stubGameStore{
+			listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*game.LeaderboardAnswer, error) {
+				return []*game.LeaderboardAnswer{
+					makeAnswer(1, "alice", true),
+					makeAnswer(2, "bob", true),
+					makeAnswer(2, "bob", true),
+				}, nil
+			},
+		}
+		qs := stubQuizStore{
+			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Quiz"}, nil
+			},
+		}
+		handler := HandleQuizLeaderboard(logger, newService(gs, qs))
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 1), http.MethodGet,
+			"/api/quizzes/quiz-1/leaderboard", nil,
+		)
+		req.SetPathValue("slugID", "quiz-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusOK; got != want {
+			t.Fatalf("status code = %v, want %v", got, want)
+		}
+
+		var body leaderboardTestResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if got, want := body.QuizID, int64(1); got != want {
+			t.Errorf("quizId = %d, want %d", got, want)
+		}
+		if got, want := len(body.Entries), 2; got != want {
+			t.Fatalf("len(entries) = %d, want %d", got, want)
+		}
+		// bob (2000) should outrank alice (1000).
+		if got, want := body.Entries[0].Username, "bob"; got != want {
+			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		}
+		if got, want := body.Entries[0].IsCurrentPlayer, false; got != want {
+			t.Errorf("entries[0].IsCurrentPlayer = %v, want %v", got, want)
+		}
+		if got, want := body.Entries[1].Username, "alice"; got != want {
+			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		}
+		if got, want := body.Entries[1].IsCurrentPlayer, true; got != want {
+			t.Errorf("entries[1].IsCurrentPlayer = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 404 when quiz not found", func(t *testing.T) {
+		t.Parallel()
+
+		qs := stubQuizStore{
+			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		}
+		handler := HandleQuizLeaderboard(logger, newService(stubGameStore{}, qs))
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 1), http.MethodGet,
+			"/api/quizzes/missing-99/leaderboard", nil,
+		)
+		req.SetPathValue("slugID", "missing-99")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 500 when player missing from context", func(t *testing.T) {
+		t.Parallel()
+
+		handler := HandleQuizLeaderboard(logger, newService(stubGameStore{}, stubQuizStore{}))
+
+		// No withPlayer wrapper — simulate a misconfigured route that
+		// forgot to wrap the handler in EnsurePlayer.
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodGet, "/api/quizzes/quiz-1/leaderboard", nil,
+		)
+		req.SetPathValue("slugID", "quiz-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 500 when service errors", func(t *testing.T) {
+		t.Parallel()
+
+		gs := stubGameStore{
+			listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*game.LeaderboardAnswer, error) {
+				return nil, errStub
+			},
+		}
+		qs := stubQuizStore{
+			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id}, nil
+			},
+		}
+		handler := HandleQuizLeaderboard(logger, newService(gs, qs))
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 1), http.MethodGet,
+			"/api/quizzes/quiz-1/leaderboard", nil,
+		)
+		req.SetPathValue("slugID", "quiz-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
 
 		if got, want := rec.Code, http.StatusInternalServerError; got != want {
 			t.Errorf("status code = %v, want %v", got, want)

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -194,6 +194,64 @@ func (q *Queries) ListAnswersByGameQuestionID(ctx context.Context, gameQuestionI
 	return items, nil
 }
 
+const listAnswersForQuizLeaderboard = `-- name: ListAnswersForQuizLeaderboard :many
+SELECT ga.player_id        AS player_id,
+       p.username           AS username,
+       gq.started_at        AS question_started_at,
+       gq.expired_at        AS question_expired_at,
+       ga.answered_at       AS answered_at,
+       o.is_correct         AS is_correct
+FROM game_answers ga
+         JOIN games g ON g.id = ga.game_id
+         JOIN game_questions gq ON gq.id = ga.game_question_id
+         JOIN options o ON o.id = ga.option_id
+         JOIN players p ON p.id = ga.player_id
+WHERE g.quiz_id = ?
+`
+
+type ListAnswersForQuizLeaderboardRow struct {
+	PlayerID          int64
+	Username          string
+	QuestionStartedAt time.Time
+	QuestionExpiredAt time.Time
+	AnsweredAt        time.Time
+	IsCorrect         bool
+}
+
+// Selects the per-answer scoring inputs for every game of the given quiz.
+// The leaderboard service assumes one attempt per (player, quiz) (#145 covers
+// enforcement) and sums these rows per player; if multiple attempts ever leak
+// through, scores will be inflated until enforcement lands.
+func (q *Queries) ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]ListAnswersForQuizLeaderboardRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAnswersForQuizLeaderboard, quizID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAnswersForQuizLeaderboardRow
+	for rows.Next() {
+		var i ListAnswersForQuizLeaderboardRow
+		if err := rows.Scan(
+			&i.PlayerID,
+			&i.Username,
+			&i.QuestionStartedAt,
+			&i.QuestionExpiredAt,
+			&i.AnsweredAt,
+			&i.IsCorrect,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listGameQuestionsByGameID = `-- name: ListGameQuestionsByGameID :many
 SELECT id, game_id, question_id, started_at, expired_at
 FROM game_questions

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -2,18 +2,22 @@
 package game
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
 const (
-	defaultExpiration = 10 * time.Second
-	maxPoints         = 1000
+	defaultExpiration       = 10 * time.Second
+	maxPoints               = 1000
+	defaultLeaderboardLimit = 10
 )
 
 // ErrGameNotFound is returned when a game is not found.
@@ -87,6 +91,31 @@ type Results struct {
 	PlayerScores map[int64]int
 }
 
+// LeaderboardAnswer is a flat row used to compute a global per-quiz
+// leaderboard. It carries every field [Service.CalculateScore] needs (the
+// option's correctness, the question's start/expiry timestamps, and the
+// answer's submission time) plus the player's username and ID for the
+// leaderboard row. The leaderboard service assumes one attempt per
+// (player, quiz) — see #145 for the enforcement ticket.
+type LeaderboardAnswer struct {
+	PlayerID          int64
+	Username          string
+	QuestionStartedAt time.Time
+	QuestionExpiredAt time.Time
+	AnsweredAt        time.Time
+	Correct           bool
+}
+
+// LeaderboardEntry is a single row of a per-quiz leaderboard: the player's
+// total score for that quiz. IsCurrentPlayer is true when the entry belongs
+// to the player making the request, which lets the client highlight the row.
+type LeaderboardEntry struct {
+	PlayerID        int64
+	Username        string
+	Score           int
+	IsCurrentPlayer bool
+}
+
 // Store represents a game store.
 type Store interface {
 	// Ping returns the status of the database connection.
@@ -98,6 +127,10 @@ type Store interface {
 	CreateParticipant(ctx context.Context, p *Participant) error
 	CreateQuestion(ctx context.Context, gq *Question) error
 	CreateAnswer(ctx context.Context, a *Answer) error
+	// ListAnswersForQuizLeaderboard returns one row per game_answer for the
+	// given quiz, joined with the fields the Service needs to score each
+	// answer.
+	ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
 }
 
 // Service represents a game service.
@@ -302,6 +335,86 @@ func (s *Service) GetResults(ctx context.Context, gameID string) (*Results, erro
 	}
 
 	return &Results{GameID: g.ID, Winner: winner, PlayerScores: plsMap}, nil
+}
+
+// GetQuizLeaderboard returns the top scoring players for the given quiz.
+// Scoring reuses [Service.CalculateScore] so values stay consistent with
+// [Service.GetResults].
+//
+// Assumes one attempt per (player, quiz): the service simply sums every
+// answer the player has on the quiz. Enforcement of that constraint is
+// tracked in #145; until it lands, a player who somehow has multiple
+// attempts will see the sum of all of them.
+//
+// Ordering: descending by score; ties are broken by ascending username for
+// determinism so a tied scoreboard is stable across requests.
+//
+// currentPlayerID flags the entry that belongs to the requesting player so
+// the client can highlight it; pass 0 to flag nothing.
+//
+// If limit <= 0 it defaults to 10. The quiz must exist; missing quizzes
+// surface as [quiz.ErrQuizNotFound].
+func (s *Service) GetQuizLeaderboard(
+	ctx context.Context, quizID, currentPlayerID int64, limit int,
+) ([]LeaderboardEntry, error) {
+	if limit <= 0 {
+		limit = defaultLeaderboardLimit
+	}
+
+	// Verify the quiz exists so callers can map ErrQuizNotFound to a 404.
+	if _, err := s.quizStore.GetQuiz(ctx, quizID); err != nil {
+		return nil, fmt.Errorf("failed to get quiz: %w", err)
+	}
+
+	rows, err := s.store.ListAnswersForQuizLeaderboard(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list leaderboard answers: %w", err)
+	}
+
+	playerTotals := make(map[int64]int)
+	usernames := make(map[int64]string)
+
+	for _, r := range rows {
+		usernames[r.PlayerID] = r.Username
+
+		// Synthesise just enough of an *Answer / *Question / *quiz.Option
+		// for CalculateScore. The formula touches only Option.Correct,
+		// Question.StartedAt, Question.ExpiredAt, and Answer.AnsweredAt.
+		a := &Answer{
+			AnsweredAt: r.AnsweredAt,
+			Question: &Question{
+				StartedAt: r.QuestionStartedAt,
+				ExpiredAt: r.QuestionExpiredAt,
+			},
+			Option: &quiz.Option{Correct: r.Correct},
+		}
+		playerTotals[r.PlayerID] += s.CalculateScore(ctx, a)
+	}
+
+	entries := make([]LeaderboardEntry, 0, len(playerTotals))
+	for playerID, score := range playerTotals {
+		entries = append(entries, LeaderboardEntry{
+			PlayerID:        playerID,
+			Username:        usernames[playerID],
+			Score:           score,
+			IsCurrentPlayer: playerID == currentPlayerID,
+		})
+	}
+
+	slices.SortFunc(entries, func(a, b LeaderboardEntry) int {
+		// Higher scores first; ties broken by ascending username.
+		if c := cmp.Compare(b.Score, a.Score); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Username, b.Username)
+	})
+
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	return entries, nil
 }
 
 // CalculateScore calculates the score for a given answer.

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1,9 +1,11 @@
 package game_test
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	_ "modernc.org/sqlite"
@@ -13,6 +15,77 @@ import (
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
 )
+
+var errStub = errors.New("stub error")
+
+// stubStore satisfies game.Store for service-level tests that do not need a
+// live database. Each behaviour is overridable per test via a func field; a
+// nil field returns errStub so accidental use surfaces loudly.
+type stubStore struct {
+	listAnswersForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
+}
+
+func (stubStore) Ping(_ context.Context) error { return nil }
+
+func (stubStore) GetGame(_ context.Context, _ string) (*Game, error) {
+	return nil, errStub
+}
+func (stubStore) CreateGame(_ context.Context, _ *Game) error               { return errStub }
+func (stubStore) StartGame(_ context.Context, _ string) error               { return errStub }
+func (stubStore) CreateParticipant(_ context.Context, _ *Participant) error { return errStub }
+func (stubStore) CreateQuestion(_ context.Context, _ *Question) error       { return errStub }
+func (stubStore) CreateAnswer(_ context.Context, _ *Answer) error           { return errStub }
+
+func (s stubStore) ListAnswersForQuizLeaderboard(
+	ctx context.Context, quizID int64,
+) ([]*LeaderboardAnswer, error) {
+	if s.listAnswersForQuizLeaderboard == nil {
+		return nil, errStub
+	}
+
+	return s.listAnswersForQuizLeaderboard(ctx, quizID)
+}
+
+// stubQuizStore satisfies quiz.Store for service-level tests. Only GetQuiz is
+// overridable since GetQuizLeaderboard never reaches the other methods.
+type stubQuizStore struct {
+	getQuiz func(ctx context.Context, id int64) (*quiz.Quiz, error)
+}
+
+func (stubQuizStore) Ping(_ context.Context) error                        { return nil }
+func (stubQuizStore) ListQuizzes(_ context.Context) ([]*quiz.Quiz, error) { return nil, nil }
+func (stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, error) {
+	return map[int64]int{}, nil
+}
+
+func (s stubQuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
+	if s.getQuiz == nil {
+		return nil, errStub
+	}
+
+	return s.getQuiz(ctx, id)
+}
+func (stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error         { return nil }
+func (stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error         { return nil }
+func (stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error              { return nil }
+func (stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
+func (stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
+func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error          { return nil }
+func (stubQuizStore) ListQuestions(_ context.Context, _ int64) ([]*quiz.Question, error) {
+	return nil, nil
+}
+
+func (stubQuizStore) GetQuestion(_ context.Context, _ int64) (*quiz.Question, error) {
+	return nil, errStub
+}
+
+func (stubQuizStore) GetOption(_ context.Context, _ int64) (*quiz.Option, error) {
+	return nil, errStub
+}
+
+func (stubQuizStore) GetOptionsByIDs(_ context.Context, _ []int64) ([]*quiz.Option, error) {
+	return nil, nil
+}
 
 func newTestQuiz(t *testing.T) *quiz.Quiz {
 	t.Helper()
@@ -322,6 +395,296 @@ func TestService_GetNextQuestion(t *testing.T) {
 
 		if cmp.Diff(gq.QuizQuestion, testQuiz.Questions[1]) != "" {
 			t.Errorf("got qs: %+v, want %+v", gq.QuizQuestion, testQuiz.Questions[1])
+		}
+	})
+}
+
+// makeAnswer produces a flat LeaderboardAnswer answered at the start of the
+// 10s answer window (matching defaultExpiration) so CalculateScore yields a
+// predictable maxPoints (1000) for a correct answer or 0 for a wrong one.
+func makeAnswer(playerID int64, username string, correct bool) *LeaderboardAnswer {
+	const window = 10 * time.Second
+	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	return &LeaderboardAnswer{
+		PlayerID:          playerID,
+		Username:          username,
+		QuestionStartedAt: start,
+		QuestionExpiredAt: start.Add(window),
+		AnsweredAt:        start,
+		Correct:           correct,
+	}
+}
+
+func TestService_GetQuizLeaderboard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 404 when quiz not found", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(stubStore{}, stubQuizStore{
+			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		}, slog.New(slog.DiscardHandler))
+
+		_, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if got, want := err, quiz.ErrQuizNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns empty slice when no games", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					return nil, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		got, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("len(entries) = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("sums a single player's answers", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					// Two correct answers + one wrong -> 1000 + 1000 + 0 = 2000.
+					return []*LeaderboardAnswer{
+						makeAnswer(1, "alice", true),
+						makeAnswer(1, "alice", true),
+						makeAnswer(1, "alice", false),
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(entries), 1; got != want {
+			t.Fatalf("len(entries) = %d, want %d", got, want)
+		}
+		if got, want := entries[0].PlayerID, int64(1); got != want {
+			t.Errorf("entries[0].PlayerID = %d, want %d", got, want)
+		}
+		if got, want := entries[0].Username, "alice"; got != want {
+			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		}
+		if got, want := entries[0].Score, 2000; got != want {
+			t.Errorf("entries[0].Score = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("sorts two players by score descending", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					return []*LeaderboardAnswer{
+						// alice: 1000.
+						makeAnswer(1, "alice", true),
+						// bob: 2000.
+						makeAnswer(2, "bob", true),
+						makeAnswer(2, "bob", true),
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(entries), 2; got != want {
+			t.Fatalf("len(entries) = %d, want %d", got, want)
+		}
+		if got, want := entries[0].Username, "bob"; got != want {
+			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		}
+		if got, want := entries[1].Username, "alice"; got != want {
+			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("breaks ties by ascending username", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					// Three players with identical 1000-point runs but
+					// usernames intentionally out of order.
+					return []*LeaderboardAnswer{
+						makeAnswer(1, "charlie", true),
+						makeAnswer(2, "alice", true),
+						makeAnswer(3, "bob", true),
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		gotNames := []string{entries[0].Username, entries[1].Username, entries[2].Username}
+		wantNames := []string{"alice", "bob", "charlie"}
+		if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+			t.Errorf("username order mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("flags the entry of the current player", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					return []*LeaderboardAnswer{
+						makeAnswer(1, "alice", true),
+						makeAnswer(2, "bob", true),
+						makeAnswer(2, "bob", true),
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 1, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var aliceEntry, bobEntry LeaderboardEntry
+		for _, e := range entries {
+			switch e.PlayerID {
+			case 1:
+				aliceEntry = e
+			case 2:
+				bobEntry = e
+			default:
+				t.Fatalf("unexpected player ID %d", e.PlayerID)
+			}
+		}
+
+		if got, want := aliceEntry.IsCurrentPlayer, true; got != want {
+			t.Errorf("aliceEntry.IsCurrentPlayer = %v, want %v", got, want)
+		}
+		if got, want := bobEntry.IsCurrentPlayer, false; got != want {
+			t.Errorf("bobEntry.IsCurrentPlayer = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("truncates results to the supplied limit", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					answers := make([]*LeaderboardAnswer, 0, 5)
+					for i := int64(1); i <= 5; i++ {
+						// Player i answers (5-i+1) correct questions so
+						// scores are strictly decreasing: 5000, 4000, 3000, 2000, 1000.
+						for range 6 - i {
+							answers = append(answers, makeAnswer(i, "p", true))
+						}
+					}
+
+					return answers, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(entries), 3; got != want {
+			t.Errorf("len(entries) = %d, want %d", got, want)
+		}
+		if got, want := entries[0].PlayerID, int64(1); got != want {
+			t.Errorf("entries[0].PlayerID = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("defaults limit to 10 when limit <= 0", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					answers := make([]*LeaderboardAnswer, 0, 15)
+					for i := int64(1); i <= 15; i++ {
+						answers = append(answers, makeAnswer(i, "p", true))
+					}
+
+					return answers, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(entries), 10; got != want {
+			t.Errorf("len(entries) = %d, want %d (default limit)", got, want)
 		}
 	})
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -61,6 +61,11 @@ func (*stubGameStore) StartGame(_ context.Context, _ string) error              
 func (*stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) error { return nil }
 func (*stubGameStore) CreateQuestion(_ context.Context, _ *game.Question) error       { return nil }
 func (*stubGameStore) CreateAnswer(_ context.Context, _ *game.Answer) error           { return nil }
+func (*stubGameStore) ListAnswersForQuizLeaderboard(
+	_ context.Context, _ int64,
+) ([]*game.LeaderboardAnswer, error) {
+	return nil, nil
+}
 
 func TestHandleHealthz(t *testing.T) {
 	t.Parallel()

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -47,3 +47,21 @@ WHERE game_question_id = ?;
 INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
 VALUES (?, ?, ?, ?)
 RETURNING *;
+
+-- name: ListAnswersForQuizLeaderboard :many
+-- Selects the per-answer scoring inputs for every game of the given quiz.
+-- The leaderboard service assumes one attempt per (player, quiz) (#145 covers
+-- enforcement) and sums these rows per player; if multiple attempts ever leak
+-- through, scores will be inflated until enforcement lands.
+SELECT ga.player_id        AS player_id,
+       p.username           AS username,
+       gq.started_at        AS question_started_at,
+       gq.expired_at        AS question_expired_at,
+       ga.answered_at       AS answered_at,
+       o.is_correct         AS is_correct
+FROM game_answers ga
+         JOIN games g ON g.id = ga.game_id
+         JOIN game_questions gq ON gq.id = ga.game_question_id
+         JOIN options o ON o.id = ga.option_id
+         JOIN players p ON p.id = ga.player_id
+WHERE g.quiz_id = ?;

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -150,6 +150,10 @@ func addAPIRoutes(
 
 	mux.Handle("GET /api/quizzes", ensurePlayer(clientapi.HandleQuizList(logger, stores.Quizzes)))
 	mux.Handle("GET /api/quizzes/{slugID}", ensurePlayer(clientapi.HandleQuizGet(logger, stores.Quizzes)))
+	mux.Handle(
+		"GET /api/quizzes/{slugID}/leaderboard",
+		ensurePlayer(clientapi.HandleQuizLeaderboard(logger, gameService)),
+	)
 	mux.Handle("POST /api/games", ensurePlayer(clientapi.HandleCreateGame(logger, gameService)))
 	mux.Handle(
 		"GET /api/games/{gameID}/questions/next",

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -136,6 +136,11 @@ func (stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) e
 }
 func (stubGameStore) CreateQuestion(_ context.Context, _ *game.Question) error { return errRouteStub }
 func (stubGameStore) CreateAnswer(_ context.Context, _ *game.Answer) error     { return errRouteStub }
+func (stubGameStore) ListAnswersForQuizLeaderboard(
+	_ context.Context, _ int64,
+) ([]*game.LeaderboardAnswer, error) {
+	return nil, nil
+}
 
 func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
 	t.Parallel()
@@ -162,6 +167,7 @@ func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
 
 		{name: "API Quiz List", method: http.MethodGet, path: "/api/quizzes"},
 		{name: "API Quiz Get", method: http.MethodGet, path: "/api/quizzes/1"},
+		{name: "API Quiz Leaderboard", method: http.MethodGet, path: "/api/quizzes/quiz-1/leaderboard"},
 
 		{name: "API Game Create", method: http.MethodPost, path: "/api/games"},
 		{name: "API Question Next", method: http.MethodGet, path: "/api/games/game-1/questions/next"},

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -155,6 +155,33 @@ func (s *GameStore) CreateAnswer(ctx context.Context, a *game.Answer) error {
 	return nil
 }
 
+// ListAnswersForQuizLeaderboard returns one flat row per game answer across
+// every game of the given quiz. The rows carry just enough fields for
+// [game.Service.GetQuizLeaderboard] to reuse [game.Service.CalculateScore]
+// without re-loading the option / question / player rows individually.
+func (s *GameStore) ListAnswersForQuizLeaderboard(
+	ctx context.Context, quizID int64,
+) ([]*game.LeaderboardAnswer, error) {
+	rows, err := s.q.ListAnswersForQuizLeaderboard(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list leaderboard answers for quiz %d: %w", quizID, err)
+	}
+
+	answers := make([]*game.LeaderboardAnswer, 0, len(rows))
+	for _, r := range rows {
+		answers = append(answers, &game.LeaderboardAnswer{
+			PlayerID:          r.PlayerID,
+			Username:          r.Username,
+			QuestionStartedAt: r.QuestionStartedAt,
+			QuestionExpiredAt: r.QuestionExpiredAt,
+			AnsweredAt:        r.AnsweredAt,
+			Correct:           r.IsCorrect,
+		})
+	}
+
+	return answers, nil
+}
+
 func (s *GameStore) listGameQuestions(ctx context.Context, gameID string) ([]*game.Question, error) {
 	var err error
 	rows, err := s.q.ListGameQuestionsByGameID(ctx, gameID)

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -260,3 +260,159 @@ func TestGameStore_CreateAnswer(t *testing.T) {
 		}
 	})
 }
+
+func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty slice for quiz with no games", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		got, err := gameStore.ListAnswersForQuizLeaderboard(t.Context(), testQuiz.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("len(answers) = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("returns one row per stored answer with joined fields", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(
+			t.Context(), "anon-leaderboard-1",
+		)
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+
+		now := time.Now().UTC().Truncate(time.Second)
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+
+		correctOption := testQuiz.Questions[0].Options[0]
+		a := &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq.ID,
+			OptionID:   correctOption.ID,
+		}
+		if err = gameStore.CreateAnswer(t.Context(), a); err != nil {
+			t.Fatalf("failed to create answer: %v", err)
+		}
+
+		rows, err := gameStore.ListAnswersForQuizLeaderboard(t.Context(), testQuiz.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(rows), 1; got != want {
+			t.Fatalf("len(rows) = %d, want %d", got, want)
+		}
+		if got, want := rows[0].PlayerID, player.ID; got != want {
+			t.Errorf("rows[0].PlayerID = %d, want %d", got, want)
+		}
+		if got, want := rows[0].Username, player.Username; got != want {
+			t.Errorf("rows[0].Username = %q, want %q", got, want)
+		}
+		if got, want := rows[0].Correct, correctOption.Correct; got != want {
+			t.Errorf("rows[0].Correct = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("only returns answers for the requested quiz", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		// Two distinct quizzes; the leaderboard query for quiz A must not
+		// see answers recorded against quiz B.
+		quizzes := newTestQuizzes()
+		quizA := quizzes[0]
+		quizB := quizzes[1]
+		if err := quizStore.CreateQuiz(t.Context(), quizA); err != nil {
+			t.Fatalf("failed to create quiz A: %v", err)
+		}
+		if err := quizStore.CreateQuiz(t.Context(), quizB); err != nil {
+			t.Fatalf("failed to create quiz B: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(
+			t.Context(), "anon-leaderboard-2",
+		)
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		now := time.Now().UTC().Truncate(time.Second)
+
+		// Record one answer on quizB (should not appear in quizA's leaderboard).
+		gB := &game.Game{QuizID: quizB.ID}
+		if err = gameStore.CreateGame(t.Context(), gB); err != nil {
+			t.Fatalf("failed to create game B: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: gB.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant for game B: %v", err)
+		}
+		gqB := &game.Question{
+			GameID:     gB.ID,
+			QuestionID: quizB.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gqB); err != nil {
+			t.Fatalf("failed to create question for game B: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     gB.ID,
+			PlayerID:   player.ID,
+			QuestionID: gqB.ID,
+			OptionID:   quizB.Questions[0].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer for game B: %v", err)
+		}
+
+		rows, err := gameStore.ListAnswersForQuizLeaderboard(t.Context(), quizA.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rows) != 0 {
+			t.Errorf("len(rows) = %d, want 0 (only quiz B has answers)", len(rows))
+		}
+	})
+}

--- a/test/e2e/tests/player.spec.ts
+++ b/test/e2e/tests/player.spec.ts
@@ -69,13 +69,15 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
   // logic adds up over four questions.
   await expect(page.getByRole('heading', { name: 'Game Finished!' })).toBeVisible({ timeout: 15_000 });
 
-  // The results table should have at least one player row, and the score
-  // column for that row must not be 0 — Q3 (all correct) and Q4 (idx 0 is
-  // prime) both yield a hit when picking the first option, so scoring being
-  // broken (always-0) needs to fail the test.
-  const firstRow = page.locator('table tbody tr').first();
-  await expect(firstRow).toBeVisible();
-  await expect(firstRow.locator('td').nth(1)).not.toHaveText('0');
+  // The leaderboard table renders rank/player/score; the player just played, so
+  // their row must be marked with .is-selected. The score column for that row
+  // must not be 0 — Q3 (all correct) and Q4 (idx 0 is prime) both yield a hit
+  // when picking the first option, so scoring being broken (always-0) needs
+  // to fail the test.
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
+  const playerRow = page.locator('table tbody tr.is-selected');
+  await expect(playerRow).toBeVisible();
+  await expect(playerRow.locator('td').nth(2)).not.toHaveText('0');
 
   // Lock in the prediction: picking option[0] of every QUIZ_QUESTIONS entry
   // currently hits Q3 (all correct) and Q4 (idx 0 is prime) — exactly 2

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -85,6 +85,21 @@ type resultsRes struct {
 	PlayerScores []playerScoreRes `json:"playerScores"`
 }
 
+// leaderboardEntryRes mirrors one entry in the leaderboard response. Pulled
+// out of the parent struct to keep nested-structs-friendly types.
+type leaderboardEntryRes struct {
+	PlayerID        int64  `json:"playerId"`
+	Username        string `json:"username"`
+	Score           int    `json:"score"`
+	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
+}
+
+// leaderboardRes is the decode target for GET /api/quizzes/{slugID}/leaderboard.
+type leaderboardRes struct {
+	QuizID  int64                 `json:"quizId"`
+	Entries []leaderboardEntryRes `json:"entries"`
+}
+
 // integrationSetup bundles the artefacts a gameplay-style integration test
 // needs. Context is intentionally returned separately from the struct (passed
 // out of setupIntegration as the first return value) to avoid containedctx.
@@ -369,6 +384,39 @@ func TestGameplay_Integration(t *testing.T) {
 	}
 	if cerr := resp.Body.Close(); cerr != nil {
 		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	// Quiz leaderboard: the player who just finished should appear with
+	// IsCurrentPlayer=true and the same score they accumulated above.
+	leaderboardURL := fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, qz.Slug, qz.ID)
+	resp = httpGet(ctx, t, client, leaderboardURL)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var leaderboard leaderboardRes
+	err = json.NewDecoder(resp.Body).Decode(&leaderboard)
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+	if err != nil {
+		t.Fatalf("failed to decode leaderboard response: %v", err)
+	}
+
+	if got, want := leaderboard.QuizID, qz.ID; got != want {
+		t.Fatalf("leaderboard.QuizID = %d, want %d", got, want)
+	}
+	if got, want := len(leaderboard.Entries), 1; got != want {
+		t.Fatalf("len(leaderboard.Entries) = %d, want %d", got, want)
+	}
+	if got, want := leaderboard.Entries[0].IsCurrentPlayer, true; got != want {
+		t.Errorf("leaderboard.Entries[0].IsCurrentPlayer = %v, want %v", got, want)
+	}
+	if got, want := leaderboard.Entries[0].Score, runningScore; got != want {
+		t.Errorf("leaderboard.Entries[0].Score = %d, want %d", got, want)
+	}
+	if got := leaderboard.Entries[0].PlayerID; got <= 0 {
+		t.Errorf("leaderboard.Entries[0].PlayerID = %d, want > 0", got)
 	}
 
 	// Shutdown server


### PR DESCRIPTION
## Summary

- New `GET /api/quizzes/{slugID}/leaderboard` endpoint returning the top 10 players for a quiz with `playerId`, `username`, `score`, and `isCurrentPlayer`. Wrapped in `EnsurePlayer` so the handler can flag the requesting player.
- Frontend results screen now renders a Bulma leaderboard table on quiz finish (rank / player / score), with the current player's row highlighted via `is-selected`. Replaces the per-game one-row results table.
- Scoring stays in `Service.CalculateScore` — the service synthesises minimal `Answer`/`Question`/`Option` shells from the SQL row and reuses the existing formula. New SQL query `ListAnswersForQuizLeaderboard` lives in `internal/queries/games.sql` and goes through sqlc.
- Assumes one attempt per (player, quiz). Enforcement is tracked separately in #145; until that lands, multiple attempts inflate the player's score.
- Closes #140.

## Test plan

- [x] `make lint-fix` clean
- [x] `make check` green (added unit, store, handler, and integration tests covering aggregation, ordering, username tiebreak, current-player flag, limit, default limit, 404, 500-no-player, 500-on-store-error, quiz isolation, end-to-end flow)
- [x] `make smoke` boots cleanly
- [x] `make test-e2e` green; player spec tightened to assert score-column non-zero on the `.is-selected` row

## Follow-ups filed during review

- #141 — Index `games(quiz_id)` and review leaderboard memory profile
- #142 — Replace `GetQuiz` existence check with a cheap `QuizExists` query
- #143 — Decide whether the global leaderboard counts unfinished games
- #144 — Add trailing newline to `internal/queries/games.sql`
- #145 — Limit each player to one attempt per quiz, with admin reset (load-bearing for the leaderboard's "one attempt" assumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)