### PR TITLE
Filter the global leaderboard to completed quiz attempts

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -95,6 +95,7 @@ Store interfaces are defined in the domain package so domain code does not impor
    Name it `YYYYMMDDHHMMSS_description.sql`.
 2. **SQL query** — add the query to the relevant file in `internal/queries/` using `sqlc` annotations.
    Run `sqlc generate` to regenerate `internal/db/`.
+   Keep `--` comments ASCII-only: non-ASCII characters (em-dashes, curly apostrophes, etc.) in the comment block above a query confuse `sqlc`'s SQLite preprocessor and produce cryptic errors pointing at *unrelated* queries below. Plain `-` and `'` only.
 3. **Domain types** — add or update structs in the relevant domain package.
 4. **Store interface** — extend the interface in the domain package if new persistence ops are needed.
 5. **Store implementation** — implement the interface method in `internal/store/`.

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -330,6 +330,8 @@ FROM game_answers ga
          JOIN options o ON o.id = ga.option_id
          JOIN players p ON p.id = ga.player_id
 WHERE g.quiz_id = ?
+  AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = g.id) >=
+      (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
 `
 
 type ListAnswersForQuizLeaderboardRow struct {
@@ -341,10 +343,14 @@ type ListAnswersForQuizLeaderboardRow struct {
 	IsCorrect         bool
 }
 
-// Selects the per-answer scoring inputs for every game of the given quiz.
-// The leaderboard service sums these rows per player. The one-attempt-per-
-// (player, quiz) constraint enforced by #145 keeps the sum from
-// double-counting a re-played quiz.
+// Selects the per-answer scoring inputs for every completed game of the
+// given quiz. A game counts as complete when every quiz question has
+// been issued, i.e. the count of game_questions rows for the game has
+// caught up with the count of questions on the quiz. Partial games
+// (where the player walked away mid-quiz) are filtered out so the
+// leaderboard only compares finishers. The one-attempt-per-(player,
+// quiz) constraint enforced by #145 keeps a player from showing up more
+// than once.
 func (q *Queries) ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]ListAnswersForQuizLeaderboardRow, error) {
 	rows, err := q.db.QueryContext(ctx, listAnswersForQuizLeaderboard, quizID)
 	if err != nil {

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -113,9 +113,10 @@ type Results struct {
 // leaderboard. It carries every field [Service.CalculateScore] needs (the
 // option's correctness, the question's start/expiry timestamps, and the
 // answer's submission time) plus the player's username and ID for the
-// leaderboard row. The leaderboard service assumes one attempt per
-// (player, quiz); that constraint is enforced by [Service.CreateGame] and
-// the admin reset flow.
+// leaderboard row. The store filters these rows to completed games only
+// (every quiz question issued), and the one-attempt-per-(player, quiz)
+// constraint enforced by [Service.CreateGame] and the admin reset flow
+// keeps a player from showing up more than once.
 type LeaderboardAnswer struct {
 	PlayerID          int64
 	Username          string
@@ -151,9 +152,11 @@ type Store interface {
 	CreateParticipant(ctx context.Context, p *Participant) error
 	CreateQuestion(ctx context.Context, gq *Question) error
 	CreateAnswer(ctx context.Context, a *Answer) error
-	// ListAnswersForQuizLeaderboard returns one row per game_answer for the
-	// given quiz, joined with the fields the Service needs to score each
-	// answer.
+	// ListAnswersForQuizLeaderboard returns one row per game_answer for
+	// completed games of the given quiz, joined with the fields the
+	// Service needs to score each answer. A game counts as completed when
+	// every quiz question has been issued (answered or timed out); partial
+	// games are filtered out at the store layer.
 	ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
 	// DeleteGamesForPlayerOnQuiz hard-deletes every game (and dependent
 	// rows) that belongs to the given player on the given quiz. No error
@@ -441,9 +444,12 @@ func (s *Service) GetResults(ctx context.Context, gameID string) (*Results, erro
 // Scoring reuses [Service.CalculateScore] so values stay consistent with
 // [Service.GetResults].
 //
-// Assumes one attempt per (player, quiz): the service simply sums every
-// answer the player has on the quiz. The constraint is enforced by
-// [Service.CreateGame] together with the admin reset flow.
+// Only completed games (every quiz question issued, answered or timed
+// out) are counted; partial games are filtered out by the store so a
+// player who walked away mid-quiz does not take a slot. Combined with
+// the one-attempt-per-(player, quiz) constraint enforced by
+// [Service.CreateGame] and the admin reset flow, that means each player
+// either appears with their final score for the quiz or not at all.
 //
 // Ordering: descending by score; ties are broken by ascending username for
 // determinism so a tied scoreboard is stable across requests.

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -49,10 +49,14 @@ VALUES (?, ?, ?, ?)
 RETURNING *;
 
 -- name: ListAnswersForQuizLeaderboard :many
--- Selects the per-answer scoring inputs for every game of the given quiz.
--- The leaderboard service sums these rows per player. The one-attempt-per-
--- (player, quiz) constraint enforced by #145 keeps the sum from
--- double-counting a re-played quiz.
+-- Selects the per-answer scoring inputs for every completed game of the
+-- given quiz. A game counts as complete when every quiz question has
+-- been issued, i.e. the count of game_questions rows for the game has
+-- caught up with the count of questions on the quiz. Partial games
+-- (where the player walked away mid-quiz) are filtered out so the
+-- leaderboard only compares finishers. The one-attempt-per-(player,
+-- quiz) constraint enforced by #145 keeps a player from showing up more
+-- than once.
 SELECT ga.player_id        AS player_id,
        p.username           AS username,
        gq.started_at        AS question_started_at,
@@ -64,7 +68,9 @@ FROM game_answers ga
          JOIN game_questions gq ON gq.id = ga.game_question_id
          JOIN options o ON o.id = ga.option_id
          JOIN players p ON p.id = ga.player_id
-WHERE g.quiz_id = ?;
+WHERE g.quiz_id = ?
+  AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = g.id) >=
+      (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id);
 
 -- name: GetGameByPlayerAndQuiz :one
 -- Returns the most-recent game for the given (player, quiz) pair. Used by the

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -509,22 +509,30 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 			t.Fatalf("failed to create participant: %v", err)
 		}
 
+		// Issue every quiz question for the game so it counts as
+		// complete; the leaderboard query now filters out partial
+		// games. Only the first question gets an answer — the
+		// second is "issued but timed out".
 		now := time.Now().UTC().Truncate(time.Second)
-		gq := &game.Question{
-			GameID:     g.ID,
-			QuestionID: testQuiz.Questions[0].ID,
-			StartedAt:  now,
-			ExpiredAt:  now.Add(10 * time.Second),
-		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
-			t.Fatalf("failed to create game question: %v", err)
+		gameQuestions := make([]*game.Question, len(testQuiz.Questions))
+		for i, q := range testQuiz.Questions {
+			gq := &game.Question{
+				GameID:     g.ID,
+				QuestionID: q.ID,
+				StartedAt:  now,
+				ExpiredAt:  now.Add(10 * time.Second),
+			}
+			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+				t.Fatalf("failed to create game question %d: %v", i, err)
+			}
+			gameQuestions[i] = gq
 		}
 
 		correctOption := testQuiz.Questions[0].Options[0]
 		a := &game.Answer{
 			GameID:     g.ID,
 			PlayerID:   player.ID,
-			QuestionID: gq.ID,
+			QuestionID: gameQuestions[0].ID,
 			OptionID:   correctOption.ID,
 		}
 		if err = gameStore.CreateAnswer(t.Context(), a); err != nil {
@@ -546,6 +554,63 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 		}
 		if got, want := rows[0].Correct, correctOption.Correct; got != want {
 			t.Errorf("rows[0].Correct = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("filters out partial games where not every question was issued", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(
+			t.Context(), "anon-leaderboard-partial",
+		)
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+
+		// Issue only the first of two questions — game is incomplete.
+		now := time.Now().UTC().Truncate(time.Second)
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer: %v", err)
+		}
+
+		rows, err := gameStore.ListAnswersForQuizLeaderboard(t.Context(), testQuiz.ID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(rows), 0; got != want {
+			t.Errorf("len(rows) = %d, want %d (partial games must be filtered out)", got, want)
 		}
 	})
 
@@ -577,7 +642,10 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 		gameStore := NewGameStore(db, slog.Default())
 		now := time.Now().UTC().Truncate(time.Second)
 
-		// Record one answer on quizB (should not appear in quizA's leaderboard).
+		// Record a complete game on quizB (every quiz question issued)
+		// so the new partial-game filter would normally let its rows
+		// through. The cross-quiz filter must still keep them out of
+		// quizA's leaderboard.
 		gB := &game.Game{QuizID: quizB.ID}
 		if err = gameStore.CreateGame(t.Context(), gB); err != nil {
 			t.Fatalf("failed to create game B: %v", err)
@@ -587,19 +655,23 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 		); err != nil {
 			t.Fatalf("failed to create participant for game B: %v", err)
 		}
-		gqB := &game.Question{
-			GameID:     gB.ID,
-			QuestionID: quizB.Questions[0].ID,
-			StartedAt:  now,
-			ExpiredAt:  now.Add(10 * time.Second),
-		}
-		if err = gameStore.CreateQuestion(t.Context(), gqB); err != nil {
-			t.Fatalf("failed to create question for game B: %v", err)
+		gameQuestionsB := make([]*game.Question, len(quizB.Questions))
+		for i, q := range quizB.Questions {
+			gq := &game.Question{
+				GameID:     gB.ID,
+				QuestionID: q.ID,
+				StartedAt:  now,
+				ExpiredAt:  now.Add(10 * time.Second),
+			}
+			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+				t.Fatalf("failed to create question %d for game B: %v", i, err)
+			}
+			gameQuestionsB[i] = gq
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
 			GameID:     gB.ID,
 			PlayerID:   player.ID,
-			QuestionID: gqB.ID,
+			QuestionID: gameQuestionsB[0].ID,
 			OptionID:   quizB.Questions[0].Options[0].ID,
 		}); err != nil {
 			t.Fatalf("failed to create answer for game B: %v", err)


### PR DESCRIPTION
## Summary

- Filters \`ListAnswersForQuizLeaderboard\` to only return rows from games where every quiz question has been issued (answered or timed out). Players who walked away mid-quiz no longer take a leaderboard slot. Combined with #145's one-attempt enforcement, each player either appears on the leaderboard with their final score for the quiz or not at all.
- Implements the filter as correlated scalar subqueries (\`(SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = g.id) >= (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)\`) so the count work scales with the result set, not with the size of \`game_questions\` and \`questions\` tables.
- Refreshes the docstrings on \`LeaderboardAnswer\`, \`Store.ListAnswersForQuizLeaderboard\`, and \`Service.GetQuizLeaderboard\` so the new "completed games only" semantic is documented at all three layers.
- Codifies the lesson from sqlc's misleading parser errors as a project rule in \`.claude/agents/backend-dev.md\`: comment blocks above sqlc queries must be ASCII-only — em-dashes and curly apostrophes confuse sqlc's SQLite preprocessor and produce errors pointing at *unrelated* queries below.

Closes #143.
Closes #144 (trailing newline already in place — verified).
Closes #104 (the original "per-quiz leaderboard, one play per player" meta-feature, now fully delivered across #146 + #145 + this PR).

## Test plan

- [x] \`make lint-fix\` clean
- [x] \`make check\` green
- [x] \`make smoke\` boots cleanly
- [x] \`make test-e2e\` 6/6
- [x] Existing store tests updated to issue every quiz question so they exercise complete games; new \`filters out partial games\` subtest pins the filter behaviour
- [x] Cross-quiz isolation test rewritten to use a complete game on the wrong quiz, so it actually proves isolation rather than passing because of the partial-game filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)