### PR TITLE
Render leaderboard "Set my name" affordance as an inline pencil icon (#204)

### DIFF
--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -196,6 +196,34 @@ h3 {
     gap: 0.6rem;
 }
 
+/* Icon-only button — inline affordance that should read as a clickable
+   glyph rather than a chrome'd button. Used for the leaderboard-row
+   "Set my name" pencil (#204) where a full Bulma button took too much
+   of the row. The :focus rule keeps the keyboard focus ring visible
+   for accessibility; the (hover: hover) gate matches the rest of the
+   palette's sticky-hover-on-touch fix from #194. */
+.icon-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: inherit;
+    line-height: 1;
+    vertical-align: middle;
+    opacity: 0.65;
+    transition: opacity 160ms ease;
+}
+.icon-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    opacity: 1;
+}
+@media (hover: hover) {
+    .icon-button:hover {
+        opacity: 1;
+    }
+}
+
 /* Progress bar — a hair-thin line in the accent gradient. */
 .progress {
     background: var(--border);

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -163,12 +163,24 @@
                                         <td x-text="entry.rank"></td>
                                         <td>
                                             <span x-text="entry.username"></span>
-                                            <!-- Entry 2: leaderboard-row link that
+                                            <!-- Entry 2: leaderboard-row pencil that
                                                  opens the same shared modal. Only
                                                  renders for the current player while
-                                                 they have not yet picked a name. -->
+                                                 they have not yet picked a name. A
+                                                 stripped-down icon button (no Bulma
+                                                 .button styling) so it sits inline
+                                                 with the username without eating a
+                                                 row-worth of space (#204). -->
                                             <template x-if="entry.isCurrentPlayer && !hasCustomName()">
-                                                <a href="#" class="ml-2" @click.prevent="openClaimModal()">Set my name</a>
+                                                <button type="button"
+                                                        class="icon-button ml-2"
+                                                        title="Set my name"
+                                                        aria-label="Set my name"
+                                                        @click="openClaimModal()">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+                                                        <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/>
+                                                    </svg>
+                                                </button>
                                             </template>
                                         </td>
                                         <td x-text="entry.score"></td>


### PR DESCRIPTION
## Summary

The "Set my name" inline link on the current player's leaderboard row used to render as a plain `<a href="#">`, which didn't read as clearly interactive. A first pass swapped it for a Bulma `.button.is-small`, but that ate too much of the row. Final shape:

- `<button class="icon-button">` containing an inline 14×14 SVG pencil (`fill="currentColor"` so it inherits the row's text color — magenta on the `.is-selected` row).
- Accessible name via `title` + `aria-label="Set my name"`; the SVG itself is `aria-hidden`.
- New `.icon-button` rule in `synthwave.css`: zero chrome, `cursor: pointer`, opacity 0.65 at rest → 1 on hover/focus, with `:focus-visible` for keyboard nav. `:hover` is gated on `@media (hover: hover)` so the state doesn't stick on touch (same pattern as #194).

Closes #204.

## Test plan

- [x] `make check` — green
- [x] `make test-e2e` — green (no e2e selectors reference "Set my name" so the swap is transparent to existing specs)
- [x] Manual: anonymous player who lands on the leaderboard sees a pencil inline next to their petname; clicking it opens the same claim modal; keyboard Tab through the row shows the focus ring on the pencil

🤖 Generated with [Claude Code](https://claude.com/claude-code)