### PR TITLE
Add index on games(quiz_id) for leaderboard query

### DIFF
--- a/internal/migrations/20260511000000_index_games_quiz_id.sql
+++ b/internal/migrations/20260511000000_index_games_quiz_id.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- The leaderboard query (ListAnswersForQuizLeaderboard) joins game_answers
+-- to games and filters by games.quiz_id. Without an index on quiz_id the
+-- planner falls back to a table scan of games. Index it so the join uses
+-- a SEARCH ... USING INDEX plan instead.
+-- +goose StatementBegin
+CREATE INDEX games_quiz_id_idx ON games (quiz_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX games_quiz_id_idx;
+-- +goose StatementEnd

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -686,3 +686,46 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 		}
 	})
 }
+
+func TestGameStore_ListAnswersForQuizLeaderboard_UsesQuizIDIndex(t *testing.T) {
+	t.Parallel()
+
+	// The leaderboard query joins game_answers to games and filters games by
+	// quiz_id; without the index, the planner has to scan one of the tables.
+	// EXPLAIN this minimal mirror of that join shape and assert the planner
+	// picks games_quiz_id_idx — the assertion is about the join access path,
+	// not the full leaderboard SQL.
+	db := dbtest.Open(t)
+	rows, err := db.QueryContext(t.Context(),
+		"EXPLAIN QUERY PLAN SELECT 1 FROM game_answers ga JOIN games g ON g.id = ga.game_id WHERE g.quiz_id = ?",
+		int64(1),
+	)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN err = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Errorf("rows.Close err = %v", closeErr)
+		}
+	})
+
+	// EXPLAIN QUERY PLAN rows: (id INTEGER, parent INTEGER, notused INTEGER, detail TEXT).
+	var plan []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if scanErr := rows.Scan(&id, &parent, &notused, &detail); scanErr != nil {
+			t.Fatalf("scan plan row err = %v", scanErr)
+		}
+		plan = append(plan, detail)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		t.Fatalf("plan rows iteration err = %v", rowsErr)
+	}
+
+	joined := strings.Join(plan, "\n")
+	t.Logf("EXPLAIN QUERY PLAN output:\n%s", joined)
+	if got, want := joined, "games_quiz_id_idx"; !strings.Contains(got, want) {
+		t.Errorf("EXPLAIN QUERY PLAN output should contain %q; got:\n%s", want, got)
+	}
+}


### PR DESCRIPTION
Partially closes #141 — index half. SQL-aggregation half deferred (see below).

## Summary
- New goose migration `20260511000000_index_games_quiz_id.sql` creates `games_quiz_id_idx` on `games(quiz_id)`. Without it, the leaderboard's `JOIN games g ON g.id = ga.game_id WHERE g.quiz_id = ?` filter fell back to a table scan of `games`.
- New test `TestGameStore_ListAnswersForQuizLeaderboard_UsesQuizIDIndex` runs `EXPLAIN QUERY PLAN` against the minimal join shape and asserts the planner picks `games_quiz_id_idx`. Falsifying check confirmed: removing the migration produces `SCAN g` and the test fails.

Also benefits `ListGameIDsForQuiz` (used by #155's cascade delete) and any future query that filters `games.quiz_id`. Write cost on `games` is negligible for this table's size and rate.

## Deferred
The ticket's second half (push the per-player leaderboard aggregation from Go into SQL to reduce memory) is not addressed here. The in-Go `CalculateScore` formula is the single source of truth; duplicating it in SQL costs more than it saves at current scale. Worth revisiting when a popular quiz produces enough plays that materialising all answer rows in Go becomes a real memory issue.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (full unit + integration suite green; new EXPLAIN test passes)
- [x] `make smoke` (migration applies cleanly on the existing populated dev DB)
- [x] Falsify-by-stash check: removing the migration makes the new test fail with `SCAN g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)