### PR TITLE
Split TestGameplay_Integration into focused subtests

### DIFF
--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -251,6 +251,13 @@ func setupIntegration(t *testing.T) (context.Context, integrationSetup) {
 	}
 }
 
+// Subtests share state (cookie jars, gameID, runningScore, completedPlayerID,
+// adminClient, freshGameID) and run sequentially by design — earlier scenarios
+// produce the player/game rows later ones rely on. Disable paralleltest and
+// tparallel so subtests don't call t.Parallel() (which would corrupt the
+// shared state).
+//
+//nolint:paralleltest,tparallel // subtests share state and must run sequentially
 func TestGameplay_Integration(t *testing.T) {
 	t.Parallel()
 
@@ -296,703 +303,761 @@ func TestGameplay_Integration(t *testing.T) {
 		t.Fatalf("failed to create quiz: %v", err)
 	}
 
-	// Deep-link smoke (#157 sec.3): GET /play/{slug}-{id} should rewrite
-	// to the SPA shell and return 200 with the player client HTML. Use a
-	// throwaway client (no jar) so any accidental cookie write from the
-	// static handler does not pollute the player session below.
-	deepLinkURL := fmt.Sprintf("%s/play/%s-%d", baseURL, qz.Slug, qz.ID)
-	deepLinkResp := httpGet(ctx, t, &http.Client{}, deepLinkURL)
-	if got, want := deepLinkResp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("GET /play/{slugID} status = %d, want %d", got, want)
-	}
-	deepLinkBody, err := io.ReadAll(deepLinkResp.Body)
-	if cerr := deepLinkResp.Body.Close(); cerr != nil {
-		t.Errorf("deep-link body close err = %v", cerr)
-	}
-	if err != nil {
-		t.Fatalf("failed to read deep-link body: %v", err)
-	}
-	if got, want := string(deepLinkBody), "<title>TopBanana"; !strings.Contains(got, want) {
-		t.Errorf(
-			"deep-link body should contain %q (proves SPA shell was served), got body of length %d",
-			want,
-			len(got),
-		)
-	}
+	// Shared state across subtests. These are declared in the parent so
+	// later subtests can read what earlier subtests produced — the
+	// scenarios run sequentially and intentionally share cookie jars,
+	// player IDs, and game IDs. New subtests inserted between existing
+	// ones must never call t.Parallel() and must use `=` (not `:=`) when
+	// assigning these variables; rebinding inside a subtest closure
+	// would silently break every later subtest that reads them.
+	//
+	// Producer / consumer map for these variables:
+	//   jar, client       set in "single player can play through to completion";
+	//                     read by every later subtest that acts as the player.
+	//   gameID            set in "single player ..."; read by "my-game returns
+	//                     the completed game ...".
+	//   runningScore      set in "single player ..."; read there + in
+	//                     "multi-player leaderboard ...".
+	//   completedPlayerID set at the end of "single player ..."; read by
+	//                     "admin reset clears the played game ...".
+	//   adminClient       set in "admin reset ..."; read by every later admin
+	//                     POST (question delete, CSRF reject, quiz delete).
+	//   freshGameID       set in "admin reset ..."; read by "in-flight game
+	//                     answer ...".
+	var (
+		jar               *cookiejar.Jar
+		client            *http.Client
+		gameID            string
+		runningScore      int
+		completedPlayerID int64
+		adminClient       *http.Client
+		freshGameID       string
+	)
 
-	// Start of the integration test. The cookie jar carries the anonymous
-	// session cookie that EnsurePlayer issues on the first request, so
-	// every subsequent request is attributed to the same player row.
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("failed to create cookie jar: %v", err)
-	}
-	client := &http.Client{Jar: jar}
+	t.Run("play deep-link serves SPA shell", func(t *testing.T) {
+		// Deep-link smoke (#157 sec.3): GET /play/{slug}-{id} should rewrite
+		// to the SPA shell and return 200 with the player client HTML. Use a
+		// throwaway client (no jar) so any accidental cookie write from the
+		// static handler does not pollute the player session below.
+		deepLinkURL := fmt.Sprintf("%s/play/%s-%d", baseURL, qz.Slug, qz.ID)
+		deepLinkResp := httpGet(ctx, t, &http.Client{}, deepLinkURL)
+		if got, want := deepLinkResp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("GET /play/{slugID} status = %d, want %d", got, want)
+		}
+		deepLinkBody, err := io.ReadAll(deepLinkResp.Body)
+		if cerr := deepLinkResp.Body.Close(); cerr != nil {
+			t.Errorf("deep-link body close err = %v", cerr)
+		}
+		if err != nil {
+			t.Fatalf("failed to read deep-link body: %v", err)
+		}
+		if got, want := string(deepLinkBody), "<title>TopBanana"; !strings.Contains(got, want) {
+			t.Errorf(
+				"deep-link body should contain %q (proves SPA shell was served), got body of length %d",
+				want,
+				len(got),
+			)
+		}
+	})
 
-	var resp *http.Response
+	t.Run("quizzes API lists the seeded quiz", func(t *testing.T) {
+		// Start of the integration test. The cookie jar carries the anonymous
+		// session cookie that EnsurePlayer issues on the first request, so
+		// every subsequent request is attributed to the same player row.
+		var err error
+		jar, err = cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("failed to create cookie jar: %v", err)
+		}
+		client = &http.Client{Jar: jar}
 
-	// Get a list of quizzes
-	resp = httpGet(ctx, t, client, baseURL+"/api/quizzes")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", resp.StatusCode)
-	}
-
-	var quizzesRes []struct {
-		Title       string `json:"title"`
-		Description string `json:"description"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&quizzesRes)
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if err != nil {
-		t.Fatalf("failed to decode quizzes response: %v", err)
-	}
-	if got, want := len(quizzesRes), 1; got != want {
-		t.Fatalf("got %d quizzes, want %d", got, want)
-	}
-	if got, want := quizzesRes[0].Title, qz.Title; got != want {
-		t.Fatalf("got quiz title %q, want %q", got, want)
-	}
-	if got, want := quizzesRes[0].Description, qz.Description; got != want {
-		t.Fatalf("got quiz description %q, want %q", got, want)
-	}
-
-	// Create Game
-	createGameReq := fmt.Sprintf(`{"quizId": %d}`, qz.ID)
-	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("expected status 201, got %d", resp.StatusCode)
-	}
-
-	var createGameRes struct {
-		ID string `json:"id"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&createGameRes)
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if err != nil {
-		t.Fatalf("failed to decode create game response: %v", err)
-	}
-	gameID := createGameRes.ID
-
-	runningScore := 0
-	// Walk through questions
-	for i := range 3 {
-		// Get Next Question
-		resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		// Get a list of quizzes
+		resp := httpGet(ctx, t, client, baseURL+"/api/quizzes")
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("list quizzes status = %d, want %d", got, want)
 		}
 
