### PR TITLE
Add a shareable per-quiz URL and admin share controls

### DIFF
--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -18,7 +18,7 @@
                     <label class="label" for="quiz-select">Select a Quiz</label>
                     <div class="control">
                         <div class="select">
-                            <select id="quiz-select" x-model="selectedQuizId">
+                            <select id="quiz-select" x-model="selectedQuizId" @change="checkAlreadyPlayed()">
                                 <template x-for="quiz in quizzes" :key="quiz.id">
                                     <option :value="quiz.id" x-text="quiz.title"></option>
                                 </template>
@@ -35,7 +35,7 @@
                 <template x-if="startError">
                     <div class="notification is-danger" x-text="startError"></div>
                 </template>
-                <button class="button is-primary" @click="startGame()" :disabled="!selectedQuizId">Start Game</button>
+                <button class="button is-primary" @click="startGame()" :disabled="!selectedQuizId || !!startError">Start Game</button>
             </div>
 
             <div x-show="gameId && !finished">
@@ -99,7 +99,6 @@
                 <template x-if="!leaderboard">
                     <p>Loading leaderboard...</p>
                 </template>
-                <button class="button is-link" @click="reset()">Play Again</button>
             </div>
         </div>
     </section>

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TopBanana Client</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
-    <script type="module" src="js/app.js"></script>
+    <script type="module" src="/client/js/app.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body>
@@ -14,7 +14,7 @@
             <h1 class="title">Top Banana!</h1>
 
             <div x-show="!gameId">
-                <div class="field">
+                <div x-show="!deepLinkedQuiz" class="field">
                     <label class="label" for="quiz-select">Select a Quiz</label>
                     <div class="control">
                         <div class="select">
@@ -26,6 +26,12 @@
                         </div>
                     </div>
                 </div>
+                <template x-if="deepLinkedQuiz">
+                    <div class="content">
+                        <h2 class="subtitle" x-text="deepLinkedQuiz.title"></h2>
+                        <p x-text="deepLinkedQuiz.description"></p>
+                    </div>
+                </template>
                 <template x-if="startError">
                     <div class="notification is-danger" x-text="startError"></div>
                 </template>

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -38,6 +38,7 @@ export class GameApp {
         } else if (this.quizzes.length > 0) {
             this.selectedQuizId = this.quizzes[0].id;
         }
+        await this.checkAlreadyPlayed();
     }
 
     // findDeepLinkedQuiz extracts the quiz ID from /play/<slug>-<id> and
@@ -50,17 +51,36 @@ export class GameApp {
         return this.quizzes.find(q => q.id === id) || null;
     }
 
