### PR TITLE
Cap login/register form body and suppress false-positive fd narrowing

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -184,16 +184,12 @@ func readNewPassword(stdin io.Reader, stdout io.Writer) (string, error) {
 // when stdin is a *[os.File]; wrapped readers always take the scanner path
 // (today's only caller is cmd/server/main.go which passes [os.Stdin]).
 func newPasswordReader(stdin io.Reader, stdout io.Writer) func(prompt string) (string, error) {
-	// File descriptors are small non-negative ints, so the uintptr -> int
-	// narrowing here cannot overflow. Suppress gosec G115 at both call sites
-	// where x/term insists on int.
-	if f, ok := stdin.(*os.File); ok &&
-		term.IsTerminal(int(f.Fd())) { //nolint:gosec // G115: file descriptors fit in int
+	if f, ok := stdin.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 		return func(prompt string) (string, error) {
 			if _, err := fmt.Fprint(stdout, prompt); err != nil {
 				return "", fmt.Errorf("write prompt: %w", err)
 			}
-			raw, err := term.ReadPassword(int(f.Fd())) //nolint:gosec // G115: file descriptors fit in int
+			raw, err := term.ReadPassword(int(f.Fd()))
 			if err != nil {
 				return "", fmt.Errorf("read password: %w", err)
 			}

--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -184,12 +184,16 @@ func readNewPassword(stdin io.Reader, stdout io.Writer) (string, error) {
 // when stdin is a *[os.File]; wrapped readers always take the scanner path
 // (today's only caller is cmd/server/main.go which passes [os.Stdin]).
 func newPasswordReader(stdin io.Reader, stdout io.Writer) func(prompt string) (string, error) {
-	if f, ok := stdin.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+	// File descriptors are small non-negative ints, so the uintptr -> int
+	// narrowing here cannot overflow. Suppress gosec G115 at both call sites
+	// where x/term insists on int.
+	if f, ok := stdin.(*os.File); ok &&
+		term.IsTerminal(int(f.Fd())) { //nolint:gosec // G115: file descriptors fit in int
 		return func(prompt string) (string, error) {
 			if _, err := fmt.Fprint(stdout, prompt); err != nil {
 				return "", fmt.Errorf("write prompt: %w", err)
 			}
-			raw, err := term.ReadPassword(int(f.Fd()))
+			raw, err := term.ReadPassword(int(f.Fd())) //nolint:gosec // G115: file descriptors fit in int
 			if err != nil {
 				return "", fmt.Errorf("read password: %w", err)
 			}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -32,6 +32,12 @@ const MaxPasswordLength = 72
 
 const adminLandingPath = "/admin/quizzes"
 
+// maxFormBodySize caps the request body for login/register form posts.
+// 64 KiB is comfortable for username + password + csrf_token while denying
+// an attacker the ability to exhaust memory by streaming a multi-megabyte
+// body into r.ParseForm. Wraps r.Body before any form-parsing call.
+const maxFormBodySize = 64 * 1024
+
 // formData is the data passed to the register and login templates.
 type formData struct {
 	Title    string
@@ -79,6 +85,7 @@ func HandleRegisterSubmit(
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/register.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxFormBodySize)
 		if err := r.ParseForm(); err != nil {
 			logger.ErrorContext(r.Context(), "error parsing register form", slog.Any("err", err))
 			http.Error(w, "bad form", http.StatusBadRequest)
@@ -238,6 +245,7 @@ func HandleLoginSubmit(
 	})
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxFormBodySize)
 		if err := r.ParseForm(); err != nil {
 			logger.ErrorContext(r.Context(), "error parsing login form", slog.Any("err", err))
 			http.Error(w, "bad form", http.StatusBadRequest)


### PR DESCRIPTION
Fixes 5 gosec violations that surfaced on main as the bundled gosec inside golangci-lint's `latest` tightened its defaults. The code itself didn't change — these are pre-existing patterns that newer gosec now flags.

## Summary
- **G120 (form parsing without size limit)** in `internal/auth/handler.go`: added `maxFormBodySize = 64 KiB` constant and wrapped `r.Body` in `http.MaxBytesReader` before `ParseForm` in both the register and login handlers. Real security fix — denies an attacker the ability to exhaust memory by streaming a multi-megabyte body into form parsing.
- **G115 (uintptr -> int narrowing)** in `cmd/server/app/app.go`: added `//nolint:gosec` at the two `int(f.Fd())` call sites in `newPasswordReader`. The conversion is safe (file descriptors are small non-negative ints, capped by the OS far below `math.MaxInt`) and `golang.org/x/term`'s public API takes `int`, so there's no fix-in-the-code path that doesn't add a dead bounds check. Textbook false positive.

## Why now?
CI runs golangci-lint at `version: latest` (`.github/workflows/golangci-lint.yml`), so the bundled gosec quietly updates with each push. A recent gosec point release added G115 to the default set and tightened G120. Worth pinning the CI version (and possibly the local install) to avoid silent rule drift — flagging for a separate ticket if you want.

## Test plan
- [x] `make lint-fix` (0 issues)
- [x] `make check` (full suite green)
- [x] Existing auth + cmd/server tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)