### PR TITLE
Limit each player to one attempt per quiz, with admin reset

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/handlers"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/web/tmpl"
@@ -577,14 +578,36 @@ func HandleQuizList(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.S
 	})
 }
 
-// HandleQuizView returns the quiz view page.
-func HandleQuizView(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+// PlayerScoreData represents one row of the "Played by" table on the quiz
+// view page: a player who has at least one answer recorded for the quiz,
+// alongside their accumulated score (computed by the game service in the
+// same way the public leaderboard computes its scores).
+type PlayerScoreData struct {
+	PlayerID int64
+	Username string
+	Score    int
+}
+
+// HandleQuizView returns the quiz view page. It also fetches the per-quiz
+// leaderboard so the admin can see who has played and reset their attempt
+// from the same screen. We reuse the leaderboard service with a high limit
+// rather than spinning up a dedicated "list participants" service method —
+// see #145 for the rationale (and #141 for the performance ceilings).
+func HandleQuizView(
+	logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store, gameService *game.Service,
+) http.Handler {
 	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizview.gohtml")
 
 	type quizViewData struct {
-		Title string
-		Quiz  *QuizData
+		Title   string
+		Quiz    *QuizData
+		Players []PlayerScoreData
 	}
+
+	// playersLimit is the upper bound on rows in the "Played by" section.
+	// Set high enough that real-world quiz playthroughs fit; #141 covers
+	// pagination for genuinely large rosters.
+	const playersLimit = 1000
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ok bool
@@ -599,11 +622,72 @@ func HandleQuizView(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.S
 			return
 		}
 
+		// Admin "Played by" doesn't highlight a current player — the
+		// template ignores IsCurrentPlayer — so pass 0 to flag nothing,
+		// per Service.GetQuizLeaderboard's documented sentinel.
+		entries, err := gameService.GetQuizLeaderboard(r.Context(), id, 0, playersLimit)
+		if err != nil {
+			logger.ErrorContext(r.Context(), "error fetching players for quiz view", slog.Any("err", err))
+			render500(w, r, logger, csrfMgr)
+
+			return
+		}
+
+		players := make([]PlayerScoreData, 0, len(entries))
+		for _, e := range entries {
+			players = append(players, PlayerScoreData{
+				PlayerID: e.PlayerID,
+				Username: e.Username,
+				Score:    e.Score,
+			})
+		}
+
 		data := quizViewData{
-			Title: "Admin Dashboard - View Quiz",
-			Quiz:  quizDataFromQuiz(qz),
+			Title:   "Admin Dashboard - View Quiz",
+			Quiz:    quizDataFromQuiz(qz),
+			Players: players,
 		}
 		render.Render(w, r, http.StatusOK, data)
+	})
+}
+
+// HandleResetGameForPlayer hard-deletes the games (and dependent rows) that
+// the given player has on the given quiz. Idempotent: if the player has no
+// games, it is a 303-redirect no-op. The admin reset button on the quiz
+// view page POSTs here.
+func HandleResetGameForPlayer(
+	logger *slog.Logger, csrfMgr *csrf.Manager, gameService *game.Service,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+
+		var quizID int64
+		if quizID, ok = handlers.ParseIDFromPath(w, r, logger, "quizID"); !ok {
+			return
+		}
+
+		var playerID int64
+		if playerID, ok = handlers.ParseIDFromPath(w, r, logger, "playerID"); !ok {
+			return
+		}
+
+		if err := gameService.ResetGamesForPlayerOnQuiz(r.Context(), playerID, quizID); err != nil {
+			if errors.Is(err, quiz.ErrQuizNotFound) {
+				render404(w, r, logger, csrfMgr)
+
+				return
+			}
+			logger.ErrorContext(r.Context(), "error resetting games for player on quiz", slog.Any("err", err))
+			render500(w, r, logger, csrfMgr)
+
+			return
+		}
+
+		// quizID came from ParseIDFromPath, which only returns an int64
+		// once the path value parses cleanly — formatting it back via
+		// strconv.FormatInt avoids gosec's open-redirect taint heuristic
+		// for fmt.Sprintf with a path argument.
+		http.Redirect(w, r, "/admin/quizzes/"+strconv.FormatInt(quizID, 10), http.StatusSeeOther)
 	})
 }
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -20,8 +20,70 @@ import (
 
 	. "github.com/starquake/topbanana/internal/admin"
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/quiz"
 )
+
+// stubGameStore satisfies game.Store for admin handler tests; only the
+// methods the admin code actually exercises are wired up. The leaderboard
+// fetch on the quiz view defaults to "no rows" so test cases that don't
+// care about the players list keep working with no extra setup.
+type stubGameStore struct {
+	listAnswersForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*game.LeaderboardAnswer, error)
+	deleteGamesForPlayerOnQuiz    func(ctx context.Context, playerID, quizID int64) error
+}
+
+func (stubGameStore) Ping(_ context.Context) error { return nil }
+
+func (stubGameStore) GetGame(_ context.Context, _ string) (*game.Game, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (stubGameStore) GetGameByPlayerAndQuiz(_ context.Context, _, _ int64) (*game.Game, error) {
+	return nil, game.ErrGameNotFound
+}
+
+func (stubGameStore) CreateGame(_ context.Context, _ *game.Game) error {
+	return errors.ErrUnsupported
+}
+func (stubGameStore) StartGame(_ context.Context, _ string) error { return errors.ErrUnsupported }
+func (stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) error {
+	return errors.ErrUnsupported
+}
+
+func (stubGameStore) CreateQuestion(_ context.Context, _ *game.Question) error {
+	return errors.ErrUnsupported
+}
+
+func (stubGameStore) CreateAnswer(_ context.Context, _ *game.Answer) error {
+	return errors.ErrUnsupported
+}
+
+func (s stubGameStore) ListAnswersForQuizLeaderboard(
+	ctx context.Context, quizID int64,
+) ([]*game.LeaderboardAnswer, error) {
+	if s.listAnswersForQuizLeaderboard == nil {
+		return nil, nil
+	}
+
+	return s.listAnswersForQuizLeaderboard(ctx, quizID)
+}
+
+func (s stubGameStore) DeleteGamesForPlayerOnQuiz(
+	ctx context.Context, playerID, quizID int64,
+) error {
+	if s.deleteGamesForPlayerOnQuiz == nil {
+		return nil
+	}
+
+	return s.deleteGamesForPlayerOnQuiz(ctx, playerID, quizID)
+}
+
+// newGameService wires the supplied stubs into a [game.Service] so
+// admin handler tests can call the constructor with the real type.
+func newGameService(gs stubGameStore, qs stubQuizStore) *game.Service {
+	return game.NewService(gs, qs, slog.New(slog.DiscardHandler))
+}
 
 type errReader struct{ err error }
 
@@ -453,7 +515,7 @@ func TestHandleQuizView(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, nil, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(stubGameStore{}, quizStore))
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -483,7 +545,7 @@ func TestHandleQuizView(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, nil, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(stubGameStore{}, quizStore))
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -513,7 +575,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 
 		quizStore := stubQuizStore{}
 
-		handler := HandleQuizView(logger, nil, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(stubGameStore{}, quizStore))
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/abc", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -545,7 +607,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 			},
 		}
 
