### PR TITLE
Cancel stale runs, dedupe integration tests, matrix e2e by browser (#202)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,16 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Cancel the older run when a new push lands on the same branch / PR.
+# Saves runner minutes on fixup pushes (#202).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v6
@@ -19,9 +25,9 @@ jobs:
       with:
         go-version: "stable"
 
-    - name: Run Integration Tests
-      run: make test-integration
-
+    # `make test-coverage` runs the full suite with -tags=integration,
+    # so a separate integration step would just duplicate the work.
+    # Dropped here as part of #202.
     - name: Run Tests with Coverage
       run: make test-coverage
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,23 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel the older run when a new push lands on the same branch / PR (#202).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    # Matrixed by browser so chromium and firefox run on separate
+    # runners in parallel — roughly halves wall-clock time. Each
+    # matrix job gets its own filesystem, so the playwright.config
+    # mkdtemp data dir is naturally isolated across browsers (#202).
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox]
+
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -30,23 +44,33 @@ jobs:
         working-directory: test/e2e
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('test/e2e/package-lock.json') }}
+          # Per-browser cache key so the chromium job doesn't pull in
+          # firefox's binaries and vice versa.
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('test/e2e/package-lock.json') }}
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+      # Browser binaries skip on cache hit; system deps still run each
+      # time because apt-get state isn't cached. See #202 for the split.
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install ${{ matrix.browser }}
+        working-directory: test/e2e
+
+      - name: Install Playwright system deps
+        run: npx playwright install-deps ${{ matrix.browser }}
         working-directory: test/e2e
 
       - name: Run Playwright tests
-        run: npm test
+        run: npx playwright test --project=${{ matrix.browser }}
         working-directory: test/e2e
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: test/e2e/playwright-report
           retention-days: 7

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches: [ main, develop]
 
+# Cancel the older run when a new push lands on the same branch / PR (#202).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   # Optional: allow read access to pull requests. Use with `only-new-issues` option.
@@ -13,7 +18,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

Three CI optimisations that should drop typical PR feedback time and free runner minutes on fixup pushes.

- **`concurrency:` block** on `ci.yml`, `golangci-lint.yml`, `e2e.yml`. New pushes to the same branch/PR cancel the previous run. Saves the most time when pushing fixup commits in quick succession (Dependabot rebases especially).
- **`ci.yml`**: dropped the standalone `Run Integration Tests` step. `make test-coverage` already runs the full suite with `-tags=integration ./...` per the Makefile, so the integration suite was running twice per CI invocation.
- **`e2e.yml`**: matrixed by browser (`chromium`, `firefox`) — each runs on its own runner in parallel, roughly halving wall-clock e2e time. Per-shard isolation comes for free from the existing `mkdtempSync` data dir in `playwright.config.ts`. The Playwright install is split into "browsers" (gated on `cache-hit != 'true'`, skipped entirely on cache hit) and "system deps" (always runs, ~10–30s of apt-get state that isn't cacheable). Report artifact names are now per-browser so the shards don't collide on upload.
- `runs-on:` pinned to `ubuntu-24.04` on the workflows I touched, so CI times are reproducible.

`deploy.yml` and `docker-publish.yml` were intentionally left untouched: `deploy.yml` is chained from Docker + manual dispatch (cancelling mid-flight is risky) and `docker-publish.yml` mixes scheduled / push / tag triggers where clean cancel semantics need more thought.

Closes #202.

## What I deliberately didn't do

- **Pin action SHAs.** Pure security hygiene, not a speed win; better handled with `pin-github-action` or similar in a dedicated PR.
- **Path-based filtering (`paths:` / `paths-ignore:`).** Discussed and decided to skip for now — the realistic wins are doc-only commits, and the risk of accidentally filtering out a relevant change is higher than the time saved. Revisit later with a narrow `paths-ignore` allowlist if the cost of doc-only CI runs becomes visible.

## Test plan

- [x] First push to this PR exercises the new e2e matrix end-to-end — confirm both browser shards run, both report individual cache hits/misses, and the wall-clock total drops vs. the previous serial layout.
- [ ] Push a fixup commit; observe the previous run is cancelled by the `concurrency` block.
- [x] Confirm `make check` (locally) still green — it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)