### PR TITLE
Fix stuck focus ring and increase touch targets on mobile

### DIFF
--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -259,6 +259,27 @@ figure.image img {
     border-radius: 4px;
 }
 
+/* Mobile UX: drop the stuck focus ring left behind after a tap. We only
+   suppress the outline when focus did NOT arrive via the keyboard, so
+   keyboard navigation still gets the visible accent ring. Scoped to the
+   answer list so other buttons keep their existing focus treatment. */
+.buttons .button.is-fullwidth:focus:not(:focus-visible) {
+    border-color: var(--border);
+    background: var(--surface);
+    box-shadow: none;
+    outline: none;
+}
+
+/* Mobile UX: bump answer-button touch targets above the WCAG 44px
+   minimum on small viewports. Questions have at most six options so the
+   extra height is comfortable. Desktop layout is untouched. */
+@media (max-width: 768px) {
+    .buttons .button.is-fullwidth {
+        min-height: 3.5rem;
+        font-size: 1rem;
+    }
+}
+
 /* Reduced-motion users get all the colour but none of the movement. The
    JS-driven animations also short-circuit via the same media query. */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes #170.

## Summary
- `.buttons .button.is-fullwidth:focus:not(:focus-visible)` drops the outline + box-shadow when focus arrived via tap, while keeping the accent ring for keyboard users (a11y preserved).
- `@media (max-width: 768px)` bumps answer-list buttons to `min-height: 3.5rem` (~56px) — above the WCAG 44px touch target minimum. Desktop layout is unchanged.

Both rules are scoped to `.buttons .button.is-fullwidth` so the start-game button, navbar links, and other buttons keep their existing treatment.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (full suite green; CSS-only change)
- [x] `make smoke` (boots clean)
- [x] `make test-e2e` (6/6 Playwright specs pass)
- [x] Browser verification at 390x844 (58px height, no stuck ring on tap) and 1280x800 (desktop unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)