-		handler := HandleQuizView(logger, nil, quizStore)
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(stubGameStore{}, quizStore))
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		if err != nil {
 			t.Fatalf("http.NewRequest error: %v", err)
@@ -2680,6 +2742,217 @@ func TestHandleQuestionDelete_ErrorHandling(t *testing.T) {
 		}
 		if got, want := buf.String(), fmt.Sprintf("err=%q", testError); !strings.Contains(got, want) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
+		}
+	})
+}
+
+func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("renders a row per player with reset button", func(t *testing.T) {
+		t.Parallel()
+
+		quizStore := stubQuizStore{
+			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Q1", Slug: "q-1"}, nil
+			},
+		}
+		// Two leaderboard answers for two distinct players, both correct,
+		// so each player accumulates a non-zero score and shows up in the
+		// "Played by" table.
+		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		gameStore := stubGameStore{
+			listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*game.LeaderboardAnswer, error) {
+				return []*game.LeaderboardAnswer{
+					{
+						PlayerID: 1, Username: "alice",
+						QuestionStartedAt: now, QuestionExpiredAt: now.Add(10 * time.Second),
+						AnsweredAt: now, Correct: true,
+					},
+					{
+						PlayerID: 2, Username: "bob",
+						QuestionStartedAt: now, QuestionExpiredAt: now.Add(10 * time.Second),
+						AnsweredAt: now, Correct: true,
+					},
+				}, nil
+			},
+		}
+
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(gameStore, quizStore))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
+		req.SetPathValue("quizID", "1")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+
+		body := rr.Body.String()
+		if got, want := body, "Played by"; !strings.Contains(got, want) {
+			t.Errorf("body should contain section header %q, got %q", want, got)
+		}
+		if got, want := body, "alice"; !strings.Contains(got, want) {
+			t.Errorf("body should contain player name %q, got %q", want, got)
+		}
+		if got, want := body, "bob"; !strings.Contains(got, want) {
+			t.Errorf("body should contain player name %q, got %q", want, got)
+		}
+		// Anchor on the form action so we know the reset button targets
+		// the right URL with the player ID and quiz ID interpolated.
+		if got, want := body, `action="/admin/quizzes/1/players/1/reset"`; !strings.Contains(got, want) {
+			t.Errorf("body should contain reset form for alice, got %q", got)
+		}
+		if got, want := body, `action="/admin/quizzes/1/players/2/reset"`; !strings.Contains(got, want) {
+			t.Errorf("body should contain reset form for bob, got %q", got)
+		}
+	})
+
+	t.Run("renders 'No plays yet.' when nobody has played", func(t *testing.T) {
+		t.Parallel()
+
+		quizStore := stubQuizStore{
+			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Q1", Slug: "q-1"}, nil
+			},
+		}
+		gameStore := stubGameStore{} // no leaderboard rows
+
+		handler := HandleQuizView(logger, nil, quizStore, newGameService(gameStore, quizStore))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
+		req.SetPathValue("quizID", "1")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+		if got, want := rr.Body.String(), "No plays yet."; !strings.Contains(got, want) {
+			t.Errorf("body should contain placeholder %q, got %q", want, got)
+		}
+	})
+}
+
+func TestHandleResetGameForPlayer(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("303 redirects back to the quiz page on success", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			seenPlayerID int64
+			seenQuizID   int64
+		)
+		quizStore := stubQuizStore{
+			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Q1"}, nil
+			},
+		}
+		gameStore := stubGameStore{
+			deleteGamesForPlayerOnQuiz: func(_ context.Context, playerID, quizID int64) error {
+				seenPlayerID = playerID
+				seenQuizID = quizID
+
+				return nil
+			},
+		}
+
+		handler := HandleResetGameForPlayer(logger, nil, newGameService(gameStore, quizStore))
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/42/players/7/reset", nil,
+		)
+		req.SetPathValue("quizID", "42")
+		req.SetPathValue("playerID", "7")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+		if got, want := rr.Header().Get("Location"), "/admin/quizzes/42"; got != want {
+			t.Errorf("Location = %q, want %q", got, want)
+		}
+		if got, want := seenPlayerID, int64(7); got != want {
+			t.Errorf("delete called with playerID = %d, want %d", got, want)
+		}
+		if got, want := seenQuizID, int64(42); got != want {
+			t.Errorf("delete called with quizID = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("404 when quiz does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		quizStore := stubQuizStore{
+			getQuizByID: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		}
+
+		handler := HandleResetGameForPlayer(logger, nil, newGameService(stubGameStore{}, quizStore))
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/99/players/7/reset", nil,
+		)
+		req.SetPathValue("quizID", "99")
+		req.SetPathValue("playerID", "7")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("500 when delete fails", func(t *testing.T) {
+		t.Parallel()
+
+		quizStore := stubQuizStore{
+			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id}, nil
+			},
+		}
+		gameStore := stubGameStore{
+			deleteGamesForPlayerOnQuiz: func(_ context.Context, _, _ int64) error {
+				return errors.New("delete boom")
+			},
+		}
+
+		handler := HandleResetGameForPlayer(logger, nil, newGameService(gameStore, quizStore))
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/1/players/2/reset", nil,
+		)
+		req.SetPathValue("quizID", "1")
+		req.SetPathValue("playerID", "2")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("400 when playerID path value is non-numeric", func(t *testing.T) {
+		t.Parallel()
+
+		handler := HandleResetGameForPlayer(logger, nil, newGameService(stubGameStore{}, stubQuizStore{}))
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/1/players/abc/reset", nil,
+		)
+		req.SetPathValue("quizID", "1")
+		req.SetPathValue("playerID", "abc")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
 		}
 	})
 }

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -26,6 +26,9 @@
                         </div>
                     </div>
                 </div>
+                <template x-if="startError">
+                    <div class="notification is-danger" x-text="startError"></div>
+                </template>
                 <button class="button is-primary" @click="startGame()" :disabled="!selectedQuizId">Start Game</button>
             </div>
 

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -18,6 +18,7 @@ export class GameApp {
         // display:none from a prior broken image would otherwise hide the
         // next image too.
         this.imageError = false;
+        this.startError = null;
     }
 
     async init() {
@@ -28,11 +29,22 @@ export class GameApp {
     }
 
     async startGame() {
+        this.startError = null;
         const quiz = this.quizzes.find(q => q.id === parseInt(this.selectedQuizId));
         if (!quiz) return;
         this.quizSlugId = `${quiz.slug}-${quiz.id}`;
-        const data = await gameService.startGame(this.selectedQuizId);
-        this.gameId = data.id;
+        const existing = await gameService.getMyGameForQuiz(this.quizSlugId);
+        if (existing && existing.completed) {
+            this.startError = "You've already completed this quiz.";
+            this.quizSlugId = null;
+            return;
+        }
+        if (existing) {
+            this.gameId = existing.gameId;
+        } else {
+            const data = await gameService.startGame(this.selectedQuizId);
+            this.gameId = data.id;
+        }
         await this.nextQuestion();
     }
 
@@ -101,5 +113,6 @@ export class GameApp {
         this.feedback = null;
         this.progress = 100;
         this.imageError = false;
+        this.startError = null;
     }
 }

--- a/internal/client/static/js/services/GameService.js
+++ b/internal/client/static/js/services/GameService.js
@@ -16,6 +16,14 @@ export class GameService {
         return await response.json();
     }
 
