### PR TITLE
Add QuizExists query for cheap existence checks

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -94,6 +94,7 @@ type stubQuizStore struct {
 	listQuizzes          func(ctx context.Context) ([]*quiz.Quiz, error)
 	questionCountsByQuiz func(ctx context.Context) (map[int64]int, error)
 	getQuizByID          func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	quizExists           func(ctx context.Context, id int64) (bool, error)
 	createQuiz           func(ctx context.Context, qz *quiz.Quiz) error
 	updateQuiz           func(ctx context.Context, qz *quiz.Quiz) error
 	deleteQuiz           func(ctx context.Context, id int64) error
@@ -114,6 +115,14 @@ func (s stubQuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error
 	}
 
 	return s.getQuizByID(ctx, id)
+}
+
+func (s stubQuizStore) QuizExists(ctx context.Context, id int64) (bool, error) {
+	if s.quizExists == nil {
+		return false, errors.ErrUnsupported
+	}
+
+	return s.quizExists(ctx, id)
 }
 
 func (s stubQuizStore) GetQuestion(ctx context.Context, id int64) (*quiz.Question, error) {
@@ -512,6 +521,9 @@ func TestHandleQuizView(t *testing.T) {
 						},
 					},
 				}, nil
+			},
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
 			},
 		}
 
@@ -2758,6 +2770,9 @@ func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
 			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
 				return &quiz.Quiz{ID: id, Title: "Q1", Slug: "q-1"}, nil
 			},
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
+			},
 		}
 		// Two leaderboard answers for two distinct players, both correct,
 		// so each player accumulates a non-zero score and shows up in the
@@ -2817,6 +2832,9 @@ func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
 			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
 				return &quiz.Quiz{ID: id, Title: "Q1", Slug: "q-1"}, nil
 			},
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
+			},
 		}
 		gameStore := stubGameStore{} // no leaderboard rows
 
@@ -2850,6 +2868,9 @@ func TestHandleResetGameForPlayer(t *testing.T) {
 		quizStore := stubQuizStore{
 			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
 				return &quiz.Quiz{ID: id, Title: "Q1"}, nil
+			},
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
 			},
 		}
 		gameStore := stubGameStore{
@@ -2889,8 +2910,8 @@ func TestHandleResetGameForPlayer(t *testing.T) {
 		t.Parallel()
 
 		quizStore := stubQuizStore{
-			getQuizByID: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
-				return nil, quiz.ErrQuizNotFound
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return false, nil
 			},
 		}
 
@@ -2915,6 +2936,9 @@ func TestHandleResetGameForPlayer(t *testing.T) {
 		quizStore := stubQuizStore{
 			getQuizByID: func(_ context.Context, id int64) (*quiz.Quiz, error) {
 				return &quiz.Quiz{ID: id}, nil
+			},
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
 			},
 		}
 		gameStore := stubGameStore{

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -29,6 +29,7 @@ var errStub = errors.New("stub error")
 type stubQuizStore struct {
 	listQuizzes func(ctx context.Context) ([]*quiz.Quiz, error)
 	getQuiz     func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	quizExists  func(ctx context.Context, id int64) (bool, error)
 	getOption   func(ctx context.Context, id int64) (*quiz.Option, error)
 }
 
@@ -52,6 +53,14 @@ func (s stubQuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error
 	}
 
 	return s.getQuiz(ctx, id)
+}
+
+func (s stubQuizStore) QuizExists(ctx context.Context, id int64) (bool, error) {
+	if s.quizExists == nil {
+		return false, errors.ErrUnsupported
+	}
+
+	return s.quizExists(ctx, id)
 }
 
 func (s stubQuizStore) GetOption(ctx context.Context, id int64) (*quiz.Option, error) {
@@ -1233,8 +1242,8 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 			},
 		}
 		qs := stubQuizStore{
-			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-				return &quiz.Quiz{ID: id, Title: "Quiz"}, nil
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
 			},
 		}
 		handler := HandleQuizLeaderboard(logger, newService(gs, qs))
@@ -1281,8 +1290,8 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 		t.Parallel()
 
 		qs := stubQuizStore{
-			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
-				return nil, quiz.ErrQuizNotFound
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return false, nil
 			},
 		}
 		handler := HandleQuizLeaderboard(logger, newService(stubGameStore{}, qs))
@@ -1328,8 +1337,8 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 			},
 		}
 		qs := stubQuizStore{
-			getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-				return &quiz.Quiz{ID: id}, nil
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return true, nil
 			},
 		}
 		handler := HandleQuizLeaderboard(logger, newService(gs, qs))

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -427,6 +427,21 @@ func (q *Queries) QuestionCountsByQuiz(ctx context.Context) ([]QuestionCountsByQ
 	return items, nil
 }
 