-    async startGame() {
+    // slugIdFor returns the `${slug}-${id}` form for the selected quiz, or
+    // null when no matching quiz exists in this.quizzes.
+    slugIdFor(quizId) {
+        const quiz = this.quizzes.find(q => q.id === parseInt(quizId));
+        return quiz ? `${quiz.slug}-${quiz.id}` : null;
+    }
+
+    // checkAlreadyPlayed pre-flights the resume probe so the start screen
+    // can show the "already completed" notification before the player
+    // bothers clicking Start. Called from init, on dropdown changes, and
+    // after reset so a returning player sees the lockout immediately.
+    // Returns the existing game payload (or null) so callers can avoid a
+    // second round-trip in startGame.
+    async checkAlreadyPlayed() {
         this.startError = null;
-        const quiz = this.quizzes.find(q => q.id === parseInt(this.selectedQuizId));
-        if (!quiz) return;
-        this.quizSlugId = `${quiz.slug}-${quiz.id}`;
-        const existing = await gameService.getMyGameForQuiz(this.quizSlugId);
+        const slugId = this.slugIdFor(this.selectedQuizId);
+        if (!slugId) return null;
+        const existing = await gameService.getMyGameForQuiz(slugId);
         if (existing && existing.completed) {
             this.startError = "You've already completed this quiz.";
-            this.quizSlugId = null;
-            return;
         }
+        return existing;
+    }
+
+    async startGame() {
+        const existing = await this.checkAlreadyPlayed();
+        if (this.startError) return;
+        const slugId = this.slugIdFor(this.selectedQuizId);
+        if (!slugId) return;
+        this.quizSlugId = slugId;
         if (existing) {
             this.gameId = existing.gameId;
         } else {
@@ -122,19 +142,4 @@ export class GameApp {
         await this.nextQuestion();
     }
 
-    reset() {
-        if (this.timer) {
-            clearInterval(this.timer);
-            this.timer = null;
-        }
-        this.gameId = null;
-        this.question = null;
-        this.finished = false;
-        this.leaderboard = null;
-        this.quizSlugId = null;
-        this.feedback = null;
-        this.progress = 100;
-        this.imageError = false;
-        this.startError = null;
-    }
 }

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -1,6 +1,10 @@
 import { quizService } from '../services/QuizService.js';
 import { gameService } from '../services/GameService.js';
 
+// PLAY_PATH_PATTERN matches /play/<anything>-<integer>; the integer suffix
+// is the quiz ID.
+const PLAY_PATH_PATTERN = /^\/play\/.+-(\d+)\/?$/;
+
 export class GameApp {
     constructor() {
         this.quizzes = [];
@@ -19,13 +23,31 @@ export class GameApp {
         // next image too.
         this.imageError = false;
         this.startError = null;
+        // Set when the page is loaded via /play/<slug>-<id>; the dropdown
+        // is hidden in that case so the player just sees a description and
+        // a Start button. Stays null on /client/, where the dropdown shows.
+        this.deepLinkedQuiz = null;
     }
 
     async init() {
         this.quizzes = await quizService.getQuizzes();
-        if (this.quizzes.length > 0) {
+        const deepLinked = this.findDeepLinkedQuiz();
+        if (deepLinked) {
+            this.deepLinkedQuiz = deepLinked;
+            this.selectedQuizId = deepLinked.id;
+        } else if (this.quizzes.length > 0) {
             this.selectedQuizId = this.quizzes[0].id;
         }
+    }
+
+    // findDeepLinkedQuiz extracts the quiz ID from /play/<slug>-<id> and
+    // returns the matching quiz, or null if the path is not a deep link or
+    // the ID does not match a known quiz.
+    findDeepLinkedQuiz() {
+        const match = window.location.pathname.match(PLAY_PATH_PATTERN);
+        if (!match) return null;
+        const id = parseInt(match[1], 10);
+        return this.quizzes.find(q => q.id === id) || null;
     }
 
     async startGame() {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -31,7 +31,18 @@ func addRoutes(
 	addAPIRoutes(mux, logger, stores, gameService, sessions)
 
 	// Client
-	mux.Handle("/client/", client.Handler(cfg))
+	clientHandler := client.Handler(cfg)
+	mux.Handle("/client/", clientHandler)
+
+	// Per-quiz share URL. Serves the same SPA shell as /client/ but the
+	// frontend reads the slug-id off the path and pre-selects the quiz.
+	// Path is rewritten to /client/ so the existing file server (and its
+	// production minification middleware) keeps doing the work.
+	mux.Handle("GET /play/{slugID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/client/"
+		clientHandler.ServeHTTP(w, r2)
+	}))
 
 	// Health
 	mux.Handle("GET /healthz", health.HandleHealthz(logger, stores))

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -179,6 +179,8 @@ func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
 		{name: "API Quiz Leaderboard", method: http.MethodGet, path: "/api/quizzes/quiz-1/leaderboard"},
 		{name: "API Quiz My Game", method: http.MethodGet, path: "/api/quizzes/quiz-1/my-game"},
 
+		{name: "Play Quiz", method: http.MethodGet, path: "/play/quiz-1"},
+
 		{name: "API Game Create", method: http.MethodPost, path: "/api/games"},
 		{name: "API Question Next", method: http.MethodGet, path: "/api/games/game-1/questions/next"},
 		{name: "API Answer Post", method: http.MethodPost, path: "/api/games/game-1/questions/1/answers"},

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -20,6 +20,15 @@
                         </a>
                     </div>
                     <div class="level-item">
+                        <a href="#"
+                           onclick="openModal('modal-share-quiz-{{.Quiz.ID}}'); return false;">
+                            <span class="icon-text has-text-link">
+                                <span class="icon"><i class="fas fa-share"></i></span>
+                                <span>Share quiz</span>
+                            </span>
+                        </a>
+                    </div>
+                    <div class="level-item">
                         <a href="#" onclick="openModal('modal-delete-quiz-{{.Quiz.ID}}'); return false;">
                             <span class="icon-text has-text-danger">
                                 <span class="icon"><i class="fas fa-trash"></i></span>
@@ -27,6 +36,44 @@
                             </span>
                         </a>
                     </div>
+                </div>
+            </div>
+
+            <div class="modal" id="modal-share-quiz-{{.Quiz.ID}}">
+                <div class="modal-background"
+                     onclick="closeModal('modal-share-quiz-{{.Quiz.ID}}')"></div>
+                <div class="modal-card">
+                    <header class="modal-card-head">
+                        <p class="modal-card-title">Share quiz</p>
+                        <button class="delete" aria-label="close"
+                                onclick="closeModal('modal-share-quiz-{{.Quiz.ID}}')"></button>
+                    </header>
+                    <section class="modal-card-body"
+                             data-share-path="/play/{{.Quiz.Slug}}-{{.Quiz.ID}}"
+                             data-share-title="{{.Quiz.Title}}">
+                        <p class="mb-3">Anyone with this link can land directly on the quiz:</p>
+                        <p class="has-text-weight-semibold mb-4 share-link"></p>
+                        <div class="buttons">
+                            <button class="button is-link share-copy" type="button">
+                                <span class="icon"><i class="fas fa-copy"></i></span>
+                                <span>Copy link</span>
+                            </button>
+                            <button class="button is-success share-whatsapp" type="button">
+                                <span class="icon"><i class="fab fa-whatsapp"></i></span>
+                                <span>Share via WhatsApp</span>
+                            </button>
+                            <button class="button share-signal" type="button">
+                                <span>Share via Signal</span>
+                            </button>
+                        </div>
+                        <p class="help share-feedback is-hidden"></p>
+                    </section>
+                    <footer class="modal-card-foot">
+                        <div class="buttons">
+                            <button class="button"
+                                    onclick="closeModal('modal-share-quiz-{{.Quiz.ID}}')">Close</button>
+                        </div>
+                    </footer>
                 </div>
             </div>
 
@@ -200,5 +247,69 @@
     <script>
         function openModal(id) { document.getElementById(id).classList.add('is-active'); }
         function closeModal(id) { document.getElementById(id).classList.remove('is-active'); }
+
+        // Wire share-modal buttons. The share modal body carries the
+        // path and title in data-* attributes; the absolute URL is
+        // derived at click time from window.location.origin so the
+        // server doesn't need to know its public hostname.
+        document.querySelectorAll('[data-share-path]').forEach(function (body) {
+            const path = body.dataset.sharePath;
+            const title = body.dataset.shareTitle;
+            const url = window.location.origin + path;
+            const linkEl = body.querySelector('.share-link');
+            const feedback = body.querySelector('.share-feedback');
+            if (linkEl) linkEl.textContent = url;
+
+            function flash(msg) {
+                if (!feedback) return;
+                feedback.textContent = msg;
+                feedback.classList.remove('is-hidden');
+                setTimeout(function () { feedback.classList.add('is-hidden'); }, 2500);
+            }
+
+            const copyBtn = body.querySelector('.share-copy');
+            if (copyBtn) {
+                copyBtn.addEventListener('click', async function () {
+                    try {
+                        await navigator.clipboard.writeText(url);
+                        flash('Link copied to clipboard.');
+                    } catch (err) {
+                        flash('Could not copy automatically — select the link above and copy it manually.');
+                    }
+                });
+            }
+
+            const whatsappBtn = body.querySelector('.share-whatsapp');
+            if (whatsappBtn) {
+                whatsappBtn.addEventListener('click', function () {
+                    const text = title + ': ' + url;
+                    window.open('https://wa.me/?text=' + encodeURIComponent(text), '_blank', 'noopener');
+                });
+            }
+
+            const signalBtn = body.querySelector('.share-signal');
+            if (signalBtn) {
+                signalBtn.addEventListener('click', async function () {
+                    // Signal has no public web share URL, so we use the
+                    // Web Share API on platforms that support it (mobile)
+                    // and fall back to clipboard everywhere else.
+                    if (navigator.share) {
+                        try {
+                            await navigator.share({ title: title, url: url });
+                            return;
+                        } catch (err) {
+                            // User cancelled the share sheet — no-op.
+                            if (err && err.name === 'AbortError') return;
+                        }
+                    }
+                    try {
+                        await navigator.clipboard.writeText(url);
+                        flash('Link copied — paste into Signal.');
+                    } catch (err) {
+                        flash('Could not share — copy the link above manually.');
+                    }
+                });
+            }
+        });
     </script>
 {{end}}

--- a/test/e2e/tests/admin.spec.ts
+++ b/test/e2e/tests/admin.spec.ts
@@ -30,4 +30,14 @@ test('register, create a quiz with varied questions, and see them on the quiz vi
   // on /admin — guards against regressing back to href="#".
   await page.getByRole('link', { name: 'Top Banana!' }).click();
   await expect(page).toHaveURL(/\/admin$/);
+
+  // Open the share modal on the quiz view and confirm the rendered share
+  // URL points at /play/<slug>-<id>. Don't try to verify the clipboard
+  // (browser permission model varies); just check the user-visible link.
+  await page.goto('/admin/quizzes');
+  await page.getByRole('cell', { name: quizTitle }).click();
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
+  await page.getByRole('link', { name: 'Share quiz' }).click();
+  const shareLinkText = await page.locator('.share-link').textContent();
+  expect(shareLinkText).toMatch(/\/play\/[a-z0-9-]+-\d+$/);
 });

--- a/test/e2e/tests/player.spec.ts
+++ b/test/e2e/tests/player.spec.ts
@@ -84,4 +84,15 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
   // successes. If a future spec edit shifts that count, this assertion fails
   // loudly so the score-not-zero guard above can't silently degrade.
   expect(expectedSuccesses).toBe(2);
+
+  // Re-visit the start screen. Because the player already completed this
+  // quiz and #145 enforces one attempt per (player, quiz), the start
+  // screen must surface the "already completed" lockout notification
+  // proactively and disable the Start button — without the player having
+  // to click Start to discover they're locked out.
+  await page.goto('/client/');
+  await page.locator('select').selectOption({ label: quizTitle });
+  await expect(page.locator('.notification.is-danger'))
+    .toContainText('already completed');
+  await expect(page.getByRole('button', { name: 'Start Game' })).toBeDisabled();
 });


### PR DESCRIPTION
## Summary

- New \`GET /play/{slugID}\` route serves the same SPA shell as \`/client/\` but the frontend reads the slug-id off the path and pre-selects that quiz. The dropdown is hidden in deep-link mode and replaced with a card showing the quiz title and description; the player still clicks Start so they can read the title before committing.
- Admin quiz view gains a \"Share quiz\" affordance opening a Bulma modal with three buttons:
  - **Copy link** — \`navigator.clipboard.writeText\` with inline confirmation.
  - **Share via WhatsApp** — opens \`https://wa.me/?text=<title>: <url>\` in a new tab.
  - **Share via Signal** — \`navigator.share()\` on platforms that support it (mobile share sheet); falls back to clipboard with a \"paste into Signal\" hint everywhere else. (Signal has no public web share URL scheme; this is the closest honest approximation.)
- All sharing logic is client-side; the URL is built from \`window.location.origin\` so the server never needs to know its public hostname.
- Already-played lockout now surfaces on the start screen — \`init()\`, the dropdown's \`@change\`, and \`startGame()\` all run a single \`checkAlreadyPlayed()\` pre-flight that sets a danger notification and disables the Start button when the player has already finished. Players no longer have to click Start to discover they're locked out.
- Removed the \"Play Again\" button on the finished screen — \`#145\` enforces one attempt per (player, quiz), so the button was misleading. The leaderboard is now the natural endpoint of the flow; players who want another quiz navigate to \`/client/\` or open a different \`/play/\` link.
- The previously-unused \`reset()\` method on \`GameApp\` is removed alongside the button.

Closes #152.

## Test plan

- [x] \`make lint-fix\` clean
- [x] \`make check\` no FAIL
- [x] \`make smoke\` boots cleanly
- [x] \`make test-e2e\` 6/6 across Chromium and Firefox
- [x] Admin spec extended to open the share modal and assert the rendered link matches \`/play/<slug>-<id>\`
- [x] Player spec extended to verify the post-completion lockout shows on the start screen (re-visit \`/client/\`, pick the quiz, danger notification visible, Start disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)