### PR TITLE
Fix the broken navbar links on admin pages

### DIFF
--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -2,7 +2,7 @@
     <nav class="navbar" role="navigation" aria-label="main navigation">
         <div class="navbar-brand">
 
-            <a class="navbar-item" href="#">
+            <a class="navbar-item" href="/admin">
                 Top Banana!
             </a>
 
@@ -17,35 +17,9 @@
 
         <div class="navbar-menu">
             <div class="navbar-start">
-                <a class="navbar-item">
-                    Home
-                </a>
-
                 <a class="navbar-item" href="/admin/quizzes">
                     List of Quizzes
                 </a>
-
-                {{/*            <div class="navbar-item has-dropdown is-hoverable">*/}}
-                {{/*                <a class="navbar-link">*/}}
-                {{/*                    More*/}}
-                {{/*                </a>*/}}
-
-                {{/*                <div class="navbar-dropdown">*/}}
-                {{/*                    <a class="navbar-item">*/}}
-                {{/*                        About*/}}
-                {{/*                    </a>*/}}
-                {{/*                    <a class="navbar-item">*/}}
-                {{/*                        Jobs*/}}
-                {{/*                    </a>*/}}
-                {{/*                    <a class="navbar-item">*/}}
-                {{/*                        Contact*/}}
-                {{/*                    </a>*/}}
-                {{/*                    <hr class="navbar-divider">*/}}
-                {{/*                    <a class="navbar-item">*/}}
-                {{/*                        Report an issue*/}}
-                {{/*                    </a>*/}}
-                {{/*                </div>*/}}
-                {{/*            </div>*/}}
             </div>
 
             <div class="navbar-end">

--- a/test/e2e/tests/admin.spec.ts
+++ b/test/e2e/tests/admin.spec.ts
@@ -25,4 +25,9 @@ test('register, create a quiz with varied questions, and see them on the quiz vi
   // share a long-lived SQLite file.
   await page.goto('/admin/quizzes');
   await expect(page.getByRole('cell', { name: quizTitle })).toBeVisible();
+
+  // The "Top Banana!" brand in the navbar should be a real link that lands
+  // on /admin — guards against regressing back to href="#".
+  await page.getByRole('link', { name: 'Top Banana!' }).click();
+  await expect(page).toHaveURL(/\/admin$/);
 });


### PR DESCRIPTION
## Summary

- The \`Top Banana!\` brand link in the admin navbar now points to \`/admin\` (was \`href=\"#\"\`, which only scrolled the page to top).
- The orphan \`Home\` item is removed — it had no \`href\` and there is no public homepage to point it at.
- Tidied up the long-commented-out \"More\" dropdown block while we were in the file.
- New e2e assertion in the admin spec: clicks the brand link and verifies the URL ends in \`/admin\`, guarding against regressing back to \`href=\"#\"\`.

Closes #150.

## Test plan

- [x] \`make lint-fix\` clean
- [x] \`make check\` green
- [x] \`make smoke\` boots cleanly
- [x] \`make test-e2e\` 6/6 (Chromium + Firefox both exercise the new brand-link click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)