+    async getMyGameForQuiz(slugId) {
+        const response = await fetch(`/api/quizzes/${slugId}/my-game`);
+        if (response.status === 404) {
+            return null;
+        }
+        return await response.json();
+    }
+
     async submitAnswer(gameId, questionId, optionId) {
         const response = await fetch(`/api/games/${gameId}/questions/${questionId}/answers`, {
             method: 'POST',

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -211,7 +211,10 @@ func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Hand
 // Returns the ID of the created game.
 // Returns 201 if the game was created successfully.
 // Returns 400 if the request body is invalid.
-// Returns 404 if the quiz or game does not exist.
+// Returns 404 if the quiz does not exist.
+// Returns 409 if the player already has a game for the quiz (in-progress or
+// completed); the client should call GET /api/quizzes/{slugID}/my-game to
+// resolve.
 // Returns 500 if an error occurs.
 func HandleCreateGame(logger *slog.Logger, service *game.Service) http.Handler {
 	type createGameRequest struct {
@@ -251,6 +254,11 @@ func HandleCreateGame(logger *slog.Logger, service *game.Service) http.Handler {
 
 				return
 			}
+			if errors.Is(err, game.ErrGameAlreadyExists) {
+				http.Error(w, err.Error(), http.StatusConflict)
+
+				return
+			}
 			logger.ErrorContext(ctx, "error creating game", slog.Any("err", err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 
@@ -262,6 +270,60 @@ func HandleCreateGame(logger *slog.Logger, service *game.Service) http.Handler {
 		err = handlers.EncodeJSON(w, http.StatusCreated, res)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error encoding quizzesResponse", slog.Any("err", err))
+
+			return
+		}
+	})
+}
+
+// HandleGameForQuiz returns the requesting player's game for the given quiz,
+// if any. The frontend uses this as the resume probe before deciding whether
+// to POST /api/games for a fresh attempt.
+//
+// Returns 200 with {"gameId":..., "completed":...} when a game exists.
+// Returns 404 when the player has no game for the quiz, or when the quiz
+// itself does not exist (consistent with other ErrQuizNotFound mappings).
+// Returns 500 when EnsurePlayer hasn't populated the player on the context
+// (a wiring bug rather than a user-facing condition).
+func HandleGameForQuiz(logger *slog.Logger, service *game.Service) http.Handler {
+	type gameForQuizResponse struct {
+		GameID    string `json:"gameId"`
+		Completed bool   `json:"completed"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		quizID, ok := handlers.ParseIDFromSlugPath(w, r, logger, "slugID")
+		if !ok {
+			return
+		}
+
+		player, ok := auth.PlayerFromContext(ctx)
+		if !ok {
+			logger.ErrorContext(ctx, "missing player on context for game-for-quiz")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		g, err := service.GetGameForPlayerOnQuiz(ctx, player.ID, quizID)
+		if err != nil {
+			if errors.Is(err, quiz.ErrQuizNotFound) || errors.Is(err, game.ErrGameNotFound) {
+				http.NotFound(w, r)
+
+				return
+			}
+			logger.ErrorContext(ctx, "error retrieving game for quiz", slog.Any("err", err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		res := gameForQuizResponse{GameID: g.ID, Completed: g.IsCompleted()}
+
+		if err = handlers.EncodeJSON(w, http.StatusOK, res); err != nil {
+			logger.ErrorContext(ctx, "error encoding gameForQuizResponse", slog.Any("err", err))
 
 			return
 		}

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -83,12 +83,14 @@ func (stubQuizStore) GetOptionsByIDs(_ context.Context, _ []int64) ([]*quiz.Opti
 
 type stubGameStore struct {
 	getGame                       func(ctx context.Context, id string) (*game.Game, error)
+	getGameByPlayerAndQuiz        func(ctx context.Context, playerID, quizID int64) (*game.Game, error)
 	createGame                    func(ctx context.Context, g *game.Game) error
 	startGame                     func(ctx context.Context, id string) error
 	createParticipant             func(ctx context.Context, p *game.Participant) error
 	createQuestion                func(ctx context.Context, gq *game.Question) error
 	createAnswer                  func(ctx context.Context, a *game.Answer) error
 	listAnswersForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*game.LeaderboardAnswer, error)
+	deleteGamesForPlayerOnQuiz    func(ctx context.Context, playerID, quizID int64) error
 }
 
 func (stubGameStore) Ping(_ context.Context) error { return nil }
@@ -101,12 +103,34 @@ func (s stubGameStore) GetGame(ctx context.Context, id string) (*game.Game, erro
 	return s.getGame(ctx, id)
 }
 
+func (s stubGameStore) GetGameByPlayerAndQuiz(
+	ctx context.Context, playerID, quizID int64,
+) (*game.Game, error) {
+	if s.getGameByPlayerAndQuiz == nil {
+		// Default to "no existing game" so existing CreateGame tests
+		// continue to exercise the success path.
+		return nil, game.ErrGameNotFound
+	}
+
+	return s.getGameByPlayerAndQuiz(ctx, playerID, quizID)
+}
+
 func (s stubGameStore) CreateGame(ctx context.Context, g *game.Game) error {
 	if s.createGame == nil {
 		return errStub
 	}
 
 	return s.createGame(ctx, g)
+}
+
+func (s stubGameStore) DeleteGamesForPlayerOnQuiz(
+	ctx context.Context, playerID, quizID int64,
+) error {
+	if s.deleteGamesForPlayerOnQuiz == nil {
+		return errStub
+	}
+
+	return s.deleteGamesForPlayerOnQuiz(ctx, playerID, quizID)
 }
 
 func (s stubGameStore) StartGame(ctx context.Context, id string) error {
@@ -459,6 +483,220 @@ func TestHandleCreateGame(t *testing.T) {
 			t.Context(), http.MethodPost, "/api/games",
 			strings.NewReader(`{"quizId": 1}`),
 		)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestHandleCreateGame_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	svc := newService(
+		stubGameStore{
+			getGameByPlayerAndQuiz: func(_ context.Context, _, _ int64) (*game.Game, error) {
+				return &game.Game{ID: "existing"}, nil
+			},
+		},
+		stubQuizStore{
+			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+				return &quiz.Quiz{ID: id, Title: "Q"}, nil
+			},
+		},
+	)
+	handler := HandleCreateGame(logger, svc)
+
+	req := httptest.NewRequestWithContext(
+		withPlayer(t.Context(), 7), http.MethodPost, "/api/games",
+		strings.NewReader(`{"quizId": 1}`),
+	)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusConflict; got != want {
+		t.Errorf("status code = %v, want %v", got, want)
+	}
+}
+
+// gameForQuizTestResponse mirrors the JSON shape returned by
+// HandleGameForQuiz; pulled out of the test fn so the parent decode target
+// is not a nested struct (revive's nested-structs rule).
+type gameForQuizTestResponse struct {
+	GameID    string `json:"gameId"`
+	Completed bool   `json:"completed"`
+}
+
+func TestHandleGameForQuiz(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("returns 200 with completed=false for an in-progress game", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(
+			stubGameStore{
+				getGameByPlayerAndQuiz: func(_ context.Context, _, _ int64) (*game.Game, error) {
+					return &game.Game{
+						ID:     "abc",
+						QuizID: 1,
+						// Only the first of two questions has been issued.
+						Questions: []*game.Question{{QuestionID: 10}},
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{
+						ID: id,
+						Questions: []*quiz.Question{
+							{ID: 10}, {ID: 20},
+						},
+					}, nil
+				},
+			},
+		)
+		handler := HandleGameForQuiz(logger, svc)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 7), http.MethodGet,
+			"/api/quizzes/q-1/my-game", nil,
+		)
+		req.SetPathValue("slugID", "q-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusOK; got != want {
+			t.Fatalf("status code = %v, want %v", got, want)
+		}
+
+		var body gameForQuizTestResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		if got, want := body.GameID, "abc"; got != want {
+			t.Errorf("body.GameID = %q, want %q", got, want)
+		}
+		if got, want := body.Completed, false; got != want {
+			t.Errorf("body.Completed = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 200 with completed=true once every question has been issued", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(
+			stubGameStore{
+				getGameByPlayerAndQuiz: func(_ context.Context, _, _ int64) (*game.Game, error) {
+					return &game.Game{
+						ID:        "done",
+						QuizID:    1,
+						Questions: []*game.Question{{QuestionID: 10}, {QuestionID: 20}},
+					}, nil
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{
+						ID: id,
+						Questions: []*quiz.Question{
+							{ID: 10}, {ID: 20},
+						},
+					}, nil
+				},
+			},
+		)
+		handler := HandleGameForQuiz(logger, svc)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 7), http.MethodGet,
+			"/api/quizzes/q-1/my-game", nil,
+		)
+		req.SetPathValue("slugID", "q-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusOK; got != want {
+			t.Fatalf("status code = %v, want %v", got, want)
+		}
+
+		var body gameForQuizTestResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		if got, want := body.Completed, true; got != want {
+			t.Errorf("body.Completed = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 404 when player has no game for the quiz", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(
+			stubGameStore{
+				getGameByPlayerAndQuiz: func(_ context.Context, _, _ int64) (*game.Game, error) {
+					return nil, game.ErrGameNotFound
+				},
+			},
+			stubQuizStore{
+				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
+					return &quiz.Quiz{ID: id}, nil
+				},
+			},
+		)
+		handler := HandleGameForQuiz(logger, svc)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 7), http.MethodGet,
+			"/api/quizzes/q-1/my-game", nil,
+		)
+		req.SetPathValue("slugID", "q-1")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 404 when quiz itself does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newService(stubGameStore{}, stubQuizStore{
+			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		})
+		handler := HandleGameForQuiz(logger, svc)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), 7), http.MethodGet,
+			"/api/quizzes/q-99/my-game", nil,
+		)
+		req.SetPathValue("slugID", "q-99")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 500 when player missing from context", func(t *testing.T) {
+		t.Parallel()
+
+		handler := HandleGameForQuiz(logger, newService(stubGameStore{}, stubQuizStore{}))
+
+		req := httptest.NewRequestWithContext(
+			t.Context(), http.MethodGet,
+			"/api/quizzes/q-1/my-game", nil,
+		)
+		req.SetPathValue("slugID", "q-1")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -120,6 +121,97 @@ func (q *Queries) CreateParticipant(ctx context.Context, arg CreateParticipantPa
 	return i, err
 }
 
+const deleteGameAnswersByGameIDs = `-- name: DeleteGameAnswersByGameIDs :exec
+DELETE
+FROM game_answers
+WHERE game_id IN (/*SLICE:game_ids*/?)
+`
+
+// Hard-deletes every game_answers row attached to the given game IDs. Used
+// by the player-on-quiz reset flow with the IDs gathered up front by
+// ListGameIDsForPlayerOnQuiz.
+func (q *Queries) DeleteGameAnswersByGameIDs(ctx context.Context, gameIds []string) error {
+	query := deleteGameAnswersByGameIDs
+	var queryParams []interface{}
+	if len(gameIds) > 0 {
+		for _, v := range gameIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", strings.Repeat(",?", len(gameIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
+const deleteGameParticipantsByGameIDs = `-- name: DeleteGameParticipantsByGameIDs :exec
+DELETE
+FROM game_participants
+WHERE game_id IN (/*SLICE:game_ids*/?)
+`
+
+// Hard-deletes every game_participants row attached to the given game IDs.
+func (q *Queries) DeleteGameParticipantsByGameIDs(ctx context.Context, gameIds []string) error {
+	query := deleteGameParticipantsByGameIDs
+	var queryParams []interface{}
+	if len(gameIds) > 0 {
+		for _, v := range gameIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", strings.Repeat(",?", len(gameIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
+const deleteGameQuestionsByGameIDs = `-- name: DeleteGameQuestionsByGameIDs :exec
+DELETE
+FROM game_questions
+WHERE game_id IN (/*SLICE:game_ids*/?)
+`
+
+// Hard-deletes every game_questions row attached to the given game IDs.
+func (q *Queries) DeleteGameQuestionsByGameIDs(ctx context.Context, gameIds []string) error {
+	query := deleteGameQuestionsByGameIDs
+	var queryParams []interface{}
+	if len(gameIds) > 0 {
+		for _, v := range gameIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", strings.Repeat(",?", len(gameIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:game_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
+const deleteGamesByIDs = `-- name: DeleteGamesByIDs :exec
+DELETE
+FROM games
+WHERE id IN (/*SLICE:ids*/?)
+`
+
+// Hard-deletes the given games themselves. Run last; the participant /
+// question / answer rows referencing these games have already been removed.
+func (q *Queries) DeleteGamesByIDs(ctx context.Context, ids []string) error {
+	query := deleteGamesByIDs
+	var queryParams []interface{}
+	if len(ids) > 0 {
+		for _, v := range ids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
 const getGame = `-- name: GetGame :one
 SELECT id, quiz_id, created_at, started_at
 FROM games
@@ -128,6 +220,37 @@ WHERE id = ?
 
 func (q *Queries) GetGame(ctx context.Context, id string) (Game, error) {
 	row := q.db.QueryRowContext(ctx, getGame, id)
+	var i Game
+	err := row.Scan(
+		&i.ID,
+		&i.QuizID,
+		&i.CreatedAt,
+		&i.StartedAt,
+	)
+	return i, err
+}
+
+const getGameByPlayerAndQuiz = `-- name: GetGameByPlayerAndQuiz :one
+SELECT g.id, g.quiz_id, g.created_at, g.started_at
+FROM games g
+         JOIN game_participants gp ON gp.game_id = g.id
+WHERE gp.player_id = ?
+  AND g.quiz_id = ?
+ORDER BY g.created_at DESC
+LIMIT 1
+`
+
+type GetGameByPlayerAndQuizParams struct {
+	PlayerID int64
+	QuizID   int64
+}
+
+// Returns the most-recent game for the given (player, quiz) pair. Used by the
+// player-side resume flow (GET /api/quizzes/{slugID}/my-game) and as a
+// defensive backstop in CreateGame so the same player cannot start a second
+// attempt at a quiz they have already played.
+func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlayerAndQuizParams) (Game, error) {
+	row := q.db.QueryRowContext(ctx, getGameByPlayerAndQuiz, arg.PlayerID, arg.QuizID)
 	var i Game
 	err := row.Scan(
 		&i.ID,
@@ -219,9 +342,9 @@ type ListAnswersForQuizLeaderboardRow struct {
 }
 
 // Selects the per-answer scoring inputs for every game of the given quiz.
-// The leaderboard service assumes one attempt per (player, quiz) (#145 covers
-// enforcement) and sums these rows per player; if multiple attempts ever leak
-// through, scores will be inflated until enforcement lands.
+// The leaderboard service sums these rows per player. The one-attempt-per-
+// (player, quiz) constraint enforced by #145 keeps the sum from
+// double-counting a re-played quiz.
 func (q *Queries) ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]ListAnswersForQuizLeaderboardRow, error) {
 	rows, err := q.db.QueryContext(ctx, listAnswersForQuizLeaderboard, quizID)
 	if err != nil {
@@ -242,6 +365,47 @@ func (q *Queries) ListAnswersForQuizLeaderboard(ctx context.Context, quizID int6
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGameIDsForPlayerOnQuiz = `-- name: ListGameIDsForPlayerOnQuiz :many
+SELECT g.id
+FROM games g
+         JOIN game_participants gp ON gp.game_id = g.id
+WHERE gp.player_id = ?
+  AND g.quiz_id = ?
+`
+
+type ListGameIDsForPlayerOnQuizParams struct {
+	PlayerID int64
+	QuizID   int64
+}
+
+// Lists every game ID the player has on the given quiz. The reset flow
+// collects these once at the start of the in-Go transaction and feeds them
+// into the dependent deletes; doing it that way avoids a delete-order
+// problem where each subsequent statement's subquery would see fewer rows
+// as we drained the dependency tables.
+func (q *Queries) ListGameIDsForPlayerOnQuiz(ctx context.Context, arg ListGameIDsForPlayerOnQuizParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listGameIDsForPlayerOnQuiz, arg.PlayerID, arg.QuizID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -20,12 +20,30 @@ const (
 	defaultLeaderboardLimit = 10
 )
 
-// ErrGameNotFound is returned when a game is not found.
 var (
-	ErrGameNotFound               = errors.New("game not found")
-	ErrNoMoreQuestions            = errors.New("no more questions")
-	ErrQuestionNotInGame          = errors.New("question not in game")
-	ErrOptionNotInQuestion        = errors.New("option does not belong to question")
+	// ErrGameNotFound is returned when a game lookup finds no matching row.
+	ErrGameNotFound = errors.New("game not found")
+
+	// ErrGameAlreadyExists is returned by [Service.CreateGame] when the
+	// player already has a game (in-progress or completed) for the quiz.
+	// Callers that need to render a "resume" affordance should call
+	// [Service.GetGameForPlayerOnQuiz] first.
+	ErrGameAlreadyExists = errors.New("game already exists for this player and quiz")
+
+	// ErrNoMoreQuestions is returned by [Service.GetNextQuestion] when
+	// every quiz question has already been issued for the game.
+	ErrNoMoreQuestions = errors.New("no more questions")
+
+	// ErrQuestionNotInGame is returned by [Service.SubmitAnswer] when the
+	// question being answered does not belong to the supplied game.
+	ErrQuestionNotInGame = errors.New("question not in game")
+
+	// ErrOptionNotInQuestion is returned by [Service.SubmitAnswer] when
+	// the option being submitted does not belong to the supplied question.
+	ErrOptionNotInQuestion = errors.New("option does not belong to question")
+
+	// ErrStartingGameNoRowsAffected is returned by [GameStore.StartGame]
+	// when the UPDATE matched no rows — i.e. the game does not exist.
 	ErrStartingGameNoRowsAffected = errors.New("no rows affected when starting game")
 )
 
@@ -96,7 +114,8 @@ type Results struct {
 // option's correctness, the question's start/expiry timestamps, and the
 // answer's submission time) plus the player's username and ID for the
 // leaderboard row. The leaderboard service assumes one attempt per
-// (player, quiz) — see #145 for the enforcement ticket.
+// (player, quiz); that constraint is enforced by [Service.CreateGame] and
+// the admin reset flow.
 type LeaderboardAnswer struct {
 	PlayerID          int64
 	Username          string
@@ -121,6 +140,11 @@ type Store interface {
 	// Ping returns the status of the database connection.
 	Ping(ctx context.Context) error
 	GetGame(ctx context.Context, id string) (*Game, error)
+	// GetGameByPlayerAndQuiz returns the most-recent game played by the
+	// given player on the given quiz, with [Game.Questions] populated so
+	// callers can call [Game.IsCompleted]. Returns [ErrGameNotFound] if
+	// the player has no game for the quiz.
+	GetGameByPlayerAndQuiz(ctx context.Context, playerID, quizID int64) (*Game, error)
 	// CreateGame creates a new game.
 	CreateGame(ctx context.Context, g *Game) error
 	StartGame(ctx context.Context, id string) error
@@ -131,6 +155,11 @@ type Store interface {
 	// given quiz, joined with the fields the Service needs to score each
 	// answer.
 	ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
+	// DeleteGamesForPlayerOnQuiz hard-deletes every game (and dependent
+	// rows) that belongs to the given player on the given quiz. No error
+	// when the player has no games for the quiz: the admin reset flow is
+	// idempotent.
+	DeleteGamesForPlayerOnQuiz(ctx context.Context, playerID, quizID int64) error
 }
 
 // Service represents a game service.
@@ -149,14 +178,43 @@ func NewService(gameStore Store, quizStore quiz.Store, logger *slog.Logger) *Ser
 	}
 }
 
+// IsCompleted reports whether the game has had every quiz question issued.
+// A question that was issued but never answered still counts as "asked"
+// because it has a [Question] row, matching [Service.GetNextQuestion]'s
+// existing semantics. Requires [Game.Quiz] to be populated; an unpopulated
+// Quiz returns false.
+func (g *Game) IsCompleted() bool {
+	if g.Quiz == nil {
+		return false
+	}
+
+	return len(g.Questions) >= len(g.Quiz.Questions) && len(g.Quiz.Questions) > 0
+}
+
 // CreateGame creates a new game with the specified quiz and player, linking the player and starting the game immediately.
 // Returns the newly created game or an error if the operation fails.
+//
+// Returns [ErrGameAlreadyExists] when the player already has a game for the
+// quiz (in-progress or completed). Callers that need to render a "resume"
+// affordance should call [Service.GetGameForPlayerOnQuiz] first; the
+// AlreadyExists error here is a defensive backstop, not the primary signal.
 func (s *Service) CreateGame(ctx context.Context, quizID, playerID int64) (*Game, error) {
 	var err error
 	// verify that the quiz exists
 	qz, err := s.quizStore.GetQuiz(ctx, quizID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quiz: %w", err)
+	}
+
+	// One-attempt-per-(player, quiz) enforcement. Checked here rather than
+	// at the DB level because the schema doesn't carry the constraint —
+	// see #145 for the design discussion.
+	existing, err := s.store.GetGameByPlayerAndQuiz(ctx, playerID, qz.ID)
+	if err != nil && !errors.Is(err, ErrGameNotFound) {
+		return nil, fmt.Errorf("failed to check existing game: %w", err)
+	}
+	if existing != nil {
+		return nil, ErrGameAlreadyExists
 	}
 
 	// Create the game record
@@ -179,6 +237,48 @@ func (s *Service) CreateGame(ctx context.Context, quizID, playerID int64) (*Game
 	}
 
 	return g, nil
+}
+
+// GetGameForPlayerOnQuiz returns the player's most-recent game for the given
+// quiz with [Game.Quiz] populated so callers can call [Game.IsCompleted].
+//
+// Returns [ErrGameNotFound] when the player has no game for the quiz, and
+// [quiz.ErrQuizNotFound] when the quiz itself does not exist.
+func (s *Service) GetGameForPlayerOnQuiz(ctx context.Context, playerID, quizID int64) (*Game, error) {
+	// Verify the quiz exists first so callers can map ErrQuizNotFound to
+	// a 404 distinct from "no game yet".
+	qz, err := s.quizStore.GetQuiz(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load quiz for player resume: %w", err)
+	}
+
+	g, err := s.store.GetGameByPlayerAndQuiz(ctx, playerID, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load game for player resume: %w", err)
+	}
+
+	g.Quiz = qz
+
+	return g, nil
+}
+
+// ResetGamesForPlayerOnQuiz hard-deletes every game (and dependent rows) the
+// given player has for the given quiz. The reset is idempotent: running it
+// against a (player, quiz) with no games is a no-op success so the admin
+// reset button can be pressed safely from any state.
+//
+// Returns [quiz.ErrQuizNotFound] when the quiz does not exist so the admin
+// route can map it to a 404.
+func (s *Service) ResetGamesForPlayerOnQuiz(ctx context.Context, playerID, quizID int64) error {
+	if _, err := s.quizStore.GetQuiz(ctx, quizID); err != nil {
+		return fmt.Errorf("failed to load quiz for reset: %w", err)
+	}
+
+	if err := s.store.DeleteGamesForPlayerOnQuiz(ctx, playerID, quizID); err != nil {
+		return fmt.Errorf("failed to delete games for player %d on quiz %d: %w", playerID, quizID, err)
+	}
+
+	return nil
 }
 
 // GetNextQuestion retrieves the next unanswered question for the specified game or returns nil if all are answered.
@@ -342,9 +442,8 @@ func (s *Service) GetResults(ctx context.Context, gameID string) (*Results, erro
 // [Service.GetResults].
 //
 // Assumes one attempt per (player, quiz): the service simply sums every
-// answer the player has on the quiz. Enforcement of that constraint is
-// tracked in #145; until it lands, a player who somehow has multiple
-// attempts will see the sum of all of them.
+// answer the player has on the quiz. The constraint is enforced by
+// [Service.CreateGame] together with the admin reset flow.
 //
 // Ordering: descending by score; ties are broken by ascending username for
 // determinism so a tied scoreboard is stable across requests.

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -20,15 +20,29 @@ var errStub = errors.New("stub error")
 
 // stubStore satisfies game.Store for service-level tests that do not need a
 // live database. Each behaviour is overridable per test via a func field; a
-// nil field returns errStub so accidental use surfaces loudly.
+// nil field returns errStub so accidental use surfaces loudly. The
+// getGameByPlayerAndQuiz field defaults to "not found" rather than errStub
+// so the existing CreateGame happy-path tests do not have to opt in.
 type stubStore struct {
 	listAnswersForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
+	getGameByPlayerAndQuiz        func(ctx context.Context, playerID, quizID int64) (*Game, error)
+	deleteGamesForPlayerOnQuiz    func(ctx context.Context, playerID, quizID int64) error
 }
 
 func (stubStore) Ping(_ context.Context) error { return nil }
 
 func (stubStore) GetGame(_ context.Context, _ string) (*Game, error) {
 	return nil, errStub
+}
+
+func (s stubStore) GetGameByPlayerAndQuiz(
+	ctx context.Context, playerID, quizID int64,
+) (*Game, error) {
+	if s.getGameByPlayerAndQuiz == nil {
+		return nil, ErrGameNotFound
+	}
+
+	return s.getGameByPlayerAndQuiz(ctx, playerID, quizID)
 }
 func (stubStore) CreateGame(_ context.Context, _ *Game) error               { return errStub }
 func (stubStore) StartGame(_ context.Context, _ string) error               { return errStub }
@@ -44,6 +58,16 @@ func (s stubStore) ListAnswersForQuizLeaderboard(
 	}
 
 	return s.listAnswersForQuizLeaderboard(ctx, quizID)
+}
+
+func (s stubStore) DeleteGamesForPlayerOnQuiz(
+	ctx context.Context, playerID, quizID int64,
+) error {
+	if s.deleteGamesForPlayerOnQuiz == nil {
+		return errStub
+	}
+
+	return s.deleteGamesForPlayerOnQuiz(ctx, playerID, quizID)
 }
 
 // stubQuizStore satisfies quiz.Store for service-level tests. Only GetQuiz is
@@ -128,6 +152,265 @@ func newTestGame(t *testing.T, qz *quiz.Quiz) *Game {
 	return &Game{
 		QuizID: qz.ID,
 	}
+}
+
+func TestGame_IsCompleted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("true when issued questions match quiz length", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Game{
+			Quiz: &quiz.Quiz{
+				Questions: []*quiz.Question{{ID: 1}, {ID: 2}},
+			},
+			Questions: []*Question{
+				{QuestionID: 1},
+				{QuestionID: 2},
+			},
+		}
+		if got, want := g.IsCompleted(), true; got != want {
+			t.Errorf("IsCompleted() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("false when fewer questions issued than quiz length", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Game{
+			Quiz: &quiz.Quiz{
+				Questions: []*quiz.Question{{ID: 1}, {ID: 2}, {ID: 3}},
+			},
+			Questions: []*Question{
+				{QuestionID: 1},
+			},
+		}
+		if got, want := g.IsCompleted(), false; got != want {
+			t.Errorf("IsCompleted() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("false when zero questions issued and quiz has some", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Game{
+			Quiz: &quiz.Quiz{
+				Questions: []*quiz.Question{{ID: 1}},
+			},
+		}
+		if got, want := g.IsCompleted(), false; got != want {
+			t.Errorf("IsCompleted() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("false when quiz is not populated", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Game{
+			Questions: []*Question{{QuestionID: 1}},
+		}
+		if got, want := g.IsCompleted(), false; got != want {
+			t.Errorf("IsCompleted() = %v, want %v (without Quiz the game cannot be known to be complete)", got, want)
+		}
+	})
+}
+
+func TestService_GetGameForPlayerOnQuiz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns existing game with quiz populated", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		const playerID = int64(1)
+		created, err := svc.CreateGame(ctx, testQuiz.ID, playerID)
+		if err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+
+		resumed, err := svc.GetGameForPlayerOnQuiz(ctx, playerID, testQuiz.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := resumed.ID, created.ID; got != want {
+			t.Errorf("resumed.ID = %q, want %q", got, want)
+		}
+		if resumed.Quiz == nil {
+			t.Fatal("resumed.Quiz is nil, want populated quiz")
+		}
+		if got, want := resumed.Quiz.ID, testQuiz.ID; got != want {
+			t.Errorf("resumed.Quiz.ID = %d, want %d", got, want)
+		}
+		// IsCompleted should work because Quiz is populated.
+		if got, want := resumed.IsCompleted(), false; got != want {
+			t.Errorf("IsCompleted() = %v, want %v (no questions issued yet)", got, want)
+		}
+	})
+
+	t.Run("returns ErrGameNotFound when player has no game", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		_, err := svc.GetGameForPlayerOnQuiz(ctx, 999, testQuiz.ID)
+		if got, want := err, ErrGameNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns ErrQuizNotFound when quiz missing", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(stubStore{}, stubQuizStore{
+			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		}, slog.New(slog.DiscardHandler))
+
+		_, err := svc.GetGameForPlayerOnQuiz(t.Context(), 1, 999)
+		if got, want := err, quiz.ErrQuizNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestService_CreateGame_RejectsSecondAttempt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	db := dbtest.Open(t)
+
+	quizStore := store.NewQuizStore(db, slog.Default())
+	gameStore := store.NewGameStore(db, slog.Default())
+
+	testQuiz := newTestQuiz(t)
+	if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+		t.Fatalf("failed to create quiz: %v", err)
+	}
+
+	svc := NewService(gameStore, quizStore, slog.Default())
+
+	const playerID = int64(1)
+	if _, err := svc.CreateGame(ctx, testQuiz.ID, playerID); err != nil {
+		t.Fatalf("failed to create initial game: %v", err)
+	}
+
+	// Second attempt for the same (player, quiz) must be rejected.
+	_, err := svc.CreateGame(ctx, testQuiz.ID, playerID)
+	if got, want := err, ErrGameAlreadyExists; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestService_ResetGamesForPlayerOnQuiz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reset clears existing game and lets a fresh CreateGame succeed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		const playerID = int64(1)
+		if _, err := svc.CreateGame(ctx, testQuiz.ID, playerID); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+
+		// Sanity check: GetGameForPlayerOnQuiz finds the game first.
+		if _, err := svc.GetGameForPlayerOnQuiz(ctx, playerID, testQuiz.ID); err != nil {
+			t.Fatalf("expected game to exist before reset: %v", err)
+		}
+
+		if err := svc.ResetGamesForPlayerOnQuiz(ctx, playerID, testQuiz.ID); err != nil {
+			t.Fatalf("ResetGamesForPlayerOnQuiz err = %v, want nil", err)
+		}
+
+		_, err := svc.GetGameForPlayerOnQuiz(ctx, playerID, testQuiz.ID)
+		if got, want := err, ErrGameNotFound; !errors.Is(got, want) {
+			t.Errorf("after reset, err = %v, want %v", got, want)
+		}
+
+		if _, err = svc.CreateGame(ctx, testQuiz.ID, playerID); err != nil {
+			t.Errorf("CreateGame after reset err = %v, want nil", err)
+		}
+	})
+
+	t.Run("idempotent — calling reset twice is fine", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		const playerID = int64(1)
+		if _, err := svc.CreateGame(ctx, testQuiz.ID, playerID); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+
+		if err := svc.ResetGamesForPlayerOnQuiz(ctx, playerID, testQuiz.ID); err != nil {
+			t.Fatalf("first reset err = %v, want nil", err)
+		}
+		if err := svc.ResetGamesForPlayerOnQuiz(ctx, playerID, testQuiz.ID); err != nil {
+			t.Errorf("second reset err = %v, want nil (reset must be idempotent)", err)
+		}
+	})
+
+	t.Run("returns ErrQuizNotFound when quiz missing", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(stubStore{}, stubQuizStore{
+			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
+				return nil, quiz.ErrQuizNotFound
+			},
+		}, slog.New(slog.DiscardHandler))
+
+		err := svc.ResetGamesForPlayerOnQuiz(t.Context(), 1, 999)
+		if got, want := err, quiz.ErrQuizNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
 }
 
 func TestService_SubmitAnswer(t *testing.T) {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -56,6 +56,10 @@ func (*stubGameStore) Ping(_ context.Context) error { return nil }
 func (*stubGameStore) GetGame(_ context.Context, _ string) (*game.Game, error) {
 	return nil, errors.ErrUnsupported
 }
+
+func (*stubGameStore) GetGameByPlayerAndQuiz(_ context.Context, _, _ int64) (*game.Game, error) {
+	return nil, errors.ErrUnsupported
+}
 func (*stubGameStore) CreateGame(_ context.Context, _ *game.Game) error               { return nil }
 func (*stubGameStore) StartGame(_ context.Context, _ string) error                    { return nil }
 func (*stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) error { return nil }
@@ -65,6 +69,10 @@ func (*stubGameStore) ListAnswersForQuizLeaderboard(
 	_ context.Context, _ int64,
 ) ([]*game.LeaderboardAnswer, error) {
 	return nil, nil
+}
+
+func (*stubGameStore) DeleteGamesForPlayerOnQuiz(_ context.Context, _, _ int64) error {
+	return nil
 }
 
 func TestHandleHealthz(t *testing.T) {

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -50,9 +50,9 @@ RETURNING *;
 
 -- name: ListAnswersForQuizLeaderboard :many
 -- Selects the per-answer scoring inputs for every game of the given quiz.
--- The leaderboard service assumes one attempt per (player, quiz) (#145 covers
--- enforcement) and sums these rows per player; if multiple attempts ever leak
--- through, scores will be inflated until enforcement lands.
+-- The leaderboard service sums these rows per player. The one-attempt-per-
+-- (player, quiz) constraint enforced by #145 keeps the sum from
+-- double-counting a re-played quiz.
 SELECT ga.player_id        AS player_id,
        p.username           AS username,
        gq.started_at        AS question_started_at,
@@ -65,3 +65,55 @@ FROM game_answers ga
          JOIN options o ON o.id = ga.option_id
          JOIN players p ON p.id = ga.player_id
 WHERE g.quiz_id = ?;
+
+-- name: GetGameByPlayerAndQuiz :one
+-- Returns the most-recent game for the given (player, quiz) pair. Used by the
+-- player-side resume flow (GET /api/quizzes/{slugID}/my-game) and as a
+-- defensive backstop in CreateGame so the same player cannot start a second
+-- attempt at a quiz they have already played.
+SELECT g.id, g.quiz_id, g.created_at, g.started_at
+FROM games g
+         JOIN game_participants gp ON gp.game_id = g.id
+WHERE gp.player_id = ?
+  AND g.quiz_id = ?
+ORDER BY g.created_at DESC
+LIMIT 1;
+
+-- name: ListGameIDsForPlayerOnQuiz :many
+-- Lists every game ID the player has on the given quiz. The reset flow
+-- collects these once at the start of the in-Go transaction and feeds them
+-- into the dependent deletes; doing it that way avoids a delete-order
+-- problem where each subsequent statement's subquery would see fewer rows
+-- as we drained the dependency tables.
+SELECT g.id
+FROM games g
+         JOIN game_participants gp ON gp.game_id = g.id
+WHERE gp.player_id = ?
+  AND g.quiz_id = ?;
+
+-- name: DeleteGameAnswersByGameIDs :exec
+-- Hard-deletes every game_answers row attached to the given game IDs. Used
+-- by the player-on-quiz reset flow with the IDs gathered up front by
+-- ListGameIDsForPlayerOnQuiz.
+DELETE
+FROM game_answers
+WHERE game_id IN (sqlc.slice('game_ids'));
+
+-- name: DeleteGameQuestionsByGameIDs :exec
+-- Hard-deletes every game_questions row attached to the given game IDs.
+DELETE
+FROM game_questions
+WHERE game_id IN (sqlc.slice('game_ids'));
+
+-- name: DeleteGameParticipantsByGameIDs :exec
+-- Hard-deletes every game_participants row attached to the given game IDs.
+DELETE
+FROM game_participants
+WHERE game_id IN (sqlc.slice('game_ids'));
+
+-- name: DeleteGamesByIDs :exec
+-- Hard-deletes the given games themselves. Run last; the participant /
+-- question / answer rows referencing these games have already been removed.
+DELETE
+FROM games
+WHERE id IN (sqlc.slice('ids'));

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,7 +27,7 @@ func addRoutes(
 	csrfMgr := csrf.New([]byte(cfg.SessionKey))
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
-	addAdminRoutes(mux, logger, stores, sessions, csrfMgr)
+	addAdminRoutes(mux, logger, stores, gameService, sessions, csrfMgr)
 	addAPIRoutes(mux, logger, stores, gameService, sessions)
 
 	// Client
@@ -79,6 +79,7 @@ func addAdminRoutes(
 	mux *http.ServeMux,
 	logger *slog.Logger,
 	stores *store.Stores,
+	gameService *game.Service,
 	sessions *session.Manager,
 	csrfMgr *csrf.Manager,
 ) {
@@ -89,7 +90,10 @@ func addAdminRoutes(
 
 	mux.Handle("GET /admin", requireAdmin(admin.HandleIndex(logger, csrfMgr)))
 	mux.Handle("GET /admin/quizzes", requireAdmin(admin.HandleQuizList(logger, csrfMgr, stores.Quizzes)))
-	mux.Handle("GET /admin/quizzes/{quizID}", requireAdmin(admin.HandleQuizView(logger, csrfMgr, stores.Quizzes)))
+	mux.Handle(
+		"GET /admin/quizzes/{quizID}",
+		requireAdmin(admin.HandleQuizView(logger, csrfMgr, stores.Quizzes, gameService)),
+	)
 	mux.Handle("GET /admin/quizzes/new", requireAdmin(admin.HandleQuizCreate(logger, csrfMgr)))
 	mux.Handle("POST /admin/quizzes", csrfMW(requireAdmin(admin.HandleQuizSave(logger, csrfMgr, stores.Quizzes))))
 	mux.Handle(
@@ -103,6 +107,10 @@ func addAdminRoutes(
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/delete",
 		csrfMW(requireAdmin(admin.HandleQuizDelete(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/players/{playerID}/reset",
+		csrfMW(requireAdmin(admin.HandleResetGameForPlayer(logger, csrfMgr, gameService))),
 	)
 	mux.Handle(
 		"GET /admin/quizzes/{quizID}/questions/new",
@@ -153,6 +161,10 @@ func addAPIRoutes(
 	mux.Handle(
 		"GET /api/quizzes/{slugID}/leaderboard",
 		ensurePlayer(clientapi.HandleQuizLeaderboard(logger, gameService)),
+	)
+	mux.Handle(
+		"GET /api/quizzes/{slugID}/my-game",
+		ensurePlayer(clientapi.HandleGameForQuiz(logger, gameService)),
 	)
 	mux.Handle("POST /api/games", ensurePlayer(clientapi.HandleCreateGame(logger, gameService)))
 	mux.Handle(

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -129,6 +129,10 @@ func (stubGameStore) GetGame(_ context.Context, _ string) (*game.Game, error) {
 	return nil, errRouteStub
 }
 
+func (stubGameStore) GetGameByPlayerAndQuiz(_ context.Context, _, _ int64) (*game.Game, error) {
+	return nil, game.ErrGameNotFound
+}
+
 func (stubGameStore) CreateGame(_ context.Context, _ *game.Game) error { return errRouteStub }
 func (stubGameStore) StartGame(_ context.Context, _ string) error      { return errRouteStub }
 func (stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) error {
@@ -140,6 +144,10 @@ func (stubGameStore) ListAnswersForQuizLeaderboard(
 	_ context.Context, _ int64,
 ) ([]*game.LeaderboardAnswer, error) {
 	return nil, nil
+}
+
+func (stubGameStore) DeleteGamesForPlayerOnQuiz(_ context.Context, _, _ int64) error {
+	return nil
 }
 
 func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
@@ -164,10 +172,12 @@ func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
 		{name: "Admin Quiz View", method: http.MethodGet, path: "/admin/quizzes/1"},
 		{name: "Admin Quiz Create", method: http.MethodGet, path: "/admin/quizzes/new"},
 		{name: "Admin Quiz Edit", method: http.MethodGet, path: "/admin/quizzes/1/edit"},
+		{name: "Admin Reset Player", method: http.MethodPost, path: "/admin/quizzes/1/players/2/reset"},
 
 		{name: "API Quiz List", method: http.MethodGet, path: "/api/quizzes"},
 		{name: "API Quiz Get", method: http.MethodGet, path: "/api/quizzes/1"},
 		{name: "API Quiz Leaderboard", method: http.MethodGet, path: "/api/quizzes/quiz-1/leaderboard"},
+		{name: "API Quiz My Game", method: http.MethodGet, path: "/api/quizzes/quiz-1/my-game"},
 
 		{name: "API Game Create", method: http.MethodPost, path: "/api/games"},
 		{name: "API Question Next", method: http.MethodGet, path: "/api/games/game-1/questions/next"},

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -72,6 +72,41 @@ func (s *GameStore) GetGame(ctx context.Context, id string) (*game.Game, error) 
 	return g, nil
 }
 
+// GetGameByPlayerAndQuiz returns the most-recent game for the given (player,
+// quiz) pair, with Questions populated so callers can call IsCompleted once
+// they wire the Quiz onto the returned game.
+// Returns [game.ErrGameNotFound] if the player has no game for the quiz.
+func (s *GameStore) GetGameByPlayerAndQuiz(ctx context.Context, playerID, quizID int64) (*game.Game, error) {
+	row, err := s.q.GetGameByPlayerAndQuiz(ctx, db.GetGameByPlayerAndQuizParams{
+		PlayerID: playerID,
+		QuizID:   quizID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, game.ErrGameNotFound
+		}
+
+		return nil, fmt.Errorf("failed to get game by player %d and quiz %d: %w", playerID, quizID, err)
+	}
+
+	g := &game.Game{
+		ID:        row.ID,
+		QuizID:    row.QuizID,
+		CreatedAt: row.CreatedAt,
+	}
+
+	if row.StartedAt.Valid {
+		g.StartedAt = &row.StartedAt.Time
+	}
+
+	g.Questions, err = s.listGameQuestions(ctx, g.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list game questions for game %q: %w", g.ID, err)
+	}
+
+	return g, nil
+}
+
 // CreateGame creates a new game record in the database using the provided game details and updates the game with generated data.
 func (s *GameStore) CreateGame(ctx context.Context, g *game.Game) error {
 	var err error
@@ -155,6 +190,39 @@ func (s *GameStore) CreateAnswer(ctx context.Context, a *game.Answer) error {
 	return nil
 }
 
+// DeleteGamesForPlayerOnQuiz hard-deletes every game (and its dependent
+// participants, questions, and answers) the given player has on the given
+// quiz. The four statements run inside a single transaction; rollback on
+// any error so a partial reset never leaves orphans behind.
+//
+// The IDs are gathered up front because the per-statement subqueries we
+// would otherwise need to scope each DELETE rely on rows that earlier
+// statements have already removed (e.g. the games delete needs participants
+// to scope, but participants are gone by then). Snapshotting the IDs once
+// sidesteps that ordering puzzle entirely.
+//
+// No-op if the player has no games for the quiz.
+func (s *GameStore) DeleteGamesForPlayerOnQuiz(ctx context.Context, playerID, quizID int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	if err = s.deleteGamesForPlayerOnQuizTx(ctx, tx, playerID, quizID); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			return fmt.Errorf("delete games failed: %w (rollback error: %w)", err, rbErr)
+		}
+
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit reset transaction: %w", err)
+	}
+
+	return nil
+}
+
 // ListAnswersForQuizLeaderboard returns one flat row per game answer across
 // every game of the given quiz. The rows carry just enough fields for
 // [game.Service.GetQuizLeaderboard] to reuse [game.Service.CalculateScore]
@@ -180,6 +248,39 @@ func (s *GameStore) ListAnswersForQuizLeaderboard(
 	}
 
 	return answers, nil
+}
+
+func (s *GameStore) deleteGamesForPlayerOnQuizTx(
+	ctx context.Context, tx *sql.Tx, playerID, quizID int64,
+) error {
+	q := s.q.WithTx(tx)
+
+	gameIDs, err := q.ListGameIDsForPlayerOnQuiz(ctx, db.ListGameIDsForPlayerOnQuizParams{
+		PlayerID: playerID,
+		QuizID:   quizID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list game IDs for player %d on quiz %d: %w", playerID, quizID, err)
+	}
+
+	if len(gameIDs) == 0 {
+		return nil
+	}
+
+	if err = q.DeleteGameAnswersByGameIDs(ctx, gameIDs); err != nil {
+		return fmt.Errorf("failed to delete answers: %w", err)
+	}
+	if err = q.DeleteGameQuestionsByGameIDs(ctx, gameIDs); err != nil {
+		return fmt.Errorf("failed to delete questions: %w", err)
+	}
+	if err = q.DeleteGameParticipantsByGameIDs(ctx, gameIDs); err != nil {
+		return fmt.Errorf("failed to delete participants: %w", err)
+	}
+	if err = q.DeleteGamesByIDs(ctx, gameIDs); err != nil {
+		return fmt.Errorf("failed to delete games: %w", err)
+	}
+
+	return nil
 }
 
 func (s *GameStore) listGameQuestions(ctx context.Context, gameID string) ([]*game.Question, error) {

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -85,15 +85,15 @@ func TestGameStore_GetGame(t *testing.T) {
 			t.Fatalf("failed to create game: %v", err)
 		}
 
-		got, err := gameStore.GetGame(t.Context(), g.ID)
+		fetched, err := gameStore.GetGame(t.Context(), g.ID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got.ID != g.ID {
-			t.Errorf("got.ID = %q, want %q", got.ID, g.ID)
+		if got, want := fetched.ID, g.ID; got != want {
+			t.Errorf("fetched.ID = %q, want %q", got, want)
 		}
-		if got, want := got.QuizID, testQuiz.ID; got != want {
-			t.Errorf("got.QuizID = %d, want %d", got, want)
+		if got, want := fetched.QuizID, testQuiz.ID; got != want {
+			t.Errorf("fetched.QuizID = %d, want %d", got, want)
 		}
 	})
 
@@ -257,6 +257,204 @@ func TestGameStore_CreateAnswer(t *testing.T) {
 		}
 		if a.AnsweredAt.IsZero() {
 			t.Error("a.AnsweredAt is zero, want non-zero time")
+		}
+	})
+}
+
+func TestGameStore_GetGameByPlayerAndQuiz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns ErrGameNotFound when player has no game", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		_, err := gameStore.GetGameByPlayerAndQuiz(t.Context(), 99, testQuiz.ID)
+		if got, want := err, game.ErrGameNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns the most-recent game for the player and quiz", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-resume-1")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+
+		existing, err := gameStore.GetGameByPlayerAndQuiz(t.Context(), player.ID, testQuiz.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := existing.ID, g.ID; got != want {
+			t.Errorf("existing.ID = %q, want %q", got, want)
+		}
+		if got, want := existing.QuizID, testQuiz.ID; got != want {
+			t.Errorf("existing.QuizID = %d, want %d", got, want)
+		}
+	})
+}
+
+func TestGameStore_DeleteGamesForPlayerOnQuiz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes games and dependent rows for the player", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-reset-1")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+
+		now := time.Now().UTC().Truncate(time.Second)
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer: %v", err)
+		}
+
+		if err = gameStore.DeleteGamesForPlayerOnQuiz(t.Context(), player.ID, testQuiz.ID); err != nil {
+			t.Fatalf("DeleteGamesForPlayerOnQuiz err = %v, want nil", err)
+		}
+
+		// All four tables for this game should be empty.
+		assertCount := func(label, sqlStr string, want int) {
+			t.Helper()
+			row := db.QueryRowContext(t.Context(), sqlStr, g.ID)
+			var got int
+			if scanErr := row.Scan(&got); scanErr != nil {
+				t.Fatalf("scan %s err = %v", label, scanErr)
+			}
+			if got != want {
+				t.Errorf("%s count = %d, want %d", label, got, want)
+			}
+		}
+		assertCount("game_answers", `SELECT COUNT(*) FROM game_answers WHERE game_id = ?`, 0)
+		assertCount("game_questions", `SELECT COUNT(*) FROM game_questions WHERE game_id = ?`, 0)
+		assertCount("game_participants", `SELECT COUNT(*) FROM game_participants WHERE game_id = ?`, 0)
+		assertCount("games", `SELECT COUNT(*) FROM games WHERE id = ?`, 0)
+	})
+
+	t.Run("no-op when player has no games for the quiz", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		if err := gameStore.DeleteGamesForPlayerOnQuiz(t.Context(), 999, testQuiz.ID); err != nil {
+			t.Errorf("DeleteGamesForPlayerOnQuiz err = %v, want nil (no rows means no error)", err)
+		}
+	})
+
+	t.Run("does not touch other players' games on the same quiz", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		victim, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-reset-victim")
+		if err != nil {
+			t.Fatalf("failed to create victim player: %v", err)
+		}
+		bystander, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-reset-bystander")
+		if err != nil {
+			t.Fatalf("failed to create bystander player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		victimGame := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), victimGame); err != nil {
+			t.Fatalf("failed to create victim game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: victimGame.ID, PlayerID: victim.ID},
+		); err != nil {
+			t.Fatalf("failed to create victim participant: %v", err)
+		}
+
+		bystanderGame := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), bystanderGame); err != nil {
+			t.Fatalf("failed to create bystander game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: bystanderGame.ID, PlayerID: bystander.ID},
+		); err != nil {
+			t.Fatalf("failed to create bystander participant: %v", err)
+		}
+
+		if err = gameStore.DeleteGamesForPlayerOnQuiz(t.Context(), victim.ID, testQuiz.ID); err != nil {
+			t.Fatalf("DeleteGamesForPlayerOnQuiz err = %v, want nil", err)
+		}
+
+		// Bystander's game must still exist.
+		if _, err = gameStore.GetGame(t.Context(), bystanderGame.ID); err != nil {
+			t.Errorf("bystander game lookup err = %v, want nil", err)
 		}
 	})
 }

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -137,6 +137,61 @@
                     <span>Add question</span>
                 </span>
             </a>
+
+            <h4 class="subtitle is-4 mt-5">Played by</h4>
+            {{if .Players}}
+                <table class="table is-striped is-fullwidth">
+                    <thead>
+                    <tr>
+                        <th>Player</th>
+                        <th>Score</th>
+                        <th>Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {{range .Players}}
+                        <tr>
+                            <td>{{.Username}}</td>
+                            <td>{{.Score}}</td>
+                            <td>
+                                <a href="#" onclick="openModal('modal-reset-player-{{.PlayerID}}'); return false;">
+                                    <span class="icon-text has-text-warning">
+                                        <span class="icon"><i class="fas fa-rotate-left"></i></span>
+                                        <span>Reset</span>
+                                    </span>
+                                </a>
+                            </td>
+                        </tr>
+                    {{end}}
+                    </tbody>
+                </table>
+
+                {{range .Players}}
+                    <div class="modal" id="modal-reset-player-{{.PlayerID}}">
+                        <div class="modal-background" onclick="closeModal('modal-reset-player-{{.PlayerID}}')"></div>
+                        <div class="modal-card">
+                            <header class="modal-card-head">
+                                <p class="modal-card-title">Reset Quiz Attempt</p>
+                                <button class="delete" aria-label="close" onclick="closeModal('modal-reset-player-{{.PlayerID}}')"></button>
+                            </header>
+                            <section class="modal-card-body">
+                                Are you sure you want to reset <strong>&#34;{{.Username}}&#34;</strong>'s attempt? Their game and all answers will be deleted, and they will be able to play this quiz again. This action cannot be undone.
+                            </section>
+                            <footer class="modal-card-foot">
+                                <div class="buttons">
+                                    <form method="post" action="/admin/quizzes/{{$.Quiz.ID}}/players/{{.PlayerID}}/reset">
+                                        <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                                        <button class="button is-warning" type="submit">Reset</button>
+                                    </form>
+                                    <button class="button" onclick="closeModal('modal-reset-player-{{.PlayerID}}')">Cancel</button>
+                                </div>
+                            </footer>
+                        </div>
+                    </div>
+                {{end}}
+            {{else}}
+                <p>No plays yet.</p>
+            {{end}}
         {{else}}
             <p>Quiz not found!</p>
         {{end}}

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -127,7 +127,13 @@ func TestAnonymous_Integration(t *testing.T) {
 		t.Errorf("[scenario 1] anonymous players added = %d, want %d", got, want)
 	}
 
-	// Scenario 2: second request from same client reuses the existing row.
+	// Scenario 2: a request that goes through EnsurePlayer reuses the
+	// existing row when the cookie jar is reused. Creating a game and
+	// then issuing a follow-up GET /api/quizzes (also wrapped in
+	// EnsurePlayer) exercises the reuse path. We can't repeat
+	// POST /api/games for the same player + quiz any more — #145
+	// enforces one attempt per (player, quiz) — so this scenario tests
+	// reuse via the safer GET route.
 	jar2, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("cookiejar.New err = %v, want nil", err)
@@ -136,7 +142,8 @@ func TestAnonymous_Integration(t *testing.T) {
 
 	startCount = countAnonymousPlayers(ctx, t, dbConn)
 	_, _ = postCreateGame(ctx, t, client2, baseURL, qz.ID)
-	_, _ = postCreateGame(ctx, t, client2, baseURL, qz.ID)
+	fetchAPIQuizzes(ctx, t, client2, baseURL)
+	fetchAPIQuizzes(ctx, t, client2, baseURL)
 	if got, want := countAnonymousPlayers(ctx, t, dbConn)-startCount, 1; got != want {
 		t.Errorf("[scenario 2] anonymous players added = %d, want %d (jar should reuse row)", got, want)
 	}
@@ -214,6 +221,31 @@ func postCreateGame(
 	}
 
 	return out.ID, hadSessionCookie
+}
+
+// fetchAPIQuizzes issues GET /api/quizzes through the supplied client. The
+// route is wrapped in EnsurePlayer so calling it on a cookie-bearing client
+// exercises the player-row reuse path without creating a game (which the
+// new one-attempt-per-quiz rule would block on the second call).
+func fetchAPIQuizzes(ctx context.Context, t *testing.T, client *http.Client, baseURL string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/quizzes", nil)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+	}()
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("GET /api/quizzes status = %d, want %d", got, want)
+	}
 }
 
 // countAnonymousPlayers returns the number of rows with NULL password_hash.

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -27,9 +28,9 @@ import (
 
 // httpGet issues a GET with a request-scoped context so the noctx linter is
 // happy and the request gets cancelled when the test ends.
-func httpGet(ctx context.Context, t *testing.T, client *http.Client, url string) *http.Response {
+func httpGet(ctx context.Context, t *testing.T, client *http.Client, target string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		t.Fatalf("NewRequest err = %v, want nil", err)
 	}
@@ -42,9 +43,9 @@ func httpGet(ctx context.Context, t *testing.T, client *http.Client, url string)
 }
 
 // httpPostJSON issues a POST with a JSON body and a request-scoped context.
-func httpPostJSON(ctx context.Context, t *testing.T, client *http.Client, url, body string) *http.Response {
+func httpPostJSON(ctx context.Context, t *testing.T, client *http.Client, target, body string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest err = %v, want nil", err)
 	}
@@ -100,6 +101,78 @@ type leaderboardRes struct {
 	Entries []leaderboardEntryRes `json:"entries"`
 }
 
+// registerAdminAndResetPlayer registers a fresh admin via the public
+// /register form (the first password-bearing registrant becomes admin),
+// then POSTs to /admin/quizzes/{quizID}/players/{playerID}/reset with a
+// freshly-fetched CSRF token. Used by the gameplay test to exercise the
+// admin reset path end-to-end after a player has finished a quiz.
+func registerAdminAndResetPlayer(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL string, quizID, playerID int64,
+) {
+	t.Helper()
+
+	// Step 1: GET /register to seed the CSRF nonce on the jar and pull
+	// the matching hidden token out of the form.
+	registerToken := fetchCSRFToken(ctx, t, client, baseURL+"/register")
+
+	registerForm := url.Values{}
+	registerForm.Add("username", "gameplay-admin")
+	registerForm.Add("password", "gameplay-admin-pass-123")
+	registerForm.Add("csrf_token", registerToken)
+
+	registerReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, baseURL+"/register",
+		strings.NewReader(registerForm.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("failed to build register request: %v", err)
+	}
+	registerReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	registerResp, err := client.Do(registerReq)
+	if err != nil {
+		t.Fatalf("failed to register: %v", err)
+	}
+	if got, want := registerResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("register status = %d, want %d", got, want)
+	}
+	if cerr := registerResp.Body.Close(); cerr != nil {
+		t.Errorf("register body close err = %v", cerr)
+	}
+
+	// Step 2: GET the quiz view to receive a CSRF token tied to the
+	// admin session jar.
+	quizViewURL := fmt.Sprintf("%s/admin/quizzes/%d", baseURL, quizID)
+	resetToken := fetchCSRFToken(ctx, t, client, quizViewURL)
+
+	resetForm := url.Values{}
+	resetForm.Add("csrf_token", resetToken)
+
+	resetURL := fmt.Sprintf("%s/admin/quizzes/%d/players/%d/reset", baseURL, quizID, playerID)
+	resetReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, resetURL, strings.NewReader(resetForm.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("failed to build reset request: %v", err)
+	}
+	resetReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resetResp, err := client.Do(resetReq)
+	if err != nil {
+		t.Fatalf("failed to POST admin reset: %v", err)
+	}
+	defer func() {
+		if cerr := resetResp.Body.Close(); cerr != nil {
+			t.Errorf("reset body close err = %v", cerr)
+		}
+	}()
+	if got, want := resetResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("admin reset status = %d, want %d", got, want)
+	}
+	wantLocation := fmt.Sprintf("/admin/quizzes/%d", quizID)
+	if got, want := resetResp.Header.Get("Location"), wantLocation; got != want {
+		t.Errorf("admin reset Location = %q, want %q", got, want)
+	}
+}
+
 // integrationSetup bundles the artefacts a gameplay-style integration test
 // needs. Context is intentionally returned separately from the struct (passed
 // out of setupIntegration as the first return value) to avoid containedctx.
@@ -124,9 +197,14 @@ func setupIntegration(t *testing.T) (context.Context, integrationSetup) {
 
 	getenv := func(key string) string {
 		env := map[string]string{
-			"HOST":   "localhost",
-			"PORT":   "0", // Let the OS choose an available port
-			"DB_URI": dbURI,
+			"HOST": "localhost",
+			"PORT": "0", // Let the OS choose an available port
+			// REGISTRATION_ENABLED=true so the admin-reset portion of the
+			// gameplay test can register the first user (which becomes the
+			// admin) and POST to /admin/quizzes/.../reset. The first
+			// registered user is the admin per the existing auth flow.
+			"REGISTRATION_ENABLED": "true",
+			"DB_URI":               dbURI,
 		}
 
 		return env[key]
@@ -417,6 +495,91 @@ func TestGameplay_Integration(t *testing.T) {
 	}
 	if got := leaderboard.Entries[0].PlayerID; got <= 0 {
 		t.Errorf("leaderboard.Entries[0].PlayerID = %d, want > 0", got)
+	}
+	completedPlayerID := leaderboard.Entries[0].PlayerID
+
+	// One-attempt-per-quiz: GET /my-game now reports the finished game
+	// with completed=true.
+	myGameURL := fmt.Sprintf("%s/api/quizzes/%s-%d/my-game", baseURL, qz.Slug, qz.ID)
+	resp = httpGet(ctx, t, client, myGameURL)
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("GET /my-game status = %d, want %d", got, want)
+	}
+
+	var myGameRes struct {
+		GameID    string `json:"gameId"`
+		Completed bool   `json:"completed"`
+	}
+	if derr := json.NewDecoder(resp.Body).Decode(&myGameRes); derr != nil {
+		t.Fatalf("failed to decode my-game response: %v", derr)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+	if got, want := myGameRes.GameID, gameID; got != want {
+		t.Errorf("my-game GameID = %q, want %q", got, want)
+	}
+	if got, want := myGameRes.Completed, true; got != want {
+		t.Errorf("my-game Completed = %v, want %v", got, want)
+	}
+
+	// A second POST /api/games for the same player + quiz must be
+	// rejected with 409 — the frontend should have called my-game first.
+	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
+	if got, want := resp.StatusCode, http.StatusConflict; got != want {
+		t.Fatalf("second create game status = %d, want %d", got, want)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	// Admin reset (drive via the HTTP route, with CSRF token from the
+	// admin form). Use a separate jar / client so the admin's own session
+	// does not interfere with the player flow above.
+	adminClient := &http.Client{
+		Jar: func() *cookiejar.Jar {
+			j, jerr := cookiejar.New(nil)
+			if jerr != nil {
+				t.Fatalf("failed to create admin cookie jar: %v", jerr)
+			}
+
+			return j
+		}(),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	registerAdminAndResetPlayer(ctx, t, adminClient, baseURL, qz.ID, completedPlayerID)
+
+	// After reset, GET /my-game returns 404 — no game for this (player, quiz).
+	resp = httpGet(ctx, t, client, myGameURL)
+	if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+		t.Fatalf("after reset, GET /my-game status = %d, want %d", got, want)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	// And the player can now POST /api/games again to start fresh.
+	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
+	if got, want := resp.StatusCode, http.StatusCreated; got != want {
+		t.Fatalf("after reset, create game status = %d, want %d", got, want)
+	}
+
+	var freshGameRes struct {
+		ID string `json:"id"`
+	}
+	if derr := json.NewDecoder(resp.Body).Decode(&freshGameRes); derr != nil {
+		t.Fatalf("failed to decode fresh create-game response: %v", derr)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+	if got := freshGameRes.ID; got == "" {
+		t.Error("fresh game ID is empty, want non-empty")
+	}
+	if freshGameRes.ID == gameID {
+		t.Errorf("fresh game ID %q equals old game ID %q, want a new ID", freshGameRes.ID, gameID)
 	}
 
 	// Shutdown server


### PR DESCRIPTION
## Summary

- Two new player-side endpoints: `GET /api/quizzes/{slugID}/my-game` returns the player's existing game (with a `completed` flag) or 404 — used by the frontend as a resume probe before deciding to create. `POST /api/games` now 409s if the player already has a game for that quiz, as a defensive backstop.
- Frontend `GameApp.startGame` GETs the resume endpoint first: resumes the in-progress game when one exists, falls back to `POST /api/games` otherwise, and surfaces a Bulma `notification is-danger` when the player has already completed the quiz (no fresh start until an admin resets).
- New admin route `POST /admin/quizzes/{quizID}/players/{playerID}/reset` (CSRF + admin-guarded), reachable from a new "Played by" section on the quiz admin page. Each row has a Reset button that opens a Bulma confirmation modal mirroring the existing delete-quiz / delete-question pattern. Reset hard-deletes the player's games, game_questions, game_answers, and game_participants for that quiz, in a single Go transaction (no `ON DELETE CASCADE` migration — SQLite would force a table rebuild).
- New service surface: `Service.GetGameForPlayerOnQuiz`, `Service.ResetGamesForPlayerOnQuiz`, `(*Game).IsCompleted`, `ErrGameAlreadyExists`. `Service.CreateGame` now defends against duplicate creation.
- Drops the "if multiple attempts ever leak through" caveats from #146 — the constraint is now enforced.
- Closes #145.

## Test plan

- [x] `make lint-fix` clean
- [x] `make check` green (added unit, store, handler, admin handler/template, and integration tests covering completion detection, resume, 409, reset cascade, idempotency, victim-only deletion)
- [x] `make smoke` boots cleanly
- [x] `make test-e2e` green (6/6); existing player spec covers the GET-first → POST flow because each e2e run uses a fresh player
- [x] Manual: confirmation modal appears with player name, Reset and Cancel buttons work as expected

## Style review

Two passes of the in-tree go-style-review skill landed clean. Cross-layer parameter order aligned to player-first; three `got` shadow sites cleaned up; `var (...)` error block now has per-error doc comments.

Project-wide `Get` → `Fetch` rename ticket: #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)