### PR TITLE
Cascade delete played game rows when removing a question

### DIFF
--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -145,6 +145,32 @@ func (q *Queries) DeleteGameAnswersByGameIDs(ctx context.Context, gameIds []stri
 	return err
 }
 
+const deleteGameAnswersByGameQuestionIDs = `-- name: DeleteGameAnswersByGameQuestionIDs :exec
+DELETE
+FROM game_answers
+WHERE game_question_id IN (/*SLICE:game_question_ids*/?)
+`
+
+// Hard-deletes game_answers rows that reference the given game_question
+// IDs. Filtering by game_question_id (not game_id) is deliberate: a single
+// game can hold answers for many questions, and the question delete must
+// only wipe the answers tied to the question being deleted, leaving the
+// other questions in the same game untouched.
+func (q *Queries) DeleteGameAnswersByGameQuestionIDs(ctx context.Context, gameQuestionIds []int64) error {
+	query := deleteGameAnswersByGameQuestionIDs
+	var queryParams []interface{}
+	if len(gameQuestionIds) > 0 {
+		for _, v := range gameQuestionIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:game_question_ids*/?", strings.Repeat(",?", len(gameQuestionIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:game_question_ids*/?", "NULL", 1)
+	}
+	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
 const deleteGameParticipantsByGameIDs = `-- name: DeleteGameParticipantsByGameIDs :exec
 DELETE
 FROM game_participants
@@ -186,6 +212,21 @@ func (q *Queries) DeleteGameQuestionsByGameIDs(ctx context.Context, gameIds []st
 		query = strings.Replace(query, "/*SLICE:game_ids*/?", "NULL", 1)
 	}
 	_, err := q.db.ExecContext(ctx, query, queryParams...)
+	return err
+}
+
+const deleteGameQuestionsByQuestionID = `-- name: DeleteGameQuestionsByQuestionID :exec
+DELETE
+FROM game_questions
+WHERE question_id = ?
+`
+
+// Hard-deletes every game_questions row issued for the given question.
+// Once the dependent game_answers rows are gone (see
+// DeleteGameAnswersByGameQuestionIDs) the FK on game_answers.game_question_id
+// no longer blocks, so a single-arg delete by question_id is enough.
+func (q *Queries) DeleteGameQuestionsByQuestionID(ctx context.Context, questionID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteGameQuestionsByQuestionID, questionID)
 	return err
 }
 
@@ -442,6 +483,40 @@ func (q *Queries) ListGameIDsForQuiz(ctx context.Context, quizID int64) ([]strin
 	var items []string
 	for rows.Next() {
 		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGameQuestionIDsForQuestion = `-- name: ListGameQuestionIDsForQuestion :many