-		var nextQsRes nextQuestionRes
-		err = json.NewDecoder(resp.Body).Decode(&nextQsRes)
+		var quizzesRes []struct {
+			Title       string `json:"title"`
+			Description string `json:"description"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&quizzesRes)
 		if cerr := resp.Body.Close(); cerr != nil {
 			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
 		}
 		if err != nil {
-			t.Fatalf("failed to decode next question response: %v", err)
+			t.Fatalf("failed to decode quizzes response: %v", err)
+		}
+		if got, want := len(quizzesRes), 1; got != want {
+			t.Fatalf("got %d quizzes, want %d", got, want)
+		}
+		if got, want := quizzesRes[0].Title, qz.Title; got != want {
+			t.Fatalf("got quiz title %q, want %q", got, want)
+		}
+		if got, want := quizzesRes[0].Description, qz.Description; got != want {
+			t.Fatalf("got quiz description %q, want %q", got, want)
+		}
+	})
+
+	createGameReq := fmt.Sprintf(`{"quizId": %d}`, qz.ID)
+
+	t.Run("single player can play through to completion", func(t *testing.T) {
+		// Create Game
+		resp := httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
+		if got, want := resp.StatusCode, http.StatusCreated; got != want {
+			t.Fatalf("create game status = %d, want %d", got, want)
 		}
 
-		// Find correct or incorrect option
-		// Let's pick correct for first and last, incorrect for middle
-		targetCorrect := i != 1
-		var optionID int64
-		found := false
+		var createGameRes struct {
+			ID string `json:"id"`
+		}
+		err := json.NewDecoder(resp.Body).Decode(&createGameRes)
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if err != nil {
+			t.Fatalf("failed to decode create game response: %v", err)
+		}
+		gameID = createGameRes.ID
 
-		// We need to know which option is correct from the seeded data
-		// but the API doesn't return that (as it shouldn't).
-		// We can find it from our local 'qz' variable.
-		for _, q := range qz.Questions {
-			if q.ID == nextQsRes.ID {
-				for _, o := range q.Options {
-					if o.Correct == targetCorrect {
-						optionID = o.ID
-						found = true
+		// Walk through questions
+		for i := range 3 {
+			// Get Next Question
+			resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Fatalf("next question status = %d, want %d", got, want)
+			}
 
-						break
+			var nextQsRes nextQuestionRes
+			err = json.NewDecoder(resp.Body).Decode(&nextQsRes)
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+			}
+			if err != nil {
+				t.Fatalf("failed to decode next question response: %v", err)
+			}
+
+			// Find correct or incorrect option
+			// Let's pick correct for first and last, incorrect for middle
+			targetCorrect := i != 1
+			var optionID int64
+			found := false
+
+			// We need to know which option is correct from the seeded data
+			// but the API doesn't return that (as it shouldn't).
+			// We can find it from our local 'qz' variable.
+			for _, q := range qz.Questions {
+				if q.ID == nextQsRes.ID {
+					for _, o := range q.Options {
+						if o.Correct == targetCorrect {
+							optionID = o.ID
+							found = true
+
+							break
+						}
 					}
 				}
+				if found {
+					break
+				}
 			}
-			if found {
-				break
+
+			if !found {
+				t.Fatalf("could not find target option for question %d", i+1)
 			}
+
+			// Submit Answer
+			answerReq := fmt.Sprintf(`{"optionId": %d}`, optionID)
+			answerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, gameID, nextQsRes.ID)
+			resp = httpPostJSON(ctx, t, client, answerURL, answerReq)
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Fatalf("answer status = %d, want %d", got, want)
+			}
+
+			var answerRes struct {
+				Correct bool `json:"correct"`
+				Score   int  `json:"score"`
+			}
+			err = json.NewDecoder(resp.Body).Decode(&answerRes)
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+			}
+			if err != nil {
+				t.Fatalf("failed to decode results response: %v", err)
+			}
+			if got, want := answerRes.Correct, targetCorrect; got != want {
+				t.Fatalf("got correct %v, want %v", got, want)
+			}
+			runningScore += answerRes.Score
 		}
 
-		if !found {
-			t.Fatalf("could not find target option for question %d", i+1)
+		// Get Results
+		resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/results", baseURL, gameID))
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("results status = %d, want %d", got, want)
 		}
 
-		// Submit Answer
-		answerReq := fmt.Sprintf(`{"optionId": %d}`, optionID)
-		answerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, gameID, nextQsRes.ID)
-		resp = httpPostJSON(ctx, t, client, answerURL, answerReq)
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-
-		var answerRes struct {
-			Correct bool `json:"correct"`
-			Score   int  `json:"score"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&answerRes)
+		var results resultsRes
+		err = json.NewDecoder(resp.Body).Decode(&results)
 		if cerr := resp.Body.Close(); cerr != nil {
 			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
 		}
 		if err != nil {
 			t.Fatalf("failed to decode results response: %v", err)
 		}
