### PR TITLE
Document Get* as accepted on hand-written DB read methods

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -89,6 +89,10 @@ Each domain exposes:
 
 Store interfaces are defined in the domain package so domain code does not import `internal/store`.
 
+### Naming: `Get*` is fine for DB read methods
+
+Hand-written Store and Service methods that read from the database use the `Get*` prefix (`GetQuiz`, `GetGameByPlayerAndQuiz`, etc.), matching the sqlc-generated layer in `internal/db/`. Do NOT rename these to `Fetch*` for stylistic reasons — the Google Go Style Guide's "no `Get` prefix" rule is aimed at pure accessors, not DB I/O wrappers, and sqlc's generated names are the ground truth we cannot change. Diverging means readers translate at every wrapper boundary forever. Considered and rejected in #147 (closed wontfix).
+
 ## Adding a new feature (checklist)
 
 1. **Migration** — add a `.sql` file in `internal/migrations/` using `goose` up/down format.

--- a/.claude/skills/go-style-review/SKILL.md
+++ b/.claude/skills/go-style-review/SKILL.md
@@ -59,6 +59,12 @@ guide explicitly calls optional. If the code is fine, say so.
   `Url`, `Id`, `Db`, `HttpRequest`.
 - No `Get` prefix on getters. Use `Counts()` not `GetCounts()`. Reserve
   `Fetch`/`Compute` for operations that are expensive or perform I/O.
+  **Project exception:** `Get*` is the accepted name for hand-written
+  `Store`/`Service` methods that read from the database, because sqlc's
+  generated layer in `internal/db/` uses `Get*` and the wrapper layer
+  intentionally mirrors it. Do NOT flag `GetQuiz`, `GetGame`,
+  `GetGameByPlayerAndQuiz`, etc. on Store/Service receivers. Considered
+  and rejected as a rename in #147.
 - Variable name length proportional to scope: short in tight loops, longer in
   package-level or exported contexts.
 - Eliminate redundancy between the package name and the exported symbol name


### PR DESCRIPTION
Records the decision from #147 (closed not planned) so it's not re-litigated in future style passes.

## Summary
- `.claude/agents/backend-dev.md` — new subsection under Domain/service pattern stating that hand-written `Store`/`Service` DB read methods use `Get*` to mirror sqlc's generated layer in `internal/db/`.
- `.claude/skills/go-style-review/SKILL.md` — added a project exception to the "No `Get` prefix on getters" rule so `/go-style-review` won't flag `GetQuiz`/`GetGame`/etc. on Store/Service receivers.

The Google Go Style Guide's `Get*` rule is most clearly aimed at pure accessors. For DB I/O wrappers, sqlc's generated names are the ground truth — diverging would mean `FetchQuiz → s.q.GetQuiz` at every wrapper, permanent friction at the boundary.

## Test plan
- [x] No code paths affected; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)