### PR TITLE
Show personal score on leaderboard for off-top-10 players (#181)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -624,8 +624,10 @@ func HandleQuizView(
 
 		// Admin "Played by" doesn't highlight a current player — the
 		// template ignores IsCurrentPlayer — so pass 0 to flag nothing,
-		// per Service.GetQuizLeaderboard's documented sentinel.
-		entries, err := gameService.GetQuizLeaderboard(r.Context(), id, 0, playersLimit)
+		// per Service.GetQuizLeaderboard's documented sentinel. The
+		// admin view also has no concept of "viewer score" so the
+		// CurrentPlayer field of the result is irrelevant here.
+		result, err := gameService.GetQuizLeaderboard(r.Context(), id, 0, playersLimit)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error fetching players for quiz view", slog.Any("err", err))
 			render500(w, r, logger, csrfMgr)
@@ -633,8 +635,8 @@ func HandleQuizView(
 			return
 		}
 
-		players := make([]PlayerScoreData, 0, len(entries))
-		for _, e := range entries {
+		players := make([]PlayerScoreData, 0, len(result.Entries))
+		for _, e := range result.Entries {
 			players = append(players, PlayerScoreData{
 				PlayerID: e.PlayerID,
 				Username: e.Username,

--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -261,6 +261,37 @@ h3 {
     border-color: rgba(255, 45, 149, 0.25);
 }
 
+/* Off-leaderboard "Your score" card on the leaderboard view. Shown when
+   the player finished but landed outside the visible top-N — gives them
+   their own rank and score in lieu of the highlighted row they don't have
+   (see #181). Cyan stripe so it pairs visually with the table's correct-
+   answer cyan while staying distinct from the magenta claim-cta. */
+.standing-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--cyan);
+    padding: 1.25rem 1.5rem;
+    border-radius: 6px;
+}
+.standing-label {
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+.standing-line {
+    color: var(--text);
+    font-size: 1.05rem;
+    line-height: 1.4;
+}
+.standing-rank,
+.standing-score {
+    color: var(--cyan);
+    font-weight: 600;
+}
+
 /* Anonymous "Playing as ..." card on the start screen. A themed
    replacement for Bulma's is-info notification (which sits awkwardly as a
    bright blue panel on the near-black synthwave page). Uses the project's

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -158,9 +158,9 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <template x-for="(entry, index) in leaderboard.entries" :key="entry.playerId">
+                                <template x-for="entry in leaderboard.entries" :key="entry.playerId">
                                     <tr :class="entry.isCurrentPlayer ? 'is-selected' : ''">
-                                        <td x-text="index + 1"></td>
+                                        <td x-text="entry.rank"></td>
                                         <td>
                                             <span x-text="entry.username"></span>
                                             <!-- Entry 2: leaderboard-row link that
@@ -178,6 +178,26 @@
                         </table>
                     </div>
                 </template>
+
+                <!-- Off-leaderboard standing: when the player has a row
+                     for this quiz but didn't make the visible top N
+                     (currentPlayer is set, no entry carries
+                     isCurrentPlayer), show the player's own rank and
+                     score below the table so they don't leave the
+                     screen with nothing to show. See #181. -->
+                <template x-if="hasOffLeaderboardStanding()">
+                    <article class="standing-card mt-5">
+                        <p class="standing-label">Your score</p>
+                        <p class="standing-line">
+                            Rank
+                            <span class="standing-rank" x-text="leaderboard.currentPlayer.rank"></span>
+                            ·
+                            <span class="standing-score" x-text="leaderboard.currentPlayer.score"></span>
+                             points
+                        </p>
+                    </article>
+                </template>
+
                 <template x-if="!leaderboard">
                     <p>Loading leaderboard...</p>
                 </template>

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -126,6 +126,17 @@ export class GameApp {
         return !!(this.player && this.player.isAnonymous);
     }
 
+    // hasOffLeaderboardStanding reports whether the requesting player
+    // finished the quiz but landed outside the visible top-N: the
+    // leaderboard payload's currentPlayer field is populated AND no
+    // visible entry carries isCurrentPlayer. The dedicated "Your
+    // score" card on the leaderboard view gates on this so a player
+    // who placed 11th+ still sees their own rank and score (#181).
+    hasOffLeaderboardStanding() {
+        if (!this.leaderboard || !this.leaderboard.currentPlayer) return false;
+        return !this.leaderboard.entries.some(e => e.isCurrentPlayer);
+    }
+
     // openClaimModal is the single entry point that any of the three
     // affordances (pre-leaderboard auto-open, inline "Set my name"
     // link, start-screen "Set your name" link) calls. The modal

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -141,6 +141,11 @@ func HandleQuizGet(logger *slog.Logger, quizStore quiz.Store) http.Handler {
 // are broken by ascending username for a stable order. IsCurrentPlayer is set
 // on the entry that matches the authenticated player on the request context
 // so the client can highlight that row.
+//
+// The response also carries a currentPlayer field with the requesting
+// player's rank and score, populated even when the player landed outside
+// the truncated top-N. Frontend uses this to render an off-leaderboard
+// "Your score" card — see #181.
 func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Handler {
 	const leaderboardLimit = 10
 
@@ -148,12 +153,24 @@ func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Hand
 		PlayerID        int64  `json:"playerId"`
 		Username        string `json:"username"`
 		Score           int    `json:"score"`
+		Rank            int    `json:"rank"`
 		IsCurrentPlayer bool   `json:"isCurrentPlayer"`
 	}
 
 	type leaderboardResponse struct {
-		QuizID  int64           `json:"quizId"`
-		Entries []entryResponse `json:"entries"`
+		QuizID        int64           `json:"quizId"`
+		Entries       []entryResponse `json:"entries"`
+		CurrentPlayer *entryResponse  `json:"currentPlayer"`
+	}
+
+	toEntryResponse := func(e game.LeaderboardEntry) entryResponse {
+		return entryResponse{
+			PlayerID:        e.PlayerID,
+			Username:        e.Username,
+			Score:           e.Score,
+			Rank:            e.Rank,
+			IsCurrentPlayer: e.IsCurrentPlayer,
+		}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -174,7 +191,7 @@ func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Hand
 			return
 		}
 
-		entries, err := service.GetQuizLeaderboard(ctx, quizID, player.ID, leaderboardLimit)
+		result, err := service.GetQuizLeaderboard(ctx, quizID, player.ID, leaderboardLimit)
 		if err != nil {
 			if errors.Is(err, quiz.ErrQuizNotFound) {
 				http.NotFound(w, r)
@@ -187,17 +204,16 @@ func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Hand
 			return
 		}
 
-		respEntries := make([]entryResponse, 0, len(entries))
-		for _, e := range entries {
-			respEntries = append(respEntries, entryResponse{
-				PlayerID:        e.PlayerID,
-				Username:        e.Username,
-				Score:           e.Score,
-				IsCurrentPlayer: e.IsCurrentPlayer,
-			})
+		respEntries := make([]entryResponse, 0, len(result.Entries))
+		for _, e := range result.Entries {
+			respEntries = append(respEntries, toEntryResponse(e))
 		}
 
 		res := leaderboardResponse{QuizID: quizID, Entries: respEntries}
+		if result.CurrentPlayer != nil {
+			cp := toEntryResponse(*result.CurrentPlayer)
+			res.CurrentPlayer = &cp
+		}
 
 		if err = handlers.EncodeJSON(w, http.StatusOK, res); err != nil {
 			logger.ErrorContext(ctx, "error encoding leaderboardResponse", slog.Any("err", err))

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -1197,13 +1197,15 @@ type leaderboardTestEntry struct {
 	PlayerID        int64  `json:"playerId"`
 	Username        string `json:"username"`
 	Score           int    `json:"score"`
+	Rank            int    `json:"rank"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
 }
 
 // leaderboardTestResponse is the decode target for the leaderboard endpoint.
 type leaderboardTestResponse struct {
-	QuizID  int64                  `json:"quizId"`
-	Entries []leaderboardTestEntry `json:"entries"`
+	QuizID        int64                  `json:"quizId"`
+	Entries       []leaderboardTestEntry `json:"entries"`
+	CurrentPlayer *leaderboardTestEntry  `json:"currentPlayer"`
 }
 
 func TestHandleQuizLeaderboard(t *testing.T) {
@@ -1275,14 +1277,31 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 		if got, want := body.Entries[0].Username, "bob"; got != want {
 			t.Errorf("entries[0].Username = %q, want %q", got, want)
 		}
+		if got, want := body.Entries[0].Rank, 1; got != want {
+			t.Errorf("entries[0].Rank = %d, want %d", got, want)
+		}
 		if got, want := body.Entries[0].IsCurrentPlayer, false; got != want {
 			t.Errorf("entries[0].IsCurrentPlayer = %v, want %v", got, want)
 		}
 		if got, want := body.Entries[1].Username, "alice"; got != want {
 			t.Errorf("entries[1].Username = %q, want %q", got, want)
 		}
+		if got, want := body.Entries[1].Rank, 2; got != want {
+			t.Errorf("entries[1].Rank = %d, want %d", got, want)
+		}
 		if got, want := body.Entries[1].IsCurrentPlayer, true; got != want {
 			t.Errorf("entries[1].IsCurrentPlayer = %v, want %v", got, want)
+		}
+		// currentPlayer field is always populated when the player has a
+		// row; in this case alice (player 1) ranks 2.
+		if body.CurrentPlayer == nil {
+			t.Fatal("currentPlayer = nil, want alice's standing")
+		}
+		if got, want := body.CurrentPlayer.PlayerID, int64(1); got != want {
+			t.Errorf("currentPlayer.PlayerID = %d, want %d", got, want)
+		}
+		if got, want := body.CurrentPlayer.Rank, 2; got != want {
+			t.Errorf("currentPlayer.Rank = %d, want %d", got, want)
 		}
 	})
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -127,13 +127,28 @@ type LeaderboardAnswer struct {
 }
 
 // LeaderboardEntry is a single row of a per-quiz leaderboard: the player's
-// total score for that quiz. IsCurrentPlayer is true when the entry belongs
-// to the player making the request, which lets the client highlight the row.
+// total score for that quiz. Rank is 1-indexed and computed before
+// truncation, so the value remains meaningful for a CurrentPlayer entry
+// returned outside the truncated top-N. IsCurrentPlayer is true when the
+// entry belongs to the player making the request, which lets the client
+// highlight the row.
 type LeaderboardEntry struct {
 	PlayerID        int64
 	Username        string
 	Score           int
+	Rank            int
 	IsCurrentPlayer bool
+}
+
+// LeaderboardResult bundles the truncated top-N entries with the requesting
+// player's full standing, so a player who finished outside the visible
+// leaderboard can still see their own score and rank. CurrentPlayer is nil
+// when the player has no completed-game row for the quiz; when populated
+// it carries Rank from the full (pre-truncation) ordering, even if the
+// same player also appears in Entries.
+type LeaderboardResult struct {
+	Entries       []LeaderboardEntry
+	CurrentPlayer *LeaderboardEntry
 }
 
 // Store represents a game store.
@@ -462,13 +477,15 @@ func (s *Service) GetResults(ctx context.Context, gameID string) (*Results, erro
 // determinism so a tied scoreboard is stable across requests.
 //
 // currentPlayerID flags the entry that belongs to the requesting player so
-// the client can highlight it; pass 0 to flag nothing.
+// the client can highlight it; pass 0 to flag nothing. The same id drives
+// the returned CurrentPlayer standing so a player who landed outside the
+// truncated top-N can still see their own score and rank — see #181.
 //
 // If limit <= 0 it defaults to 10. The quiz must exist; missing quizzes
 // surface as [quiz.ErrQuizNotFound].
 func (s *Service) GetQuizLeaderboard(
 	ctx context.Context, quizID, currentPlayerID int64, limit int,
-) ([]LeaderboardEntry, error) {
+) (*LeaderboardResult, error) {
 	if limit <= 0 {
 		limit = defaultLeaderboardLimit
 	}
@@ -528,11 +545,42 @@ func (s *Service) GetQuizLeaderboard(
 		return strings.Compare(a.Username, b.Username)
 	})
 
+	return finalizeLeaderboardInPlace(entries, currentPlayerID, limit), nil
+}
+
+// finalizeLeaderboardInPlace stamps 1-indexed rank on every entry, extracts the
+// current player's standing from the full ordering (so a player outside
+// the visible top-N still gets a Rank that matches their global position),
+// and then truncates entries to the requested limit. Split out of
+// GetQuizLeaderboard to keep that function under the project's per-function
+// length budget; the steps need to run in this order — ranks must be stamped
+// before the CurrentPlayer copy or it gets a zero rank, and the truncation
+// must come after both or the off-leaderboard player vanishes.
+//
+// The entries slice is mutated in place (rank field writes + sub-slicing);
+// callers must not retain the original slice after invocation.
+func finalizeLeaderboardInPlace(entries []LeaderboardEntry, currentPlayerID int64, limit int) *LeaderboardResult {
+	for i := range entries {
+		entries[i].Rank = i + 1
+	}
+
+	var currentPlayer *LeaderboardEntry
+	if currentPlayerID != 0 {
+		for i := range entries {
+			if entries[i].PlayerID == currentPlayerID {
+				cp := entries[i]
+				currentPlayer = &cp
+
+				break
+			}
+		}
+	}
+
 	if len(entries) > limit {
 		entries = entries[:limit]
 	}
 
-	return entries, nil
+	return &LeaderboardResult{Entries: entries, CurrentPlayer: currentPlayer}
 }
 
 // CalculateScore calculates the score for a given answer.

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -3,6 +3,7 @@ package game_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -748,8 +749,11 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(got) != 0 {
-			t.Errorf("len(entries) = %d, want 0", len(got))
+		if len(got.Entries) != 0 {
+			t.Errorf("len(entries) = %d, want 0", len(got.Entries))
+		}
+		if got.CurrentPlayer != nil {
+			t.Errorf("CurrentPlayer = %+v, want nil", got.CurrentPlayer)
 		}
 	})
 
@@ -775,21 +779,24 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := len(entries), 1; got != want {
+		if got, want := len(result.Entries), 1; got != want {
 			t.Fatalf("len(entries) = %d, want %d", got, want)
 		}
-		if got, want := entries[0].PlayerID, int64(1); got != want {
+		if got, want := result.Entries[0].PlayerID, int64(1); got != want {
 			t.Errorf("entries[0].PlayerID = %d, want %d", got, want)
 		}
-		if got, want := entries[0].Username, "alice"; got != want {
+		if got, want := result.Entries[0].Username, "alice"; got != want {
 			t.Errorf("entries[0].Username = %q, want %q", got, want)
 		}
-		if got, want := entries[0].Score, 2000; got != want {
+		if got, want := result.Entries[0].Score, 2000; got != want {
 			t.Errorf("entries[0].Score = %d, want %d", got, want)
+		}
+		if got, want := result.Entries[0].Rank, 1; got != want {
+			t.Errorf("entries[0].Rank = %d, want %d", got, want)
 		}
 	})
 
@@ -816,18 +823,24 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := len(entries), 2; got != want {
+		if got, want := len(result.Entries), 2; got != want {
 			t.Fatalf("len(entries) = %d, want %d", got, want)
 		}
-		if got, want := entries[0].Username, "bob"; got != want {
+		if got, want := result.Entries[0].Username, "bob"; got != want {
 			t.Errorf("entries[0].Username = %q, want %q", got, want)
 		}
-		if got, want := entries[1].Username, "alice"; got != want {
+		if got, want := result.Entries[1].Username, "alice"; got != want {
 			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		}
+		if got, want := result.Entries[0].Rank, 1; got != want {
+			t.Errorf("entries[0].Rank = %d, want %d", got, want)
+		}
+		if got, want := result.Entries[1].Rank, 2; got != want {
+			t.Errorf("entries[1].Rank = %d, want %d", got, want)
 		}
 	})
 
@@ -854,12 +867,12 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		gotNames := []string{entries[0].Username, entries[1].Username, entries[2].Username}
+		gotNames := []string{result.Entries[0].Username, result.Entries[1].Username, result.Entries[2].Username}
 		wantNames := []string{"alice", "bob", "charlie"}
 		if diff := cmp.Diff(wantNames, gotNames); diff != "" {
 			t.Errorf("username order mismatch (-want +got):\n%s", diff)
@@ -887,13 +900,13 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 1, 10)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 1, 10)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		var aliceEntry, bobEntry LeaderboardEntry
-		for _, e := range entries {
+		for _, e := range result.Entries {
 			switch e.PlayerID {
 			case 1:
 				aliceEntry = e
@@ -909,6 +922,19 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		}
 		if got, want := bobEntry.IsCurrentPlayer, false; got != want {
 			t.Errorf("bobEntry.IsCurrentPlayer = %v, want %v", got, want)
+		}
+		// CurrentPlayer is also surfaced separately so off-leaderboard
+		// players can see their own row (#181). Alice is in the top-N
+		// here so it duplicates her entry, but the field is populated
+		// either way.
+		if result.CurrentPlayer == nil {
+			t.Fatal("CurrentPlayer = nil, want alice's standing")
+		}
+		if got, want := result.CurrentPlayer.PlayerID, int64(1); got != want {
+			t.Errorf("CurrentPlayer.PlayerID = %d, want %d", got, want)
+		}
+		if got, want := result.CurrentPlayer.Rank, 2; got != want {
+			t.Errorf("CurrentPlayer.Rank = %d, want %d (alice trails bob)", got, want)
 		}
 	})
 
@@ -938,14 +964,14 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 3)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 3)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := len(entries), 3; got != want {
+		if got, want := len(result.Entries), 3; got != want {
 			t.Errorf("len(entries) = %d, want %d", got, want)
 		}
-		if got, want := entries[0].PlayerID, int64(1); got != want {
+		if got, want := result.Entries[0].PlayerID, int64(1); got != want {
 			t.Errorf("entries[0].PlayerID = %d, want %d", got, want)
 		}
 	})
@@ -972,12 +998,99 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			slog.New(slog.DiscardHandler),
 		)
 
-		entries, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 0)
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got, want := len(entries), 10; got != want {
+		if got, want := len(result.Entries), 10; got != want {
 			t.Errorf("len(entries) = %d, want %d (default limit)", got, want)
+		}
+	})
+
+	t.Run("surfaces CurrentPlayer when current player is outside the top-N", func(t *testing.T) {
+		t.Parallel()
+
+		// Five players, strictly decreasing scores (5000, 4000, 3000,
+		// 2000, 1000). Limit to top-3. Player 5 (lowest score) is the
+		// requesting player — they should NOT appear in Entries but
+		// SHOULD appear in CurrentPlayer with Rank=5. This is the
+		// scenario from #181.
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					answers := make([]*LeaderboardAnswer, 0, 5)
+					for i := int64(1); i <= 5; i++ {
+						for range 6 - i {
+							answers = append(answers, makeAnswer(i, fmt.Sprintf("p%d", i), true))
+						}
+					}
+
+					return answers, nil
+				},
+			},
+			stubQuizStore{
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 5, 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(result.Entries), 3; got != want {
+			t.Fatalf("len(entries) = %d, want %d", got, want)
+		}
+		for _, e := range result.Entries {
+			if e.PlayerID == 5 {
+				t.Errorf("player 5 should be outside the top-3, found in entries: %+v", e)
+			}
+		}
+		if result.CurrentPlayer == nil {
+			t.Fatal("CurrentPlayer = nil, want player 5's standing")
+		}
+		if got, want := result.CurrentPlayer.PlayerID, int64(5); got != want {
+			t.Errorf("CurrentPlayer.PlayerID = %d, want %d", got, want)
+		}
+		if got, want := result.CurrentPlayer.Rank, 5; got != want {
+			t.Errorf("CurrentPlayer.Rank = %d, want %d", got, want)
+		}
+		if got, want := result.CurrentPlayer.Score, 1000; got != want {
+			t.Errorf("CurrentPlayer.Score = %d, want %d", got, want)
+		}
+		if got, want := result.CurrentPlayer.IsCurrentPlayer, true; got != want {
+			t.Errorf("CurrentPlayer.IsCurrentPlayer = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("CurrentPlayer is nil when current player has no row", func(t *testing.T) {
+		t.Parallel()
+
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					return []*LeaderboardAnswer{
+						makeAnswer(1, "alice", true),
+					}, nil
+				},
+			},
+			stubQuizStore{
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		// Request as player 99, who never played.
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 99, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.CurrentPlayer != nil {
+			t.Errorf("CurrentPlayer = %+v, want nil (player has no row)", result.CurrentPlayer)
 		}
 	})
 }

--- a/test/e2e/tests/player.spec.ts
+++ b/test/e2e/tests/player.spec.ts
@@ -79,6 +79,14 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
   await expect(playerRow).toBeVisible();
   await expect(playerRow.locator('td').nth(2)).not.toHaveText('0');
 
+  // The off-leaderboard "Your score" standing (#181) must NOT show when
+  // the player already has a visible row on the leaderboard — the
+  // hasOffLeaderboardStanding gate keys on the absence of an
+  // isCurrentPlayer entry. Asserting it is hidden here pins the gate
+  // against an always-on regression; the populated-card case is covered
+  // by the Go service + handler tests where seeding 11+ rows is cheap.
+  await expect(page.locator('.standing-card')).toBeHidden();
+
   // Lock in the prediction: picking option[0] of every QUIZ_QUESTIONS entry
   // currently hits Q3 (all correct) and Q4 (idx 0 is prime) — exactly 2
   // successes. If a future spec edit shifts that count, this assertion fails


### PR DESCRIPTION
## Summary
- Adds a cyan-striped "Your score" card to the leaderboard view for players who finished a quiz but landed outside the visible top-10. Shows their global rank and score so they don't leave the screen empty-handed.
- Service computes rank from the full pre-truncation ordering and returns a `LeaderboardResult { Entries, CurrentPlayer }`. The handler serializes `currentPlayer` alongside `entries`; the frontend renders the card only when the player has a row that is not on the visible board.
- Frontend rank column switched from `index + 1` to server-authoritative `entry.rank`.

Closes #181.

## Test plan
- [x] `make check` — green
- [x] `make test-e2e` (16 tests including a new assertion in `player.spec.ts` that the card stays hidden when the player IS on the leaderboard) — green
- [ ] Manual: complete a quiz where the player ranks inside the top-10 and verify the card is hidden; with seeded data, verify a player ranked 11+ sees the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)