### PR TITLE
Allow user creation after quiz (#165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Never create commits yourself. When work is ready to commit, suggest a one-line 
 Every change or new feature must have tests. Run `make lint-fix`, `make check`, `make test-e2e`, and `make smoke` before marking work done.
 `make check` only exercises a fresh DB, so migration or startup issues that only surface against populated data otherwise slip through. `make smoke` runs `go run ./cmd/server/ -check` to parse config, open the dev DB, run migrations, and exit — no port juggling, no leftover process.
 
+**Prefer integration tests over ad-hoc smoke scripts.** When verifying a new endpoint or flow, write a test under `test/integration/` rather than running one-off `curl` commands or scripted Playwright sessions. A scripted check verifies behaviour once at implementation time; an integration test catches regressions forever. The harness in `test/integration/` already provides a real server, real DB, and cookie jars — add scenarios to existing tests or create a new `*_test.go` there. Use one-off scripts only for genuinely interactive debugging that can't be expressed as a test (e.g. visual layout in a browser).
+
 ## Workflow
 
 When starting work on a new ticket: switch to `main`, run `git pull`, then create a new branch. Branch names use dashes (not slashes) and are prefixed with the ticket number — e.g. `1-fix-bugs`. Ask for the ticket number if not provided. Omit the prefix if there is no ticket.

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -23,6 +23,20 @@ type stubPlayerStore struct {
 	byName  map[string]*auth.Player
 	nextID  int64
 	failGet bool
+	// forceAnonCollisions, when > 0, makes the next N CreateAnonymousPlayer
+	// calls return ErrUsernameTaken without inserting. Each call decrements
+	// the counter, so once it reaches zero the stub returns to its normal
+	// insert-or-conflict behaviour. Used by the petname retry-loop tests
+	// to drive the middleware down the collision path a deterministic
+	// number of times.
+	forceAnonCollisions int
+	// forceAnonErr, when set, is returned by the NEXT CreateAnonymousPlayer
+	// call and then automatically cleared. The single-shot semantics keep
+	// each test scenario self-contained: setting the error and then
+	// triggering a single request exercises one error branch without
+	// leaking the failure into any follow-up call inside the same test.
+	// Used to exercise the non-collision error branch of EnsurePlayer.
+	forceAnonErr error
 }
 
 func newStubPlayerStore() *stubPlayerStore {
@@ -96,6 +110,18 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if s.forceAnonErr != nil {
+		err := s.forceAnonErr
+		s.forceAnonErr = nil
+
+		return nil, err
+	}
+	if s.forceAnonCollisions > 0 {
+		s.forceAnonCollisions--
+
+		return nil, auth.ErrUsernameTaken
+	}
+
 	if _, exists := s.byName[username]; exists {
 		return nil, auth.ErrUsernameTaken
 	}
@@ -138,6 +164,30 @@ func (s *stubPlayerStore) ClaimPlayer(
 	existing.Username = username
 	existing.PasswordHash = passwordHash
 	existing.Role = s.resolveRoleLocked(requestedRole)
+	s.byName[username] = existing
+
+	return existing, nil
+}
+
+func (s *stubPlayerStore) UpdatePlayerUsername(
+	_ context.Context, playerID int64, username string,
+) (*auth.Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.byID[playerID]
+	if !ok {
+		return nil, auth.ErrPlayerNotFound
+	}
+	if existing.PasswordHash != "" {
+		return nil, auth.ErrPlayerNotAnonymous
+	}
+	if other, exists := s.byName[username]; exists && other.ID != playerID {
+		return nil, auth.ErrUsernameTaken
+	}
+
+	delete(s.byName, existing.Username)
+	existing.Username = username
 	s.byName[username] = existing
 
 	return existing, nil

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -11,11 +13,19 @@ import (
 	"github.com/starquake/topbanana/internal/session"
 )
 
-// anonymousUsernamePrefix is prepended to the random xid used as the username
-// for an EnsurePlayer-created row. Keeping a recognisable prefix means an
-// admin scrolling through the players table can tell a never-claimed visitor
-// apart from a real registration without inspecting password_hash.
+// anonymousUsernamePrefix is the prefix used by the last-resort xid-backed
+// fallback when GeneratePetname collisions exhaust the retry budget. The
+// petname path is the common case; this prefix only appears in the
+// astronomically unlikely event that the petname pool becomes saturated or
+// the same petname is drawn N times in a row.
 const anonymousUsernamePrefix = "anon-"
+
+// petnameMaxAttempts caps how many times EnsurePlayer will retry a petname
+// against the UNIQUE-on-username index before falling back to an xid-backed
+// name. With ~15M combinations the chance of one collision is tiny and the
+// chance of five in a row is effectively zero, so five attempts is a safe
+// upper bound that still keeps the request latency bounded.
+const petnameMaxAttempts = 5
 
 // EnsurePlayer guarantees the request carries a session that points at an
 // existing players row. If the request has no session, an invalid one, or a
@@ -33,25 +43,22 @@ const anonymousUsernamePrefix = "anon-"
 // without a session would leave the handler unable to attribute writes.
 func EnsurePlayer(next http.Handler, players PlayerStore, sessions *session.Manager, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if playerID, ok := sessions.PlayerID(r); ok {
-			player, err := players.GetPlayerByID(r.Context(), playerID)
-			if err == nil {
-				next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
+		player, err := loadSessionPlayer(r, players, sessions)
+		if err != nil && !errors.Is(err, ErrPlayerNotFound) {
+			logger.ErrorContext(r.Context(), "error loading player for ensure", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
 
-				return
-			}
-			if !errors.Is(err, ErrPlayerNotFound) {
-				logger.ErrorContext(r.Context(), "error loading player for ensure", slog.Any("err", err))
-				http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if player != nil {
+			next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
 
-				return
-			}
-			// Fall through: the cookie referenced a deleted row, mint a new
-			// anonymous player and replace the cookie.
+			return
 		}
 
-		username := anonymousUsernamePrefix + xid.New().String()
-		player, err := players.CreateAnonymousPlayer(r.Context(), username)
+		// Fall-through from loadSessionPlayer (no cookie or deleted row):
+		// the session cookie must be replaced before the next handler runs.
+		player, err = mintAnonymousPlayer(r.Context(), players)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error creating anonymous player", slog.Any("err", err))
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -62,6 +69,57 @@ func EnsurePlayer(next http.Handler, players PlayerStore, sessions *session.Mana
 		sessions.Set(w, player.ID)
 		next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
 	})
+}
+
+// loadSessionPlayer resolves the player referenced by the request's session
+// cookie. It returns (player, nil) when a usable row was found,
+// (nil, ErrPlayerNotFound) when there is no session cookie OR the cookie
+// referenced a deleted row, and (nil, otherErr) when the store returned an
+// unexpected error.
+func loadSessionPlayer(r *http.Request, players PlayerStore, sessions *session.Manager) (*Player, error) {
+	playerID, hasSession := sessions.PlayerID(r)
+	if !hasSession {
+		return nil, ErrPlayerNotFound
+	}
+
+	player, err := players.GetPlayerByID(r.Context(), playerID)
+	if err != nil {
+		if errors.Is(err, ErrPlayerNotFound) {
+			return nil, ErrPlayerNotFound
+		}
+
+		return nil, fmt.Errorf("load player by id: %w", err)
+	}
+
+	return player, nil
+}
+
+// mintAnonymousPlayer creates a brand-new anonymous players row. The happy
+// path takes a fresh petname; on UNIQUE collisions it retries up to
+// petnameMaxAttempts times before falling back to an xid-backed name that is
+// unique by construction.
+func mintAnonymousPlayer(ctx context.Context, players PlayerStore) (*Player, error) {
+	var lastErr error
+	for range petnameMaxAttempts {
+		player, err := players.CreateAnonymousPlayer(ctx, GeneratePetname())
+		if err == nil {
+			return player, nil
+		}
+		if !errors.Is(err, ErrUsernameTaken) {
+			return nil, fmt.Errorf("create anonymous player: %w", err)
+		}
+		lastErr = err
+	}
+
+	// Petname pool collided every attempt. Fall back to an xid-backed name,
+	// which is unique by construction and effectively guarantees the insert
+	// succeeds even if the petname pool ever becomes saturated.
+	player, err := players.CreateAnonymousPlayer(ctx, anonymousUsernamePrefix+xid.New().String())
+	if err != nil {
+		return nil, fmt.Errorf("petname exhausted (last: %w); xid fallback: %w", lastErr, err)
+	}
+
+	return player, nil
 }
 
 // RequireAdmin wraps the next handler so only admins can reach it.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth_test
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -221,8 +222,14 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 	if !seenPlayer.IsAnonymous() {
 		t.Errorf("seenPlayer.IsAnonymous() = false, want true (PasswordHash = %q)", seenPlayer.PasswordHash)
 	}
-	if got, want := seenPlayer.Username[:5], "anon-"; got != want {
-		t.Errorf("seenPlayer.Username prefix = %q, want %q", got, want)
+	// EnsurePlayer should mint a petname-style "Adjective-Adjective-Noun"
+	// username, not the legacy "anon-<xid>" form (the xid form is the
+	// last-resort fallback only).
+	if got := seenPlayer.Username; strings.HasPrefix(got, "anon-") {
+		t.Errorf("seenPlayer.Username = %q, want a petname-style name (no anon- prefix)", got)
+	}
+	if got, want := strings.Count(seenPlayer.Username, "-"), 2; got != want {
+		t.Errorf("seenPlayer.Username = %q, want %d hyphens (Adjective-Adjective-Noun)", seenPlayer.Username, want)
 	}
 	cookie, ok := findCookie(rec, session.CookieName)
 	if !ok {
@@ -332,6 +339,88 @@ func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 	}
 	if seenIDs[0] == seenIDs[1] {
 		t.Errorf("two cookieless requests produced the same player ID %d, want distinct", seenIDs[0])
+	}
+}
+
+func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	// Force the first three CreateAnonymousPlayer calls to return
+	// ErrUsernameTaken; the fourth attempt should succeed and produce a
+	// regular petname row.
+	store.forceAnonCollisions = 3
+	sessions := session.New([]byte("k"))
+
+	var seenPlayer *auth.Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; middleware should have retried past the collisions")
+	}
+	if got := seenPlayer.Username; strings.HasPrefix(got, "anon-") {
+		t.Errorf("seenPlayer.Username = %q, want a petname-style name (no anon- fallback)", got)
+	}
+	if got, want := strings.Count(seenPlayer.Username, "-"), 2; got != want {
+		t.Errorf("seenPlayer.Username = %q, want %d hyphens", seenPlayer.Username, want)
+	}
+}
+
+func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	// Force every petname attempt (5) to collide so the fallback xid path
+	// has to run.
+	store.forceAnonCollisions = 5
+	sessions := session.New([]byte("k"))
+
+	var seenPlayer *auth.Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; fallback should have produced one")
+	}
+	if got, want := seenPlayer.Username[:5], "anon-"; got != want {
+		t.Errorf("seenPlayer.Username prefix = %q, want %q (xid fallback after exhausted retries)", got, want)
+	}
+}
+
+func TestEnsurePlayer_CreateAnonymousNonCollisionError_500(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	store.forceAnonErr = errors.New("boom")
+	sessions := session.New([]byte("k"))
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("next should not be called when CreateAnonymousPlayer returns a non-collision error")
+	})
+
+	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
 	}
 }
 

