### PR TITLE
Cascade delete played games when removing a quiz

### DIFF
--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -422,6 +422,40 @@ func (q *Queries) ListGameIDsForPlayerOnQuiz(ctx context.Context, arg ListGameID
 	return items, nil
 }
 
+const listGameIDsForQuiz = `-- name: ListGameIDsForQuiz :many
+SELECT id
+FROM games
+WHERE quiz_id = ?
+`
+
+// Lists every game ID for the quiz, regardless of player. Used by the
+// quiz delete flow so the in-Go transaction can drop dependent
+// game_answers / game_questions / game_participants / games rows before
+// the quiz row itself is deleted (questions and options cascade from
+// the quiz, but the game_* tables do not).
+func (q *Queries) ListGameIDsForQuiz(ctx context.Context, quizID int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listGameIDsForQuiz, quizID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listGameQuestionsByGameID = `-- name: ListGameQuestionsByGameID :many
 SELECT id, game_id, question_id, started_at, expired_at
 FROM game_questions

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -97,6 +97,16 @@ FROM games g
 WHERE gp.player_id = ?
   AND g.quiz_id = ?;
 
+-- name: ListGameIDsForQuiz :many
+-- Lists every game ID for the quiz, regardless of player. Used by the
+-- quiz delete flow so the in-Go transaction can drop dependent
+-- game_answers / game_questions / game_participants / games rows before
+-- the quiz row itself is deleted (questions and options cascade from
+-- the quiz, but the game_* tables do not).
+SELECT id
+FROM games
+WHERE quiz_id = ?;
+
 -- name: DeleteGameAnswersByGameIDs :exec
 -- Hard-deletes every game_answers row attached to the given game IDs. Used
 -- by the player-on-quiz reset flow with the IDs gathered up front by

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -434,6 +434,32 @@ func (s *QuizStore) execUpdateQuestion(ctx context.Context, q *db.Queries, qs *q
 }
 
 func (*QuizStore) execDeleteQuiz(ctx context.Context, q *db.Queries, id int64) error {
+	// The cascade only covers questions -> options. The game_* tables
+	// reference quizzes (via games.quiz_id), questions (via
+	// game_questions.question_id), and options (via game_answers.option_id)
+	// without ON DELETE CASCADE, so they would block the quiz row delete
+	// once the quiz has been played. Snapshot the affected game IDs and
+	// drop the dependent rows explicitly, in the same order the
+	// player-on-quiz reset uses, before deleting the quiz itself.
+	gameIDs, err := q.ListGameIDsForQuiz(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to list game IDs for quiz %d: %w", id, err)
+	}
+	if len(gameIDs) > 0 {
+		if err = q.DeleteGameAnswersByGameIDs(ctx, gameIDs); err != nil {
+			return fmt.Errorf("failed to delete game answers: %w", err)
+		}
+		if err = q.DeleteGameQuestionsByGameIDs(ctx, gameIDs); err != nil {
+			return fmt.Errorf("failed to delete game questions: %w", err)
+		}
+		if err = q.DeleteGameParticipantsByGameIDs(ctx, gameIDs); err != nil {
+			return fmt.Errorf("failed to delete game participants: %w", err)
+		}
+		if err = q.DeleteGamesByIDs(ctx, gameIDs); err != nil {
+			return fmt.Errorf("failed to delete games: %w", err)
+		}
+	}
+
 	res, err := q.DeleteQuiz(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete quiz: %w", err)

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -15,6 +15,7 @@ import (
 	sqlite3 "modernc.org/sqlite/lib"
 
 	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/quiz"
 	. "github.com/starquake/topbanana/internal/store"
 )
@@ -1413,6 +1414,79 @@ func TestQuizStore_DeleteQuiz(t *testing.T) {
 		if got, want := err, quiz.ErrDeletingQuizNoRowsAffected; !errors.Is(got, want) {
 			t.Fatalf("DeleteQuiz err = %v, want %v", got, want)
 		}
+	})
+
+	t.Run("delete quiz also wipes played games and their dependent rows", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-quiz-delete")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		// Stand up a played game: game + participant + question issued +
+		// answer recorded. Without the cascade fix, deleting the quiz
+		// would fail with FOREIGN KEY constraint failed because
+		// game_answers.option_id and games.quiz_id both reference rows
+		// the quiz delete touches.
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+		now := time.Now().UTC().Truncate(time.Second)
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer: %v", err)
+		}
+
+		if err = quizStore.DeleteQuiz(t.Context(), testQuiz.ID); err != nil {
+			t.Fatalf("DeleteQuiz err = %v, want nil", err)
+		}
+
+		assertCount := func(label, sqlStr string, arg any, want int) {
+			t.Helper()
+			row := db.QueryRowContext(t.Context(), sqlStr, arg)
+			var got int
+			if scanErr := row.Scan(&got); scanErr != nil {
+				t.Fatalf("scan %s err = %v", label, scanErr)
+			}
+			if got != want {
+				t.Errorf("%s count = %d, want %d", label, got, want)
+			}
+		}
+		assertCount("game_answers", `SELECT COUNT(*) FROM game_answers WHERE game_id = ?`, g.ID, 0)
+		assertCount("game_questions", `SELECT COUNT(*) FROM game_questions WHERE game_id = ?`, g.ID, 0)
+		assertCount("game_participants", `SELECT COUNT(*) FROM game_participants WHERE game_id = ?`, g.ID, 0)
+		assertCount("games", `SELECT COUNT(*) FROM games WHERE id = ?`, g.ID, 0)
+		assertCount("questions", `SELECT COUNT(*) FROM questions WHERE quiz_id = ?`, testQuiz.ID, 0)
 	})
 }
 

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -582,6 +582,179 @@ func TestGameplay_Integration(t *testing.T) {
 		t.Errorf("fresh game ID %q equals old game ID %q, want a new ID", freshGameRes.ID, gameID)
 	}
 
+	// Auth gate: an unauthenticated client requesting an /admin route is
+	// redirected to /login with 303, not allowed through to render the
+	// admin page. A throwaway client with no jar and no auto-redirect so
+	// we can assert on the redirect itself.
+	anonClient := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	anonResp := httpGet(ctx, t, anonClient, baseURL+"/admin/quizzes")
+	if got, want := anonResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Errorf("anon /admin/quizzes status = %d, want %d", got, want)
+	}
+	if got, want := anonResp.Header.Get("Location"), "/login"; got != want {
+		t.Errorf("anon /admin/quizzes Location = %q, want %q", got, want)
+	}
+	if cerr := anonResp.Body.Close(); cerr != nil {
+		t.Errorf("anonResp body close err = %v", cerr)
+	}
+
+	// Regression for #155: admin delete of a played quiz must not 500.
+	// Answer one question on the fresh game first so game_questions and
+	// game_answers both have rows referencing the quiz at the moment the
+	// delete fires. Without QuizStore's in-Go cascade those rows would
+	// trigger a FOREIGN KEY constraint failure and surface as a 500.
+	freshGameID := freshGameRes.ID
+	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, freshGameID))
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("fresh next question status = %d, want %d", got, want)
+	}
+
+	var freshQs nextQuestionRes
+	if derr := json.NewDecoder(resp.Body).Decode(&freshQs); derr != nil {
+		t.Fatalf("failed to decode fresh next question: %v", derr)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	freshAnswerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, freshGameID, freshQs.ID)
+	freshAnswerBody := fmt.Sprintf(`{"optionId": %d}`, freshQs.Options[0].ID)
+	resp = httpPostJSON(ctx, t, client, freshAnswerURL, freshAnswerBody)
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("fresh answer status = %d, want %d", got, want)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	// /my-game during an in-flight game: the player has answered one
+	// question but not finished, so the response is 200 with the
+	// in-flight game ID and completed=false. The player client uses
+	// this to skip the start-game button and resume.
+	resp = httpGet(ctx, t, client, myGameURL)
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("in-flight /my-game status = %d, want %d", got, want)
+	}
+
+	var inFlightMyGame struct {
+		GameID    string `json:"gameId"`
+		Completed bool   `json:"completed"`
+	}
+	if derr := json.NewDecoder(resp.Body).Decode(&inFlightMyGame); derr != nil {
+		t.Fatalf("failed to decode in-flight my-game response: %v", derr)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+	if got, want := inFlightMyGame.GameID, freshGameID; got != want {
+		t.Errorf("in-flight my-game GameID = %q, want %q", got, want)
+	}
+	if got, want := inFlightMyGame.Completed, false; got != want {
+		t.Errorf("in-flight my-game Completed = %v, want %v", got, want)
+	}
+
+	// CSRF: a POST to a state-changing admin route without the
+	// csrf_token form field is rejected by the CSRF middleware before
+	// the handler runs. The middleware sits in front of requireAdmin,
+	// so the response is 403 (not a 303 to /login). Use a body with no
+	// csrf_token field so the cookie is present but the form value is
+	// missing.
+	csrfRejectURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
+	csrfRejectReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, csrfRejectURL, strings.NewReader(""),
+	)
+	if err != nil {
+		t.Fatalf("failed to build CSRF-reject request: %v", err)
+	}
+	csrfRejectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	csrfRejectResp, err := adminClient.Do(csrfRejectReq)
+	if err != nil {
+		t.Fatalf("failed to POST CSRF-reject request: %v", err)
+	}
+	if got, want := csrfRejectResp.StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("CSRF-less admin delete status = %d, want %d", got, want)
+	}
+	if cerr := csrfRejectResp.Body.Close(); cerr != nil {
+		t.Errorf("csrfReject body close err = %v", cerr)
+	}
+
+	// CSRF: a forged token (cookie present, form value present but
+	// mismatched) is also rejected. Different code path from the
+	// missing-field case above — the cookie HMAC verification fails
+	// rather than the form-value lookup.
+	badTokenForm := url.Values{}
+	badTokenForm.Add("csrf_token", "not-a-real-token")
+	badTokenReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, csrfRejectURL, strings.NewReader(badTokenForm.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("failed to build bad-token request: %v", err)
+	}
+	badTokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	badTokenResp, err := adminClient.Do(badTokenReq)
+	if err != nil {
+		t.Fatalf("failed to POST bad-token request: %v", err)
+	}
+	if got, want := badTokenResp.StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("bad-token admin delete status = %d, want %d", got, want)
+	}
+	if cerr := badTokenResp.Body.Close(); cerr != nil {
+		t.Errorf("badToken body close err = %v", cerr)
+	}
+
+	// Admin POSTs /admin/quizzes/{id}/delete with a CSRF token tied to
+	// the admin session jar created by registerAdminAndResetPlayer above.
+	quizDetailURL := fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID)
+	deleteToken := fetchCSRFToken(ctx, t, adminClient, quizDetailURL)
+
+	deleteForm := url.Values{}
+	deleteForm.Add("csrf_token", deleteToken)
+
+	deleteURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
+	deleteReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, deleteURL, strings.NewReader(deleteForm.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("failed to build admin delete request: %v", err)
+	}
+	deleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	deleteResp, err := adminClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("failed to POST admin delete: %v", err)
+	}
+	if got, want := deleteResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("admin delete status = %d, want %d (500 here means the FK cascade regressed)", got, want)
+	}
+	if got, want := deleteResp.Header.Get("Location"), "/admin/quizzes"; got != want {
+		t.Errorf("admin delete Location = %q, want %q", got, want)
+	}
+	if cerr := deleteResp.Body.Close(); cerr != nil {
+		t.Errorf("delete body close err = %v", cerr)
+	}
+
+	// /api/quizzes no longer lists the deleted quiz.
+	resp = httpGet(ctx, t, client, baseURL+"/api/quizzes")
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("post-delete /api/quizzes status = %d, want %d", got, want)
+	}
+
+	var afterDelete []struct {
+		Title string `json:"title"`
+	}
+	if derr := json.NewDecoder(resp.Body).Decode(&afterDelete); derr != nil {
+		t.Fatalf("failed to decode quizzes after delete: %v", derr)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+	if got, want := len(afterDelete), 0; got != want {
+		t.Errorf("quizzes after delete len = %d, want %d", got, want)
+	}
+
 	// Shutdown server
 	stop()
 	select {


### PR DESCRIPTION
Closes #155.

## Summary
- `QuizStore.execDeleteQuiz` snapshots affected game IDs and drops `game_answers → game_questions → game_participants → games` rows before the quiz delete, all inside the existing `ExecTx`. The schema only cascades `quizzes → questions → options`, so without this the quiz delete failed with `FOREIGN KEY constraint failed (787)` once the quiz had been played.
- New unit subtest in `quiz_test.go` exercises the cascade with all four `game_*` tables populated.
- New section in `TestGameplay_Integration` covers admin delete of a played quiz via the HTTP route, plus three bonus assertions: anonymous `/admin/quizzes` redirects to `/login`, CSRF-less and bad-token POSTs both 403, and `/my-game` returns `completed=false` during an in-flight game.

Sibling latent bug (`execDeleteQuestion` has the same cascade gap) and broader integration coverage (multi-player leaderboard, deep-link, test-split) are deferred to #157.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (unit + integration green)
- [x] Verified the integration test fails with `FOREIGN KEY constraint failed (787)` when the cascade fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)