-		if got, want := answerRes.Correct, targetCorrect; got != want {
-			t.Fatalf("got correct %v, want %v", got, want)
+
+		if got, want := results.GameID, gameID; got != want {
+			t.Fatalf("got game ID %q, want %q", got, want)
 		}
-		runningScore += answerRes.Score
-	}
-
-	// Get Results
-	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/results", baseURL, gameID))
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", resp.StatusCode)
-	}
-
-	var results resultsRes
-	err = json.NewDecoder(resp.Body).Decode(&results)
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if err != nil {
-		t.Fatalf("failed to decode results response: %v", err)
-	}
-
-	if got, want := results.GameID, gameID; got != want {
-		t.Fatalf("got game ID %q, want %q", got, want)
-	}
-	if got, want := len(results.PlayerScores), 1; got != want {
-		t.Fatalf("got %d player scores, want %d", got, want)
-	}
-
-	// The server picks the player ID for an anonymous session, so we
-	// don't assert a specific value — just that it is a real row.
-	if got := results.PlayerScores[0].PlayerID; got <= 0 {
-		t.Fatalf("got player ID %d, want > 0", got)
-	}
-	if got, want := results.PlayerScores[0].Score, runningScore; got != want {
-		t.Fatalf("got score %d, want %d", got, want)
-	}
-
-	// Verify no more questions
-	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected status 404, got %d", resp.StatusCode)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-
-	// Quiz leaderboard: the player who just finished should appear with
-	// IsCurrentPlayer=true and the same score they accumulated above.
-	leaderboardURL := fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, qz.Slug, qz.ID)
-	resp = httpGet(ctx, t, client, leaderboardURL)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", resp.StatusCode)
-	}
-
-	var leaderboard leaderboardRes
-	err = json.NewDecoder(resp.Body).Decode(&leaderboard)
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if err != nil {
-		t.Fatalf("failed to decode leaderboard response: %v", err)
-	}
-
-	if got, want := leaderboard.QuizID, qz.ID; got != want {
-		t.Fatalf("leaderboard.QuizID = %d, want %d", got, want)
-	}
-	if got, want := len(leaderboard.Entries), 1; got != want {
-		t.Fatalf("len(leaderboard.Entries) = %d, want %d", got, want)
-	}
-	if got, want := leaderboard.Entries[0].IsCurrentPlayer, true; got != want {
-		t.Errorf("leaderboard.Entries[0].IsCurrentPlayer = %v, want %v", got, want)
-	}
-	if got, want := leaderboard.Entries[0].Score, runningScore; got != want {
-		t.Errorf("leaderboard.Entries[0].Score = %d, want %d", got, want)
-	}
-	if got := leaderboard.Entries[0].PlayerID; got <= 0 {
-		t.Errorf("leaderboard.Entries[0].PlayerID = %d, want > 0", got)
-	}
-	completedPlayerID := leaderboard.Entries[0].PlayerID
-
-	// Multi-player leaderboard (#157 sec.2): a second player finishes the
-	// same quiz with a different (strictly higher) score so we can assert
-	// ranking by score descending and per-requester IsCurrentPlayer flags.
-	// The first player got Q1+Q3 correct (2/3); player 2 gets all three
-	// correct so the totals are unambiguously different.
-	jar2, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("failed to create second cookie jar: %v", err)
-	}
-	client2 := &http.Client{Jar: jar2}
-
-	resp = httpPostJSON(ctx, t, client2, baseURL+"/api/games", createGameReq)
-	if got, want := resp.StatusCode, http.StatusCreated; got != want {
-		t.Fatalf("player2 create game status = %d, want %d", got, want)
-	}
-
-	var createGame2Res struct {
-		ID string `json:"id"`
-	}
-	if derr := json.NewDecoder(resp.Body).Decode(&createGame2Res); derr != nil {
-		t.Fatalf("failed to decode player2 create-game response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	gameID2 := createGame2Res.ID
-
-	runningScore2 := 0
-	for i := range 3 {
-		resp = httpGet(ctx, t, client2, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID2))
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("player2 next question status = %d, want %d", got, want)
+		if got, want := len(results.PlayerScores), 1; got != want {
+			t.Fatalf("got %d player scores, want %d", got, want)
 		}
 
-		var nextQs2Res nextQuestionRes
-		if derr := json.NewDecoder(resp.Body).Decode(&nextQs2Res); derr != nil {
-			t.Fatalf("failed to decode player2 next question: %v", derr)
+		// The server picks the player ID for an anonymous session, so we
+		// don't assert a specific value — just that it is a real row.
+		if got := results.PlayerScores[0].PlayerID; got <= 0 {
+			t.Fatalf("got player ID %d, want > 0", got)
+		}
+		if got, want := results.PlayerScores[0].Score, runningScore; got != want {
+			t.Fatalf("got score %d, want %d", got, want)
+		}
+
+		// Verify no more questions
+		resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
+		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+			t.Fatalf("post-completion next question status = %d, want %d", got, want)
 		}
 		if cerr := resp.Body.Close(); cerr != nil {
 			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
 		}
 
-		// Player 2 gets all three questions correct.
-		var optionID2 int64
-		found2 := false
-		for _, q := range qz.Questions {
-			if q.ID == nextQs2Res.ID {
-				for _, o := range q.Options {
-					if o.Correct {
-						optionID2 = o.ID
-						found2 = true
+		// Quiz leaderboard: the player who just finished should appear with
+		// IsCurrentPlayer=true and the same score they accumulated above.
+		leaderboardURL := fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, qz.Slug, qz.ID)
+		resp = httpGet(ctx, t, client, leaderboardURL)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("leaderboard status = %d, want %d", got, want)
+		}
 
-						break
+		var leaderboard leaderboardRes
+		err = json.NewDecoder(resp.Body).Decode(&leaderboard)
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if err != nil {
+			t.Fatalf("failed to decode leaderboard response: %v", err)
+		}
+
+		if got, want := leaderboard.QuizID, qz.ID; got != want {
+			t.Fatalf("leaderboard.QuizID = %d, want %d", got, want)
+		}
+		if got, want := len(leaderboard.Entries), 1; got != want {
+			t.Fatalf("len(leaderboard.Entries) = %d, want %d", got, want)
+		}
+		if got, want := leaderboard.Entries[0].IsCurrentPlayer, true; got != want {
+			t.Errorf("leaderboard.Entries[0].IsCurrentPlayer = %v, want %v", got, want)
+		}
+		if got, want := leaderboard.Entries[0].Score, runningScore; got != want {
+			t.Errorf("leaderboard.Entries[0].Score = %d, want %d", got, want)
+		}
+		if got := leaderboard.Entries[0].PlayerID; got <= 0 {
+			t.Errorf("leaderboard.Entries[0].PlayerID = %d, want > 0", got)
+		}
+		completedPlayerID = leaderboard.Entries[0].PlayerID
+	})
+
+	leaderboardURL := fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, qz.Slug, qz.ID)
+	myGameURL := fmt.Sprintf("%s/api/quizzes/%s-%d/my-game", baseURL, qz.Slug, qz.ID)
+
+	t.Run("multi-player leaderboard ranks by score and flips IsCurrentPlayer per requester", func(t *testing.T) {
+		// Multi-player leaderboard (#157 sec.2): a second player finishes the
+		// same quiz with a different (strictly higher) score so we can assert
+		// ranking by score descending and per-requester IsCurrentPlayer flags.
+		// The first player got Q1+Q3 correct (2/3); player 2 gets all three
+		// correct so the totals are unambiguously different.
+		jar2, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("failed to create second cookie jar: %v", err)
+		}
+		client2 := &http.Client{Jar: jar2}
+
+		resp := httpPostJSON(ctx, t, client2, baseURL+"/api/games", createGameReq)
+		if got, want := resp.StatusCode, http.StatusCreated; got != want {
+			t.Fatalf("player2 create game status = %d, want %d", got, want)
+		}
+
+		var createGame2Res struct {
+			ID string `json:"id"`
+		}
+		if derr := json.NewDecoder(resp.Body).Decode(&createGame2Res); derr != nil {
+			t.Fatalf("failed to decode player2 create-game response: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		gameID2 := createGame2Res.ID
+
+		runningScore2 := 0
+		for i := range 3 {
+			resp = httpGet(ctx, t, client2, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID2))
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Fatalf("player2 next question status = %d, want %d", got, want)
+			}
+
+			var nextQs2Res nextQuestionRes
+			if derr := json.NewDecoder(resp.Body).Decode(&nextQs2Res); derr != nil {
+				t.Fatalf("failed to decode player2 next question: %v", derr)
+			}
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+			}
+
+			// Player 2 gets all three questions correct.
+			var optionID2 int64
+			found2 := false
+			for _, q := range qz.Questions {
+				if q.ID == nextQs2Res.ID {
+					for _, o := range q.Options {
+						if o.Correct {
+							optionID2 = o.ID
+							found2 = true
+
+							break
+						}
 					}
 				}
+				if found2 {
+					break
+				}
 			}
-			if found2 {
-				break
+			if !found2 {
+				t.Fatalf("could not find correct option for player2 question %d", i+1)
 			}
-		}
-		if !found2 {
-			t.Fatalf("could not find correct option for player2 question %d", i+1)
+
+			answer2Req := fmt.Sprintf(`{"optionId": %d}`, optionID2)
+			answer2URL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, gameID2, nextQs2Res.ID)
+			resp = httpPostJSON(ctx, t, client2, answer2URL, answer2Req)
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Fatalf("player2 answer status = %d, want %d", got, want)
+			}
+
+			var answer2Res struct {
+				Correct bool `json:"correct"`
+				Score   int  `json:"score"`
+			}
+			if derr := json.NewDecoder(resp.Body).Decode(&answer2Res); derr != nil {
+				t.Fatalf("failed to decode player2 answer response: %v", derr)
+			}
+			if cerr := resp.Body.Close(); cerr != nil {
+				t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+			}
+			if got, want := answer2Res.Correct, true; got != want {
+				t.Fatalf("player2 Q%d correct = %v, want %v", i+1, got, want)
+			}
+			runningScore2 += answer2Res.Score
 		}
 