--- a/internal/auth/petname.go
+++ b/internal/auth/petname.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// GeneratePetname returns a memorable three-segment identifier of the form
+// "Adjective-Adjective-Noun" (e.g. "Steamy-Farty-Bear"). The format follows
+// the Heroku/Docker petname tradition: short, easy to read aloud, and
+// distinctive enough that a glance at the players table tells real
+// registrations apart from never-claimed visitors.
+//
+// The names are NOT guaranteed unique on their own — the combined pool of
+// len(petnameAdjectives)^2 * len(petnameNouns) is large enough that random
+// collisions are vanishingly rare, but the caller (EnsurePlayer) handles
+// the unique-constraint case explicitly with a small retry loop. Pool size
+// is sized for ≥ 2 million combinations so per-request collision probability
+// stays well under 0.0001% for the foreseeable user count.
+//
+// Randomness comes from crypto/rand. This isn't a security-critical value,
+// but using crypto/rand removes the predictability that the math/rand
+// package-level seed historically had, and matches the Google Go style
+// preference of "crypto/rand by default for user-facing randoms".
+func GeneratePetname() string {
+	a1 := pickRandom(petnameAdjectives)
+	a2 := pickRandom(petnameAdjectives)
+	n := pickRandom(petnameNouns)
+
+	return a1 + "-" + a2 + "-" + n
+}
+
+// pickRandom returns a uniformly-random element from words. On the
+// (effectively impossible) failure of crypto/rand it falls back to the first
+// element rather than panicking — losing some variety is preferable to
+// taking down the request path.
+func pickRandom(words []string) string {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(words))))
+	if err != nil {
+		return words[0]
+	}
+
+	return words[n.Int64()]
+}
+
+// petnameAdjectives is a curated list of family-friendly playful adjectives.
+// Title-cased so the joined output reads as a proper noun. Mildly cheeky
+// entries (e.g. "Farty", "Stinky") are included by request — they stay on
+// the cartoon-silly side and never veer into anything genuinely offensive.
+//
+//nolint:gochecknoglobals // dictionary table; values never mutate.
+var petnameAdjectives = []string{
+	"Ancient", "Angry", "Bashful", "Beefy", "Bendy", "Blissful", "Bold",
+	"Bouncy", "Brave", "Breezy", "Bright", "Bubbly", "Bumpy", "Burly",
+	"Busy", "Buzzy", "Calm", "Cheeky", "Cheerful", "Chilly", "Chirpy",
+	"Chonky", "Chubby", "Chunky", "Classy", "Clever", "Cloudy", "Clumsy",
+	"Cosmic", "Cosy", "Cranky", "Crispy", "Crunchy", "Cuddly", "Curious",
+	"Curly", "Dainty", "Dapper", "Daring", "Dazzling", "Dippy", "Dizzy",
+	"Doughy", "Dreamy", "Drowsy", "Dusty", "Eager", "Earnest", "Easy",
+	"Electric", "Epic", "Fancy", "Farty", "Feisty", "Fierce", "Fiery",
+	"Fizzy", "Flaky", "Flappy", "Floppy", "Fluffy", "Foggy", "Frilly",
+	"Frisky", "Frosty", "Funky", "Funny", "Fuzzy", "Gentle", "Giddy",
+	"Giggly", "Glittery", "Gloomy", "Glowing", "Glum", "Goofy", "Grand",
+	"Greasy", "Greedy", "Grumpy", "Hairy", "Handy", "Happy", "Hasty",
+	"Hearty", "Hefty", "Honest", "Hoppy", "Humble", "Hungry", "Husky",
+	"Icy", "Itchy", "Jaunty", "Jazzy", "Jiggly", "Jolly", "Jumpy",
+	"Kindly", "Lanky", "Lazy", "Leaky", "Lively", "Loopy", "Lucky",
+	"Lumpy", "Magical", "Manic", "Melted", "Mellow", "Merry", "Mighty",
+	"Misty", "Moody", "Mossy", "Muddy", "Muffled", "Mushy", "Mystic",
+	"Nappy", "Naughty", "Neat", "Nerdy", "Nibbly", "Nifty", "Nimble",
+	"Noble", "Noisy", "Nosy", "Nutty", "Odd", "Oily", "Pearly",
+	"Peppy", "Perky", "Pesky", "Plucky", "Plumpy", "Pointy", "Poky",
+	"Polite", "Posh", "Pouty", "Prickly", "Proud", "Puffy", "Pungent",
+	"Quaint", "Queasy", "Quick", "Quiet", "Quirky", "Quizzical", "Rapid",
+	"Rascally", "Roaming", "Roasty", "Rosy", "Rowdy", "Royal", "Ruffled",
+	"Rumbly", "Rusty", "Sassy", "Sauntering", "Scrappy", "Scruffy", "Shaggy",
+	"Shaky", "Sharp", "Shifty", "Shiny", "Shivery", "Shy", "Silky",
+	"Silly", "Sincere", "Sketchy", "Skittish", "Sleepy", "Sleek", "Slick",
+	"Slimy", "Slinky", "Sloppy", "Slow", "Sluggish", "Sly", "Smelly",
+	"Smiley", "Smirky", "Smoky", "Smug", "Snappy", "Sneaky", "Sniffly",
+	"Snoozy", "Snooty", "Snorty", "Snuggly", "Soggy", "Sparkly", "Speedy",
+	"Spiky", "Spongy", "Spooky", "Spotty", "Springy", "Squeaky", "Squiggly",
+	"Squishy", "Starry", "Steamy", "Stinky", "Stompy", "Stormy", "Stretchy",
+	"Stubby", "Sturdy", "Subtle", "Sunny", "Sweaty", "Sweet", "Swift",
+	"Tangy", "Tasty", "Tender", "Thirsty", "Thrifty", "Thumpy", "Ticklish",
+	"Tidy", "Tiny", "Tipsy", "Toasty", "Toothy", "Tricky", "Trusty",
+	"Tubby", "Twinkly", "Twirly", "Twitchy", "Vivid", "Wacky", "Waddly",
+	"Warm", "Wary", "Weary", "Weepy", "Weird", "Whiny", "Whirly",
+	"Whisky", "Wibbly", "Wiggly", "Wild", "Willowy", "Windy", "Winsome",
+	"Wise", "Witty", "Wobbly", "Wonky", "Woolly", "Woozy", "Yawning",
+	"Yummy", "Zany", "Zealous", "Zesty", "Zippy",
+}
+
+// petnameNouns is a curated list of mostly animals with a sprinkle of
+// fantastical / edible / cosmic objects. Title-cased to match adjectives.
+//
+//nolint:gochecknoglobals // dictionary table; values never mutate.
+var petnameNouns = []string{
+	"Aardvark", "Albatross", "Alpaca", "Antelope", "Ape", "Armadillo",
+	"Asteroid", "Avocado", "Badger", "Banana", "Barnacle", "Bat",
+	"Beaver", "Beetle", "Biscuit", "Bison", "Blobfish", "Boar",
+	"Bobcat", "Buffalo", "Bullfrog", "Bumblebee", "Bunny", "Butterfly",
+	"Cactus", "Camel", "Capybara", "Caribou", "Cat", "Caterpillar",
+	"Catfish", "Centaur", "Chameleon", "Cheetah", "Chickadee", "Chimera",
+	"Chinchilla", "Chipmunk", "Cobra", "Comet", "Cookie", "Coyote",
+	"Crab", "Crane", "Cricket", "Crocodile", "Crow", "Cupcake",
+	"Cuttlefish", "Cyclops", "Dingo", "Dodo", "Dolphin", "Donkey",
+	"Doughnut", "Dragon", "Dragonfly", "Duck", "Dumpling", "Eagle",
+	"Eel", "Elephant", "Elk", "Emu", "Ferret", "Finch", "Firefly",
+	"Flamingo", "Fox", "Frog", "Galaxy", "Gazelle", "Gecko", "Gerbil",
+	"Ghost", "Giraffe", "Gnome", "Goblin", "Goldfish", "Goose",
+	"Gopher", "Gorilla", "Grasshopper", "Griffin", "Hamster", "Hare",
+	"Hawk", "Hedgehog", "Heron", "Hippo", "Hornet", "Hummingbird",
+	"Hyena", "Iguana", "Impala", "Jackal", "Jackrabbit", "Jaguar",
+	"Jellyfish", "Kangaroo", "Kingfisher", "Kiwi", "Koala", "Kraken",
+	"Lemming", "Lemur", "Leopard", "Lion", "Lizard", "Llama", "Lobster",
+	"Lynx", "Macaw", "Magpie", "Mammoth", "Manatee", "Mantis", "Marmot",
+	"Meerkat", "Mole", "Mongoose", "Monkey", "Moose", "Moth", "Muffin",
+	"Mule", "Narwhal", "Nebula", "Newt", "Nightingale", "Octopus",
+	"Okapi", "Opossum", "Orangutan", "Ostrich", "Otter", "Owl", "Oyster",
+	"Panda", "Pancake", "Pangolin", "Parrot", "Peacock", "Pelican",
+	"Penguin", "Phoenix", "Piglet", "Platypus", "Porcupine", "Possum",
+	"Pufferfish", "Puffin", "Pug", "Pumpkin", "Quail", "Quokka",
+	"Rabbit", "Raccoon", "Ram", "Raven", "Reindeer", "Rhino", "Robin",
+	"Salamander", "Sandwich", "Sardine", "Scorpion", "Seal", "Seahorse",
+	"Shark", "Sheep", "Shrew", "Shrimp", "Skunk", "Sloth", "Snail",
+	"Sparrow", "Sphinx", "Spider", "Squid", "Squirrel", "Starfish",
+	"Stingray", "Stork", "Sunfish", "Swan", "Tadpole", "Tapir", "Tiger",
+	"Toad", "Tortoise", "Toucan", "Turkey", "Turtle", "Unicorn", "Viper",
+	"Vulture", "Walrus", "Warthog", "Wasp", "Weasel", "Whale", "Wolf",
+	"Wolverine", "Wombat", "Woodpecker", "Yak", "Zebra",
+}

--- a/internal/auth/petname_test.go
+++ b/internal/auth/petname_test.go
@@ -1,0 +1,47 @@
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+func TestGeneratePetname_Shape(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		name := auth.GeneratePetname()
+		if name == "" {
+			t.Fatal("GeneratePetname() = empty string, want non-empty")
+		}
+		parts := strings.Split(name, "-")
+		if got, want := len(parts), 3; got != want {
+			t.Errorf("GeneratePetname() = %q, want %d hyphen-separated segments", name, want)
+		}
+		for i, p := range parts {
+			if p == "" {
+				t.Errorf("GeneratePetname() = %q, segment %d is empty", name, i)
+			}
+		}
+	}
+}
+
+// TestGeneratePetname_Distinct sanity-checks that the pool is wide enough to
+// produce a healthy spread of distinct names over 1000 calls. The exact pool
+// size isn't asserted (that would couple the test to the word-list contents),
+// only that the generator isn't degenerate.
+func TestGeneratePetname_Distinct(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]struct{}, 1000)
+	for range 1000 {
+		seen[auth.GeneratePetname()] = struct{}{}
+	}
+	// With ~15M combinations, the birthday-problem expectation on 1000 draws
+	// is ~999 distinct outcomes. Allow generous slack to keep the test stable
+	// while still failing loudly if the generator collapses to a tiny pool.
+	if got, want := len(seen), 900; got < want {
+		t.Errorf("len(distinct petnames over 1000 calls) = %d, want >= %d", got, want)
+	}
+}

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -16,14 +16,26 @@ var ErrUsernameTaken = errors.New("username taken")
 // already has a password_hash set, so it cannot be upgraded again.
 var ErrPlayerAlreadyClaimed = errors.New("player already claimed")
 
