### PR TITLE
Anchor the claim-name modal above the on-screen keyboard on mobile (#196)

### DIFF
--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -376,6 +376,36 @@ figure.image img {
     }
 }
 
+/* Mobile UX (#196): keep the claim-name modal above the on-screen
+   keyboard. Bulma centres .modal-card vertically; when the keyboard
+   slides up, the visible viewport shrinks but the layout viewport
+   stays the same, so the centred card disappears under the keyboard.
+
+   Mobile Firefox (and historically other engines) does NOT shrink
+   CSS units like vh / svh / dvh in response to the on-screen
+   keyboard — only window.visualViewport reports the reduced height.
+   app.js subscribes to visualViewport.resize and publishes that
+   height as --visual-viewport-height; the modal-card consumes it
+   below so its max-height tracks the visible window.
+
+   The fallback chain is: --visual-viewport-height (JS-driven) →
+   100svh (CSS, in case JS hasn't run yet) → 100vh (very old
+   browsers). */
+@media (max-width: 768px) {
+    /* Bulma's .modal uses flex-direction: column, so vertical alignment
+       is controlled by justify-content (main axis), not align-items.
+       Overriding align-items leaves the card centred top-to-bottom — */
+    .modal {
+        justify-content: flex-start;
+    }
+    .modal-card {
+        margin-top: 1rem;
+        max-height: calc(100vh - 2rem);
+        max-height: calc(100svh - 2rem);
+        max-height: calc(var(--visual-viewport-height, 100svh) - 2rem);
+    }
+}
+
 /* Reduced-motion users get all the colour but none of the movement. The
    JS-driven animations also short-circuit via the same media query. */
 @media (prefers-reduced-motion: reduce) {

--- a/internal/client/static/js/app.js
+++ b/internal/client/static/js/app.js
@@ -9,3 +9,27 @@ document.addEventListener('alpine:init', () => {
     // alongside gameApp.
     Alpine.data('claimNameForm', claimNameForm);
 });
+
+// Publish the visual-viewport height as a CSS custom property
+// (--visual-viewport-height) so layout can react to the on-screen
+// keyboard appearing on mobile. CSS units (vh/svh/dvh) on Mobile
+// Firefox are tied to the layout viewport and do NOT shrink when
+// the keyboard slides up; only window.visualViewport reports the
+// reduced height. The claim-name modal's max-height reads this
+// property to stay above the keyboard — see #196. Falls back to
+// window.innerHeight when visualViewport is unavailable (very old
+// browsers); on those the keyboard-avoidance does not kick in but
+// the page is otherwise unaffected.
+function updateVisualViewportHeight() {
+    const vh = window.visualViewport
+        ? window.visualViewport.height
+        : window.innerHeight;
+    document.documentElement.style.setProperty(
+        '--visual-viewport-height', `${vh}px`,
+    );
+}
+updateVisualViewportHeight();
+if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', updateVisualViewportHeight);
+    window.visualViewport.addEventListener('scroll', updateVisualViewportHeight);
+}


### PR DESCRIPTION
## Summary
The claim-name modal slid under the on-screen keyboard on mobile — players couldn't see the Save/Cancel buttons or any error banner once the input took focus.

Two changes:

- **`internal/client/static/js/app.js`** — subscribes to `window.visualViewport.resize`/`.scroll` and publishes the current visible-viewport height as the `--visual-viewport-height` CSS custom property on `:root`. Needed because Mobile Firefox (and the spec-compliant default on most engines) does NOT shrink CSS units like `vh` / `svh` / `dvh` when the keyboard appears — only `window.visualViewport.height` reports the reduced area.

- **`internal/client/static/css/synthwave.css`** — on `@media (max-width: 768px)`, anchors `.modal` to the top of the layout viewport via `justify-content: flex-start` (Bulma's `.modal` uses `flex-direction: column`, so the vertical-centering axis is `justify-content`, not `align-items` — important detail caught during debugging). The `.modal-card`'s `max-height` reads the JS-driven custom property with a fallback chain to `100svh` then `100vh`, so it always fits within the visible window.

Browser auto-scroll-on-focus handles the secondary case of fitting the input within the (now smaller) modal card — players can type even in tight landscape; Save/Cancel are reachable via the body's internal scroll.

Closes #196.

## Test plan
- [x] `make check` — green
- [x] Manual: Mobile Firefox portrait — tap *Set your name*, verify the modal sits near the top with title + input + Save/Cancel all visible above the keyboard
- [x] Manual: Mobile Firefox landscape — same flow; modal anchored at top, text field auto-scrolls into view on focus, Save reachable via internal scroll (acceptable trade-off given limited landscape height)
- [x] Manual: Desktop — modal still centres vertically (the new rules are gated on `max-width: 768px`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)