### PR TITLE
Reorder quiz questions with Up/Down buttons (#16)

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -407,13 +407,6 @@ func fillQuestionFromForm(
 
 	qs.Text = r.PostFormValue("text")
 	qs.ImageURL = r.PostFormValue("image_url")
-	if qs.Position, err = strconv.Atoi(r.PostFormValue("position")); err != nil {
-		msg := "error parsing position"
-		logger.ErrorContext(r.Context(), msg, slog.Any("err", err))
-		render400(w, r, logger, csrfMgr, msg)
-
-		return false
-	}
 
 	newOptions := make([]*quiz.Option, 0, maxOptions)
 
@@ -599,9 +592,12 @@ func HandleQuizView(
 	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizview.gohtml")
 
 	type quizViewData struct {
-		Title   string
-		Quiz    *QuizData
-		Players []PlayerScoreData
+		Title             string
+		Quiz              *QuizData
+		Players           []PlayerScoreData
+		LastQuestionIndex int // len(.Quiz.Questions) - 1; used by the
+		// template to disable the Down button on the last row. Sized
+		// here because html/template lacks a `sub` builtin.
 	}
 
 	// playersLimit is the upper bound on rows in the "Played by" section.
@@ -644,10 +640,12 @@ func HandleQuizView(
 			})
 		}
 
+		quizData := quizDataFromQuiz(qz)
 		data := quizViewData{
-			Title:   "Admin Dashboard - View Quiz",
-			Quiz:    quizDataFromQuiz(qz),
-			Players: players,
+			Title:             "Admin Dashboard - View Quiz",
+			Quiz:              quizData,
+			Players:           players,
+			LastQuestionIndex: len(quizData.Questions) - 1,
 		}
 		render.Render(w, r, http.StatusOK, data)
 	})
@@ -881,6 +879,55 @@ func HandleQuizDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz
 	})
 }
 