+// ErrPlayerNotAnonymous is returned by UpdatePlayerUsername when the target
+// row exists but already carries a non-anonymous identity (password_hash IS
+// NOT NULL). Username-only changes are reserved for anonymous rows; a
+// credentialled account must change its name through a different flow.
+var ErrPlayerNotAnonymous = errors.New("player is not anonymous")
+
+// ErrUsernameEmpty is returned by UpdatePlayerUsername when the supplied
+// username trims to the empty string. Surfaced as a store-level sentinel
+// so callers can map it to a 400 without re-validating themselves.
+var ErrUsernameEmpty = errors.New("username is empty")
+
 // Player represents an authenticated user (admin or player).
 type Player struct {
-	ID           int64
-	Username     string
-	Email        string
-	PasswordHash string
-	Role         string
-	CreatedAt    time.Time
+	ID              int64
+	Username        string
+	Email           string
+	PasswordHash    string
+	Role            string
+	CreatedAt       time.Time
+	UsernameClaimed bool
 }
 
 // IsAnonymous reports whether the player has no credentials set yet (no
@@ -36,6 +48,16 @@ type Player struct {
 // anonymous row by HandleRegisterSubmit's claim path.
 func (p *Player) IsAnonymous() bool {
 	return p.PasswordHash == "" && p.Role != RoleAdmin
+}
+
+// HasCustomName reports whether the player has explicitly picked their
+// username. Anonymous rows start with HasCustomName=false (the username
+// is an auto-generated petname); they flip to true on a successful
+// PATCH /api/players/me or via the register flow. The frontend uses
+// this to decide whether to show the claim affordances; the existing
+// IsAnonymous() check (no password) is a different concern.
+func (p *Player) HasCustomName() bool {
+	return p.UsernameClaimed
 }
 
 // PlayerStore is the persistence interface used by the auth package.
@@ -56,9 +78,11 @@ type PlayerStore interface {
 	// CreateAnonymousPlayer creates a row with the given username, no email,
 	// no password_hash, and role = "player". Used by EnsurePlayer to back a
 	// brand-new visitor with a real row before they can play. The caller
-	// generates the username (typically "anon-<xid>") so the store stays
-	// agnostic about the format.
-	// Returns ErrUsernameTaken on the (effectively impossible) collision.
+	// generates the username (commonly a GeneratePetname result, with an
+	// xid-backed "anon-<xid>" form as the last-resort fallback) so the
+	// store stays agnostic about the format.
+	// Returns ErrUsernameTaken when the username collides on the UNIQUE
+	// index; the petname caller treats this as a retry signal.
 	CreateAnonymousPlayer(ctx context.Context, username string) (*Player, error)
 	// ClaimPlayer upgrades an anonymous row (password_hash IS NULL) in place
 	// with the supplied credentials and requested role. The store mirrors the
@@ -73,4 +97,14 @@ type PlayerStore interface {
 	// by username. Used by the operator-only -reset-password tool to rotate a
 	// forgotten admin password. Returns ErrPlayerNotFound when no row matches.
 	SetPlayerPasswordHash(ctx context.Context, username, passwordHash string) error
+	// UpdatePlayerUsername renames an anonymous (password_hash IS NULL) row
+	// in place. The session cookie keeps pointing at the same row, so the
+	// caller stays "logged in" as the same player; the player remains
+	// anonymous after the rename.
+	// Returns ErrUsernameEmpty when the supplied username trims to the empty
+	// string, ErrUsernameTaken when the requested username is already in use,
+	// ErrPlayerNotAnonymous when the target row already carries a
+	// password_hash (i.e. it is no longer a valid target for a username-only
+	// update), and ErrPlayerNotFound when no row matches the id.
+	UpdatePlayerUsername(ctx context.Context, playerID int64, username string) (*Player, error)
 }

--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -253,6 +253,39 @@ h3 {
     border-color: rgba(255, 45, 149, 0.25);
 }
 
+/* Anonymous "Playing as ..." card on the start screen. A themed
+   replacement for Bulma's is-info notification (which sits awkwardly as a
+   bright blue panel on the near-black synthwave page). Uses the project's
+   own surface + accent tokens: dark card, magenta left-stripe, dimmed
+   meta label, accent username, dimmed body copy. */
+.claim-cta {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    padding: 1.25rem 1.5rem;
+    border-radius: 6px;
+}
+.claim-cta-label {
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+.claim-cta-name {
+    font-family: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+    color: var(--accent);
+    font-size: 1.15rem;
+    margin-bottom: 1rem;
+    word-break: break-all;
+}
+.claim-cta-body {
+    color: var(--text-dim);
+    margin-bottom: 1.25rem;
+    line-height: 1.5;
+}
+
 /* Question image — a clean 1px frame, no neon halo. */
 figure.image img {
     border: 1px solid var(--border);

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -16,10 +16,44 @@
 </head>
 <body>
     <section class="section">
-        <div class="container" x-data="gameApp">
+        <div class="container" x-data="gameApp" @keydown.escape.window="claimModalOpen && closeClaimModal()">
             <h1 class="title">Top Banana!</h1>
 
             <div x-show="!gameId">
+                <!-- Entry 3: anytime affordance on the start screen.
+                     Renders for any anonymous player (no password yet),
+                     even after they have already claimed a display name,
+                     so they can keep tweaking it before they start a
+                     quiz. The body text and button label adapt to whether
+                     they have already picked something. The end-of-quiz
+                     modal is the one-shot "auto-prompt" path and gates on
+                     hasCustomName() instead — see #165.
+
+                     NB: this article is duplicated below inside the
+                     finished-leaderboard view because the two need
+                     different visual positions (above the quiz selector
+                     here, above the table there) and Alpine has no
+                     template-include primitive. The markup is kept
+                     byte-identical so future copy edits are a single
+                     search-and-replace. -->
+                <template x-if="isAnonymous()">
+                    <article class="claim-cta mb-5">
+                        <p class="claim-cta-label">Playing as</p>
+                        <p class="claim-cta-name" x-text="player ? player.username : ''"></p>
+                        <p class="claim-cta-body" x-show="!hasCustomName()">
+                            Pick a display name and your leaderboard row will show it
+                            instead of the random one above.
+                        </p>
+                        <p class="claim-cta-body" x-show="hasCustomName()">
+                            Not happy with it? Pick a different display name.
+                        </p>
+                        <button class="button is-primary" @click="openClaimModal()">
+                            <span x-show="!hasCustomName()">Set your name</span>
+                            <span x-show="hasCustomName()">Change your name</span>
+                        </button>
+                    </article>
+                </template>
+
                 <div x-show="!deepLinkedQuiz" class="field">
                     <label class="label" for="quiz-select">Select a Quiz</label>
                     <div class="control">
@@ -77,8 +111,37 @@
                 </template>
             </div>
 
+            <!-- Leaderboard view. Renders as soon as the quiz is
+                 finished; the claim modal (below) opens on top of it
+                 for anonymous players. -->
             <div x-show="finished">
                 <h2 class="subtitle">Game Finished!</h2>
+
+                <!-- Persistent claim affordance on the leaderboard screen.
+                     Renders for any anonymous player (no password) so a
+                     player who landed outside the top 10 can still pick or
+                     change their name — the inline row-level link in the
+                     table only shows up if the current player made the
+                     cut. Markup mirrors the start-screen instance above
+                     byte-for-byte (see comment there). -->
+                <template x-if="isAnonymous()">
+                    <article class="claim-cta mb-5">
+                        <p class="claim-cta-label">Playing as</p>
+                        <p class="claim-cta-name" x-text="player ? player.username : ''"></p>
+                        <p class="claim-cta-body" x-show="!hasCustomName()">
+                            Pick a display name and your leaderboard row will show it
+                            instead of the random one above.
+                        </p>
+                        <p class="claim-cta-body" x-show="hasCustomName()">
+                            Not happy with it? Pick a different display name.
+                        </p>
+                        <button class="button is-primary" @click="openClaimModal()">
+                            <span x-show="!hasCustomName()">Set your name</span>
+                            <span x-show="hasCustomName()">Change your name</span>
+                        </button>
+                    </article>
+                </template>
+
                 <template x-if="leaderboard">
                     <div class="content">
                         <h3>Leaderboard</h3>
@@ -94,7 +157,16 @@
                                 <template x-for="(entry, index) in leaderboard.entries" :key="entry.playerId">
                                     <tr :class="entry.isCurrentPlayer ? 'is-selected' : ''">
                                         <td x-text="index + 1"></td>
-                                        <td x-text="entry.username"></td>
+                                        <td>
+                                            <span x-text="entry.username"></span>
+                                            <!-- Entry 2: leaderboard-row link that
+                                                 opens the same shared modal. Only
+                                                 renders for the current player while
+                                                 they have not yet picked a name. -->
+                                            <template x-if="entry.isCurrentPlayer && !hasCustomName()">
+                                                <a href="#" class="ml-2" @click.prevent="openClaimModal()">Set my name</a>
+                                            </template>
+                                        </td>
                                         <td x-text="entry.score"></td>
                                     </tr>
                                 </template>
@@ -106,6 +178,63 @@
                     <p>Loading leaderboard...</p>
                 </template>
             </div>
+
+            <!-- Shared claim-name modal. Mounted via x-if so each open
+                 gets a fresh claimNameForm instance (empty input,
+                 cleared error). All three entry points
+                 (pre-leaderboard auto-open, leaderboard-row link,
+                 start-screen link) flip the same claimModalOpen flag
+                 and wire the same claimFromModal callback. -->
+            <template x-if="claimModalOpen">
+                <div class="modal is-active" role="dialog" aria-modal="true" aria-labelledby="claim-modal-title">
+                    <div class="modal-background" @click="closeClaimModal()"></div>
+                    <div class="modal-card"
+                         x-data="claimNameForm({
+                                submitLabel: 'Save',
+                                cancelLabel: 'Cancel',
+                                onSubmit: (name) => claimFromModal(name),
+                                onCancel: () => closeClaimModal(),
+                             })">
+                        <header class="modal-card-head">
+                            <p class="modal-card-title" id="claim-modal-title">Pick a display name</p>
+                            <button class="delete" aria-label="close" @click="cancel()" :disabled="submitting"></button>
+                        </header>
+                        <section class="modal-card-body">
+                            <p class="mb-3">This is the name that will appear on the leaderboard.</p>
+                            <div class="field">
+                                <label class="label" for="claim-name-modal">Display name</label>
+                                <div class="control">
+                                    <input id="claim-name-modal" type="text" class="input"
+                                           maxlength="64" autocomplete="off"
+                                           x-init="$nextTick(() => $el.focus())"
+                                           x-model="username"
+                                           @keydown.enter.prevent="submit()"
+                                           :disabled="submitting">
+                                </div>
+                            </div>
+                            <template x-if="error">
+                                <div class="notification is-danger" x-text="error"></div>
+                            </template>
+                        </section>
+                        <footer class="modal-card-foot">
+                            <div class="field is-grouped">
+                                <div class="control">
+                                    <button class="button is-primary"
+                                            @click="submit()"
+                                            :disabled="submitting"
+                                            x-text="submitting ? 'Saving...' : submitLabel"></button>
+                                </div>
+                                <div class="control">
+                                    <button class="button is-light"
+                                            @click="cancel()"
+                                            :disabled="submitting"
+                                            x-text="cancelLabel"></button>
+                                </div>
+                            </div>
+                        </footer>
+                    </div>
+                </div>
+            </template>
         </div>
     </section>
 </body>

--- a/internal/client/static/js/app.js
+++ b/internal/client/static/js/app.js
@@ -1,5 +1,11 @@
 import { GameApp } from './components/GameApp.js';
+import { claimNameForm } from './components/ClaimNameForm.js';
 
 document.addEventListener('alpine:init', () => {
     Alpine.data('gameApp', () => new GameApp());
+    // claimNameForm is a per-instance Alpine subcomponent. Each x-data
+    // call gets its own input value / submitting / error state, which
+    // is why we register it as a factory rather than constructing it
+    // alongside gameApp.
+    Alpine.data('claimNameForm', claimNameForm);
 });

--- a/internal/client/static/js/components/ClaimNameForm.js
+++ b/internal/client/static/js/components/ClaimNameForm.js
@@ -1,0 +1,55 @@
+// claimNameForm is the Alpine x-data factory for the shared
+// "pick a name" form rendered in three contexts: the pre-leaderboard
+// prompt, the inline edit on the leaderboard row, and the start-screen
+// "set your name" affordance. Each instance owns its own input value,
+// submitting flag, and error text, so opening the inline form on the
+// leaderboard doesn't carry stray state from a dismissed start-screen
+// form.
+//
+// The parent gameApp injects two callbacks via Alpine's $data:
+//   onSubmit(username) -> { ok, message }  (resolves to the
+//       PlayerService.claimName result, with errors already mapped to
+//       human-friendly messages)
+//   onCancel()                              (optional; controls how the
+//       form closes — collapse inline, dismiss modal, skip to
+//       leaderboard, etc.)
+//
+// Keeping rendering and state inside Alpine (rather than building it
+// into a single shared <template>) avoids the awkwardness of sharing
+// reactive input/error state across three separate form instances on
+// the page at once.
+export function claimNameForm({ initialValue = '', cancelLabel = 'Cancel', submitLabel = 'Save', onSubmit, onCancel } = {}) {
+    return {
+        username: initialValue,
+        submitting: false,
+        error: '',
+        cancelLabel,
+        submitLabel,
+        async submit() {
+            if (this.submitting) return;
+            const trimmed = (this.username || '').trim();
+            if (trimmed === '') {
+                this.error = 'Please enter a name.';
+                return;
+            }
+            this.submitting = true;
+            this.error = '';
+            try {
+                const result = await onSubmit(trimmed);
+                if (!result || !result.ok) {
+                    this.error = (result && result.message) || "Couldn't save your name — try again later.";
+                    return;
+                }
+                // On success the parent component swaps the surrounding
+                // UI; we deliberately don't reset `username` here so a
+                // reopened form would inherit the saved value if needed.
+            } finally {
+                this.submitting = false;
+            }
+        },
+        cancel() {
+            if (this.submitting) return;
+            if (typeof onCancel === 'function') onCancel();
+        },
+    };
+}

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -1,5 +1,6 @@
 import { quizService } from '../services/QuizService.js';
 import { gameService } from '../services/GameService.js';
+import { playerService } from '../services/PlayerService.js';
 
 // PLAY_PATH_PATTERN matches /play/<anything>-<integer>; the integer suffix
 // is the quiz ID.
@@ -61,10 +62,32 @@ export class GameApp {
         // is hidden in that case so the player just sees a description and
         // a Start button. Stays null on /client/, where the dropdown shows.
         this.deepLinkedQuiz = null;
+        // Current player as returned by GET /api/players/me. Stays null
+        // until init() resolves; templates guard with `player &&`. When
+        // the player renames, the PATCH response replaces this object
+        // so player.username and player.hasCustomName flow through every
+        // bound template at once.
+        this.player = null;
+        // Visibility of the shared claim-name modal. A single piece of
+        // state drives the modal across all three entry points
+        // (pre-leaderboard, inline leaderboard row, start screen).
+        // The modal sits on top of whatever view is currently rendered,
+        // so the leaderboard is never gated by this flag — the modal
+        // simply overlays it.
+        this.claimModalOpen = false;
     }
 
     async init() {
-        this.quizzes = await quizService.getQuizzes();
+        // Kick off both in parallel; neither depends on the other.
+        // playerService.getMe is best-effort: a null result just means
+        // the claim affordances stay hidden, the rest of the page is
+        // unaffected.
+        const [quizzes, player] = await Promise.all([
+            quizService.getQuizzes(),
+            playerService.getMe(),
+        ]);
+        this.quizzes = quizzes;
+        this.player = player;
         const deepLinked = this.findDeepLinkedQuiz();
         if (deepLinked) {
             this.deepLinkedQuiz = deepLinked;
@@ -73,6 +96,73 @@ export class GameApp {
             this.selectedQuizId = this.quizzes[0].id;
         }
         await this.checkAlreadyPlayed();
+    }
+
+    // hasCustomName reports whether the current player has explicitly
+    // picked their display name (either through PATCH /api/players/me
+    // or through the register form). The templates gate every claim
+    // affordance on the negation of this, so a player who has already
+    // chosen a name does not see the claim modal/links again — which
+    // was the bug fixed in #165: the previous gate (isAnonymous, i.e.
+    // "no password_hash") stayed truthy after a PATCH because the
+    // claim flow does not set a password, re-opening the modal on
+    // every subsequent finished quiz.
+    hasCustomName() {
+        return !!(this.player && this.player.hasCustomName);
+    }
+
+    // isAnonymous reports whether the current player has no password set
+    // (anonymous in the credential sense). Distinct from hasCustomName:
+    // a player who claims a display name without registering stays
+    // anonymous. The start-screen "Playing as" card uses this so the
+    // affordance keeps showing post-claim, letting the player retune
+    // their name before they start a quiz.
+    isAnonymous() {
+        return !!(this.player && this.player.isAnonymous);
+    }
+
+    // openClaimModal is the single entry point that any of the three
+    // affordances (pre-leaderboard auto-open, inline "Set my name"
+    // link, start-screen "Set your name" link) calls. The modal
+    // template is mounted via x-if so each open gets a fresh
+    // claimNameForm instance with empty input/error state.
+    openClaimModal() {
+        this.claimModalOpen = true;
+    }
+
+    // closeClaimModal hides the modal. Used by the Cancel button,
+    // the modal-background click, and the ESC key handler.
+    closeClaimModal() {
+        this.claimModalOpen = false;
+    }
+
+    // claimFromModal is the single onSubmit callback wired into the
+    // shared claimNameForm. Returns the discriminated result from
+    // PlayerService so the form can render an error banner without
+    // knowing anything about HTTP status codes. On success it updates
+    // `this.player` (so hasCustomName flips to true and every gated
+    // template hides at once), closes the modal, and — if the
+    // leaderboard is already rendered — re-fetches it so the player's
+    // row swaps from the auto-petname to the chosen name. The re-fetch
+    // is best-effort: a failure leaves the stale leaderboard in place
+    // (the new name will appear on the next page load) rather than
+    // surfacing an error on the success path, since the PATCH itself
+    // already succeeded.
+    async claimFromModal(username) {
+        const result = await playerService.claimName(username);
+        if (result.ok) {
+            this.player = result.player;
+            this.claimModalOpen = false;
+            if (this.finished && this.quizSlugId) {
+                try {
+                    this.leaderboard = await gameService.getQuizLeaderboard(this.quizSlugId);
+                    this.animateLeaderboard();
+                } catch (err) {
+                    console.warn('leaderboard re-fetch after claim failed; row will update on next load', err);
+                }
+            }
+        }
+        return result;
     }
 
     // findDeepLinkedQuiz extracts the quiz ID from /play/<slug>-<id> and
@@ -132,8 +222,23 @@ export class GameApp {
         const question = await gameService.getNextQuestion(this.gameId);
         if (!question) {
             this.finished = true;
+            // Re-fetch /me so the player's claim status is current.
+            // Could in principle have flipped since page load (rare,
+            // but cheap to verify and keeps the UI honest if they
+            // logged in mid-quiz from a second tab).
+            const fresh = await playerService.getMe();
+            if (fresh) this.player = fresh;
+            // Render the leaderboard first so the player sees their
+            // row populated immediately; then open the claim modal on
+            // top — but only if the player has not already chosen a
+            // display name. On a successful claim the modal handler
+            // re-fetches the leaderboard so the row updates from the
+            // auto-petname to the chosen name.
             this.leaderboard = await gameService.getQuizLeaderboard(this.quizSlugId);
             this.animateLeaderboard();
+            if (!this.hasCustomName()) {
+                this.openClaimModal();
+            }
             return;
         }
         this.imageError = false;

--- a/internal/client/static/js/services/PlayerService.js
+++ b/internal/client/static/js/services/PlayerService.js
@@ -1,0 +1,64 @@
+// PlayerService wraps the /api/players/me endpoints used by the
+// "claim your display name" flow. The same anonymous row is returned
+// across requests because EnsurePlayer middleware keeps the cookie
+// stable, so the component can re-fetch /me any time it wants the
+// latest username/isAnonymous/hasCustomName triple.
+export class PlayerService {
+    // getMe returns {id, username, isAnonymous, hasCustomName}, or null
+    // if the server somehow rejects the call (401 from a misconfigured
+    // route, network failure, etc.). The component treats null as "skip
+    // claim UI" so a broken auth wiring degrades to the previous
+    // experience instead of throwing on page load.
+    //
+    // hasCustomName is what the frontend gates the claim affordances on
+    // (#165): a registered or already-renamed visitor has it set, so the
+    // modal does not re-open on a subsequent finished quiz. isAnonymous
+    // remains for callers that care about the credential-level distinction.
+    async getMe() {
+        try {
+            const response = await fetch('/api/players/me');
+            if (!response.ok) return null;
+            return await response.json();
+        } catch {
+            return null;
+        }
+    }
+
+    // claimName PATCHes /api/players/me with a trimmed username and
+    // returns a discriminated result the component can branch on
+    // without inspecting raw status codes. The shape is:
+    //   { ok: true,  player: {...} }                 on 200
+    //   { ok: false, status, kind: 'taken'|'empty'|'error', message }
+    // 'taken' covers both 409 cases (the name is in use, or the player
+    // already has a password — the latter is impossible from the
+    // anonymous flow today but is handled so the surface is honest).
+    async claimName(rawUsername) {
+        const username = (rawUsername || '').trim();
+        if (username === '') {
+            return { ok: false, status: 400, kind: 'empty', message: 'Please enter a name.' };
+        }
+        let response;
+        try {
+            response = await fetch('/api/players/me', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username })
+            });
+        } catch {
+            return { ok: false, status: 0, kind: 'error', message: "Couldn't save your name — try again later." };
+        }
+        if (response.status === 200) {
+            const player = await response.json();
+            return { ok: true, player };
+        }
+        if (response.status === 409) {
+            return { ok: false, status: 409, kind: 'taken', message: 'That name is taken.' };
+        }
+        if (response.status === 400) {
+            return { ok: false, status: 400, kind: 'empty', message: 'Please enter a name.' };
+        }
+        return { ok: false, status: response.status, kind: 'error', message: "Couldn't save your name — try again later." };
+    }
+}
+
+export const playerService = new PlayerService();

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/starquake/topbanana/internal/auth"
@@ -477,6 +478,125 @@ func HandleAnswerPost(logger *slog.Logger, service *game.Service) http.Handler {
 		err = handlers.EncodeJSON(w, http.StatusOK, res)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error encoding answerResponse", slog.Any("err", err))
+
+			return
+		}
+	})
+}
+
+// playerResponse is the JSON shape returned by both GET and PATCH
+// /api/players/me. Shared so the two handlers cannot drift out of sync
+// when a field is added — the frontend's PlayerService.getMe() and
+// .claimName() decode into the same model.
+type playerResponse struct {
+	ID            int64  `json:"id"`
+	Username      string `json:"username"`
+	IsAnonymous   bool   `json:"isAnonymous"`
+	HasCustomName bool   `json:"hasCustomName"`
+}
+
+// newPlayerResponse projects an auth.Player onto the wire format.
+func newPlayerResponse(p *auth.Player) playerResponse {
+	return playerResponse{
+		ID:            p.ID,
+		Username:      p.Username,
+		IsAnonymous:   p.IsAnonymous(),
+		HasCustomName: p.HasCustomName(),
+	}
+}
+
+// HandlePlayerGetMe returns a handler for GET /api/players/me that reports
+// the calling player's id, username, whether they are still anonymous
+// (no password_hash set), and whether they have explicitly picked a
+// display name. The frontend uses hasCustomName to gate the "claim your
+// name" affordances; isAnonymous remains as a distinct, credential-level
+// concept (a registered user with a password is never anonymous, but a
+// claimed-but-passwordless visitor still is). The username is shown
+// verbatim so a fresh petname can be displayed as-is until the player
+// renames.
+func HandlePlayerGetMe(logger *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		current, ok := auth.PlayerFromContext(ctx)
+		if !ok {
+			http.Error(w, "unauthenticated", http.StatusUnauthorized)
+
+			return
+		}
+
+		if err := handlers.EncodeJSON(w, http.StatusOK, newPlayerResponse(current)); err != nil {
+			logger.ErrorContext(ctx, "error encoding playerResponse", slog.Any("err", err))
+
+			return
+		}
+	})
+}
+
+// HandlePlayerClaimName returns a handler for PATCH /api/players/me that
+// renames the calling player's row in place. It targets the score-claim flow
+// for anonymous visitors who want to pick a friendlier display name without
+// going through the full register form: the player keeps the same row (and
+// session cookie) and stays anonymous afterwards.
+//
+// Behaviour:
+//   - 200 with the updated player JSON on success.
+//   - 400 when the request body is malformed or the username is empty.
+//   - 401 when EnsurePlayer has not populated a player on the context.
+//     This is a wiring bug rather than a user-facing condition, but the
+//     401 keeps the contract honest if the route is reused elsewhere.
+//   - 409 when the username is already in use by another row, OR when the
+//     player has already claimed a non-anonymous identity (password_hash
+//     is set). Both are conflict states; the distinct error messages let
+//     the client distinguish them.
+//   - 500 on any other error.
+func HandlePlayerClaimName(logger *slog.Logger, players auth.PlayerStore) http.Handler {
+	type claimNameRequest struct {
+		Username string `json:"username"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		current, ok := auth.PlayerFromContext(ctx)
+		if !ok {
+			http.Error(w, "unauthenticated", http.StatusUnauthorized)
+
+			return
+		}
+
+		req, err := handlers.DecodeJSON[claimNameRequest](r)
+		if err != nil {
+			logger.ErrorContext(ctx, "error decoding claimNameRequest", slog.Any("err", err))
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+		if strings.TrimSpace(req.Username) == "" {
+			http.Error(w, "username is required", http.StatusBadRequest)
+
+			return
+		}
+
+		updated, err := players.UpdatePlayerUsername(ctx, current.ID, req.Username)
+		if err != nil {
+			switch {
+			case errors.Is(err, auth.ErrUsernameTaken):
+				http.Error(w, "username already taken", http.StatusConflict)
+			case errors.Is(err, auth.ErrPlayerNotAnonymous):
+				http.Error(w, "username already set for this account", http.StatusConflict)
+			case errors.Is(err, auth.ErrUsernameEmpty):
+				http.Error(w, "username is required", http.StatusBadRequest)
+			default:
+				logger.ErrorContext(ctx, "error updating player username", slog.Any("err", err))
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+
+			return
+		}
+
+		if err = handlers.EncodeJSON(w, http.StatusOK, newPlayerResponse(updated)); err != nil {
+			logger.ErrorContext(ctx, "error encoding playerResponse", slog.Any("err", err))
 
 			return
 		}

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -303,7 +303,7 @@ func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlaye
 }
 
 const getPlayer = `-- name: GetPlayer :one
-SELECT id, username, email, password_hash, role, created_at
+SELECT id, username, email, password_hash, role, created_at, username_claimed
 FROM players
 WHERE id = ?
 `
@@ -318,6 +318,7 @@ func (q *Queries) GetPlayer(ctx context.Context, id int64) (Player, error) {
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
+		&i.UsernameClaimed,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -48,12 +48,13 @@ type Option struct {
 }
 
 type Player struct {
-	ID           int64
-	Username     string
-	Email        sql.NullString
-	PasswordHash sql.NullString
-	Role         string
-	CreatedAt    time.Time
+	ID              int64
+	Username        string
+	Email           sql.NullString
+	PasswordHash    sql.NullString
+	Role            string
+	CreatedAt       time.Time
+	UsernameClaimed int64
 }
 
 type Question struct {

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -18,10 +18,11 @@ SET username = ?1,
         WHEN CAST(?3 AS TEXT) = 'admin' THEN 'admin'
         WHEN (SELECT COUNT(*) FROM players AS pp WHERE pp.password_hash IS NOT NULL) = 0 THEN 'admin'
         ELSE 'player'
-    END
+    END,
+    username_claimed = 1
 WHERE players.id = ?4
   AND players.password_hash IS NULL
-RETURNING id, username, email, password_hash, role, created_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed
 `
 
 type ClaimPlayerParams struct {
@@ -43,6 +44,11 @@ type ClaimPlayerParams struct {
 // played anonymously first). The subquery aliases the players table as pp
 // so the column reference in the WHERE is unambiguous against the row
 // being updated.
+//
+// username_claimed is set to 1 because the visitor is explicitly choosing
+// their username via the register form. This is the register-after-playing
+// path; from this point on the frontend should no longer offer the
+// claim-name affordances.
 func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, claimPlayer,
 		arg.Username,
@@ -58,6 +64,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
+		&i.UsernameClaimed,
 	)
 	return i, err
 }
@@ -65,7 +72,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 const createAnonymousPlayer = `-- name: CreateAnonymousPlayer :one
 INSERT INTO players (username, role)
 VALUES (?1, 'player')
-RETURNING id, username, email, password_hash, role, created_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed
 `
 
 // Used by the EnsurePlayer middleware to back a fresh visitor with a real
@@ -73,6 +80,10 @@ RETURNING id, username, email, password_hash, role, created_at
 // is fixed to 'player' because the "first password-bearing registrant
 // becomes admin" SQL above filters by password_hash IS NOT NULL, so an
 // anonymous row never qualifies for promotion.
+//
+// username_claimed defaults to 0: the auto-generated petname is not a name
+// the visitor picked, so the frontend should keep offering the claim-name
+// affordance until they pick one explicitly.
 func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (Player, error) {
 	row := q.db.QueryRowContext(ctx, createAnonymousPlayer, username)
 	var i Player
@@ -83,12 +94,13 @@ func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (P
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
+		&i.UsernameClaimed,
 	)
 	return i, err
 }
 
 const createPlayerWithCredentials = `-- name: CreatePlayerWithCredentials :one
-INSERT INTO players (username, password_hash, role)
+INSERT INTO players (username, password_hash, role, username_claimed)
 VALUES (
     ?1,
     ?2,
@@ -96,9 +108,10 @@ VALUES (
         WHEN CAST(?3 AS TEXT) = 'admin' THEN 'admin'
         WHEN (SELECT COUNT(*) FROM players WHERE password_hash IS NOT NULL) = 0 THEN 'admin'
         ELSE 'player'
-    END
+    END,
+    1
 )
-RETURNING id, username, email, password_hash, role, created_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed
 `
 
 type CreatePlayerWithCredentialsParams struct {
@@ -117,6 +130,11 @@ type CreatePlayerWithCredentialsParams struct {
 // otherwise "player"). If "admin" is requested explicitly we honour that;
 // otherwise we promote when there are no other rows with a password_hash
 // (legacy seed admin without a password is intentionally ignored).
+//
+// username_claimed is set to 1 because a registering user explicitly chose
+// their username at the form. The frontend uses this flag (surfaced as
+// hasCustomName) to decide whether to show the claim-name affordances, so
+// a fresh registrant must not see them.
 func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePlayerWithCredentialsParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, createPlayerWithCredentials, arg.Username, arg.PasswordHash, arg.RequestedRole)
 	var i Player
@@ -127,12 +145,13 @@ func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePla
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
+		&i.UsernameClaimed,
 	)
 	return i, err
 }
 
 const getPlayerByUsername = `-- name: GetPlayerByUsername :one
-SELECT id, username, email, password_hash, role, created_at
+SELECT id, username, email, password_hash, role, created_at, username_claimed
 FROM players
 WHERE username = ?
 LIMIT 1
@@ -148,6 +167,7 @@ func (q *Queries) GetPlayerByUsername(ctx context.Context, username string) (Pla
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
+		&i.UsernameClaimed,
 	)
 	return i, err
 }
@@ -173,4 +193,44 @@ func (q *Queries) SetPlayerPasswordHash(ctx context.Context, arg SetPlayerPasswo
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const updatePlayerUsername = `-- name: UpdatePlayerUsername :one
+UPDATE players
+SET username = ?1,
+    username_claimed = 1
+WHERE id = ?2 AND password_hash IS NULL
+RETURNING id, username, email, password_hash, role, created_at, username_claimed
+`
+
+type UpdatePlayerUsernameParams struct {
+	Username string
+	ID       int64
+}
+
+// Updates the username on an anonymous player row in place. The WHERE
+// clause refuses the update when the player has already claimed a
+// non-anonymous identity (password_hash IS NOT NULL), so the SQL is the
+// atomic guard against a stale anonymous check in the service layer.
+// Returns the updated row when one was affected; the wrapper distinguishes
+// "not anonymous anymore" (sql.ErrNoRows) from "username collision"
+// (UNIQUE constraint failure on players.username).
+//
+// username_claimed is set to 1 because this is the dedicated claim-name
+// endpoint (PATCH /api/players/me); the visitor is explicitly picking
+// their display name. The frontend gates the claim-name modal on the
+// flipped flag so it does not re-open on subsequent visits.
+func (q *Queries) UpdatePlayerUsername(ctx context.Context, arg UpdatePlayerUsernameParams) (Player, error) {
+	row := q.db.QueryRowContext(ctx, updatePlayerUsername, arg.Username, arg.ID)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.Email,
+		&i.PasswordHash,
+		&i.Role,
+		&i.CreatedAt,
+		&i.UsernameClaimed,
+	)
+	return i, err
 }

--- a/internal/migrations/20260511120000_add_username_claimed_to_players.sql
+++ b/internal/migrations/20260511120000_add_username_claimed_to_players.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE players ADD COLUMN username_claimed INTEGER NOT NULL DEFAULT 0;
+-- Backfill: any row with a password_hash chose their username during
+-- registration, so it counts as claimed. Anonymous rows (no password)
+-- stay at the default 0, which matches the new-row case from
+-- CreateAnonymousPlayer below.
+UPDATE players SET username_claimed = 1 WHERE password_hash IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE players DROP COLUMN username_claimed;
+-- +goose StatementEnd

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -15,7 +15,12 @@ LIMIT 1;
 -- otherwise "player"). If "admin" is requested explicitly we honour that;
 -- otherwise we promote when there are no other rows with a password_hash
 -- (legacy seed admin without a password is intentionally ignored).
-INSERT INTO players (username, password_hash, role)
+--
+-- username_claimed is set to 1 because a registering user explicitly chose
+-- their username at the form. The frontend uses this flag (surfaced as
+-- hasCustomName) to decide whether to show the claim-name affordances, so
+-- a fresh registrant must not see them.
+INSERT INTO players (username, password_hash, role, username_claimed)
 VALUES (
     sqlc.arg('username'),
     sqlc.arg('password_hash'),
@@ -23,7 +28,8 @@ VALUES (
         WHEN CAST(sqlc.arg('requested_role') AS TEXT) = 'admin' THEN 'admin'
         WHEN (SELECT COUNT(*) FROM players WHERE password_hash IS NOT NULL) = 0 THEN 'admin'
         ELSE 'player'
-    END
+    END,
+    1
 )
 RETURNING *;
 
@@ -33,6 +39,10 @@ RETURNING *;
 -- is fixed to 'player' because the "first password-bearing registrant
 -- becomes admin" SQL above filters by password_hash IS NOT NULL, so an
 -- anonymous row never qualifies for promotion.
+--
+-- username_claimed defaults to 0: the auto-generated petname is not a name
+-- the visitor picked, so the frontend should keep offering the claim-name
+-- affordance until they pick one explicitly.
 INSERT INTO players (username, role)
 VALUES (sqlc.arg('username'), 'player')
 RETURNING *;
@@ -50,6 +60,11 @@ RETURNING *;
 -- played anonymously first). The subquery aliases the players table as pp
 -- so the column reference in the WHERE is unambiguous against the row
 -- being updated.
+--
+-- username_claimed is set to 1 because the visitor is explicitly choosing
+-- their username via the register form. This is the register-after-playing
+-- path; from this point on the frontend should no longer offer the
+-- claim-name affordances.
 UPDATE players
 SET username = sqlc.arg('username'),
     password_hash = sqlc.arg('password_hash'),
@@ -57,7 +72,8 @@ SET username = sqlc.arg('username'),
         WHEN CAST(sqlc.arg('requested_role') AS TEXT) = 'admin' THEN 'admin'
         WHEN (SELECT COUNT(*) FROM players AS pp WHERE pp.password_hash IS NOT NULL) = 0 THEN 'admin'
         ELSE 'player'
-    END
+    END,
+    username_claimed = 1
 WHERE players.id = sqlc.arg('id')
   AND players.password_hash IS NULL
 RETURNING *;
@@ -70,3 +86,22 @@ RETURNING *;
 UPDATE players
 SET password_hash = sqlc.arg('password_hash')
 WHERE username = sqlc.arg('username');
+
+-- name: UpdatePlayerUsername :one
+-- Updates the username on an anonymous player row in place. The WHERE
+-- clause refuses the update when the player has already claimed a
+-- non-anonymous identity (password_hash IS NOT NULL), so the SQL is the
+-- atomic guard against a stale anonymous check in the service layer.
+-- Returns the updated row when one was affected; the wrapper distinguishes
+-- "not anonymous anymore" (sql.ErrNoRows) from "username collision"
+-- (UNIQUE constraint failure on players.username).
+--
+-- username_claimed is set to 1 because this is the dedicated claim-name
+-- endpoint (PATCH /api/players/me); the visitor is explicitly picking
+-- their display name. The frontend gates the claim-name modal on the
+-- flipped flag so it does not re-open on subsequent visits.
+UPDATE players
+SET username = sqlc.arg('username'),
+    username_claimed = 1
+WHERE id = sqlc.arg('id') AND password_hash IS NULL
+RETURNING *;

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -167,6 +167,11 @@ func addAPIRoutes(
 		return auth.EnsurePlayer(h, stores.Players, sessions, logger)
 	}
 
+	mux.Handle("GET /api/players/me", ensurePlayer(clientapi.HandlePlayerGetMe(logger)))
+	mux.Handle(
+		"PATCH /api/players/me",
+		ensurePlayer(clientapi.HandlePlayerClaimName(logger, stores.Players)),
+	)
 	mux.Handle("GET /api/quizzes", ensurePlayer(clientapi.HandleQuizList(logger, stores.Quizzes)))
 	mux.Handle("GET /api/quizzes/{slugID}", ensurePlayer(clientapi.HandleQuizGet(logger, stores.Quizzes)))
 	mux.Handle(

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -46,6 +46,10 @@ func (stubPlayerStore) SetPlayerPasswordHash(_ context.Context, _, _ string) err
 	return errRouteStub
 }
 
+func (stubPlayerStore) UpdatePlayerUsername(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+	return nil, errRouteStub
+}
+
 var errRouteStub = errors.New("stub")
 
 type stubQuizStore struct{}

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -145,6 +145,43 @@ func (s *PlayerStore) ClaimPlayer(
 	return playerFromRow(row), nil
 }
 
+// UpdatePlayerUsername renames an anonymous (password_hash IS NULL) row in
+// place so an anonymous visitor can pick their own display name without
+// going through the full claim flow. The session cookie continues to point
+// at the same row, so the player stays "signed in" as the same player and
+// remains anonymous after the rename.
+//
+// The username is trimmed before storage to mirror CreatePlayer's
+// normalisation; lookups in GetPlayerByUsername perform the same trim so
+// "alice" and " alice " cannot become distinct identities.
+//
+// Returns auth.ErrUsernameTaken when the requested username collides with
+// another row, and auth.ErrPlayerNotAnonymous when the target row exists
+// but already has a password_hash (the WHERE guard filters it out and the
+// UPDATE returns no rows). An unknown player ID also yields no rows; the
+// wrapper re-queries by id to disambiguate, returning ErrPlayerNotFound
+// when the row genuinely does not exist.
+func (s *PlayerStore) UpdatePlayerUsername(
+	ctx context.Context,
+	playerID int64,
+	username string,
+) (*auth.Player, error) {
+	cleaned := strings.TrimSpace(username)
+	if cleaned == "" {
+		return nil, auth.ErrUsernameEmpty
+	}
+
+	row, err := s.q.UpdatePlayerUsername(ctx, db.UpdatePlayerUsernameParams{
+		Username: cleaned,
+		ID:       playerID,
+	})
+	if err != nil {
+		return nil, s.classifyUpdateUsernameErr(ctx, playerID, err)
+	}
+
+	return playerFromRow(row), nil
+}
+
 // SetPlayerPasswordHash overwrites the password_hash on the row identified
 // by username. Returns auth.ErrPlayerNotFound when no row matches; intended
 // for the cmd/server -reset-password operator tool, not the public auth flow.
@@ -161,6 +198,30 @@ func (s *PlayerStore) SetPlayerPasswordHash(ctx context.Context, username, passw
 	}
 
 	return nil
+}
+
+// classifyUpdateUsernameErr maps an UpdatePlayerUsername storage error onto
+// the auth-package sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous
+// (the id might not exist OR the row already carries a password_hash), so it
+// re-queries by id to disambiguate.
+func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID int64, err error) error {
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
+		return auth.ErrUsernameTaken
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("failed to update player username: %w", err)
+	}
+
+	if _, getErr := s.q.GetPlayer(ctx, playerID); getErr != nil {
+		if errors.Is(getErr, sql.ErrNoRows) {
+			return auth.ErrPlayerNotFound
+		}
+
+		return fmt.Errorf("failed to verify player after username update: %w", getErr)
+	}
+
+	return auth.ErrPlayerNotAnonymous
 }
 
 // classifyClaimErr maps a ClaimPlayer storage error onto the auth-package
@@ -189,10 +250,11 @@ func (s *PlayerStore) classifyClaimErr(ctx context.Context, playerID int64, err 
 
 func playerFromRow(row db.Player) *auth.Player {
 	p := &auth.Player{
-		ID:        row.ID,
-		Username:  row.Username,
-		Role:      row.Role,
-		CreatedAt: row.CreatedAt,
+		ID:              row.ID,
+		Username:        row.Username,
+		Role:            row.Role,
+		CreatedAt:       row.CreatedAt,
+		UsernameClaimed: row.UsernameClaimed != 0,
 	}
 	if row.Email.Valid {
 		p.Email = row.Email.String

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -64,6 +64,11 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 	if got, want := created.PasswordHash, "hashed-secret"; got != want {
 		t.Errorf("CreatePlayer PasswordHash = %q, want %q", got, want)
 	}
+	// A registered user explicitly picked their username at the form, so
+	// the frontend must see hasCustomName=true and skip the claim modal.
+	if got, want := created.HasCustomName(), true; got != want {
+		t.Errorf("CreatePlayer HasCustomName() = %v, want %v", got, want)
+	}
 
 	fetched, err := ps.GetPlayerByUsername(t.Context(), "alice")
 	if err != nil {
@@ -74,6 +79,9 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 	}
 	if got, want := fetched.Role, auth.RoleAdmin; got != want {
 		t.Errorf("GetPlayerByUsername Role = %q, want %q", got, want)
+	}
+	if got, want := fetched.HasCustomName(), true; got != want {
+		t.Errorf("GetPlayerByUsername HasCustomName() = %v, want %v (re-fetch must persist the flag)", got, want)
 	}
 }
 
@@ -202,6 +210,28 @@ func TestPlayerStore_CreateAnonymousPlayer(t *testing.T) {
 	if !created.IsAnonymous() {
 		t.Error("IsAnonymous() = false, want true")
 	}
+	// Fresh anonymous rows wear an auto-generated petname, not a name the
+	// visitor picked, so the claim affordances must still render until they
+	// rename via PATCH /api/players/me.
+	if got, want := created.HasCustomName(), false; got != want {
+		t.Errorf("HasCustomName() = %v, want %v (auto-petname is not a chosen name)", got, want)
+	}
+}
+
+func TestPlayerStore_CreateAnonymousPlayer_DuplicateUsername(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	if _, err := ps.CreateAnonymousPlayer(t.Context(), "anon-clash"); err != nil {
+		t.Fatalf("first CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	_, err := ps.CreateAnonymousPlayer(t.Context(), "anon-clash")
+	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v (UNIQUE violation should map to ErrUsernameTaken)", got, want)
+	}
 }
 
 func TestPlayerStore_CreateAnonymousPlayer_DoesNotBlockFirstAdmin(t *testing.T) {
@@ -253,6 +283,11 @@ func TestPlayerStore_ClaimPlayer_UpgradesAnonymousRow(t *testing.T) {
 	// First password-bearing registrant — even via the claim path — becomes admin.
 	if got, want := claimed.Role, auth.RoleAdmin; got != want {
 		t.Errorf("claimed.Role = %q, want %q", got, want)
+	}
+	// The claim flow is an explicit username choice: the player typed it
+	// into the register form, so the flag must flip alongside the password.
+	if got, want := claimed.HasCustomName(), true; got != want {
+		t.Errorf("claimed.HasCustomName() = %v, want %v", got, want)
 	}
 }
 
@@ -315,4 +350,136 @@ func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
 	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
+}
+
+func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renames an anonymous player in place", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-xyz")
+		if err != nil {
+			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+		}
+		// Sanity-check the precondition: a fresh anonymous row has not
+		// claimed its username yet — that is what makes this scenario
+		// meaningful.
+		if got, want := anon.HasCustomName(), false; got != want {
+			t.Fatalf("precondition anon.HasCustomName() = %v, want %v", got, want)
+		}
+
+		updated, err := ps.UpdatePlayerUsername(t.Context(), anon.ID, "alice")
+		if err != nil {
+			t.Fatalf("UpdatePlayerUsername err = %v, want nil", err)
+		}
+		if got, want := updated.ID, anon.ID; got != want {
+			t.Errorf("updated.ID = %d, want %d (same row)", got, want)
+		}
+		if got, want := updated.Username, "alice"; got != want {
+			t.Errorf("updated.Username = %q, want %q", got, want)
+		}
+		if got, want := updated.IsAnonymous(), true; got != want {
+			t.Errorf("updated.IsAnonymous() = %v, want %v (no password set)", got, want)
+		}
+		// The frontend gates the end-of-quiz claim modal on hasCustomName,
+		// so a successful PATCH must flip the flag; otherwise the modal
+		// re-opens on the next finished quiz.
+		if got, want := updated.HasCustomName(), true; got != want {
+			t.Errorf("updated.HasCustomName() = %v, want %v (PATCH must mark the name as claimed)", got, want)
+		}
+
+		// Re-fetch by id to make sure the flag was persisted to the row,
+		// not just returned by the RETURNING clause.
+		refetched, err := ps.GetPlayerByID(t.Context(), anon.ID)
+		if err != nil {
+			t.Fatalf("GetPlayerByID err = %v, want nil", err)
+		}
+		if got, want := refetched.HasCustomName(), true; got != want {
+			t.Errorf("refetched.HasCustomName() = %v, want %v (flag must persist across fetches)", got, want)
+		}
+	})
+
+	t.Run("trims whitespace before storage", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-trim")
+		if err != nil {
+			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+		}
+
+		updated, err := ps.UpdatePlayerUsername(t.Context(), anon.ID, "  bob  ")
+		if err != nil {
+			t.Fatalf("UpdatePlayerUsername err = %v, want nil", err)
+		}
+		if got, want := updated.Username, "bob"; got != want {
+			t.Errorf("updated.Username = %q, want %q (whitespace trimmed)", got, want)
+		}
+	})
+
+	t.Run("empty username returns ErrUsernameEmpty", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-empty")
+		if err != nil {
+			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+		}
+
+		_, err = ps.UpdatePlayerUsername(t.Context(), anon.ID, "   ")
+		if got, want := err, auth.ErrUsernameEmpty; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("collision returns ErrUsernameTaken", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		if _, err := ps.CreatePlayer(t.Context(), "claimed", "h", auth.RolePlayer); err != nil {
+			t.Fatalf("seed CreatePlayer err = %v, want nil", err)
+		}
+		anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-collider")
+		if err != nil {
+			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+		}
+
+		_, err = ps.UpdatePlayerUsername(t.Context(), anon.ID, "claimed")
+		if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("non-anonymous row returns ErrPlayerNotAnonymous", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		credentialled, err := ps.CreatePlayer(t.Context(), "credentialled", "h", auth.RolePlayer)
+		if err != nil {
+			t.Fatalf("CreatePlayer err = %v, want nil", err)
+		}
+
+		_, err = ps.UpdatePlayerUsername(t.Context(), credentialled.ID, "newname")
+		if got, want := err, auth.ErrPlayerNotAnonymous; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown player ID returns ErrPlayerNotFound", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		_, err := ps.UpdatePlayerUsername(t.Context(), 99999, "ghost")
+		if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -56,9 +56,11 @@ export default defineConfig({
       // applies to the very first registration, which would leave subsequent
       // browser projects stuck on the role of `player`.
       ADMIN_USERNAMES: [
-        'e2e-admin-chromium', 'e2e-admin-firefox',                // auth.spec.ts
-        'e2e-admin-create-chromium', 'e2e-admin-create-firefox',  // admin.spec.ts
-        'e2e-admin-player-chromium', 'e2e-admin-player-firefox',  // player.spec.ts
+        'e2e-admin-chromium', 'e2e-admin-firefox',                          // auth.spec.ts
+        'e2e-admin-create-chromium', 'e2e-admin-create-firefox',            // admin.spec.ts
+        'e2e-admin-player-chromium', 'e2e-admin-player-firefox',            // player.spec.ts
+        'e2e-admin-claim-chromium', 'e2e-admin-claim-firefox',              // claim.spec.ts test 3
+        'e2e-admin-claim-skip-chromium', 'e2e-admin-claim-skip-firefox',    // claim.spec.ts test 4
       ].join(','),
     },
     reuseExistingServer: false,

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+import { registerAdmin, createQuizWithQuestions, QUIZ_QUESTIONS } from './helpers';
+
+// Petname format: Title-cased Adjective-Adjective-Noun, e.g. "Steamy-Farty-Bear".
+// EnsurePlayer middleware generates one of these for every fresh anonymous
+// visitor on the first /api/players/me round-trip.
+const PETNAME_PATTERN = /^[A-Z][a-z]+-[A-Z][a-z]+-[A-Z][a-z]+$/;
+
+// Test 1 — petname card visible for fresh anonymous visitor.
+test('start screen shows a Playing as card with an auto-generated petname for a fresh anonymous visitor', async ({ page }) => {
+  // Playwright's default per-test context has fresh cookies, so navigating
+  // to /client/ triggers EnsurePlayer to mint a new anonymous row whose
+  // username is the generated petname.
+  await page.goto('/client/');
+
+  // Two `.claim-cta` blocks live in the DOM at once — start-screen and
+  // leaderboard — because `x-show` on their parent toggles CSS, not
+  // mount state. Scope to the visible one.
+  const card = page.locator('.claim-cta:visible');
+  await expect(card).toBeVisible();
+
+  // Petname format: Adjective-Adjective-Noun, each segment Title-cased.
+  const name = await page.locator('.claim-cta-name:visible').textContent();
+  expect(name).toMatch(PETNAME_PATTERN);
+
+  // Body copy and button label both default to the "no name picked yet" branch.
+  // Both .claim-cta-body paragraphs stay in the DOM (Alpine's x-show toggles
+  // CSS, not DOM presence), so scope to the visible one.
+  await expect(page.locator('.claim-cta-body:visible')).toContainText('Pick a display name');
+  await expect(page.getByRole('button', { name: 'Set your name' })).toBeVisible();
+});
+
+// Test 2 — claim updates the card in place, no navigation.
+test('submitting a name via the start-screen modal updates the Playing as card in place', async ({ page, browserName }) => {
+  await page.goto('/client/');
+
+  // Capture the auto-generated petname so we can prove it was replaced.
+  // Two `.claim-cta` nodes are mounted at once (start-screen + leaderboard,
+  // both kept in DOM by `x-show`); scope to the visible one.
+  const card = page.locator('.claim-cta:visible');
+  await expect(card).toBeVisible();
+  const petname = await page.locator('.claim-cta-name:visible').textContent();
+  expect(petname).toMatch(PETNAME_PATTERN);
+
+  // Open the shared modal via the start-screen affordance.
+  await page.getByRole('button', { name: 'Set your name' }).click();
+  const modal = page.locator('.modal.is-active');
+  await expect(modal).toBeVisible();
+
+  // Unique-per-run name so chromium and firefox don't collide on the shared
+  // SQLite file, and reruns against a populated DB still work.
+  const chosenName = `Claimed-${browserName}-${Date.now()}`;
+  const input = modal.locator('input#claim-name-modal');
+  await input.fill(chosenName);
+  await modal.getByRole('button', { name: 'Save' }).click();
+
+  // The modal closes on successful PATCH, and the card re-renders with the
+  // chosen name plus the "already claimed" branch of body copy and button label.
+  await expect(modal).toBeHidden();
+  await expect(page.locator('.claim-cta-name:visible')).toHaveText(chosenName);
+  await expect(page.locator('.claim-cta-name:visible')).not.toHaveText(petname ?? '');
+  // Both paragraphs stay in the DOM via x-show, so scope to the visible one.
+  await expect(page.locator('.claim-cta-body:visible')).toContainText('Not happy with it?');
+  await expect(page.getByRole('button', { name: 'Change your name' })).toBeVisible();
+  // The "Set your name" span is also still in the DOM (gated by x-show), so
+  // assert on its visibility rather than DOM count.
+  await expect(page.getByRole('button', { name: 'Set your name' })).not.toBeVisible();
+
+  // No navigation — still on /client/. Use a regex tolerant of an optional
+  // trailing slash so the test doesn't depend on a redirect quirk.
+  await expect(page).toHaveURL(/\/client\/?$/);
+});
+
+// playThroughQuiz walks every question by clicking the first option each time
+// and waiting for the per-question feedback notification. Extracted so Tests
+// 3 and 4 share the same play loop. Mirrors the inline loop in player.spec.ts
+// (which intentionally stays unchanged for this PR).
+async function playThroughQuiz(page: import('@playwright/test').Page, quizTitle: string): Promise<void> {
+  await page.goto('/client/');
+
+  // Alpine fetches the quiz list asynchronously, so wait for our title.
+  const select = page.locator('select');
+  await expect(select.locator('option', { hasText: quizTitle })).toHaveCount(1);
+  await select.selectOption({ label: quizTitle });
+  await page.getByRole('button', { name: 'Start Game' }).click();
+
+  for (const q of QUIZ_QUESTIONS) {
+    const choice = q.options[0];
+    const wasCorrect = q.correctIndices.includes(0);
+
+    const optionButton = page.getByRole('button', { name: choice });
+    await expect(optionButton).toBeVisible();
+    await optionButton.click();
+
+    if (wasCorrect) {
+      await expect(page.locator('.notification.is-success')).toBeVisible();
+    } else {
+      await expect(page.locator('.notification.is-danger')).toBeVisible();
+    }
+  }
+
+  // The leaderboard renders after the last answer's auto-advance hits 404
+  // on getNextQuestion. Generous timeout because the per-question feedback
+  // delay adds up over four questions.
+  await expect(page.getByRole('heading', { name: 'Game Finished!' })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
+}
+
+// Test 3 — fresh anonymous visitor sees the claim modal auto-open after the
+// leaderboard renders.
+test('claim modal auto-opens on top of the leaderboard for a fresh anonymous visitor', async ({ page, browserName }) => {
+  // Four questions × ~2s feedback + admin setup overhead pushes this test
+  // past Playwright's 30s default; match player.spec.ts's bump.
+  test.setTimeout(60_000);
+
+  const adminUser = `e2e-admin-claim-${browserName}`;
+  const quizTitle = `E2E Claim Quiz ${browserName}`;
+
+  // Admin setup: register, create the quiz, log out so the next steps
+  // run anonymously.
+  await registerAdmin(page, adminUser);
+  await createQuizWithQuestions(page, quizTitle);
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Anonymous player walks the quiz. The pre-leaderboard claim card is
+  // shown because the player is still on the auto-petname; once finished,
+  // the modal auto-opens on top of the leaderboard.
+  await playThroughQuiz(page, quizTitle);
+
+  // Modal is visible — gate is `!hasCustomName()`, which is true for a fresh
+  // anonymous visitor who never PATCHed /api/players/me.
+  const modal = page.locator('.modal.is-active');
+  await expect(modal).toBeVisible();
+  await expect(modal.locator('#claim-modal-title')).toHaveText('Pick a display name');
+});
+
+// Test 4 — an already-claimed visitor does NOT see the auto-modal after a
+// finished quiz. This is the regression #165 fixed: the prior gate
+// (`isAnonymous()` — i.e. "no password_hash") stayed true after a claim,
+// re-opening the modal every time. The corrected gate is `hasCustomName()`.
+test('claim modal does not auto-open for a visitor who already claimed a name', async ({ page, browserName }) => {
+  test.setTimeout(60_000);
+
+  const adminUser = `e2e-admin-claim-skip-${browserName}`;
+  const quizTitle = `E2E Claim Skip Quiz ${browserName}`;
+  const chosenName = `Already-Claimed-${browserName}-${Date.now()}`;
+
+  await registerAdmin(page, adminUser);
+  await createQuizWithQuestions(page, quizTitle);
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Visit /client/, claim a name via the start-screen modal, then play through.
+  await page.goto('/client/');
+  // Scope to :visible: both start-screen and leaderboard cards live in DOM
+  // at the same time (x-show toggles CSS, not mount state).
+  await expect(page.locator('.claim-cta:visible')).toBeVisible();
+  await page.getByRole('button', { name: 'Set your name' }).click();
+
+  const startModal = page.locator('.modal.is-active');
+  await expect(startModal).toBeVisible();
+  await startModal.locator('input#claim-name-modal').fill(chosenName);
+  await startModal.getByRole('button', { name: 'Save' }).click();
+  await expect(startModal).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Change your name' })).toBeVisible();
+
+  // Now play through. playThroughQuiz issues its own goto('/client/'), which
+  // is fine — the session cookie keeps the same anonymous-but-claimed row.
+  await playThroughQuiz(page, quizTitle);
+
+  // The claim modal must NOT auto-open: the player already has a custom name,
+  // so the `!hasCustomName()` gate in nextQuestion() short-circuits.
+  await expect(page.locator('.modal.is-active')).toHaveCount(0);
+
+  // The leaderboard row for the current player should already show the
+  // chosen name (no second claim step required). Match within the
+  // .is-selected row to ignore any other rows.
+  const playerRow = page.locator('table tbody tr.is-selected');
+  await expect(playerRow).toBeVisible();
+  await expect(playerRow).toContainText(chosenName);
+});

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -127,6 +127,15 @@ func TestAnonymous_Integration(t *testing.T) {
 		t.Errorf("[scenario 1] anonymous players added = %d, want %d", got, want)
 	}
 
+	// Scenario 1b: the newly-minted anonymous player should carry a
+	// petname-style username (Adjective-Adjective-Noun) rather than the
+	// legacy "anon-<xid>" format. The petname path is the default; the
+	// xid fallback only runs when the petname pool collides several times
+	// in a row, which is astronomically unlikely in a single-call test.
+	if got, want := countLegacyAnonUsernames(ctx, t, dbConn), 0; got != want {
+		t.Errorf("[scenario 1b] rows matching anon-%% = %d, want %d (petname path should win)", got, want)
+	}
+
 	// Scenario 2: a request that goes through EnsurePlayer reuses the
 	// existing row when the cookie jar is reused. Creating a game and
 	// then issuing a follow-up GET /api/quizzes (also wrapped in
@@ -165,6 +174,54 @@ func TestAnonymous_Integration(t *testing.T) {
 	_, _ = postCreateGame(ctx, t, clientB, baseURL, qz.ID)
 	if got, want := countAnonymousPlayers(ctx, t, dbConn)-startCount, 2; got != want {
 		t.Errorf("[scenario 3] anonymous players added = %d, want %d (two jars → two rows)", got, want)
+	}
+
+	// Scenario 4: an anonymous player can PATCH /api/players/me to set
+	// their own display name. The row stays the same (still anonymous,
+	// session cookie unchanged); only the username changes.
+	if got, want := patchPlayerUsername(ctx, t, client1, baseURL, "named-one"), http.StatusOK; got != want {
+		t.Errorf("[scenario 4] PATCH /api/players/me status = %d, want %d", got, want)
+	}
+
+	// Scenario 4b: GET /api/players/me reflects the new username and the
+	// row is still anonymous (no password_hash) — the front-end relies
+	// on this so the claim affordances disappear after a successful
+	// PATCH but the flow keeps working without forcing a login.
+	gotMe := fetchPlayerMe(ctx, t, client1, baseURL)
+	if got, want := gotMe.Username, "named-one"; got != want {
+		t.Errorf("[scenario 4b] /me username = %q, want %q", got, want)
+	}
+	if got, want := gotMe.IsAnonymous, true; got != want {
+		t.Errorf("[scenario 4b] /me isAnonymous = %v, want %v", got, want)
+	}
+	// hasCustomName flips to true on a successful PATCH; this is what
+	// the frontend now gates the end-of-quiz claim modal on, so the
+	// integration test pins the contract that a returning visitor with
+	// a claimed name does not re-trigger the modal (#165).
+	if got, want := gotMe.HasCustomName, true; got != want {
+		t.Errorf("[scenario 4b] /me hasCustomName = %v, want %v (PATCH must flip the flag)", got, want)
+	}
+
+	// Scenario 4c: a freshly minted anonymous visitor (clientB has not
+	// PATCHed yet) sees hasCustomName=false so the claim affordances
+	// stay rendered. Counterpart to 4b — without this we cannot tell
+	// whether the flag is wired or accidentally hard-coded to true.
+	gotMeB := fetchPlayerMe(ctx, t, clientB, baseURL)
+	if got, want := gotMeB.HasCustomName, false; got != want {
+		t.Errorf("[scenario 4c] fresh /me hasCustomName = %v, want %v", got, want)
+	}
+
+	// Scenario 5: a second anonymous player trying to claim the same
+	// username gets 409. The first player keeps "named-one".
+	if got, want := patchPlayerUsername(ctx, t, clientA, baseURL, "named-one"), http.StatusConflict; got != want {
+		t.Errorf("[scenario 5] colliding PATCH status = %d, want %d", got, want)
+	}
+
+	// Scenario 6: whitespace-only username is rejected as 400 by the
+	// server-side trim — the front-end trims too, but the contract is
+	// what the integration test pins down.
+	if got, want := patchPlayerUsername(ctx, t, clientA, baseURL, "   "), http.StatusBadRequest; got != want {
+		t.Errorf("[scenario 6] whitespace PATCH status = %d, want %d", got, want)
 	}
 
 	stop()
@@ -248,6 +305,73 @@ func fetchAPIQuizzes(ctx context.Context, t *testing.T, client *http.Client, bas
 	}
 }
 
+// meResponse mirrors the JSON shape returned by GET /api/players/me. Local
+// to the integration test rather than imported from clientapi so the test
+// double-pins the wire contract the front-end consumes.
+type meResponse struct {
+	ID            int64  `json:"id"`
+	Username      string `json:"username"`
+	IsAnonymous   bool   `json:"isAnonymous"`
+	HasCustomName bool   `json:"hasCustomName"`
+}
+
+// fetchPlayerMe issues GET /api/players/me on the supplied client and
+// returns the parsed response. Fatal on non-200 so callers can read the
+// returned struct without nil-guards.
+func fetchPlayerMe(ctx context.Context, t *testing.T, client *http.Client, baseURL string) meResponse {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/players/me", nil)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+		}
+	}()
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("GET /api/players/me status = %d, want %d", got, want)
+	}
+	var out meResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("json.Decode err = %v, want nil", err)
+	}
+
+	return out
+}
+
+// patchPlayerUsername issues PATCH /api/players/me with the given username
+// on the supplied client and returns the response status code. Body close
+// errors are reported but don't fail the test.
+func patchPlayerUsername(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, username string,
+) int {
+	t.Helper()
+
+	body := fmt.Sprintf(`{"username": %q}`, username)
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPatch, baseURL+"/api/players/me", strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+	if cerr := resp.Body.Close(); cerr != nil {
+		t.Errorf("resp.Body.Close err = %v, want nil", cerr)
+	}
+
+	return resp.StatusCode
+}
+
 // countAnonymousPlayers returns the number of rows with NULL password_hash.
 // The EnsurePlayer middleware is the only path that creates such rows, so
 // the value is a direct proxy for "how many anonymous visitors the server
@@ -259,6 +383,25 @@ func countAnonymousPlayers(ctx context.Context, t *testing.T, dbConn *sql.DB) in
 	err := dbConn.QueryRowContext(
 		ctx,
 		`SELECT COUNT(*) FROM players WHERE password_hash IS NULL`,
+	).Scan(&n)
+	if err != nil {
+		t.Fatalf("QueryRow err = %v, want nil", err)
+	}
+
+	return n
+}
+
+// countLegacyAnonUsernames returns the number of anonymous rows whose
+// username still uses the legacy "anon-<xid>" prefix. After #165, fresh
+// anonymous players get a petname-style name; a non-zero count here
+// indicates the xid fallback path ran (or the migration did not flow).
+func countLegacyAnonUsernames(ctx context.Context, t *testing.T, dbConn *sql.DB) int {
+	t.Helper()
+
+	var n int
+	err := dbConn.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM players WHERE password_hash IS NULL AND username LIKE 'anon-%'`,
 	).Scan(&n)
 	if err != nil {
 		t.Fatalf("QueryRow err = %v, want nil", err)


### PR DESCRIPTION
## Summary
- Anonymous players get an auto-generated Heroku-style petname (Adjective-Adjective-Noun, ~15M pool) on first visit instead of `anon-<xid>`; xid form is retained as a last-resort fallback after 5 collisions.
- New `GET` and `PATCH /api/players/me` lets visitors claim a display name in place without registering. Backed by a `username_claimed` column so credential anonymity (`IsAnonymous`) stays orthogonal to naming state (`HasCustomName`) — fixes the bug where the claim modal re-opened forever after a successful claim.
- Three UI affordances drive the same shared Bulma modal: pre-leaderboard auto-prompt, inline "Set my name" link on the current player's leaderboard row, and persistent "Playing as ..." cards on the start screen and above the leaderboard.

Closes #165.

## Test plan
- [x] `make check` (lint, sql-lint, build, unit + integration) — green
- [x] `make test-e2e` (Chromium + Firefox, 14 tests) — green
- [x] `make smoke` — green
- [x] Manual: claim a name from each of the three entry points; verify the modal doesn't re-open after a claim; verify a player who lands outside the top 10 still sees the claim card

🤖 Generated with [Claude Code](https://claude.com/claude-code)