-		answer2Req := fmt.Sprintf(`{"optionId": %d}`, optionID2)
-		answer2URL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, gameID2, nextQs2Res.ID)
-		resp = httpPostJSON(ctx, t, client2, answer2URL, answer2Req)
+		// Sanity: player2 must strictly out-score player1 for the ranking
+		// assertion below to be meaningful.
+		if got := runningScore2; got <= runningScore {
+			t.Fatalf("runningScore2 = %d, want > runningScore (%d)", got, runningScore)
+		}
+
+		// GET leaderboard from player2's session: 2 entries, descending by
+		// score (player2 first), player2 flagged IsCurrentPlayer=true.
+		resp = httpGet(ctx, t, client2, leaderboardURL)
 		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("player2 answer status = %d, want %d", got, want)
+			t.Fatalf("player2 leaderboard status = %d, want %d", got, want)
 		}
 
-		var answer2Res struct {
-			Correct bool `json:"correct"`
-			Score   int  `json:"score"`
-		}
-		if derr := json.NewDecoder(resp.Body).Decode(&answer2Res); derr != nil {
-			t.Fatalf("failed to decode player2 answer response: %v", derr)
+		var leaderboard2 leaderboardRes
+		if derr := json.NewDecoder(resp.Body).Decode(&leaderboard2); derr != nil {
+			t.Fatalf("failed to decode player2 leaderboard response: %v", derr)
 		}
 		if cerr := resp.Body.Close(); cerr != nil {
 			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
 		}
-		if got, want := answer2Res.Correct, true; got != want {
-			t.Fatalf("player2 Q%d correct = %v, want %v", i+1, got, want)
+
+		if got, want := len(leaderboard2.Entries), 2; got != want {
+			t.Fatalf("len(leaderboard2.Entries) = %d, want %d", got, want)
 		}
-		runningScore2 += answer2Res.Score
-	}
+		if got, want := leaderboard2.Entries[0].Score, runningScore2; got != want {
+			t.Errorf("leaderboard2.Entries[0].Score = %d, want %d (player2 should rank first)", got, want)
+		}
+		if got, want := leaderboard2.Entries[1].Score, runningScore; got != want {
+			t.Errorf("leaderboard2.Entries[1].Score = %d, want %d (player1 should rank second)", got, want)
+		}
+		if got, want := leaderboard2.Entries[0].IsCurrentPlayer, true; got != want {
+			t.Errorf("leaderboard2.Entries[0].IsCurrentPlayer = %v, want %v (requester is player2)", got, want)
+		}
+		if got, want := leaderboard2.Entries[1].IsCurrentPlayer, false; got != want {
+			t.Errorf("leaderboard2.Entries[1].IsCurrentPlayer = %v, want %v (player1 is not the requester)", got, want)
+		}
+		if got := leaderboard2.Entries[0].PlayerID; got <= 0 {
+			t.Errorf("leaderboard2.Entries[0].PlayerID = %d, want > 0", got)
+		}
+		if got := leaderboard2.Entries[1].PlayerID; got <= 0 {
+			t.Errorf("leaderboard2.Entries[1].PlayerID = %d, want > 0", got)
+		}
+		if leaderboard2.Entries[0].PlayerID == leaderboard2.Entries[1].PlayerID {
+			t.Errorf("leaderboard2 entries have same PlayerID %d, want distinct", leaderboard2.Entries[0].PlayerID)
+		}
+		if got, want := leaderboard2.Entries[1].PlayerID, completedPlayerID; got != want {
+			t.Errorf("leaderboard2.Entries[1].PlayerID = %d, want %d (player1)", got, want)
+		}
 
-	// Sanity: player2 must strictly out-score player1 for the ranking
-	// assertion below to be meaningful.
-	if got := runningScore2; got <= runningScore {
-		t.Fatalf("runningScore2 = %d, want > runningScore (%d)", got, runningScore)
-	}
+		// Re-fetch leaderboard from player1's session: same order (score is
+		// the only sort key) but the IsCurrentPlayer flags flip.
+		resp = httpGet(ctx, t, client, leaderboardURL)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("player1 re-fetch leaderboard status = %d, want %d", got, want)
+		}
 