+// HandleQuestionMove handles the per-row Up/Down reorder buttons on the
+// quiz view (#16). The {direction} path segment must be "up" or "down";
+// the underlying store handles the swap atomically and returns sentinel
+// errors for boundary conditions (already at top/bottom) which we map
+// to 400 here so the operator sees the cause rather than a generic
+// 500. After a successful swap we redirect back to the quiz view; the
+// re-rendered page reflects the new order from the database.
+func HandleQuestionMove(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+
+		var quizID int64
+		if quizID, ok = handlers.ParseIDFromPath(w, r, logger, "quizID"); !ok {
+			return
+		}
+
+		var questionID int64
+		if questionID, ok = handlers.ParseIDFromPath(w, r, logger, "questionID"); !ok {
+			return
+		}
+
+		direction := r.PathValue("direction")
+
+		if err := quizStore.SwapQuestionPositions(r.Context(), quizID, questionID, direction); err != nil {
+			switch {
+			case errors.Is(err, quiz.ErrInvalidDirection):
+				render400(w, r, logger, csrfMgr, "invalid direction")
+			case errors.Is(err, quiz.ErrQuestionAtTop),
+				errors.Is(err, quiz.ErrQuestionAtBottom):
+				// Boundary case: the button should have been disabled in
+				// the UI, so a request here is unusual but harmless.
+				// Redirect back to the view without surfacing an error.
+				// strconv.FormatInt avoids gosec's open-redirect taint
+				// heuristic (G710) — same pattern as HandleQuestionSave.
+				http.Redirect(w, r, "/admin/quizzes/"+strconv.FormatInt(quizID, 10), http.StatusSeeOther)
+			case errors.Is(err, quiz.ErrQuestionNotFound):
+				render404(w, r, logger, csrfMgr)
+			default:
+				logger.ErrorContext(r.Context(), "error swapping question positions", slog.Any("err", err))
+				render500(w, r, logger, csrfMgr)
+			}
+
+			return
+		}
+
+		http.Redirect(w, r, "/admin/quizzes/"+strconv.FormatInt(quizID, 10), http.StatusSeeOther)
+	})
+}
+
 // HandleQuestionDelete deletes a question and all its options.
 func HandleQuestionDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -949,6 +996,20 @@ func HandleQuestionSave(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore qu
 
 		if !fillQuestionFromForm(w, r, logger, csrfMgr, qs) {
 			return
+		}
+
+		// Auto-assign position for new questions so authors do not have
+		// to type integers (#16). Called after form validation so form
+		// errors surface as 400 before this hits the store.
+		if newQuestion {
+			nextPos, posErr := quizStore.NextQuestionPosition(r.Context(), qz.ID)
+			if posErr != nil {
+				logger.ErrorContext(r.Context(), "error fetching next question position", slog.Any("err", posErr))
+				render500(w, r, logger, csrfMgr)
+
+				return
+			}
+			qs.Position = nextPos
 		}
 
 		if !storeQuestion(w, r, logger, csrfMgr, quizStore, qs) {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -91,18 +91,20 @@ func (e errReader) Read(_ []byte) (int, error) { return 0, e.err }
 func (errReader) Close() error                 { return nil }
 
 type stubQuizStore struct {
-	listQuizzes          func(ctx context.Context) ([]*quiz.Quiz, error)
-	questionCountsByQuiz func(ctx context.Context) (map[int64]int, error)
-	getQuizByID          func(ctx context.Context, id int64) (*quiz.Quiz, error)
-	quizExists           func(ctx context.Context, id int64) (bool, error)
-	createQuiz           func(ctx context.Context, qz *quiz.Quiz) error
-	updateQuiz           func(ctx context.Context, qz *quiz.Quiz) error
-	deleteQuiz           func(ctx context.Context, id int64) error
-	getQuestionByID      func(ctx context.Context, id int64) (*quiz.Question, error)
-	createQuestion       func(ctx context.Context, qs *quiz.Question) error
-	updateQuestion       func(ctx context.Context, qs *quiz.Question) error
-	deleteQuestion       func(ctx context.Context, id int64) error
-	listQuestions        func(ctx context.Context, quizID int64) ([]*quiz.Question, error)
+	listQuizzes           func(ctx context.Context) ([]*quiz.Quiz, error)
+	questionCountsByQuiz  func(ctx context.Context) (map[int64]int, error)
+	getQuizByID           func(ctx context.Context, id int64) (*quiz.Quiz, error)
+	quizExists            func(ctx context.Context, id int64) (bool, error)
+	createQuiz            func(ctx context.Context, qz *quiz.Quiz) error
+	updateQuiz            func(ctx context.Context, qz *quiz.Quiz) error
+	deleteQuiz            func(ctx context.Context, id int64) error
+	getQuestionByID       func(ctx context.Context, id int64) (*quiz.Question, error)
+	createQuestion        func(ctx context.Context, qs *quiz.Question) error
+	updateQuestion        func(ctx context.Context, qs *quiz.Question) error
+	deleteQuestion        func(ctx context.Context, id int64) error
+	listQuestions         func(ctx context.Context, quizID int64) ([]*quiz.Question, error)
+	nextQuestionPosition  func(ctx context.Context, quizID int64) (int, error)
+	swapQuestionPositions func(ctx context.Context, quizID, questionID int64, direction string) error
 }
 
 func (stubQuizStore) Ping(_ context.Context) error {
@@ -187,6 +189,24 @@ func (s stubQuizStore) UpdateQuestion(ctx context.Context, qs *quiz.Question) er
 	}
 
 	return s.updateQuestion(ctx, qs)
+}
+
+func (s stubQuizStore) NextQuestionPosition(ctx context.Context, quizID int64) (int, error) {
+	if s.nextQuestionPosition == nil {
+		return 0, errors.New("nextQuestionPosition not supplied in stub")
+	}
+
+	return s.nextQuestionPosition(ctx, quizID)
+}
+
+func (s stubQuizStore) SwapQuestionPositions(
+	ctx context.Context, quizID, questionID int64, direction string,
+) error {
+	if s.swapQuestionPositions == nil {
+		return errors.New("swapQuestionPositions not supplied in stub")
+	}
+
+	return s.swapQuestionPositions(ctx, quizID, questionID, direction)
 }
 
 func (s stubQuizStore) DeleteQuestion(ctx context.Context, id int64) error {
@@ -1769,11 +1789,15 @@ func TestHandleQuestionSave(t *testing.T) {
 				},
 			},
 		}