+const quizExists = `-- name: QuizExists :one
+SELECT EXISTS(SELECT 1 FROM quizzes WHERE id = ?) AS quiz_exists
+`
+
+// Cheap existence check for a quiz by ID. Returns 1 when the row exists,
+// 0 otherwise. Used by handlers and services that need to validate the
+// quiz is real before doing further work but do not need the full tree
+// of questions and options that GetQuiz materialises.
+func (q *Queries) QuizExists(ctx context.Context, id int64) (bool, error) {
+	row := q.db.QueryRowContext(ctx, quizExists, id)
+	var quiz_exists bool
+	err := row.Scan(&quiz_exists)
+	return quiz_exists, err
+}
+
 const updateOption = `-- name: UpdateOption :execresult
 UPDATE options
 SET text = ?,

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -273,8 +273,15 @@ func (s *Service) GetGameForPlayerOnQuiz(ctx context.Context, playerID, quizID i
 // Returns [quiz.ErrQuizNotFound] when the quiz does not exist so the admin
 // route can map it to a 404.
 func (s *Service) ResetGamesForPlayerOnQuiz(ctx context.Context, playerID, quizID int64) error {
-	if _, err := s.quizStore.GetQuiz(ctx, quizID); err != nil {
-		return fmt.Errorf("failed to load quiz for reset: %w", err)
+	// Existence-only check: we don't need the quiz's questions or options,
+	// so use QuizExists to skip the per-question/per-option fan-out reads
+	// GetQuiz performs.
+	exists, err := s.quizStore.QuizExists(ctx, quizID)
+	if err != nil {
+		return fmt.Errorf("failed to check quiz exists for reset: %w", err)
+	}
+	if !exists {
+		return quiz.ErrQuizNotFound
 	}
 
 	if err := s.store.DeleteGamesForPlayerOnQuiz(ctx, playerID, quizID); err != nil {
@@ -467,8 +474,14 @@ func (s *Service) GetQuizLeaderboard(
 	}
 
 	// Verify the quiz exists so callers can map ErrQuizNotFound to a 404.
-	if _, err := s.quizStore.GetQuiz(ctx, quizID); err != nil {
-		return nil, fmt.Errorf("failed to get quiz: %w", err)
+	// Cheap existence check — leaderboard rendering does not need the
+	// quiz's questions or options.
+	exists, err := s.quizStore.QuizExists(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check quiz exists for leaderboard: %w", err)
+	}
+	if !exists {
+		return nil, quiz.ErrQuizNotFound
 	}
 
 	rows, err := s.store.ListAnswersForQuizLeaderboard(ctx, quizID)

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -70,10 +70,12 @@ func (s stubStore) DeleteGamesForPlayerOnQuiz(
 	return s.deleteGamesForPlayerOnQuiz(ctx, playerID, quizID)
 }
 
-// stubQuizStore satisfies quiz.Store for service-level tests. Only GetQuiz is
-// overridable since GetQuizLeaderboard never reaches the other methods.
+// stubQuizStore satisfies quiz.Store for service-level tests. Only GetQuiz
+// and QuizExists are overridable since the leaderboard/reset paths never
+// reach the other methods.
 type stubQuizStore struct {
-	getQuiz func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	getQuiz    func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	quizExists func(ctx context.Context, id int64) (bool, error)
 }
 
 func (stubQuizStore) Ping(_ context.Context) error                        { return nil }
@@ -88,6 +90,14 @@ func (s stubQuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error
 	}
 
 	return s.getQuiz(ctx, id)
+}
+
+func (s stubQuizStore) QuizExists(ctx context.Context, id int64) (bool, error) {
+	if s.quizExists == nil {
+		return false, errStub
+	}
+
+	return s.quizExists(ctx, id)
 }
 func (stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error         { return nil }
 func (stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error         { return nil }
@@ -401,8 +411,8 @@ func TestService_ResetGamesForPlayerOnQuiz(t *testing.T) {
 		t.Parallel()
 
 		svc := NewService(stubStore{}, stubQuizStore{
-			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
-				return nil, quiz.ErrQuizNotFound
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return false, nil
 			},
 		}, slog.New(slog.DiscardHandler))
 
@@ -706,8 +716,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		t.Parallel()
 
 		svc := NewService(stubStore{}, stubQuizStore{
-			getQuiz: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
-				return nil, quiz.ErrQuizNotFound
+			quizExists: func(_ context.Context, _ int64) (bool, error) {
+				return false, nil
 			},
 		}, slog.New(slog.DiscardHandler))
 
@@ -727,8 +737,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -758,8 +768,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -799,8 +809,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -837,8 +847,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -870,8 +880,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -921,8 +931,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),
@@ -955,8 +965,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 			},
 			stubQuizStore{
-				getQuiz: func(_ context.Context, id int64) (*quiz.Quiz, error) {
-					return &quiz.Quiz{ID: id}, nil
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
 				},
 			},
 			slog.New(slog.DiscardHandler),

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -29,6 +29,10 @@ func (*stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, er
 func (*stubQuizStore) GetQuiz(_ context.Context, _ int64) (*quiz.Quiz, error) {
 	return nil, errors.ErrUnsupported
 }
+
+func (*stubQuizStore) QuizExists(_ context.Context, _ int64) (bool, error) {
+	return false, errors.ErrUnsupported
+}
 func (*stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error { return nil }
 func (*stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error { return nil }
 func (*stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error      { return nil }

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -18,6 +18,13 @@ FROM quizzes
 WHERE id = ?
 LIMIT 1;
 
+-- name: QuizExists :one
+-- Cheap existence check for a quiz by ID. Returns 1 when the row exists,
+-- 0 otherwise. Used by handlers and services that need to validate the
+-- quiz is real before doing further work but do not need the full tree
+-- of questions and options that GetQuiz materialises.
+SELECT EXISTS(SELECT 1 FROM quizzes WHERE id = ?) AS quiz_exists;
+
 -- name: CreateQuiz :one
 INSERT INTO quizzes (title, slug, description, updated_at)
 VALUES (?, ?, ?, CURRENT_TIMESTAMP)

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -24,6 +24,12 @@ type Store interface {
 	// GetQuiz returns a quiz including related questions and options by its ID.
 	// Returns ErrQuizNotFound if the quiz is not found.
 	GetQuiz(ctx context.Context, id int64) (*Quiz, error)
+	// QuizExists is a cheap existence check for a quiz by ID. It runs a
+	// single one-row SELECT EXISTS probe and does not load the quiz's
+	// questions or options. Prefer this over GetQuiz when the caller only
+	// needs to know whether the quiz is real (e.g. to map a missing quiz
+	// to a 404) and does not need the rest of the tree.
+	QuizExists(ctx context.Context, id int64) (bool, error)
 	// CreateQuiz creates a quiz.
 	CreateQuiz(ctx context.Context, qz *Quiz) error
 	// UpdateQuiz updates a quiz.

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -64,6 +64,10 @@ func (stubQuizStore) GetQuiz(_ context.Context, id int64) (*quiz.Quiz, error) {
 	}, nil
 }
 
+func (stubQuizStore) QuizExists(_ context.Context, _ int64) (bool, error) {
+	return true, nil
+}
+
 func (stubQuizStore) GetQuestion(_ context.Context, id int64) (*quiz.Question, error) {
 	return &quiz.Question{
 		ID:       id,

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -75,6 +75,19 @@ func (s *QuizStore) QuestionCountsByQuiz(ctx context.Context) (map[int64]int, er
 	return counts, nil
 }
 
+// QuizExists reports whether a quiz with the given ID exists. It runs a
+// single one-row SELECT EXISTS probe and does not load the quiz's
+// questions or options, so callers that only need to validate the quiz
+// is real should prefer this over [QuizStore.GetQuiz].
+func (s *QuizStore) QuizExists(ctx context.Context, id int64) (bool, error) {
+	exists, err := s.q.QuizExists(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("failed to check quiz exists: %w", err)
+	}
+
+	return exists, nil
+}
+
 // GetQuiz returns a quiz by its ID.
 func (s *QuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
 	var err error

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -406,6 +406,45 @@ func TestQuizStore_GetQuiz_ErrorHandling(t *testing.T) {
 	})
 }
 
+func TestQuizStore_QuizExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true for an existing quiz", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		exists, err := quizStore.QuizExists(t.Context(), testQuiz.ID)
+		if err != nil {
+			t.Fatalf("QuizExists err = %v, want nil", err)
+		}
+		if got, want := exists, true; got != want {
+			t.Errorf("QuizExists = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns false for a missing quiz", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		exists, err := quizStore.QuizExists(t.Context(), 999)
+		if err != nil {
+			t.Fatalf("QuizExists err = %v, want nil", err)
+		}
+		if got, want := exists, false; got != want {
+			t.Errorf("QuizExists = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestQuizStore_GetQuestion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #142.

## Summary
- New `-- name: QuizExists :one` query in `internal/queries/quizzes.sql` returning a bool from `SELECT EXISTS(SELECT 1 FROM quizzes WHERE id = ?)`. Costs one row read instead of loading the full quiz tree.
- New `QuizStore.QuizExists(ctx, id) (bool, error)` wrapper, added to the `quiz.Store` interface.
- Migrated two existence-only callers in `internal/game/game.go`: `Service.GetQuizLeaderboard` (the canonical case from the ticket) and `Service.ResetGamesForPlayerOnQuiz` (same shape — pure existence probe before a delete). Both map `(false, nil)` to `quiz.ErrQuizNotFound` so the downstream 404 mapping in handlers is preserved.
- Five remaining `GetQuiz` callers (`Service.CreateGame`, `Service.GetGameForPlayerOnQuiz`, `Service.GetNextQuestion`, `HandleQuizGet`, `quizByID` admin helper) genuinely need the loaded question/option tree and stay on `GetQuiz`.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (full suite green; new `TestQuizStore_QuizExists` covers exists/not-exists)
- [x] `make smoke` (boots clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)