-	// GET leaderboard from player2's session: 2 entries, descending by
-	// score (player2 first), player2 flagged IsCurrentPlayer=true.
-	resp = httpGet(ctx, t, client2, leaderboardURL)
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("player2 leaderboard status = %d, want %d", got, want)
-	}
+		var leaderboard1Again leaderboardRes
+		if derr := json.NewDecoder(resp.Body).Decode(&leaderboard1Again); derr != nil {
+			t.Fatalf("failed to decode player1 re-fetch leaderboard response: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
 
-	var leaderboard2 leaderboardRes
-	if derr := json.NewDecoder(resp.Body).Decode(&leaderboard2); derr != nil {
-		t.Fatalf("failed to decode player2 leaderboard response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
+		if got, want := len(leaderboard1Again.Entries), 2; got != want {
+			t.Fatalf("len(leaderboard1Again.Entries) = %d, want %d", got, want)
+		}
+		if got, want := leaderboard1Again.Entries[0].Score, runningScore2; got != want {
+			t.Errorf("leaderboard1Again.Entries[0].Score = %d, want %d", got, want)
+		}
+		if got, want := leaderboard1Again.Entries[1].Score, runningScore; got != want {
+			t.Errorf("leaderboard1Again.Entries[1].Score = %d, want %d", got, want)
+		}
+		if got, want := leaderboard1Again.Entries[0].IsCurrentPlayer, false; got != want {
+			t.Errorf(
+				"leaderboard1Again.Entries[0].IsCurrentPlayer = %v, want %v (player2 is not the requester)",
+				got,
+				want,
+			)
+		}
+		if got, want := leaderboard1Again.Entries[1].IsCurrentPlayer, true; got != want {
+			t.Errorf("leaderboard1Again.Entries[1].IsCurrentPlayer = %v, want %v (requester is player1)", got, want)
+		}
+		if got, want := leaderboard1Again.Entries[1].PlayerID, completedPlayerID; got != want {
+			t.Errorf("leaderboard1Again.Entries[1].PlayerID = %d, want %d (player1)", got, want)
+		}
+	})
 
-	if got, want := len(leaderboard2.Entries), 2; got != want {
-		t.Fatalf("len(leaderboard2.Entries) = %d, want %d", got, want)
-	}
-	if got, want := leaderboard2.Entries[0].Score, runningScore2; got != want {
-		t.Errorf("leaderboard2.Entries[0].Score = %d, want %d (player2 should rank first)", got, want)
-	}
-	if got, want := leaderboard2.Entries[1].Score, runningScore; got != want {
-		t.Errorf("leaderboard2.Entries[1].Score = %d, want %d (player1 should rank second)", got, want)
-	}
-	if got, want := leaderboard2.Entries[0].IsCurrentPlayer, true; got != want {
-		t.Errorf("leaderboard2.Entries[0].IsCurrentPlayer = %v, want %v (requester is player2)", got, want)
-	}
-	if got, want := leaderboard2.Entries[1].IsCurrentPlayer, false; got != want {
-		t.Errorf("leaderboard2.Entries[1].IsCurrentPlayer = %v, want %v (player1 is not the requester)", got, want)
-	}
-	if got := leaderboard2.Entries[0].PlayerID; got <= 0 {
-		t.Errorf("leaderboard2.Entries[0].PlayerID = %d, want > 0", got)
-	}
-	if got := leaderboard2.Entries[1].PlayerID; got <= 0 {
-		t.Errorf("leaderboard2.Entries[1].PlayerID = %d, want > 0", got)
-	}
-	if leaderboard2.Entries[0].PlayerID == leaderboard2.Entries[1].PlayerID {
-		t.Errorf("leaderboard2 entries have same PlayerID %d, want distinct", leaderboard2.Entries[0].PlayerID)
-	}
-	if got, want := leaderboard2.Entries[1].PlayerID, completedPlayerID; got != want {
-		t.Errorf("leaderboard2.Entries[1].PlayerID = %d, want %d (player1)", got, want)
-	}
+	t.Run("my-game returns the completed game and second-attempt is rejected", func(t *testing.T) {
+		// One-attempt-per-quiz: GET /my-game now reports the finished game
+		// with completed=true.
+		resp := httpGet(ctx, t, client, myGameURL)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("GET /my-game status = %d, want %d", got, want)
+		}
 
-	// Re-fetch leaderboard from player1's session: same order (score is
-	// the only sort key) but the IsCurrentPlayer flags flip.
-	resp = httpGet(ctx, t, client, leaderboardURL)
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("player1 re-fetch leaderboard status = %d, want %d", got, want)
-	}
+		var myGameRes struct {
+			GameID    string `json:"gameId"`
+			Completed bool   `json:"completed"`
+		}
+		if derr := json.NewDecoder(resp.Body).Decode(&myGameRes); derr != nil {
+			t.Fatalf("failed to decode my-game response: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if got, want := myGameRes.GameID, gameID; got != want {
+			t.Errorf("my-game GameID = %q, want %q", got, want)
+		}
+		if got, want := myGameRes.Completed, true; got != want {
+			t.Errorf("my-game Completed = %v, want %v", got, want)
+		}
 
-	var leaderboard1Again leaderboardRes
-	if derr := json.NewDecoder(resp.Body).Decode(&leaderboard1Again); derr != nil {
-		t.Fatalf("failed to decode player1 re-fetch leaderboard response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
+		// A second POST /api/games for the same player + quiz must be
+		// rejected with 409 — the frontend should have called my-game first.
+		resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
+		if got, want := resp.StatusCode, http.StatusConflict; got != want {
+			t.Fatalf("second create game status = %d, want %d", got, want)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+	})
 
-	if got, want := len(leaderboard1Again.Entries), 2; got != want {
-		t.Fatalf("len(leaderboard1Again.Entries) = %d, want %d", got, want)
-	}
-	if got, want := leaderboard1Again.Entries[0].Score, runningScore2; got != want {
-		t.Errorf("leaderboard1Again.Entries[0].Score = %d, want %d", got, want)
-	}
-	if got, want := leaderboard1Again.Entries[1].Score, runningScore; got != want {
-		t.Errorf("leaderboard1Again.Entries[1].Score = %d, want %d", got, want)
-	}
-	if got, want := leaderboard1Again.Entries[0].IsCurrentPlayer, false; got != want {
-		t.Errorf("leaderboard1Again.Entries[0].IsCurrentPlayer = %v, want %v (player2 is not the requester)", got, want)
-	}
-	if got, want := leaderboard1Again.Entries[1].IsCurrentPlayer, true; got != want {
-		t.Errorf("leaderboard1Again.Entries[1].IsCurrentPlayer = %v, want %v (requester is player1)", got, want)
-	}
-	if got, want := leaderboard1Again.Entries[1].PlayerID, completedPlayerID; got != want {
-		t.Errorf("leaderboard1Again.Entries[1].PlayerID = %d, want %d (player1)", got, want)
-	}
+	t.Run("admin reset clears the played game and unblocks replay", func(t *testing.T) {
+		// Admin reset (drive via the HTTP route, with CSRF token from the
+		// admin form). Use a separate jar / client so the admin's own session
+		// does not interfere with the player flow above.
+		adminClient = &http.Client{
+			Jar: func() *cookiejar.Jar {
+				j, jerr := cookiejar.New(nil)
+				if jerr != nil {
+					t.Fatalf("failed to create admin cookie jar: %v", jerr)
+				}
 
-	// One-attempt-per-quiz: GET /my-game now reports the finished game
-	// with completed=true.
-	myGameURL := fmt.Sprintf("%s/api/quizzes/%s-%d/my-game", baseURL, qz.Slug, qz.ID)
-	resp = httpGet(ctx, t, client, myGameURL)
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("GET /my-game status = %d, want %d", got, want)
-	}
+				return j
+			}(),
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		registerAdminAndResetPlayer(ctx, t, adminClient, baseURL, qz.ID, completedPlayerID)
 
-	var myGameRes struct {
-		GameID    string `json:"gameId"`
-		Completed bool   `json:"completed"`
-	}
-	if derr := json.NewDecoder(resp.Body).Decode(&myGameRes); derr != nil {
-		t.Fatalf("failed to decode my-game response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if got, want := myGameRes.GameID, gameID; got != want {
-		t.Errorf("my-game GameID = %q, want %q", got, want)
-	}
-	if got, want := myGameRes.Completed, true; got != want {
-		t.Errorf("my-game Completed = %v, want %v", got, want)
-	}
+		// After reset, GET /my-game returns 404 — no game for this (player, quiz).
+		resp := httpGet(ctx, t, client, myGameURL)
+		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+			t.Fatalf("after reset, GET /my-game status = %d, want %d", got, want)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
 
-	// A second POST /api/games for the same player + quiz must be
-	// rejected with 409 — the frontend should have called my-game first.
-	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
-	if got, want := resp.StatusCode, http.StatusConflict; got != want {
-		t.Fatalf("second create game status = %d, want %d", got, want)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
+		// And the player can now POST /api/games again to start fresh.
+		resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
+		if got, want := resp.StatusCode, http.StatusCreated; got != want {
+			t.Fatalf("after reset, create game status = %d, want %d", got, want)
+		}
 
-	// Admin reset (drive via the HTTP route, with CSRF token from the
-	// admin form). Use a separate jar / client so the admin's own session
-	// does not interfere with the player flow above.
-	adminClient := &http.Client{
-		Jar: func() *cookiejar.Jar {
-			j, jerr := cookiejar.New(nil)
-			if jerr != nil {
-				t.Fatalf("failed to create admin cookie jar: %v", jerr)
-			}
+		var freshGameRes struct {
+			ID string `json:"id"`
+		}
+		if derr := json.NewDecoder(resp.Body).Decode(&freshGameRes); derr != nil {
+			t.Fatalf("failed to decode fresh create-game response: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if got := freshGameRes.ID; got == "" {
+			t.Error("fresh game ID is empty, want non-empty")
+		}
+		if freshGameRes.ID == gameID {
+			t.Errorf("fresh game ID %q equals old game ID %q, want a new ID", freshGameRes.ID, gameID)
+		}
+		freshGameID = freshGameRes.ID
+	})
 
-			return j
-		}(),
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	registerAdminAndResetPlayer(ctx, t, adminClient, baseURL, qz.ID, completedPlayerID)
+	t.Run("anonymous admin requests redirect to login", func(t *testing.T) {
+		// Auth gate: an unauthenticated client requesting an /admin route is
+		// redirected to /login with 303, not allowed through to render the
+		// admin page. A throwaway client with no jar and no auto-redirect so
+		// we can assert on the redirect itself.
+		anonClient := &http.Client{
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		anonResp := httpGet(ctx, t, anonClient, baseURL+"/admin/quizzes")
+		if got, want := anonResp.StatusCode, http.StatusSeeOther; got != want {
+			t.Errorf("anon /admin/quizzes status = %d, want %d", got, want)
+		}
+		if got, want := anonResp.Header.Get("Location"), "/login"; got != want {
+			t.Errorf("anon /admin/quizzes Location = %q, want %q", got, want)
+		}
+		if cerr := anonResp.Body.Close(); cerr != nil {
+			t.Errorf("anonResp body close err = %v", cerr)
+		}
+	})
 
-	// After reset, GET /my-game returns 404 — no game for this (player, quiz).
-	resp = httpGet(ctx, t, client, myGameURL)
-	if got, want := resp.StatusCode, http.StatusNotFound; got != want {
-		t.Fatalf("after reset, GET /my-game status = %d, want %d", got, want)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
+	t.Run("in-flight game answer surfaces in my-game with completed=false", func(t *testing.T) {
+		// Regression for #155: admin delete of a played quiz must not 500.
+		// Answer one question on the fresh game first so game_questions and
+		// game_answers both have rows referencing the quiz at the moment the
+		// delete fires. Without QuizStore's in-Go cascade those rows would
+		// trigger a FOREIGN KEY constraint failure and surface as a 500.
+		resp := httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, freshGameID))
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("fresh next question status = %d, want %d", got, want)
+		}
 
-	// And the player can now POST /api/games again to start fresh.
-	resp = httpPostJSON(ctx, t, client, baseURL+"/api/games", createGameReq)
-	if got, want := resp.StatusCode, http.StatusCreated; got != want {
-		t.Fatalf("after reset, create game status = %d, want %d", got, want)
-	}
+		var freshQs nextQuestionRes
+		if derr := json.NewDecoder(resp.Body).Decode(&freshQs); derr != nil {
+			t.Fatalf("failed to decode fresh next question: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
 
-	var freshGameRes struct {
-		ID string `json:"id"`
-	}
-	if derr := json.NewDecoder(resp.Body).Decode(&freshGameRes); derr != nil {
-		t.Fatalf("failed to decode fresh create-game response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if got := freshGameRes.ID; got == "" {
-		t.Error("fresh game ID is empty, want non-empty")
-	}
-	if freshGameRes.ID == gameID {
-		t.Errorf("fresh game ID %q equals old game ID %q, want a new ID", freshGameRes.ID, gameID)
-	}
+		freshAnswerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, freshGameID, freshQs.ID)
+		freshAnswerBody := fmt.Sprintf(`{"optionId": %d}`, freshQs.Options[0].ID)
+		resp = httpPostJSON(ctx, t, client, freshAnswerURL, freshAnswerBody)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("fresh answer status = %d, want %d", got, want)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
 
-	// Auth gate: an unauthenticated client requesting an /admin route is
-	// redirected to /login with 303, not allowed through to render the
-	// admin page. A throwaway client with no jar and no auto-redirect so
-	// we can assert on the redirect itself.
-	anonClient := &http.Client{
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	anonResp := httpGet(ctx, t, anonClient, baseURL+"/admin/quizzes")
-	if got, want := anonResp.StatusCode, http.StatusSeeOther; got != want {
-		t.Errorf("anon /admin/quizzes status = %d, want %d", got, want)
-	}
-	if got, want := anonResp.Header.Get("Location"), "/login"; got != want {
-		t.Errorf("anon /admin/quizzes Location = %q, want %q", got, want)
-	}
-	if cerr := anonResp.Body.Close(); cerr != nil {
-		t.Errorf("anonResp body close err = %v", cerr)
-	}
+		// /my-game during an in-flight game: the player has answered one
+		// question but not finished, so the response is 200 with the
+		// in-flight game ID and completed=false. The player client uses
+		// this to skip the start-game button and resume.
+		resp = httpGet(ctx, t, client, myGameURL)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("in-flight /my-game status = %d, want %d", got, want)
+		}
 
-	// Regression for #155: admin delete of a played quiz must not 500.
-	// Answer one question on the fresh game first so game_questions and
-	// game_answers both have rows referencing the quiz at the moment the
-	// delete fires. Without QuizStore's in-Go cascade those rows would
-	// trigger a FOREIGN KEY constraint failure and surface as a 500.
-	freshGameID := freshGameRes.ID
-	resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, freshGameID))
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("fresh next question status = %d, want %d", got, want)
-	}
+		var inFlightMyGame struct {
+			GameID    string `json:"gameId"`
+			Completed bool   `json:"completed"`
+		}
+		if derr := json.NewDecoder(resp.Body).Decode(&inFlightMyGame); derr != nil {
+			t.Fatalf("failed to decode in-flight my-game response: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if got, want := inFlightMyGame.GameID, freshGameID; got != want {
+			t.Errorf("in-flight my-game GameID = %q, want %q", got, want)
+		}
+		if got, want := inFlightMyGame.Completed, false; got != want {
+			t.Errorf("in-flight my-game Completed = %v, want %v", got, want)
+		}
+	})
 
-	var freshQs nextQuestionRes
-	if derr := json.NewDecoder(resp.Body).Decode(&freshQs); derr != nil {
-		t.Fatalf("failed to decode fresh next question: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-
-	freshAnswerURL := fmt.Sprintf("%s/api/games/%s/questions/%d/answers", baseURL, freshGameID, freshQs.ID)
-	freshAnswerBody := fmt.Sprintf(`{"optionId": %d}`, freshQs.Options[0].ID)
-	resp = httpPostJSON(ctx, t, client, freshAnswerURL, freshAnswerBody)
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("fresh answer status = %d, want %d", got, want)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-
-	// /my-game during an in-flight game: the player has answered one
-	// question but not finished, so the response is 200 with the
-	// in-flight game ID and completed=false. The player client uses
-	// this to skip the start-game button and resume.
-	resp = httpGet(ctx, t, client, myGameURL)
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("in-flight /my-game status = %d, want %d", got, want)
-	}
-
-	var inFlightMyGame struct {
-		GameID    string `json:"gameId"`
-		Completed bool   `json:"completed"`
-	}
-	if derr := json.NewDecoder(resp.Body).Decode(&inFlightMyGame); derr != nil {
-		t.Fatalf("failed to decode in-flight my-game response: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if got, want := inFlightMyGame.GameID, freshGameID; got != want {
-		t.Errorf("in-flight my-game GameID = %q, want %q", got, want)
-	}
-	if got, want := inFlightMyGame.Completed, false; got != want {
-		t.Errorf("in-flight my-game Completed = %v, want %v", got, want)
-	}
-
-	// Regression for #157 sec.1: admin delete of a played question must not
-	// 500. The fresh game above answered question[0], so game_questions and
-	// game_answers both have rows referencing that question at the moment
-	// the delete fires. Without the in-Go cascade in execDeleteQuestion the
-	// FK on game_questions.question_id would raise FOREIGN KEY constraint
-	// failed (787) and the admin route would surface it as a 500.
-	questionDeleteToken := fetchCSRFToken(
-		ctx, t, adminClient, fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID),
-	)
-	questionDeleteForm := url.Values{}
-	questionDeleteForm.Add("csrf_token", questionDeleteToken)
-	questionDeleteURL := fmt.Sprintf(
-		"%s/admin/quizzes/%d/questions/%d/delete", baseURL, qz.ID, qz.Questions[0].ID,
-	)
-	questionDeleteReq, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, questionDeleteURL, strings.NewReader(questionDeleteForm.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("failed to build question delete request: %v", err)
-	}
-	questionDeleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	questionDeleteResp, err := adminClient.Do(questionDeleteReq)
-	if err != nil {
-		t.Fatalf("failed to POST question delete: %v", err)
-	}
-	if got, want := questionDeleteResp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf(
-			"question delete status = %d, want %d (500 here means the FK cascade for question delete regressed)",
-			got, want,
+	t.Run("admin can delete a played question without FK 787", func(t *testing.T) {
+		// Regression for #157 sec.1: admin delete of a played question must not
+		// 500. The fresh game above answered question[0], so game_questions and
+		// game_answers both have rows referencing that question at the moment
+		// the delete fires. Without the in-Go cascade in execDeleteQuestion the
+		// FK on game_questions.question_id would raise FOREIGN KEY constraint
+		// failed (787) and the admin route would surface it as a 500.
+		questionDeleteToken := fetchCSRFToken(
+			ctx, t, adminClient, fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID),
 		)
-	}
-	wantQuestionDeleteLocation := fmt.Sprintf("/admin/quizzes/%d", qz.ID)
-	if got, want := questionDeleteResp.Header.Get("Location"), wantQuestionDeleteLocation; got != want {
-		t.Errorf("question delete Location = %q, want %q", got, want)
-	}
-	if cerr := questionDeleteResp.Body.Close(); cerr != nil {
-		t.Errorf("question delete body close err = %v", cerr)
-	}
+		questionDeleteForm := url.Values{}
+		questionDeleteForm.Add("csrf_token", questionDeleteToken)
+		questionDeleteURL := fmt.Sprintf(
+			"%s/admin/quizzes/%d/questions/%d/delete", baseURL, qz.ID, qz.Questions[0].ID,
+		)
+		questionDeleteReq, err := http.NewRequestWithContext(
+			ctx, http.MethodPost, questionDeleteURL, strings.NewReader(questionDeleteForm.Encode()),
+		)
+		if err != nil {
+			t.Fatalf("failed to build question delete request: %v", err)
+		}
+		questionDeleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		questionDeleteResp, err := adminClient.Do(questionDeleteReq)
+		if err != nil {
+			t.Fatalf("failed to POST question delete: %v", err)
+		}
+		if got, want := questionDeleteResp.StatusCode, http.StatusSeeOther; got != want {
+			t.Fatalf(
+				"question delete status = %d, want %d (500 here means the FK cascade for question delete regressed)",
+				got, want,
+			)
+		}
+		wantQuestionDeleteLocation := fmt.Sprintf("/admin/quizzes/%d", qz.ID)
+		if got, want := questionDeleteResp.Header.Get("Location"), wantQuestionDeleteLocation; got != want {
+			t.Errorf("question delete Location = %q, want %q", got, want)
+		}
+		if cerr := questionDeleteResp.Body.Close(); cerr != nil {
+			t.Errorf("question delete body close err = %v", cerr)
+		}
+	})
 
-	// CSRF: a POST to a state-changing admin route without the
-	// csrf_token form field is rejected by the CSRF middleware before
-	// the handler runs. The middleware sits in front of requireAdmin,
-	// so the response is 403 (not a 303 to /login). Use a body with no
-	// csrf_token field so the cookie is present but the form value is
-	// missing.
-	csrfRejectURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
-	csrfRejectReq, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, csrfRejectURL, strings.NewReader(""),
-	)
-	if err != nil {
-		t.Fatalf("failed to build CSRF-reject request: %v", err)
-	}
-	csrfRejectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	csrfRejectResp, err := adminClient.Do(csrfRejectReq)
-	if err != nil {
-		t.Fatalf("failed to POST CSRF-reject request: %v", err)
-	}
-	if got, want := csrfRejectResp.StatusCode, http.StatusForbidden; got != want {
-		t.Errorf("CSRF-less admin delete status = %d, want %d", got, want)
-	}
-	if cerr := csrfRejectResp.Body.Close(); cerr != nil {
-		t.Errorf("csrfReject body close err = %v", cerr)
-	}
+	t.Run("CSRF middleware rejects POSTs missing or carrying bad tokens", func(t *testing.T) {
+		// CSRF: a POST to a state-changing admin route without the
+		// csrf_token form field is rejected by the CSRF middleware before
+		// the handler runs. The middleware sits in front of requireAdmin,
+		// so the response is 403 (not a 303 to /login). Use a body with no
+		// csrf_token field so the cookie is present but the form value is
+		// missing.
+		csrfRejectURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
+		csrfRejectReq, err := http.NewRequestWithContext(
+			ctx, http.MethodPost, csrfRejectURL, strings.NewReader(""),
+		)
+		if err != nil {
+			t.Fatalf("failed to build CSRF-reject request: %v", err)
+		}
+		csrfRejectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		csrfRejectResp, err := adminClient.Do(csrfRejectReq)
+		if err != nil {
+			t.Fatalf("failed to POST CSRF-reject request: %v", err)
+		}
+		if got, want := csrfRejectResp.StatusCode, http.StatusForbidden; got != want {
+			t.Errorf("CSRF-less admin delete status = %d, want %d", got, want)
+		}
+		if cerr := csrfRejectResp.Body.Close(); cerr != nil {
+			t.Errorf("csrfReject body close err = %v", cerr)
+		}
 
-	// CSRF: a forged token (cookie present, form value present but
-	// mismatched) is also rejected. Different code path from the
-	// missing-field case above — the cookie HMAC verification fails
-	// rather than the form-value lookup.
-	badTokenForm := url.Values{}
-	badTokenForm.Add("csrf_token", "not-a-real-token")
-	badTokenReq, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, csrfRejectURL, strings.NewReader(badTokenForm.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("failed to build bad-token request: %v", err)
-	}
-	badTokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	badTokenResp, err := adminClient.Do(badTokenReq)
-	if err != nil {
-		t.Fatalf("failed to POST bad-token request: %v", err)
-	}
-	if got, want := badTokenResp.StatusCode, http.StatusForbidden; got != want {
-		t.Errorf("bad-token admin delete status = %d, want %d", got, want)
-	}
-	if cerr := badTokenResp.Body.Close(); cerr != nil {
-		t.Errorf("badToken body close err = %v", cerr)
-	}
+		// CSRF: a forged token (cookie present, form value present but
+		// mismatched) is also rejected. Different code path from the
+		// missing-field case above — the cookie HMAC verification fails
+		// rather than the form-value lookup.
+		badTokenForm := url.Values{}
+		badTokenForm.Add("csrf_token", "not-a-real-token")
+		badTokenReq, err := http.NewRequestWithContext(
+			ctx, http.MethodPost, csrfRejectURL, strings.NewReader(badTokenForm.Encode()),
+		)
+		if err != nil {
+			t.Fatalf("failed to build bad-token request: %v", err)
+		}
+		badTokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		badTokenResp, err := adminClient.Do(badTokenReq)
+		if err != nil {
+			t.Fatalf("failed to POST bad-token request: %v", err)
+		}
+		if got, want := badTokenResp.StatusCode, http.StatusForbidden; got != want {
+			t.Errorf("bad-token admin delete status = %d, want %d", got, want)
+		}
+		if cerr := badTokenResp.Body.Close(); cerr != nil {
+			t.Errorf("badToken body close err = %v", cerr)
+		}
+	})
 
-	// Admin POSTs /admin/quizzes/{id}/delete with a CSRF token tied to
-	// the admin session jar created by registerAdminAndResetPlayer above.
-	quizDetailURL := fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID)
-	deleteToken := fetchCSRFToken(ctx, t, adminClient, quizDetailURL)
+	t.Run("admin can delete a played quiz and clears it from the listing", func(t *testing.T) {
+		// Admin POSTs /admin/quizzes/{id}/delete with a CSRF token tied to
+		// the admin session jar created by registerAdminAndResetPlayer above.
+		quizDetailURL := fmt.Sprintf("%s/admin/quizzes/%d", baseURL, qz.ID)
+		deleteToken := fetchCSRFToken(ctx, t, adminClient, quizDetailURL)
 
-	deleteForm := url.Values{}
-	deleteForm.Add("csrf_token", deleteToken)
+		deleteForm := url.Values{}
+		deleteForm.Add("csrf_token", deleteToken)
 
-	deleteURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
-	deleteReq, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, deleteURL, strings.NewReader(deleteForm.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("failed to build admin delete request: %v", err)
-	}
-	deleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	deleteResp, err := adminClient.Do(deleteReq)
-	if err != nil {
-		t.Fatalf("failed to POST admin delete: %v", err)
-	}
-	if got, want := deleteResp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("admin delete status = %d, want %d (500 here means the FK cascade regressed)", got, want)
-	}
-	if got, want := deleteResp.Header.Get("Location"), "/admin/quizzes"; got != want {
-		t.Errorf("admin delete Location = %q, want %q", got, want)
-	}
-	if cerr := deleteResp.Body.Close(); cerr != nil {
-		t.Errorf("delete body close err = %v", cerr)
-	}
+		deleteURL := fmt.Sprintf("%s/admin/quizzes/%d/delete", baseURL, qz.ID)
+		deleteReq, err := http.NewRequestWithContext(
+			ctx, http.MethodPost, deleteURL, strings.NewReader(deleteForm.Encode()),
+		)
+		if err != nil {
+			t.Fatalf("failed to build admin delete request: %v", err)
+		}
+		deleteReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		deleteResp, err := adminClient.Do(deleteReq)
+		if err != nil {
+			t.Fatalf("failed to POST admin delete: %v", err)
+		}
+		if got, want := deleteResp.StatusCode, http.StatusSeeOther; got != want {
+			t.Fatalf("admin delete status = %d, want %d (500 here means the FK cascade regressed)", got, want)
+		}
+		if got, want := deleteResp.Header.Get("Location"), "/admin/quizzes"; got != want {
+			t.Errorf("admin delete Location = %q, want %q", got, want)
+		}
+		if cerr := deleteResp.Body.Close(); cerr != nil {
+			t.Errorf("delete body close err = %v", cerr)
+		}
 
-	// /api/quizzes no longer lists the deleted quiz.
-	resp = httpGet(ctx, t, client, baseURL+"/api/quizzes")
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("post-delete /api/quizzes status = %d, want %d", got, want)
-	}
+		// /api/quizzes no longer lists the deleted quiz.
+		resp := httpGet(ctx, t, client, baseURL+"/api/quizzes")
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("post-delete /api/quizzes status = %d, want %d", got, want)
+		}
 
-	var afterDelete []struct {
-		Title string `json:"title"`
-	}
-	if derr := json.NewDecoder(resp.Body).Decode(&afterDelete); derr != nil {
-		t.Fatalf("failed to decode quizzes after delete: %v", derr)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
-	}
-	if got, want := len(afterDelete), 0; got != want {
-		t.Errorf("quizzes after delete len = %d, want %d", got, want)
-	}
+		var afterDelete []struct {
+			Title string `json:"title"`
+		}
+		if derr := json.NewDecoder(resp.Body).Decode(&afterDelete); derr != nil {
+			t.Fatalf("failed to decode quizzes after delete: %v", derr)
+		}
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+		if got, want := len(afterDelete), 0; got != want {
+			t.Errorf("quizzes after delete len = %d, want %d", got, want)
+		}
+	})
 
 	// Shutdown server
 	stop()
 	select {
-	case err = <-errCh:
+	case err := <-errCh:
 		// Ignore context.Canceled because we triggered it ourselves via stop()
 		if err != nil && !errors.Is(err, context.Background().Err()) && !errors.Is(err, context.Canceled) {
 			t.Errorf("run() returned error: %v", err)


### PR DESCRIPTION
Closes #157 §4 (and the rest of #157 with it).

## Summary
- `TestGameplay_Integration` is now 11 named `t.Run` subtests sharing parent-scope state (cookie jars, `gameID`, `runningScore`, `completedPlayerID`, `adminClient`, `freshGameID`). A regression in any one path now points at the smallest scenario by name (e.g. `admin_can_delete_a_played_question_without_FK_787`) rather than a line buried in a 950-line block.
- Subtests run sequentially — they intentionally share state, and a producer/consumer map in the parent's var block documents which subtest sets and reads each variable. `nolint:paralleltest,tparallel` is set on the parent with a one-line explanation; new subtests must continue to use `=` (not `:=`) when assigning the shared variables.
- Server setup, quiz seeding, and shutdown stay in the parent; helpers (`httpGet`, `httpPostJSON`, `fetchCSRFToken`, `registerAdminAndResetPlayer`, `setupIntegration`) are unchanged.
- Drive-by: fixed seven pre-existing `expected status N, got M` assertions that reversed the project's `got, want` ordering. Each now reads `got, want := resp.StatusCode, http.StatusX; got != want` with a descriptive label (e.g. `list quizzes status`, `next question status`).

No assertions added or removed; this is a structural and stylistic refactor.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (full suite green; all 11 subtests visible by name in `go test -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)