+		// Position is auto-assigned by the handler (#16); the
+		// existing quiz has questions at positions 10, 20, 30 so the
+		// next-position stub returns 40.
+		const autoAssignedPosition = 40
 		testQuestion := quiz.Question{
 			QuizID:   testQuiz.ID,
 			Text:     "Question Four",
 			ImageURL: "https://example.com/image.png",
-			Position: 10,
+			Position: autoAssignedPosition,
 			Options: []*quiz.Option{
 				{Text: "Option 1"},
 				{Text: "Option 2", Correct: true},
@@ -1789,6 +1813,9 @@ func TestHandleQuestionSave(t *testing.T) {
 				}
 
 				return &testQuiz, nil
+			},
+			nextQuestionPosition: func(_ context.Context, _ int64) (int, error) {
+				return autoAssignedPosition, nil
 			},
 			createQuestion: func(_ context.Context, q *quiz.Question) error {
 				q.ID = int64(len(questions) + 1)
@@ -1807,7 +1834,6 @@ func TestHandleQuestionSave(t *testing.T) {
 		form := url.Values{
 			"text":      {testQuestion.Text},
 			"image_url": {testQuestion.ImageURL},
-			"position":  {strconv.Itoa(testQuestion.Position)},
 		}
 		for i, option := range testQuestion.Options {
 			form.Add(fmt.Sprintf("option[%d].text", i), option.Text)
@@ -1887,7 +1913,9 @@ func TestHandleQuestionSave(t *testing.T) {
 			QuizID:   originalQuestion.QuizID,
 			Text:     originalQuestion.Text + " Updated",
 			ImageURL: originalQuestion.ImageURL + "?updated",
-			Position: originalQuestion.Position + 10,
+			// Position no longer comes from the form (#16); the
+			// stored position is whatever was loaded from the DB.
+			Position: originalQuestion.Position,
 			Options: []*quiz.Option{
 				{
 					ID:         originalQuestion.Options[1].ID,
@@ -1942,7 +1970,6 @@ func TestHandleQuestionSave(t *testing.T) {
 		form := url.Values{
 			"text":      {updatedQuestion.Text},
 			"image_url": {updatedQuestion.ImageURL},
-			"position":  {strconv.Itoa(updatedQuestion.Position)},
 		}
 		for i, option := range updatedQuestion.Options {
 			if option.ID != 0 {
@@ -2136,47 +2163,6 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 		}
 	})
 
-	t.Run("parsing form position fails", func(t *testing.T) {
-		t.Parallel()
-
-		buf := bytes.Buffer{}
-		logger := slog.New(slog.NewTextHandler(&buf, nil))
-
-		quizStore := stubQuizStore{
-			getQuizByID: func(_ context.Context, _ int64) (*quiz.Quiz, error) {
-				return &quiz.Quiz{}, nil
-			},
-		}
-
-		handler := HandleQuestionSave(logger, nil, quizStore)
-
-		form := url.Values{
-			"text":      {""},
-			"image_url": {"http://example.com/image.png"},
-		}
-
-		req, err := http.NewRequestWithContext(
-			t.Context(),
-			http.MethodPost,
-			"/admin/quizzes/1234/questions",
-			strings.NewReader(form.Encode()),
-		)
-		if err != nil {
-			t.Fatalf("http.NewRequest error: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		rr := httptest.NewRecorder()
-
-		handler.ServeHTTP(rr, req)
-
-		if got, want := rr.Code, http.StatusBadRequest; got != want {
-			t.Fatalf("got status code %v, want %v, log:\n%v", got, want, buf.String())
-		}
-		if got, want := rr.Body.String(), "error parsing position"; !strings.Contains(got, want) {
-			t.Fatalf("got: %v, should contain: %q", got, want)
-		}
-	})
-
 	t.Run("form is invalid", func(t *testing.T) {
 		t.Parallel()
 
@@ -2229,7 +2215,6 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 		testQuestion := quiz.Question{
 			Text:     "Question One",
 			ImageURL: "https://example.com/image.png",
-			Position: 10,
 			Options: []*quiz.Option{
 				{
 					Text: "Option 1",
@@ -2253,6 +2238,9 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 
 				return &testQuiz, nil
 			},
+			nextQuestionPosition: func(_ context.Context, _ int64) (int, error) {
+				return 10, nil
+			},
 			createQuestion: func(_ context.Context, _ *quiz.Question) error {
 				return testError
 			},
@@ -2261,7 +2249,6 @@ func TestHandleQuestionSave_HandleError(t *testing.T) {
 		form := url.Values{
 			"text":      {testQuestion.Text},
 			"image_url": {testQuestion.ImageURL},
-			"position":  {strconv.Itoa(testQuestion.Position)},
 		}
 		for i, option := range testQuestion.Options {
 			form.Add(fmt.Sprintf("option[%d].text", i), option.Text)
@@ -2579,6 +2566,122 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 		}
 		if got, want := buf.String(), fmt.Sprintf("err=%q", testError); !strings.Contains(got, want) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
+		}
+	})
+}
+
+func TestHandleQuestionMove(t *testing.T) {
+	t.Parallel()
+
+	t.Run("swap succeeds and redirects to quiz view", func(t *testing.T) {
+		t.Parallel()
+
+		buf := bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+		var seen struct {
+			quizID, questionID int64
+			direction          string
+		}
+		store := stubQuizStore{
+			swapQuestionPositions: func(_ context.Context, quizID, questionID int64, direction string) error {
+				seen.quizID, seen.questionID, seen.direction = quizID, questionID, direction
+
+				return nil
+			},
+		}
+
+		handler := HandleQuestionMove(logger, nil, store)
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/7/questions/42/move/up", nil,
+		)
+		if err != nil {
+			t.Fatalf("NewRequest err = %v, want nil", err)
+		}
+		req.SetPathValue("quizID", "7")
+		req.SetPathValue("questionID", "42")
+		req.SetPathValue("direction", "up")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("status = %d, want %d, log:\n%v", got, want, buf.String())
+		}
+		if got, want := rr.Header().Get("Location"), "/admin/quizzes/7"; got != want {
+			t.Errorf("Location = %q, want %q", got, want)
+		}
+		if got, want := seen.quizID, int64(7); got != want {
+			t.Errorf("seen.quizID = %d, want %d", got, want)
+		}
+		if got, want := seen.questionID, int64(42); got != want {
+			t.Errorf("seen.questionID = %d, want %d", got, want)
+		}
+		if got, want := seen.direction, "up"; got != want {
+			t.Errorf("seen.direction = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("boundary error redirects without surfacing the failure", func(t *testing.T) {
+		t.Parallel()
+		// ErrQuestionAtTop / ErrQuestionAtBottom happen when the button
+		// should already have been disabled in the UI. Treat as a
+		// silent no-op: redirect back so the page re-renders.
+
+		buf := bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		store := stubQuizStore{
+			swapQuestionPositions: func(_ context.Context, _, _ int64, _ string) error {
+				return quiz.ErrQuestionAtTop
+			},
+		}
+
+		handler := HandleQuestionMove(logger, nil, store)
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/7/questions/42/move/up", nil,
+		)
+		if err != nil {
+			t.Fatalf("NewRequest err = %v, want nil", err)
+		}
+		req.SetPathValue("quizID", "7")
+		req.SetPathValue("questionID", "42")
+		req.SetPathValue("direction", "up")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("status = %d, want %d, log:\n%v", got, want, buf.String())
+		}
+	})
+
+	t.Run("invalid direction renders 400", func(t *testing.T) {
+		t.Parallel()
+
+		buf := bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		store := stubQuizStore{
+			swapQuestionPositions: func(_ context.Context, _, _ int64, _ string) error {
+				return quiz.ErrInvalidDirection
+			},
+		}
+
+		handler := HandleQuestionMove(logger, nil, store)
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodPost,
+			"/admin/quizzes/7/questions/42/move/sideways", nil,
+		)
+		if err != nil {
+			t.Fatalf("NewRequest err = %v, want nil", err)
+		}
+		req.SetPathValue("quizID", "7")
+		req.SetPathValue("questionID", "42")
+		req.SetPathValue("direction", "sideways")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if got, want := rr.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d, log:\n%v", got, want, buf.String())
 		}
 	})
 }

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -76,7 +76,14 @@ func (stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error         {
 func (stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error              { return nil }
 func (stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
 func (stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
-func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error          { return nil }
+func (stubQuizStore) NextQuestionPosition(_ context.Context, _ int64) (int, error) {
+	return 0, errStub
+}
+
+func (stubQuizStore) SwapQuestionPositions(_ context.Context, _, _ int64, _ string) error {
+	return errStub
+}
+func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error { return nil }
 
 func (stubQuizStore) ListQuestions(_ context.Context, _ int64) ([]*quiz.Question, error) {
 	return nil, errStub

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -389,6 +389,23 @@ func (q *Queries) ListQuizzes(ctx context.Context) ([]Quiz, error) {
 	return items, nil
 }
 
+const maxQuestionPosition = `-- name: MaxQuestionPosition :one
+SELECT CAST(COALESCE(MAX(position), 0) AS INTEGER) AS max_position
+FROM questions
+WHERE quiz_id = ?
+`
+
+// Returns the highest position in use for the given quiz, or 0 when the
+// quiz has no questions yet. The CAST + COALESCE forces sqlc to type
+// the result as int64 instead of interface{} (raw MAX can return NULL).
+// Callers add 1 to get the next-position to assign on a new question.
+func (q *Queries) MaxQuestionPosition(ctx context.Context, quizID int64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, maxQuestionPosition, quizID)
+	var max_position int64
+	err := row.Scan(&max_position)
+	return max_position, err
+}
+
 const questionCountsByQuiz = `-- name: QuestionCountsByQuiz :many
 SELECT quiz_id, COUNT(*) AS question_count
 FROM questions
@@ -481,6 +498,24 @@ func (q *Queries) UpdateQuestion(ctx context.Context, arg UpdateQuestionParams) 
 		arg.ImageUrl,
 		arg.ID,
 	)
+}
+
+const updateQuestionPosition = `-- name: UpdateQuestionPosition :execresult
+UPDATE questions
+SET position = ?
+WHERE id = ?
+`
+
+type UpdateQuestionPositionParams struct {
+	Position int64
+	ID       int64
+}
+
+// Position-only update. Used by the reorder flow (#16) to swap a pair
+// of questions atomically inside a transaction without rewriting the
+// text/image fields.
+func (q *Queries) UpdateQuestionPosition(ctx context.Context, arg UpdateQuestionPositionParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateQuestionPosition, arg.Position, arg.ID)
 }
 
 const updateQuiz = `-- name: UpdateQuiz :execresult

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -105,7 +105,14 @@ func (stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error         {
 func (stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error              { return nil }
 func (stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
 func (stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
-func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error          { return nil }
+func (stubQuizStore) NextQuestionPosition(_ context.Context, _ int64) (int, error) {
+	return 0, errStub
+}
+
+func (stubQuizStore) SwapQuestionPositions(_ context.Context, _, _ int64, _ string) error {
+	return errStub
+}
+func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error { return nil }
 func (stubQuizStore) ListQuestions(_ context.Context, _ int64) ([]*quiz.Question, error) {
 	return nil, nil
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -45,7 +45,14 @@ func (*stubQuizStore) GetQuestion(_ context.Context, _ int64) (*quiz.Question, e
 }
 func (*stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
 func (*stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error { return nil }
-func (*stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error          { return nil }
+func (*stubQuizStore) NextQuestionPosition(_ context.Context, _ int64) (int, error) {
+	return 0, errors.ErrUnsupported
+}
+
+func (*stubQuizStore) SwapQuestionPositions(_ context.Context, _, _ int64, _ string) error {
+	return errors.ErrUnsupported
+}
+func (*stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error { return nil }
 func (*stubQuizStore) GetOption(_ context.Context, _ int64) (*quiz.Option, error) {
 	return nil, errors.ErrUnsupported
 }

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -73,6 +73,23 @@ SET text = ?,
     image_url = ?
 WHERE id = ?;
 
+-- name: UpdateQuestionPosition :execresult
+-- Position-only update. Used by the reorder flow (#16) to swap a pair
+-- of questions atomically inside a transaction without rewriting the
+-- text/image fields.
+UPDATE questions
+SET position = ?
+WHERE id = ?;
+
+-- name: MaxQuestionPosition :one
+-- Returns the highest position in use for the given quiz, or 0 when the
+-- quiz has no questions yet. The CAST + COALESCE forces sqlc to type
+-- the result as int64 instead of interface{} (raw MAX can return NULL).
+-- Callers add 1 to get the next-position to assign on a new question.
+SELECT CAST(COALESCE(MAX(position), 0) AS INTEGER) AS max_position
+FROM questions
+WHERE quiz_id = ?;
+
 -- name: DeleteQuestion :execresult
 DELETE FROM questions
 WHERE id = ?;

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -42,6 +42,19 @@ type Store interface {
 	CreateQuestion(ctx context.Context, qs *Question) error
 	// UpdateQuestion updates a question.
 	UpdateQuestion(ctx context.Context, qs *Question) error
+	// NextQuestionPosition returns max(position)+1 for the given quiz,
+	// or 1 when the quiz has no questions yet. Used by the question-
+	// creation flow to auto-assign positions so authors do not have to
+	// type integers manually (#16).
+	NextQuestionPosition(ctx context.Context, quizID int64) (int, error)
+	// SwapQuestionPositions swaps the question with questionID against
+	// its neighbour on the given side ("up" = previous position,
+	// "down" = next position) within the same quiz, atomically.
+	// Returns ErrQuestionAtTop / ErrQuestionAtBottom when there is no
+	// neighbour in that direction, ErrQuestionNotFound when the id
+	// does not belong to the quiz, and ErrInvalidDirection on any
+	// direction other than "up"/"down".
+	SwapQuestionPositions(ctx context.Context, quizID, questionID int64, direction string) error
 	// GetOption returns an option by its ID.
 	GetOption(ctx context.Context, optionID int64) (*Option, error)
 	// GetOptionsByIDs returns options for the given IDs.
@@ -75,6 +88,23 @@ var (
 	ErrCannotUpdateQuizWithIDZero = errors.New("cannot update quiz with ID 0")
 	// ErrCannotUpdateQuestionWithIDZero is returned when trying to update a question with ID 0.
 	ErrCannotUpdateQuestionWithIDZero = errors.New("cannot update question with ID 0")
+	// ErrQuestionAtTop is returned by SwapQuestionPositions when the
+	// caller asked to move a question up but it already has the
+	// lowest position in its quiz.
+	ErrQuestionAtTop = errors.New("question is already at the top")
+	// ErrQuestionAtBottom is returned by SwapQuestionPositions when the
+	// caller asked to move a question down but it already has the
+	// highest position in its quiz.
+	ErrQuestionAtBottom = errors.New("question is already at the bottom")
+	// ErrInvalidDirection is returned by SwapQuestionPositions when the
+	// supplied direction is neither "up" nor "down".
+	ErrInvalidDirection = errors.New("invalid direction")
+)
+
+// Reorder directions accepted by [Store.SwapQuestionPositions].
+const (
+	DirectionUp   = "up"
+	DirectionDown = "down"
 )
 
 // Quiz represents a quiz.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -143,6 +143,10 @@ func addAdminRoutes(
 		"POST /admin/quizzes/{quizID}/questions/{questionID}/delete",
 		csrfMW(requireAdmin(admin.HandleQuestionDelete(logger, csrfMgr, stores.Quizzes))),
 	)
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/questions/{questionID}/move/{direction}",
+		csrfMW(requireAdmin(admin.HandleQuestionMove(logger, csrfMgr, stores.Quizzes))),
+	)
 }
 
 // addAPIRoutes registers the JSON API routes consumed by the game client.

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -113,6 +113,14 @@ func (stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error {
 	return nil
 }
 
+func (stubQuizStore) NextQuestionPosition(_ context.Context, _ int64) (int, error) {
+	return 0, errRouteStub
+}
+
+func (stubQuizStore) SwapQuestionPositions(_ context.Context, _, _ int64, _ string) error {
+	return errRouteStub
+}
+
 func (stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error {
 	return nil
 }

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -251,6 +251,105 @@ func (s *QuizStore) UpdateQuestion(ctx context.Context, qs *quiz.Question) error
 	return nil
 }
 
+// NextQuestionPosition returns max(position)+1 for the given quiz, or 1
+// when the quiz has no questions yet. The SQL COALESCE keeps the typed
+// return as int64 even on an empty quiz; we add 1 here so callers get
+// the position they should assign on a new question.
+func (s *QuizStore) NextQuestionPosition(ctx context.Context, quizID int64) (int, error) {
+	maxPos, err := s.q.MaxQuestionPosition(ctx, quizID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read max question position: %w", err)
+	}
+
+	return int(maxPos) + 1, nil
+}
+
+// SwapQuestionPositions swaps the questionID's position with its
+// neighbour on the given side within the same quiz, atomically. The
+// implementation reads the full ordered list once and finds the
+// adjacent row in Go rather than via SQL — quizzes hold a handful of
+// questions in practice, so the simpler code beats a second LIMIT/
+// ORDER query. Both position updates run inside a single transaction
+// so a concurrent read never observes a half-swapped state.
+//
+// Returns [quiz.ErrInvalidDirection] when direction is neither "up"
+// nor "down", [quiz.ErrQuestionNotFound] when the question does not
+// belong to the quiz, and [quiz.ErrQuestionAtTop] /
+// [quiz.ErrQuestionAtBottom] when the question is already at the
+// requested boundary.
+func (s *QuizStore) SwapQuestionPositions(
+	ctx context.Context, quizID, questionID int64, direction string,
+) error {
+	if direction != quiz.DirectionUp && direction != quiz.DirectionDown {
+		return quiz.ErrInvalidDirection
+	}
+
+	rows, err := s.q.ListQuestionsByQuizID(ctx, quizID)
+	if err != nil {
+		return fmt.Errorf("failed to list questions for swap: %w", err)
+	}
+
+	idx := -1
+	for i := range rows {
+		if rows[i].ID == questionID {
+			idx = i
+
+			break
+		}
+	}
+	if idx == -1 {
+		return quiz.ErrQuestionNotFound
+	}
+
+	var neighbourIdx int
+	switch direction {
+	case quiz.DirectionUp:
+		if idx == 0 {
+			return quiz.ErrQuestionAtTop
+		}
+		neighbourIdx = idx - 1
+	case quiz.DirectionDown:
+		if idx == len(rows)-1 {
+			return quiz.ErrQuestionAtBottom
+		}
+		neighbourIdx = idx + 1
+	default:
+		// Guarded above by the early return for invalid directions,
+		// so this branch is unreachable. The explicit default keeps
+		// revive's enforce-switch-style happy.
+		return quiz.ErrInvalidDirection
+	}
+
+	current, neighbour := rows[idx], rows[neighbourIdx]
+
+	err = database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		// Two position-only updates inside the same transaction. The
+		// schema has no UNIQUE constraint on (quiz_id, position), so
+		// the order does not matter for correctness — but the txn
+		// boundary keeps any reader on the table from seeing two
+		// rows with the same position mid-swap.
+		if _, swapErr := q.UpdateQuestionPosition(ctx, db.UpdateQuestionPositionParams{
+			Position: neighbour.Position,
+			ID:       current.ID,
+		}); swapErr != nil {
+			return fmt.Errorf("failed to update current question position: %w", swapErr)
+		}
+		if _, swapErr := q.UpdateQuestionPosition(ctx, db.UpdateQuestionPositionParams{
+			Position: current.Position,
+			ID:       neighbour.ID,
+		}); swapErr != nil {
+			return fmt.Errorf("failed to update neighbour question position: %w", swapErr)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to swap question positions: %w", err)
+	}
+
+	return nil
+}
+
 // GetOption retrieves an option by its ID from the data store and returns it. Returns ErrOptionNotFound if no option is found.
 func (s *QuizStore) GetOption(ctx context.Context, optionID int64) (*quiz.Option, error) {
 	var err error

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -1876,4 +1877,157 @@ func TestQuizStore_ListQuizzes_OrderedByUpdatedAtDesc(t *testing.T) {
 	if got, want := quizzes[0].Title, "First Edited"; got != want {
 		t.Errorf("quizzes[0].Title = %q, want %q", got, want)
 	}
+}
+
+// seedQuizWithQuestions creates a quiz with `n` questions at positions
+// 10, 20, ..., 10*n and returns it. Helper for the position-reorder
+// tests so each subtest can start from a known order without rebuilding
+// the fixture inline.
+func seedQuizWithQuestions(t *testing.T, quizStore *QuizStore, n int) *quiz.Quiz {
+	t.Helper()
+
+	qz := &quiz.Quiz{Title: "Reorder Quiz", Slug: "reorder-quiz", Description: "for reorder tests"}
+	for i := 1; i <= n; i++ {
+		qz.Questions = append(qz.Questions, &quiz.Question{
+			Text:     fmt.Sprintf("Q%d", i),
+			Position: i * 10,
+			Options: []*quiz.Option{
+				{Text: "A", Correct: true},
+				{Text: "B"},
+			},
+		})
+	}
+
+	if err := quizStore.CreateQuiz(t.Context(), qz); err != nil {
+		t.Fatalf("failed to seed quiz: %v", err)
+	}
+
+	return qz
+}
+
+func TestQuizStore_NextQuestionPosition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 1 for an empty quiz", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := &quiz.Quiz{Title: "Empty", Slug: "empty", Description: "no questions"}
+		if err := quizStore.CreateQuiz(t.Context(), qz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		got, err := quizStore.NextQuestionPosition(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("NextQuestionPosition err = %v, want nil", err)
+		}
+		if want := 1; got != want {
+			t.Errorf("NextQuestionPosition = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("returns max+1 for an existing quiz", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 3) // positions 10, 20, 30
+
+		got, err := quizStore.NextQuestionPosition(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("NextQuestionPosition err = %v, want nil", err)
+		}
+		if want := 31; got != want {
+			t.Errorf("NextQuestionPosition = %d, want %d (30+1)", got, want)
+		}
+	})
+}
+
+func TestQuizStore_SwapQuestionPositions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("swap down moves a question past its successor", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 3) // Q1@10, Q2@20, Q3@30
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, qz.Questions[0].ID, quiz.DirectionDown)
+		if err != nil {
+			t.Fatalf("SwapQuestionPositions err = %v, want nil", err)
+		}
+
+		// After swap Q1 should hold position 20 and Q2 should hold 10,
+		// so listing by position yields Q2, Q1, Q3.
+		listed, err := quizStore.ListQuestions(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("ListQuestions err = %v, want nil", err)
+		}
+		got := []string{listed[0].Text, listed[1].Text, listed[2].Text}
+		want := []string{"Q2", "Q1", "Q3"}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("order mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("swap up moves a question past its predecessor", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 3)
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, qz.Questions[2].ID, quiz.DirectionUp)
+		if err != nil {
+			t.Fatalf("SwapQuestionPositions err = %v, want nil", err)
+		}
+
+		listed, err := quizStore.ListQuestions(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("ListQuestions err = %v, want nil", err)
+		}
+		got := []string{listed[0].Text, listed[1].Text, listed[2].Text}
+		want := []string{"Q1", "Q3", "Q2"}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("order mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("swap up from the first question returns ErrQuestionAtTop", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 3)
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, qz.Questions[0].ID, quiz.DirectionUp)
+		if got, want := err, quiz.ErrQuestionAtTop; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("swap down from the last question returns ErrQuestionAtBottom", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 3)
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, qz.Questions[2].ID, quiz.DirectionDown)
+		if got, want := err, quiz.ErrQuestionAtBottom; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("invalid direction returns ErrInvalidDirection", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 2)
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, qz.Questions[0].ID, "sideways")
+		if got, want := err, quiz.ErrInvalidDirection; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown question ID returns ErrQuestionNotFound", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		qz := seedQuizWithQuestions(t, quizStore, 2)
+
+		err := quizStore.SwapQuestionPositions(t.Context(), qz.ID, 9999, quiz.DirectionUp)
+		if got, want := err, quiz.ErrQuestionNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
 }

--- a/internal/web/tmpl/admin/pages/questionform.gohtml
+++ b/internal/web/tmpl/admin/pages/questionform.gohtml
@@ -29,12 +29,17 @@
                 </div>
             </div>
 
-            <div class="field">
-                <label class="label" for="position">Position</label>
-                <div class="control">
-                    <input id="position" name="position" class="input" type="text" value="{{.Question.Position}}">
+            {{if .Question.ID}}
+                <div class="field">
+                    <label class="label">Position</label>
+                    <div class="control">
+                        <p class="content is-small">
+                            {{.Question.Position}}
+                            <span class="has-text-grey">— use the Up/Down buttons on the quiz page to reorder.</span>
+                        </p>
+                    </div>
                 </div>
-            </div>
+            {{end}}
 
             <h4 class="title is-4">Options</h4>
 

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -107,6 +107,7 @@
                 <table class="table is-striped is-fullwidth">
                     <thead>
                     <tr>
+                        <th>Order</th>
                         <th>Question</th>
                         <th>Options</th>
                         <th>Actions</th>
@@ -114,12 +115,38 @@
                     </thead>
 
                     <tbody>
-                    {{range .Quiz.Questions}}
+                    {{range $i, $q := .Quiz.Questions}}
                         <tr>
-                            <td>{{.Text}}</td>
+                            <td>
+                                <form method="post"
+                                      action="/admin/quizzes/{{$q.QuizID}}/questions/{{$q.ID}}/move/up"
+                                      class="is-inline">
+                                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                                    <button class="button is-small is-white"
+                                            type="submit"
+                                            title="Move up"
+                                            aria-label="Move up"
+                                            {{if eq $i 0}}disabled{{end}}>
+                                        <span class="icon"><i class="fas fa-arrow-up"></i></span>
+                                    </button>
+                                </form>
+                                <form method="post"
+                                      action="/admin/quizzes/{{$q.QuizID}}/questions/{{$q.ID}}/move/down"
+                                      class="is-inline">
+                                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                                    <button class="button is-small is-white"
+                                            type="submit"
+                                            title="Move down"
+                                            aria-label="Move down"
+                                            {{if eq $i $.LastQuestionIndex}}disabled{{end}}>
+                                        <span class="icon"><i class="fas fa-arrow-down"></i></span>
+                                    </button>
+                                </form>
+                            </td>
+                            <td>{{$q.Text}}</td>
                             <td>
                                 <ul>
-                                    {{range .Options}}
+                                    {{range $q.Options}}
                                         <li>
                                             {{.Text}}
                                             {{if .Correct}}
@@ -132,14 +159,14 @@
                                 </ul>
                             </td>
                             <td>
-                                <a href="/admin/quizzes/{{.QuizID}}/questions/{{.ID}}/edit">
+                                <a href="/admin/quizzes/{{$q.QuizID}}/questions/{{$q.ID}}/edit">
                                     <span class="icon-text">
                                         <span class="icon"><i class="fas fa-pen"></i></span>
                                         <span>Edit question</span>
                                     </span>
                                 </a>
                                 &nbsp;
-                                <a href="#" onclick="openModal('modal-delete-question-{{.ID}}'); return false;">
+                                <a href="#" onclick="openModal('modal-delete-question-{{$q.ID}}'); return false;">
                                     <span class="icon-text has-text-danger">
                                         <span class="icon"><i class="fas fa-trash"></i></span>
                                         <span>Delete question</span>

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -72,7 +72,10 @@ export async function createQuizWithQuestions(
     await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/new$/);
 
     await page.locator('input[name=text]').fill(q.text);
-    await page.locator('input[name=position]').fill(String(index + 1));
+    // Position is auto-assigned by the server now (#16) — no input field
+    // on the question form. The index variable is kept on the for-of
+    // signature so future helpers can use it without re-binding.
+    void index;
     if (q.imageUrl !== undefined) {
       await page.locator('input[name=image_url]').fill(q.imageUrl);
     }


### PR DESCRIPTION
## Summary
Authors can now reorder questions on the quiz view with per-row Up/Down buttons; the position field is gone from the question form and auto-assigned on create.

- **Up/Down buttons** on the quiz view swap a question's position with its neighbour atomically. Up is disabled on the first row, Down on the last.
- **Position is auto-assigned** to `max(position) + 1` when a new question is saved — no more typing integers.
- **New endpoint** `POST /admin/quizzes/{quizID}/questions/{questionID}/move/{direction}` (CSRF-protected, admin-only) backs the buttons. Boundary errors return a silent redirect (the button should have been disabled); invalid directions return 400.
- **Store-layer swap** loads the ordered list once, finds the neighbour, runs two position-only `UPDATE`s in one transaction. Schema has no `UNIQUE (quiz_id, position)` constraint so the order is safe.

Closes #16.

Follow-up: #199 tracks drag-and-drop reorder for when the click-count of Up/Down becomes painful on longer quizzes.

## Test plan
- [x] `make check` — green (0 lint issues, 14 packages PASS, new store + handler tests)
- [x] `make test-e2e` — green (16 tests; helpers updated to drop the now-removed position input)
- [x] Manual: create a 3-question quiz; click Up on Q3 → order becomes Q1 Q3 Q2; click Down on Q1 → order becomes Q3 Q1 Q2; verify Up is disabled on Q3 and Down on Q2

🤖 Generated with [Claude Code](https://claude.com/claude-code)