### PR TITLE
Handle question timer running out (#175)

### DIFF
--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -16,6 +16,7 @@
     --cyan: #66e8ff;
     --cyan-soft: rgba(102, 232, 255, 0.12);
     --danger: #ff5c5c;
+    --warning: #ffb454;
 }
 
 html, body {
@@ -216,6 +217,13 @@ h3 {
 .notification.is-danger,
 .notification.is-danger .is-size-4 {
     color: var(--danger);
+}
+.notification.is-warning {
+    border-top-color: var(--warning);
+}
+.notification.is-warning,
+.notification.is-warning .is-size-4 {
+    color: var(--warning);
 }
 
 /* Leaderboard table — flat surface, restrained header microtype, accent

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -93,9 +93,13 @@
                         </template>
 
                         <template x-if="feedback">
-                            <div class="notification" :class="feedback.correct ? 'is-success' : 'is-danger'">
-                                <p class="is-size-4" x-text="feedback.correct ? 'Correct! ✅' : 'Wrong! ❌'"></p>
-                                <p>Score: <span x-text="feedback.score"></span></p>
+                            <div class="notification"
+                                 :class="feedback.timedOut ? 'is-warning' : feedback.correct ? 'is-success' : 'is-danger'">
+                                <p class="is-size-4"
+                                   x-text="feedback.timedOut ? 'Time out! ⏰' : feedback.correct ? 'Correct! ✅' : 'Wrong! ❌'"></p>
+                                <template x-if="!feedback.timedOut">
+                                    <p>Score: <span x-text="feedback.score"></span></p>
+                                </template>
                             </div>
                         </template>
 

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -75,6 +75,11 @@ export class GameApp {
         // so the leaderboard is never gated by this flag — the modal
         // simply overlays it.
         this.claimModalOpen = false;
+        // True while a submitAnswer POST is in flight. Without this,
+        // the countdown could fire between the click and the response
+        // and overwrite the real feedback with a timeout banner — see
+        // the race notes on handleTimeout for #175.
+        this.submittingAnswer = false;
     }
 
     async init() {
@@ -309,6 +314,21 @@ export class GameApp {
         });
     }
 
+    // animateTimeout settles the timeout banner in with a soft scale + fade,
+    // intentionally quieter than the wrong-answer shake: the player did not
+    // make a wrong decision — the clock simply ran out — so the motion
+    // should feel like a gentle "moving on" rather than a buzzer.
+    animateTimeout() {
+        requestAnimationFrame(() => {
+            runAnim('.notification', {
+                opacity: [0, 1],
+                scale: [0.96, 1],
+                duration: 420,
+                easing: 'easeOutQuart',
+            });
+        });
+    }
+
     startCountdown() {
         const start = new Date(this.question.startedAt).getTime();
         const end = new Date(this.question.expiredAt).getTime();
@@ -324,29 +344,61 @@ export class GameApp {
             if (this.progress <= 0) {
                 clearInterval(this.timer);
                 this.timer = null;
+                // Fire-and-forget: setInterval callbacks can't await,
+                // and resolveAndAdvance handles its own teardown.
+                void this.handleTimeout();
             }
         }, 100);
     }
 
-    async submitAnswer(optionId) {
-        if (this.feedback) return;
-        this.feedback = await gameService.submitAnswer(this.gameId, this.question.id, optionId);
-        this.animateFeedback(this.feedback.correct);
+    // handleTimeout fires when the per-question countdown reaches zero
+    // without a submitted answer. Skips when feedback is already set
+    // (the user beat the clock) or while a submit is in flight (the
+    // POST is racing the timer — let it finish and use the real
+    // result). On a real timeout it shows a "Time out!" notification
+    // and auto-advances via resolveAndAdvance after the same 2s pause
+    // the answered path uses. No POST is issued: the server's
+    // GetNextQuestion advances on the "asked" set rather than the
+    // "answered" set, and a missing answer row already produces a
+    // zero-score on the leaderboard.
+    async handleTimeout() {
+        if (this.feedback || this.submittingAnswer) return;
+        this.feedback = { timedOut: true, correct: false, score: 0 };
+        this.animateTimeout();
+        await this.resolveAndAdvance();
+    }
 
-        // Stop timer
+    async submitAnswer(optionId) {
+        if (this.feedback || this.submittingAnswer) return;
+        this.submittingAnswer = true;
+        try {
+            this.feedback = await gameService.submitAnswer(this.gameId, this.question.id, optionId);
+            this.animateFeedback(this.feedback.correct);
+        } finally {
+            this.submittingAnswer = false;
+        }
+
+        // Stop the countdown so it cannot fire handleTimeout on top
+        // of a real submission while we wait for the 2s feedback pause.
         if (this.timer) {
             clearInterval(this.timer);
             this.timer = null;
         }
 
-        // Wait for 2 seconds before moving to next question
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await this.resolveAndAdvance();
+    }
 
-        // Clear the previous question alongside the feedback so the new
-        // render swaps to the "Loading question..." placeholder. Without
-        // this, the buttons region (gated only on `!feedback`) re-mounts
-        // for one frame with the *old* question's options before
-        // nextQuestion() resolves and re-binds them.
+    // resolveAndAdvance waits the per-question feedback pause and then
+    // tears down current-question state before fetching the next one.
+    // Shared by submitAnswer and handleTimeout so both paths look the
+    // same to the user — only the feedback banner differs. Clears the
+    // previous question alongside the feedback so the new render swaps
+    // to the "Loading question..." placeholder; without this, the
+    // buttons region (gated only on `!feedback`) re-mounts for one
+    // frame with the old question's options before nextQuestion()
+    // resolves and re-binds them.
+    async resolveAndAdvance() {
+        await new Promise(resolve => setTimeout(resolve, 2000));
         this.question = null;
         this.feedback = null;
         await this.nextQuestion();

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
         'e2e-admin-player-chromium', 'e2e-admin-player-firefox',            // player.spec.ts
         'e2e-admin-claim-chromium', 'e2e-admin-claim-firefox',              // claim.spec.ts test 3
         'e2e-admin-claim-skip-chromium', 'e2e-admin-claim-skip-firefox',    // claim.spec.ts test 4
+        'e2e-admin-timeout-chromium', 'e2e-admin-timeout-firefox',          // timeout.spec.ts
       ].join(','),
     },
     reuseExistingServer: false,

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { registerAdmin, createQuizWithQuestions, QUIZ_QUESTIONS } from './helpers';
+import { registerAdmin, createQuizWithQuestions, playThroughQuiz } from './helpers';
 
 // Petname format: Title-cased Adjective-Adjective-Noun, e.g. "Steamy-Farty-Bear".
 // EnsurePlayer middleware generates one of these for every fresh anonymous
@@ -70,41 +70,6 @@ test('submitting a name via the start-screen modal updates the Playing as card i
   // trailing slash so the test doesn't depend on a redirect quirk.
   await expect(page).toHaveURL(/\/client\/?$/);
 });
-
-// playThroughQuiz walks every question by clicking the first option each time
-// and waiting for the per-question feedback notification. Extracted so Tests
-// 3 and 4 share the same play loop. Mirrors the inline loop in player.spec.ts
-// (which intentionally stays unchanged for this PR).
-async function playThroughQuiz(page: import('@playwright/test').Page, quizTitle: string): Promise<void> {
-  await page.goto('/client/');
-
-  // Alpine fetches the quiz list asynchronously, so wait for our title.
-  const select = page.locator('select');
-  await expect(select.locator('option', { hasText: quizTitle })).toHaveCount(1);
-  await select.selectOption({ label: quizTitle });
-  await page.getByRole('button', { name: 'Start Game' }).click();
-
-  for (const q of QUIZ_QUESTIONS) {
-    const choice = q.options[0];
-    const wasCorrect = q.correctIndices.includes(0);
-
-    const optionButton = page.getByRole('button', { name: choice });
-    await expect(optionButton).toBeVisible();
-    await optionButton.click();
-
-    if (wasCorrect) {
-      await expect(page.locator('.notification.is-success')).toBeVisible();
-    } else {
-      await expect(page.locator('.notification.is-danger')).toBeVisible();
-    }
-  }
-
-  // The leaderboard renders after the last answer's auto-advance hits 404
-  // on getNextQuestion. Generous timeout because the per-question feedback
-  // delay adds up over four questions.
-  await expect(page.getByRole('heading', { name: 'Game Finished!' })).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
-}
 
 // Test 3 — fresh anonymous visitor sees the claim modal auto-open after the
 // leaderboard renders.

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -92,3 +92,56 @@ export async function createQuizWithQuestions(
     await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   }
 }
+
+// playThroughQuiz walks the full quiz by clicking the first option on each
+// question and waiting for the per-question feedback notification. Used by
+// claim.spec.ts (and indirectly composes startQuizAsAnonymous +
+// answerRemainingQuestions for tests that need to interleave behaviour).
+export async function playThroughQuiz(page: Page, quizTitle: string): Promise<void> {
+  await startQuizAsAnonymous(page, quizTitle);
+  await answerRemainingQuestions(page);
+}
+
+// startQuizAsAnonymous navigates to /client/, picks the named quiz from the
+// dropdown, and clicks Start Game. Stops before the first question's options
+// are clicked so a caller can interleave timer/timeout behaviour between the
+// start and the answer loop.
+export async function startQuizAsAnonymous(page: Page, quizTitle: string): Promise<void> {
+  await page.goto('/client/');
+
+  // Alpine fetches the quiz list asynchronously, so wait for our title.
+  const select = page.locator('select');
+  await expect(select.locator('option', { hasText: quizTitle })).toHaveCount(1);
+  await select.selectOption({ label: quizTitle });
+  await page.getByRole('button', { name: 'Start Game' }).click();
+}
+
+// answerRemainingQuestions clicks the first option for each question starting
+// at fromIndex (default 0) and asserts the matching success/danger feedback.
+// Waits for the leaderboard at the end so the caller can pick up immediately
+// after the auto-advance from the final question. fromIndex lets timeout
+// specs skip the questions that have already been resolved (e.g. via the
+// timer-expired path).
+export async function answerRemainingQuestions(page: Page, fromIndex = 0): Promise<void> {
+  for (let i = fromIndex; i < QUIZ_QUESTIONS.length; i++) {
+    const q = QUIZ_QUESTIONS[i];
+    const choice = q.options[0];
+    const wasCorrect = q.correctIndices.includes(0);
+
+    const optionButton = page.getByRole('button', { name: choice });
+    await expect(optionButton).toBeVisible();
+    await optionButton.click();
+
+    if (wasCorrect) {
+      await expect(page.locator('.notification.is-success')).toBeVisible();
+    } else {
+      await expect(page.locator('.notification.is-danger')).toBeVisible();
+    }
+  }
+
+  // The leaderboard renders after the last answer's auto-advance hits 404
+  // on getNextQuestion. Generous timeout because the per-question feedback
+  // delay adds up.
+  await expect(page.getByRole('heading', { name: 'Game Finished!' })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
+}

--- a/test/e2e/tests/timeout.spec.ts
+++ b/test/e2e/tests/timeout.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import {
+  registerAdmin,
+  createQuizWithQuestions,
+  startQuizAsAnonymous,
+  answerRemainingQuestions,
+  QUIZ_QUESTIONS,
+} from './helpers';
+
+// PROGRESS_DRAIN_BUDGET_MS is a wall-clock budget for waiting until the
+// per-question progress bar reaches 0. Sized to comfortably cover the
+// server-side question countdown (currently 10s, see defaultExpiration
+// in internal/game/game.go) plus client jitter — but the test does NOT
+// assert any specific server-side timeout value; it only needs the
+// progress bar to drain before the banner appears. Bumping or lowering
+// the server's defaultExpiration only needs this budget to stay larger
+// than the new value.
+const PROGRESS_DRAIN_BUDGET_MS = 20_000;
+const SETTLE_MS = 4_000;
+
+// Letting the timer expire without answering takes one full countdown
+// plus the 2s feedback pause plus the next question's render time.
+// Following questions are answered immediately (~2s feedback each). The
+// setup overhead (registerAdmin + createQuizWithQuestions) pushes this
+// well past the Playwright default — bump generously.
+test('timing out a question shows the Time out banner and the rest of the quiz still plays through', async ({ page, browserName }) => {
+  test.setTimeout(120_000);
+
+  const adminUser = `e2e-admin-timeout-${browserName}`;
+  const quizTitle = `E2E Timeout Quiz ${browserName}`;
+
+  await registerAdmin(page, adminUser);
+  await createQuizWithQuestions(page, quizTitle);
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Start the quiz as an anonymous player.
+  await startQuizAsAnonymous(page, quizTitle);
+
+  // First question is on screen; do NOT click any option. Wait for the
+  // countdown to expire and the "Time out!" notification to appear.
+  const firstQuestion = QUIZ_QUESTIONS[0];
+  await expect(page.getByRole('button', { name: firstQuestion.options[0] })).toBeVisible();
+
+  // Progress bar must visibly drain to 0 before the banner appears —
+  // this pins the "banner only shows on real expiry, not prematurely"
+  // contract. The progress element's `value` attribute is updated by
+  // startCountdown on each 100 ms tick.
+  await expect(page.locator('progress.progress')).toHaveAttribute(
+    'value',
+    '0',
+    { timeout: PROGRESS_DRAIN_BUDGET_MS },
+  );
+
+  const timeoutBanner = page.locator('.notification.is-warning');
+  await expect(timeoutBanner).toBeVisible({ timeout: SETTLE_MS });
+  await expect(timeoutBanner).toContainText('Time out!');
+
+  // No score line on a timeout — the warning banner shows just the headline.
+  await expect(timeoutBanner).not.toContainText('Score:');
+
+  // Answer buttons are gone while feedback is shown; the option that was
+  // visible above must not be clickable now. Use the visibility check to
+  // confirm the lock-out.
+  await expect(page.getByRole('button', { name: firstQuestion.options[0] })).toBeHidden();
+
+  // After the 2s feedback pause, the next question appears. Asserting the
+  // second question's first option proves the auto-advance fired.
+  const secondQuestion = QUIZ_QUESTIONS[1];
+  await expect(page.getByRole('button', { name: secondQuestion.options[0] })).toBeVisible({
+    timeout: SETTLE_MS,
+  });
+
+  // Play through the remaining questions. The point of this loop is not
+  // to verify scoring but to prove the game progresses past the
+  // timed-out Q1: a regression where the server refused to advance
+  // without an answer row would loop or 5xx inside the helper.
+  await answerRemainingQuestions(page, 1);
+
+  // The player's row must be on the leaderboard with a positive numeric
+  // score: QUIZ_QUESTIONS[2] (all-correct) and QUIZ_QUESTIONS[3] (idx 0
+  // is prime) both score positive when picking option 0. Regex form
+  // avoids the stringly comparison to literal '0' so a future number
+  // format (e.g. thousands separators) doesn't silently weaken the check.
+  const playerRow = page.locator('table tbody tr.is-selected');
+  await expect(playerRow).toBeVisible();
+  await expect(playerRow.locator('td').nth(2)).toHaveText(/^[1-9]\d*$/);
+});


### PR DESCRIPTION
## Summary
- When the per-question countdown reaches 0 without a submitted answer, the client now shows a "Time out! ⏰" notification (new amber `is-warning` variant) and auto-advances after the same 2s pause the answered path uses.
- New `submittingAnswer` flag closes the race where the timer could fire mid-POST and clobber a real answer with a timeout banner. The 2s-wait-then-advance is extracted into `resolveAndAdvance` so the answered and timed-out paths share one implementation.
- Backend untouched: `GetNextQuestion` already advances on the "asked" set rather than the "answered" set, and a missing answer row already scores zero on the leaderboard.

Closes #175.

## Test plan
- [x] `make check` — green
- [x] `make test-e2e` (16 tests: Chromium + Firefox, includes new `timeout.spec.ts` covering banner, lock-out, auto-advance, full play-through after the timed-out question, and a non-zero leaderboard score) — green
- [x] Manual: let the timer expire on a question; verify the "Time out!" banner, the absence of the score line, the buttons disappearing, and the next question loading after ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)