+SELECT id
+FROM game_questions
+WHERE question_id = ?
+`
+
+// Lists every game_questions.id where the given question has been issued.
+// Used by the question delete flow so the in-Go transaction can drop
+// dependent game_answers rows scoped to THIS question's game_question rows
+// before deleting the game_questions and the question itself. Snapshotted
+// up front so subsequent deletes do not see a moving target as rows drain.
+func (q *Queries) ListGameQuestionIDsForQuestion(ctx context.Context, questionID int64) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, listGameQuestionIDsForQuestion, questionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
 		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -115,6 +115,35 @@ DELETE
 FROM game_answers
 WHERE game_id IN (sqlc.slice('game_ids'));
 
+-- name: ListGameQuestionIDsForQuestion :many
+-- Lists every game_questions.id where the given question has been issued.
+-- Used by the question delete flow so the in-Go transaction can drop
+-- dependent game_answers rows scoped to THIS question's game_question rows
+-- before deleting the game_questions and the question itself. Snapshotted
+-- up front so subsequent deletes do not see a moving target as rows drain.
+SELECT id
+FROM game_questions
+WHERE question_id = ?;
+
+-- name: DeleteGameAnswersByGameQuestionIDs :exec
+-- Hard-deletes game_answers rows that reference the given game_question
+-- IDs. Filtering by game_question_id (not game_id) is deliberate: a single
+-- game can hold answers for many questions, and the question delete must
+-- only wipe the answers tied to the question being deleted, leaving the
+-- other questions in the same game untouched.
+DELETE
+FROM game_answers
+WHERE game_question_id IN (sqlc.slice('game_question_ids'));
+
+-- name: DeleteGameQuestionsByQuestionID :exec
+-- Hard-deletes every game_questions row issued for the given question.
+-- Once the dependent game_answers rows are gone (see
+-- DeleteGameAnswersByGameQuestionIDs) the FK on game_answers.game_question_id
+-- no longer blocks, so a single-arg delete by question_id is enough.
+DELETE
+FROM game_questions
+WHERE question_id = ?;
+
 -- name: DeleteGameQuestionsByGameIDs :exec
 -- Hard-deletes every game_questions row attached to the given game IDs.
 DELETE

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -473,6 +473,29 @@ func (*QuizStore) execDeleteQuiz(ctx context.Context, q *db.Queries, id int64) e
 }
 
 func (*QuizStore) execDeleteQuestion(ctx context.Context, q *db.Queries, id int64) error {
+	// game_questions.question_id and game_answers.option_id /
+	// game_answers.game_question_id reference this question (and its
+	// options) without ON DELETE CASCADE, so once the question has been
+	// played SQLite raises FOREIGN KEY constraint failed (787) on the
+	// raw question delete. Snapshot the affected game_question IDs and
+	// drop the dependent game_answers / game_questions rows first.
+	// Filtering the answer delete by game_question_id (not game_id) is
+	// deliberate: a single game can hold answers for many questions, and
+	// dropping by game_id would over-delete answers for OTHER questions
+	// in the same game. Options cascade from the question itself.
+	gqIDs, err := q.ListGameQuestionIDsForQuestion(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to list game question IDs for question %d: %w", id, err)
+	}
+	if len(gqIDs) > 0 {
+		if err = q.DeleteGameAnswersByGameQuestionIDs(ctx, gqIDs); err != nil {
+			return fmt.Errorf("failed to delete game answers: %w", err)
+		}
+		if err = q.DeleteGameQuestionsByQuestionID(ctx, id); err != nil {
+			return fmt.Errorf("failed to delete game questions: %w", err)
+		}
+	}
+
 	res, err := q.DeleteQuestion(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete question: %w", err)

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -1535,6 +1535,125 @@ func TestQuizStore_DeleteQuestion(t *testing.T) {
 			t.Fatalf("DeleteQuestion err = %v, want %v", got, want)
 		}
 	})
+
+	t.Run("delete question also wipes played game_questions and game_answers for that question", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-question-delete")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		// Stand up a played game in which BOTH questions have been issued
+		// and answered. Deleting question[0] must wipe its game_questions
+		// and game_answers rows, but the rows tied to question[1] in the
+		// same game must remain — that is the difference from the quiz
+		// delete cascade. Without the FK cascade fix, the question delete
+		// would fail with FOREIGN KEY constraint failed because
+		// game_questions.question_id and game_answers.option_id both
+		// reference rows the delete touches.
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+
+		now := time.Now().UTC().Truncate(time.Second)
+		gq0 := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq0); err != nil {
+			t.Fatalf("failed to create game question 0: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq0.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer for question 0: %v", err)
+		}
+
+		gq1 := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[1].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq1); err != nil {
+			t.Fatalf("failed to create game question 1: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq1.ID,
+			OptionID:   testQuiz.Questions[1].Options[0].ID,
+		}); err != nil {
+			t.Fatalf("failed to create answer for question 1: %v", err)
+		}
+
+		question0ID := testQuiz.Questions[0].ID
+		question1ID := testQuiz.Questions[1].ID
+		if err = quizStore.DeleteQuestion(t.Context(), question0ID); err != nil {
+			t.Fatalf("DeleteQuestion err = %v, want nil", err)
+		}
+
+		assertCount := func(label, sqlStr string, arg any, want int) {
+			t.Helper()
+			row := db.QueryRowContext(t.Context(), sqlStr, arg)
+			var got int
+			if scanErr := row.Scan(&got); scanErr != nil {
+				t.Fatalf("scan %s err = %v", label, scanErr)
+			}
+			if got != want {
+				t.Errorf("%s count = %d, want %d", label, got, want)
+			}
+		}
+
+		// Rows for the deleted question are gone.
+		assertCount(
+			"game_questions for deleted question",
+			`SELECT COUNT(*) FROM game_questions WHERE question_id = ?`, question0ID, 0,
+		)
+		assertCount(
+			"game_answers for deleted question's game_question",
+			`SELECT COUNT(*) FROM game_answers WHERE game_question_id = ?`, gq0.ID, 0,
+		)
+
+		// Rows for the OTHER question in the same game are untouched.
+		// This is the bit that distinguishes the question delete from the
+		// quiz delete: only the deleted question's chain is wiped.
+		assertCount(
+			"game_questions for sibling question",
+			`SELECT COUNT(*) FROM game_questions WHERE question_id = ?`, question1ID, 1,
+		)
+		assertCount(
+			"game_answers for sibling question's game_question",
+			`SELECT COUNT(*) FROM game_answers WHERE game_question_id = ?`, gq1.ID, 1,
+		)
+
+		// The game itself and its participant survive — only the
+		// per-question rows for the deleted question were dropped.
+		assertCount("games", `SELECT COUNT(*) FROM games WHERE id = ?`, g.ID, 1)
+		assertCount("game_participants", `SELECT COUNT(*) FROM game_participants WHERE game_id = ?`, g.ID, 1)
+	})
 }
 
 // SQLite's CURRENT_TIMESTAMP has 1-second granularity, so the bump tests

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -657,6 +657,45 @@ func TestGameplay_Integration(t *testing.T) {
 		t.Errorf("in-flight my-game Completed = %v, want %v", got, want)
 	}
 
+	// Regression for #157 sec.1: admin delete of a played question must not
+	// 500. The fresh game above answered question[0], so game_questions and
+	// game_answers both have rows referencing that question at the moment
+	// the delete fires. Without the in-Go cascade in execDeleteQuestion the
+	// FK on game_questions.question_id would raise FOREIGN KEY constraint
+	// failed (787) and the admin route would surface it as a 500.
+	questionDeleteToken := fetchCSRFToken(
+		ctx, t, adminClient, fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID),
+	)
+	questionDeleteForm := url.Values{}
+	questionDeleteForm.Add("csrf_token", questionDeleteToken)
+	questionDeleteURL := fmt.Sprintf(
+		"%s/admin/quizzes/%d/questions/%d/delete", baseURL, qz.ID, qz.Questions[0].ID,
+	)
+	questionDeleteReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, questionDeleteURL, strings.NewReader(questionDeleteForm.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("failed to build question delete request: %v", err)
+	}
+	questionDeleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	questionDeleteResp, err := adminClient.Do(questionDeleteReq)
+	if err != nil {
+		t.Fatalf("failed to POST question delete: %v", err)
+	}
+	if got, want := questionDeleteResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf(
+			"question delete status = %d, want %d (500 here means the FK cascade for question delete regressed)",
+			got, want,
+		)
+	}
+	wantQuestionDeleteLocation := fmt.Sprintf("/admin/quizzes/%d", qz.ID)
+	if got, want := questionDeleteResp.Header.Get("Location"), wantQuestionDeleteLocation; got != want {
+		t.Errorf("question delete Location = %q, want %q", got, want)
+	}
+	if cerr := questionDeleteResp.Body.Close(); cerr != nil {
+		t.Errorf("question delete body close err = %v", cerr)
+	}
+
 	// CSRF: a POST to a state-changing admin route without the
 	// csrf_token form field is rejected by the CSRF middleware before
 	// the handler runs. The middleware sits in front of requireAdmin,


### PR DESCRIPTION
Closes #157 §1.

## Summary
- `QuizStore.execDeleteQuestion` snapshots affected `game_questions.id` rows and drops dependent `game_answers` (filtered by `game_question_id` to avoid wiping sibling questions) and `game_questions` rows before the question delete, all inside the existing `ExecTx`. Without this, deleting a question that has been answered raised `FOREIGN KEY constraint failed (787)` and the admin route returned 500 — the same shape as the just-merged #155, but scoped to a single question's chain rather than the whole quiz.
- Three new sqlc queries: `ListGameQuestionIDsForQuestion`, `DeleteGameAnswersByGameQuestionIDs`, `DeleteGameQuestionsByQuestionID`.
- New unit subtest in `quiz_test.go` builds a played game where two questions are answered, deletes one, and asserts the deleted question's chain is gone while the sibling question's rows survive.
- New integration assertion in `TestGameplay_Integration` POSTs `/admin/quizzes/{id}/questions/{qid}/delete` on a played question and expects 303.

Both call sites of `execDeleteQuestion` (admin POST and the orphan cleanup in `handleQuestions` during quiz update) inherit the cascade.

The remaining items on #157 (multi-player leaderboard, deep-link smoke, test split) are independent and stay open.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (unit + integration green)
- [x] Verified the integration test fails with `FOREIGN KEY constraint failed (787)` when the cascade is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)