### PR TITLE
Suppress sticky :hover on touch devices (#194)

### DIFF
--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -120,7 +120,15 @@ h3 {
 }
 
 /* Buttons — neutral surface at rest, magenta accent on hover/focus. No
-   idle pulse, no permanent glow. */
+   idle pulse, no permanent glow.
+
+   :hover is split off from :focus and wrapped in @media (hover: hover)
+   so it only fires on devices with a real hovering input (mouse,
+   trackpad). On touch-only devices the :hover state would otherwise
+   stick to the last-touched button because there is no pointer-leave
+   event, leaving a permanent magenta glow until the user taps
+   somewhere else — see #194. :focus stays unconditional so keyboard
+   navigation still gets a visible accent ring on every button. */
 .button {
     background: var(--surface);
     color: var(--text);
@@ -134,12 +142,18 @@ h3 {
     transition: border-color 160ms ease, background 160ms ease, transform 120ms ease, box-shadow 200ms ease;
     box-shadow: none;
 }
-.button:hover,
 .button:focus {
     border-color: var(--accent);
     background: var(--surface-2);
     box-shadow: 0 0 0 3px var(--accent-soft);
     outline: none;
+}
+@media (hover: hover) {
+    .button:hover {
+        border-color: var(--accent);
+        background: var(--surface-2);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
 }
 .button:active {
     transform: translateY(1px);
@@ -150,12 +164,19 @@ h3 {
     border-color: var(--accent);
     font-weight: 600;
 }
-.button.is-primary:hover,
 .button.is-primary:focus {
     background: var(--text);
     color: var(--bg);
     border-color: var(--text);
     box-shadow: 0 0 0 3px var(--accent-soft);
+}
+@media (hover: hover) {
+    .button.is-primary:hover {
+        background: var(--text);
+        color: var(--bg);
+        border-color: var(--text);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
 }
 .button.is-fullwidth {
     text-align: left;
@@ -335,48 +356,14 @@ figure.image img {
    suppress the outline when focus did NOT arrive via the keyboard, so
    keyboard navigation still gets the visible accent ring on the answer
    buttons. Scoped to the answer list so other buttons keep their
-   existing focus treatment. */
+   existing focus treatment. The :hover side of the sticky-tap problem
+   is handled at the source by the (hover: hover) gate on .button:hover
+   earlier in this file (#194). */
 .buttons .button.is-fullwidth:focus:not(:focus-visible) {
     border-color: var(--border);
     background: var(--surface);
     box-shadow: none;
     outline: none;
-}
-
-/* Mobile UX (#194): kill the magenta glow on :hover and :active for the
-   answer buttons specifically. On Mobile Firefox a touch-down sets
-   :active (and the :hover state lingers because touch devices have no
-   pointer-leave event), so the glow from the base .button:hover rule
-   earlier in this file sticks to the touched button until the user
-   taps somewhere else. The :focus-visible rule above does not catch
-   this because the state is :hover/:active, not :focus.
-
-   We suppress unconditionally first so any device without a real hover
-   (and any device whose hover media-query reports unexpectedly) lands
-   on the no-glow path. The (hover: hover) block below then layers the
-   accent glow back on for real desktop pointers. Inverting the gate
-   like this is safer than `(hover: none)`: a mis-evaluating media
-   query fails toward no-glow, which is the bug-free state rather than
-   the regression. */
-.buttons .button.is-fullwidth:hover,
-.buttons .button.is-fullwidth:active {
-    border-color: var(--border);
-    background: var(--surface);
-    box-shadow: none;
-    outline: none;
-}
-
-/* Desktop-only: re-introduce the accent glow on hover for the answer
-   buttons. (hover: hover) matches devices with a real hovering input
-   (mouse, trackpad, paired keyboard with a pointer); it does NOT match
-   on a phone's touchscreen, so the suppression above is the final word
-   there. */
-@media (hover: hover) {
-    .buttons .button.is-fullwidth:hover {
-        border-color: var(--accent);
-        background: var(--surface-2);
-        box-shadow: 0 0 0 3px var(--accent-soft);
-    }
 }
 
 /* Mobile UX: bump answer-button touch targets above the WCAG 44px

--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -333,13 +333,50 @@ figure.image img {
 
 /* Mobile UX: drop the stuck focus ring left behind after a tap. We only
    suppress the outline when focus did NOT arrive via the keyboard, so
-   keyboard navigation still gets the visible accent ring. Scoped to the
-   answer list so other buttons keep their existing focus treatment. */
+   keyboard navigation still gets the visible accent ring on the answer
+   buttons. Scoped to the answer list so other buttons keep their
+   existing focus treatment. */
 .buttons .button.is-fullwidth:focus:not(:focus-visible) {
     border-color: var(--border);
     background: var(--surface);
     box-shadow: none;
     outline: none;
+}
+
+/* Mobile UX (#194): kill the magenta glow on :hover and :active for the
+   answer buttons specifically. On Mobile Firefox a touch-down sets
+   :active (and the :hover state lingers because touch devices have no
+   pointer-leave event), so the glow from the base .button:hover rule
+   earlier in this file sticks to the touched button until the user
+   taps somewhere else. The :focus-visible rule above does not catch
+   this because the state is :hover/:active, not :focus.
+
+   We suppress unconditionally first so any device without a real hover
+   (and any device whose hover media-query reports unexpectedly) lands
+   on the no-glow path. The (hover: hover) block below then layers the
+   accent glow back on for real desktop pointers. Inverting the gate
+   like this is safer than `(hover: none)`: a mis-evaluating media
+   query fails toward no-glow, which is the bug-free state rather than
+   the regression. */
+.buttons .button.is-fullwidth:hover,
+.buttons .button.is-fullwidth:active {
+    border-color: var(--border);
+    background: var(--surface);
+    box-shadow: none;
+    outline: none;
+}
+
+/* Desktop-only: re-introduce the accent glow on hover for the answer
+   buttons. (hover: hover) matches devices with a real hovering input
+   (mouse, trackpad, paired keyboard with a pointer); it does NOT match
+   on a phone's touchscreen, so the suppression above is the final word
+   there. */
+@media (hover: hover) {
+    .buttons .button.is-fullwidth:hover {
+        border-color: var(--accent);
+        background: var(--surface-2);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
 }
 
 /* Mobile UX: bump answer-button touch targets above the WCAG 44px


### PR DESCRIPTION
## Summary
The magenta hover glow stayed glued to the last-touched answer button on Mobile Firefox until the user tapped somewhere else. The base \`.button:hover, .button:focus\` rule in \`synthwave.css\` paints a 3px accent-soft box-shadow on hover; on touch devices there is no pointer-leave event, so once \`:hover\` was set on touchdown it just sat there.

## What we tried, in order

1. **Existing rule (#173):** \`.buttons .button.is-fullwidth:focus:not(:focus-visible)\` suppressed the post-tap focus ring. Worked on Chrome/Safari but Mobile Firefox treats touch focus as \`:focus-visible\`, so the gate never matched.
2. **\`@media (hover: none) and (pointer: coarse)\` scoped to the answer buttons:** killed \`:focus\` only — touch-and-hold-then-move-off still left the glow because the lingering state turned out to be \`:hover\` (and \`:active\`), not \`:focus\`. Confirmed via Firefox remote debug inspector: \`.button:hover\` was matching on the stuck button while \`.button:focus\` was struck through.
3. **Unconditional suppression with \`(hover: hover)\` re-add:** fixed the bug but scoped only to answer buttons and kept the override-and-re-add dance.
4. **Source-gated fix (this PR):** split \`.button:hover\` off from \`.button:focus\` in the base rule and wrapped it in \`@media (hover: hover)\`. Same split for \`.button.is-primary\`. Now \`:hover\` only fires on devices with a real hovering input (mouse, trackpad) — touch-only devices never enter the hover state. \`:focus\` stays unconditional so keyboard navigation still gets a visible accent ring.

The kept \`:focus:not(:focus-visible)\` rule still suppresses the post-mouse-click focus ring on the answer buttons (the original #173 behaviour).

Closes #194.

## Test plan
- [x] \`make check\` — green
- [x] \`make test-e2e\` — green
- [x] Manual: Mobile Firefox — touch-and-hold an answer button and drag off without lifting; verify no lingering magenta glow on the button you originally touched
- [x] Manual: Desktop Firefox/Chrome — hover any button; verify the magenta glow still appears
- [x] Manual: Desktop keyboard — Tab through buttons; verify the magenta focus ring still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)