### PR TITLE
Admin redesign foundation: shared tokens + banana-yellow brand swap (#207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,14 @@ make smoke            # validate startup against the existing dev DB (no HTTP li
 
 ## Commits
 
-Never create commits yourself. When work is ready to commit, suggest a one-line commit message and wait for the user to review and commit. Use plain language — avoid jargon. Prefer simple verbs like "change", "update", "fix", "add", "remove". Start the message with a capital letter.
+You may create commits, but only after the user has reviewed and signed off on every line of the diff. Workflow:
+
+1. Show the user the change (or point at the diff they need to read).
+2. Ask explicitly: "Did the review look OK?" or equivalent. Wait for their explicit go-ahead — silence is not consent.
+3. Only then run `git add` / `git commit`.
+4. Use plain language commit messages — avoid jargon. Prefer simple verbs like "change", "update", "fix", "add", "remove". Start the message with a capital letter.
+
+If you make further changes after the sign-off (e.g. fixing a lint issue, addressing a comment), ask for sign-off on the new lines too before committing.
 
 ## Testing
 

--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -2,22 +2,10 @@
    magenta accent on near-black, generous whitespace, Inter throughout.
    The synthwave heritage is in the accent colour and the kinetic
    animations driven from GameApp.js — not in the static decoration.
-   File name kept for diff continuity; the contents have moved on. */
+   File name kept for diff continuity; the contents have moved on.
 
-:root {
-    --bg: #0a0a0f;
-    --surface: #15151c;
-    --surface-2: #1d1d26;
-    --border: #2a2a35;
-    --text: #e8e8ee;
-    --text-dim: #7a7a85;
-    --accent: #ff2d95;
-    --accent-soft: rgba(255, 45, 149, 0.14);
-    --cyan: #66e8ff;
-    --cyan-soft: rgba(102, 232, 255, 0.12);
-    --danger: #ff5c5c;
-    --warning: #ffb454;
-}
+   Design tokens (--bg, --accent, etc.) live in tokens.css, which must
+   be loaded before this file — see #207. */
 
 html, body {
     background: var(--bg);

--- a/internal/client/static/css/synthwave.css
+++ b/internal/client/static/css/synthwave.css
@@ -295,7 +295,10 @@ h3 {
 }
 .table tbody tr.is-selected td {
     color: var(--accent);
-    border-color: rgba(255, 45, 149, 0.25);
+    /* rgba mirror of --accent (banana #ffd23f) at slightly higher
+       alpha than --accent-soft so the row border is visible against
+       the yellow-tinted background. */
+    border-color: rgba(255, 210, 63, 0.3);
 }
 
 /* Off-leaderboard "Your score" card on the leaderboard view. Shown when

--- a/internal/client/static/css/tokens.css
+++ b/internal/client/static/css/tokens.css
@@ -1,0 +1,20 @@
+/* Design tokens shared by every page (player client + admin dashboard).
+   Loaded before each surface's component CSS so rules can reference
+   --bg, --accent, etc. without re-declaring them. Defined in one place
+   so a palette change ripples through both surfaces — see #207 for the
+   admin redesign that motivates the split. */
+
+:root {
+    --bg: #0a0a0f;
+    --surface: #15151c;
+    --surface-2: #1d1d26;
+    --border: #2a2a35;
+    --text: #e8e8ee;
+    --text-dim: #7a7a85;
+    --accent: #ff2d95;
+    --accent-soft: rgba(255, 45, 149, 0.14);
+    --cyan: #66e8ff;
+    --cyan-soft: rgba(102, 232, 255, 0.12);
+    --danger: #ff5c5c;
+    --warning: #ffb454;
+}

--- a/internal/client/static/css/tokens.css
+++ b/internal/client/static/css/tokens.css
@@ -11,8 +11,12 @@
     --border: #2a2a35;
     --text: #e8e8ee;
     --text-dim: #7a7a85;
-    --accent: #ff2d95;
-    --accent-soft: rgba(255, 45, 149, 0.14);
+    /* Banana yellow — matches the brand name. Warm tone (slight orange
+       bias) keeps it from drifting into a lemon / warning-sign read.
+       Swapped from magenta in #207; everywhere that consumed --accent
+       follows along automatically. */
+    --accent: #ffd23f;
+    --accent-soft: rgba(255, 210, 63, 0.14);
     --cyan: #66e8ff;
     --cyan-soft: rgba(102, 232, 255, 0.12);
     --danger: #ff5c5c;

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
+    <link rel="stylesheet" href="/client/css/tokens.css">
     <link rel="stylesheet" href="/client/css/synthwave.css">
     <script src="https://cdn.jsdelivr.net/npm/animejs@4.2.0/dist/bundles/anime.umd.min.js"></script>
     <script type="module" src="/client/js/app.js"></script>

--- a/internal/web/tmpl/admin/layouts/base.gohtml
+++ b/internal/web/tmpl/admin/layouts/base.gohtml
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Title}} - Admin</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
+    <link rel="stylesheet" href="/client/css/tokens.css">
     <script src="https://cdn.jsdelivr.net/npm/fontawesome-free@1.0.4/js/all.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fontawesome-free@1.0.4/css/fontawesome.min.css">
 </head>

--- a/mockups/admin-redesign/index.html
+++ b/mockups/admin-redesign/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin redesign mockup — top banana</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-inner">
+            <a class="nav-brand" href="index.html"><span class="nav-brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>TOP<span>BANANA</span></a>
+            <div class="nav-meta">
+                <span class="nav-user">Mockup index</span>
+            </div>
+        </div>
+    </nav>
+
+    <main class="shell">
+        <header class="page-header">
+            <div>
+                <h1 class="page-title">Admin redesign</h1>
+                <p class="page-sub">Three mockup pages exploring the dark, editorial, mobile-first direction for #207. Open each one and resize the viewport — they're shaped for 360 px upward.</p>
+            </div>
+        </header>
+
+        <section class="quiz-grid">
+            <a class="quiz-card" href="quiz-list.html" style="text-decoration: none;">
+                <div class="quiz-card-meta">
+                    <span>Page 1 of 3</span>
+                </div>
+                <h3 class="quiz-card-title">Quiz list</h3>
+                <span class="quiz-card-slug">quiz-list.html</span>
+                <p class="quiz-card-desc">Card grid of quizzes with title, slug, description, play count, and per-card actions. Includes the empty state at the bottom of the page.</p>
+            </a>
+            <a class="quiz-card" href="quiz-view.html" style="text-decoration: none;">
+                <div class="quiz-card-meta">
+                    <span>Page 2 of 3</span>
+                </div>
+                <h3 class="quiz-card-title">Quiz view</h3>
+                <span class="quiz-card-slug">quiz-view.html</span>
+                <p class="quiz-card-desc">Quiz header with visibility pill, share URL, and edit/share/delete actions. Question rows with Up/Down reorder. "Played by" players list.</p>
+            </a>
+            <a class="quiz-card" href="question-form.html" style="text-decoration: none;">
+                <div class="quiz-card-meta">
+                    <span>Page 3 of 3</span>
+                </div>
+                <h3 class="quiz-card-title">Question form</h3>
+                <span class="quiz-card-slug">question-form.html</span>
+                <p class="quiz-card-desc">Single-column form: question text, image drop zone, four option rows with cyan correct-pills, read-only position, time-limit override.</p>
+            </a>
+        </section>
+
+        <section style="margin-top: 4rem; color: var(--text-dim); font-size: 0.85rem; max-width: 60ch;">
+            <p class="eyebrow">Design notes</p>
+            <p style="margin: 0 0 1rem;">Sans throughout: Inter for body, Orbitron for every display moment — brand wordmark, page titles, quiz titles, position numbers, option letters. Geometric retro-futurist face that puts a synthwave/cyber stamp on the surface without sliding into arcade-game territory. Mostly used in caps where the type was designed to live, with measured tracking so it reads less ALARM and more INTERFACE.</p>
+            <p style="margin: 0 0 1rem;">Banana yellow as the primary accent (matches the name), cyan reserved for positive states (correct answers, "copy link" affordance). Magenta dropped — two-color discipline. Subtle yellow vignette behind the navbar plus a quiet dot-grid for surface texture. The primary CTA gets a controlled glow on hover (negative spread keeps it tight, no permanent halo). Hover affordances gated to <code>@media (hover: hover)</code> so they do not stick on touch.</p>
+            <p style="margin: 0 0 1rem;">All three pages tested at 360 px width; touch targets ≥ 44 px; tables collapse to stacked cards on mobile. <code>:focus-visible</code> outlines on every interactive element.</p>
+            <p style="margin: 0;">Future-feature placeholders included: visibility pill (#103), image drop zone (#168), time-limit override (#99). Empty slots make it easy to fill them in later without re-skinning.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/mockups/admin-redesign/question-form.html
+++ b/mockups/admin-redesign/question-form.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit question — top banana admin</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-inner">
+            <a class="nav-brand" href="index.html"><span class="nav-brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>TOP<span>BANANA</span></a>
+            <div class="nav-meta">
+                <span class="nav-user">Signed in as <strong>alice</strong></span>
+                <a class="nav-logout" href="#" aria-label="Log out">Log out</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="shell">
+        <div class="crumb">
+            <a href="index.html">Admin</a>
+            <span class="sep">/</span>
+            <a href="quiz-list.html">Quizzes</a>
+            <span class="sep">/</span>
+            <a href="quiz-view.html">Capital Cities of Europe</a>
+            <span class="sep">/</span>
+            <span>Question 01</span>
+        </div>
+
+        <header class="page-header">
+            <div>
+                <h1 class="page-title">Edit question</h1>
+                <p class="page-sub">Question 01 of "Capital Cities of Europe". Order is managed from the quiz view.</p>
+            </div>
+        </header>
+
+        <form class="form-shell">
+            <div class="form-field">
+                <label class="label" for="text">Question text</label>
+                <textarea class="textarea" id="text" rows="3">Which city sits on the river Vltava and is the capital of the Czech Republic?</textarea>
+            </div>
+
+            <div class="form-field">
+                <label class="label">Image</label>
+                <div class="dropzone">
+                    <div class="dropzone-icon">
+                        <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.002 5.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/><path d="M2.002 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2h-12zm12 1a1 1 0 0 1 1 1v6.5l-3.777-1.947a.5.5 0 0 0-.577.093l-3.71 3.71-2.66-1.772a.5.5 0 0 0-.63.062L1.002 12V3a1 1 0 0 1 1-1h12z"/></svg>
+                    </div>
+                    <strong class="dropzone-strong">Drop an image, or click to choose</strong>
+                    <span style="color: var(--text-mute); font-size: 0.78rem;">PNG, JPG, or WebP — up to 4 MB</span>
+                    <div class="dropzone-alt">
+                        <span>Or paste a URL</span>
+                        <input type="text" value="https://example.com/prague-vltava.jpg">
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-field">
+                <label class="label">Options <span class="label-hint">Tap "Correct" to mark the right answer(s)</span></label>
+                <div>
+                    <div class="option-row">
+                        <span class="option-letter">A</span>
+                        <input class="option-input" type="text" value="Bratislava">
+                        <label class="option-check">
+                            <input type="checkbox">
+                            <span class="option-check-pill">Correct</span>
+                        </label>
+                    </div>
+                    <div class="option-row">
+                        <span class="option-letter">B</span>
+                        <input class="option-input" type="text" value="Budapest">
+                        <label class="option-check">
+                            <input type="checkbox">
+                            <span class="option-check-pill">Correct</span>
+                        </label>
+                    </div>
+                    <div class="option-row">
+                        <span class="option-letter">C</span>
+                        <input class="option-input" type="text" value="Prague">
+                        <label class="option-check">
+                            <input type="checkbox" checked>
+                            <span class="option-check-pill">Correct</span>
+                        </label>
+                    </div>
+                    <div class="option-row">
+                        <span class="option-letter">D</span>
+                        <input class="option-input" type="text" value="Warsaw">
+                        <label class="option-check">
+                            <input type="checkbox">
+                            <span class="option-check-pill">Correct</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-field">
+                <label class="label" for="position">Position <span class="label-hint">Use Up/Down on the quiz view to reorder</span></label>
+                <input class="input input-readonly" id="position" type="text" value="01" readonly>
+            </div>
+
+            <div class="form-field">
+                <label class="label" for="time-limit">Time limit <span class="label-hint">Override the quiz default (10s)</span></label>
+                <div style="display: flex; align-items: center; gap: 0.75rem;">
+                    <input class="input" id="time-limit" type="number" value="10" min="3" max="60" style="max-width: 100px;">
+                    <span style="color: var(--text-dim); font-size: 0.85rem;">seconds</span>
+                </div>
+            </div>
+
+            <div class="form-actions">
+                <button class="btn btn-primary" type="submit">Save question</button>
+                <a class="btn btn-ghost" href="quiz-view.html">Cancel</a>
+            </div>
+        </form>
+    </main>
+</body>
+</html>

--- a/mockups/admin-redesign/quiz-list.html
+++ b/mockups/admin-redesign/quiz-list.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quizzes — top banana admin</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-inner">
+            <a class="nav-brand" href="index.html"><span class="nav-brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>TOP<span>BANANA</span></a>
+            <div class="nav-meta">
+                <span class="nav-user">Signed in as <strong>alice</strong></span>
+                <a class="nav-logout" href="#" aria-label="Log out">Log out</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="shell">
+        <div class="crumb">
+            <a href="index.html">Admin</a>
+            <span class="sep">/</span>
+            <span>Quizzes</span>
+        </div>
+
+        <header class="page-header">
+            <div>
+                <h1 class="page-title">Quizzes</h1>
+                <p class="page-sub">Author, share, and review quizzes. Tap a card to manage questions.</p>
+            </div>
+            <a class="btn btn-primary" href="#">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.5.5 0 0 1 .5.5v5.5H14a.5.5 0 0 1 0 1H8.5V14a.5.5 0 0 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 .5-.5z"/></svg>
+                New quiz
+            </a>
+        </header>
+
+        <section class="quiz-grid" aria-label="Your quizzes">
+            <article class="quiz-card">
+                <div class="quiz-card-meta">
+                    <span>Quiz · 12 plays</span>
+                    <span class="when">3 hr ago</span>
+                </div>
+                <h3 class="quiz-card-title">Capital Cities of Europe</h3>
+                <span class="quiz-card-slug">/play/capital-cities-of-europe-7</span>
+                <p class="quiz-card-desc">A geography refresher. Twelve quick-fire questions covering EU capitals, with one curveball about a country that joined in 2007.</p>
+                <div class="quiz-card-foot">
+                    <span class="quiz-card-counts"><strong>12</strong> questions</span>
+                    <div class="quiz-card-actions">
+                        <button class="icon-btn" title="View" aria-label="View">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Edit" aria-label="Edit">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Share" aria-label="Share">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5zm-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete" aria-label="Delete">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </div>
+            </article>
+
+            <article class="quiz-card">
+                <div class="quiz-card-meta">
+                    <span>Quiz · 47 plays</span>
+                    <span class="when">2 days ago</span>
+                </div>
+                <h3 class="quiz-card-title">Films of the 90s</h3>
+                <span class="quiz-card-slug">/play/films-of-the-90s-3</span>
+                <p class="quiz-card-desc">Working titles, taglines, and one director identification round. Built for the office quiz night — light on trivia, heavy on visuals.</p>
+                <div class="quiz-card-foot">
+                    <span class="quiz-card-counts"><strong>8</strong> questions</span>
+                    <div class="quiz-card-actions">
+                        <button class="icon-btn" title="View" aria-label="View">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Edit" aria-label="Edit">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Share" aria-label="Share">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5zm-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete" aria-label="Delete">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </div>
+            </article>
+
+            <article class="quiz-card">
+                <div class="quiz-card-meta">
+                    <span>Quiz · 0 plays</span>
+                    <span class="when">Just now</span>
+                </div>
+                <h3 class="quiz-card-title">Pub Quiz: Half&nbsp;1</h3>
+                <span class="quiz-card-slug">/play/pub-quiz-half-1-12</span>
+                <p class="quiz-card-desc">Draft. Geography, music from 1965–1985, two picture rounds. Aiming for fifteen questions before Thursday.</p>
+                <div class="quiz-card-foot">
+                    <span class="quiz-card-counts"><strong>3</strong> questions</span>
+                    <div class="quiz-card-actions">
+                        <button class="icon-btn" title="View" aria-label="View">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Edit" aria-label="Edit">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Share" aria-label="Share">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5zm-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete" aria-label="Delete">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </div>
+            </article>
+        </section>
+
+        <section style="margin-top: 4rem;" aria-label="Empty state preview">
+            <p class="eyebrow">Empty state · preview</p>
+            <div class="empty">
+                <p class="empty-title">No quizzes yet</p>
+                <p class="empty-sub">Create your first quiz to get going. You can add questions, share a link, and watch the leaderboard fill in.</p>
+                <a class="btn btn-primary" href="#">Create your first quiz</a>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/mockups/admin-redesign/quiz-view.html
+++ b/mockups/admin-redesign/quiz-view.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Capital Cities of Europe — top banana admin</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-inner">
+            <a class="nav-brand" href="index.html"><span class="nav-brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>TOP<span>BANANA</span></a>
+            <div class="nav-meta">
+                <span class="nav-user">Signed in as <strong>alice</strong></span>
+                <a class="nav-logout" href="#" aria-label="Log out">Log out</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="shell">
+        <div class="crumb">
+            <a href="index.html">Admin</a>
+            <span class="sep">/</span>
+            <a href="quiz-list.html">Quizzes</a>
+            <span class="sep">/</span>
+            <span>Capital Cities of Europe</span>
+        </div>
+
+        <header class="quiz-hero">
+            <div class="quiz-hero-meta">
+                <span class="pill pill-public">Public</span>
+                <span class="eyebrow" style="margin: 0;">Quiz · 12 plays · created 3 days ago</span>
+            </div>
+            <h1 class="quiz-hero-title">
+                Capital Cities of Europe
+                <a class="quiz-edit" href="#" title="Edit quiz" aria-label="Edit quiz">
+                    <svg width="22" height="22" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                </a>
+            </h1>
+            <p class="quiz-hero-desc">A geography refresher. Twelve quick-fire questions covering EU capitals, with one curveball about a country that joined in 2007.</p>
+            <div class="quiz-hero-share">
+                <span>topbanana.app/play/capital-cities-of-europe-7</span>
+                <button class="copy-link" type="button">Copy link</button>
+            </div>
+            <div class="quiz-hero-actions">
+                <button class="btn">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M13.5 1a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5zm-8.5 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm11 5.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/></svg>
+                    Share
+                </button>
+                <button class="btn btn-danger">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                    Delete
+                </button>
+            </div>
+        </header>
+
+        <section aria-label="Questions">
+            <div class="section-head">
+                <h2>Questions</h2>
+                <span class="section-count">3 of 12 shown</span>
+            </div>
+
+            <div class="q-list">
+                <article class="q-row">
+                    <div class="q-position">01</div>
+                    <div class="q-thumb"><img src="" alt="" style="display: none;">IMG</div>
+                    <div class="q-body">
+                        <p class="q-text">Which city sits on the river Vltava and is the capital of the Czech Republic?</p>
+                        <ul class="q-options">
+                            <li>Bratislava</li>
+                            <li>Budapest</li>
+                            <li class="correct">Prague</li>
+                            <li>Warsaw</li>
+                        </ul>
+                    </div>
+                    <div class="q-reorder">
+                        <button class="icon-btn" disabled title="Move up" aria-label="Move up">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Move down" aria-label="Move down">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 4a.5.5 0 0 1 .5.5v5.793l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 10.293V4.5A.5.5 0 0 1 8 4z"/></svg>
+                        </button>
+                    </div>
+                    <div class="q-actions">
+                        <button class="icon-btn" title="Edit question" aria-label="Edit question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete question" aria-label="Delete question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </article>
+
+                <article class="q-row">
+                    <div class="q-position">02</div>
+                    <div class="q-thumb">IMG</div>
+                    <div class="q-body">
+                        <p class="q-text">Lisbon is the capital of which country?</p>
+                        <ul class="q-options">
+                            <li>Spain</li>
+                            <li class="correct">Portugal</li>
+                            <li>Italy</li>
+                            <li>Greece</li>
+                        </ul>
+                    </div>
+                    <div class="q-reorder">
+                        <button class="icon-btn" title="Move up" aria-label="Move up">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/></svg>
+                        </button>
+                        <button class="icon-btn" title="Move down" aria-label="Move down">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 4a.5.5 0 0 1 .5.5v5.793l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 10.293V4.5A.5.5 0 0 1 8 4z"/></svg>
+                        </button>
+                    </div>
+                    <div class="q-actions">
+                        <button class="icon-btn" title="Edit question" aria-label="Edit question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete question" aria-label="Delete question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </article>
+
+                <article class="q-row">
+                    <div class="q-position">03</div>
+                    <div class="q-thumb">IMG</div>
+                    <div class="q-body">
+                        <p class="q-text">Which capital was founded in 1043 and overlooks the Bosphorus strait?</p>
+                        <ul class="q-options">
+                            <li>Athens</li>
+                            <li>Sofia</li>
+                            <li class="correct">Istanbul</li>
+                            <li>Bucharest</li>
+                        </ul>
+                    </div>
+                    <div class="q-reorder">
+                        <button class="icon-btn" title="Move up" aria-label="Move up">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/></svg>
+                        </button>
+                        <button class="icon-btn" disabled title="Move down" aria-label="Move down">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 4a.5.5 0 0 1 .5.5v5.793l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 10.293V4.5A.5.5 0 0 1 8 4z"/></svg>
+                        </button>
+                    </div>
+                    <div class="q-actions">
+                        <button class="icon-btn" title="Edit question" aria-label="Edit question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+                        </button>
+                        <button class="icon-btn btn-danger" title="Delete question" aria-label="Delete question">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+                        </button>
+                    </div>
+                </article>
+            </div>
+
+            <div style="margin-top: 1.5rem;">
+                <a class="btn btn-primary" href="question-form.html">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.5.5 0 0 1 .5.5v5.5H14a.5.5 0 0 1 0 1H8.5V14a.5.5 0 0 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 .5-.5z"/></svg>
+                    Add question
+                </a>
+            </div>
+        </section>
+
+        <section aria-label="Played by">
+            <div class="section-head">
+                <h2>Played by</h2>
+                <span class="section-count">12 players</span>
+            </div>
+
+            <div class="player-list">
+                <div class="player-row">
+                    <div class="player-name">Bouncy-Plucky-Wombat <span class="username-meta">anonymous</span></div>
+                    <div class="player-score">4 800</div>
+                    <button class="player-reset" type="button">Reset</button>
+                </div>
+                <div class="player-row">
+                    <div class="player-name">remco</div>
+                    <div class="player-score">4 200</div>
+                    <button class="player-reset" type="button">Reset</button>
+                </div>
+                <div class="player-row">
+                    <div class="player-name">Sneaky-Toasty-Otter <span class="username-meta">anonymous</span></div>
+                    <div class="player-score">3 900</div>
+                    <button class="player-reset" type="button">Reset</button>
+                </div>
+                <div class="player-row">
+                    <div class="player-name">jan</div>
+                    <div class="player-score">2 700</div>
+                    <button class="player-reset" type="button">Reset</button>
+                </div>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/mockups/admin-redesign/styles.css
+++ b/mockups/admin-redesign/styles.css
@@ -1,0 +1,1032 @@
+/* topbanana admin — redesign mockup, v3.
+   Dark by default, mobile-first, sans-serif throughout, modernised
+   with synthwave/cyber energy. Orbitron carries every display moment
+   (brand wordmark, page titles, quiz titles, position numbers, option
+   letters) — geometric, retro-futurist, Tron-coded. Inter for body,
+   exactly matching the player client. Banana yellow primary, cyan
+   for positives, no magenta. */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap');
+
+:root {
+    /* Banana-yellow brand palette. Yellow primary (matches the name),
+       cyan for positives, no magenta. Picked the warm shade #ffd23f
+       deliberately — pure lemon (#facc15) drifts into warning-sign
+       territory; a hint of orange keeps it readable as "playful". */
+    --bg: #0a0a0f;
+    --surface: #15151c;
+    --surface-2: #1d1d26;
+    --border: #2a2a35;
+    --border-soft: #1f1f28;
+    --text: #e8e8ee;
+    --text-dim: #7a7a85;
+    --text-mute: #4a4a55;
+    --accent: #ffd23f;
+    --accent-soft: rgba(255, 210, 63, 0.14);
+    --accent-line: rgba(255, 210, 63, 0.4);
+    --accent-deep: #f5b800;
+    --cyan: #66e8ff;
+    --cyan-soft: rgba(102, 232, 255, 0.12);
+    --danger: #ff5c5c;
+    --warning: #ffb454;
+
+    --radius-sm: 4px;
+    --radius: 8px;
+    --radius-lg: 12px;
+
+    --shadow-focus: 0 0 0 3px var(--accent-soft);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+}
+
+body {
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-feature-settings: 'cv11', 'ss01', 'tnum';
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    line-height: 1.55;
+    min-height: 100vh;
+
+    /* Layered atmosphere: a soft magenta vignette behind the navbar
+       (synthwave hint) sitting on top of a subtle dot-grid. Both are
+       fixed/static — no scroll-bound effects, no permanent glow on
+       individual elements. */
+    background-color: var(--bg);
+    background-image:
+        radial-gradient(ellipse 80% 600px at 50% -200px, rgba(255, 210, 63, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 400px at 50% -100px, rgba(102, 232, 255, 0.04), transparent 70%),
+        radial-gradient(circle at 1px 1px, rgba(255,255,255,0.025) 1px, transparent 0);
+    background-size: 100% 100%, 100% 100%, 24px 24px;
+    background-repeat: no-repeat, no-repeat, repeat;
+    background-attachment: fixed, fixed, fixed;
+}
+
+a {
+    color: var(--text);
+    text-decoration: none;
+}
+a:hover {
+    color: var(--accent);
+}
+
+/* —————————————————————————————————————————————————————
+   Navbar
+   ————————————————————————————————————————————————————— */
+
+.nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: rgba(10, 10, 15, 0.86);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-soft);
+}
+.nav-inner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 1rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+.nav-brand {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    color: var(--text);
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.05em;
+}
+.nav-brand span {
+    color: var(--accent);
+    font-weight: 800;
+}
+.nav-brand-icon {
+    width: 22px;
+    height: 22px;
+    margin-right: 0.55rem;
+    color: var(--accent);
+    filter: drop-shadow(0 0 8px rgba(255, 210, 63, 0.45));
+    flex-shrink: 0;
+}
+.nav-brand-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+.nav-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.85rem;
+}
+.nav-user {
+    color: var(--text-dim);
+}
+.nav-user strong {
+    color: var(--text);
+    font-weight: 500;
+}
+.nav-logout {
+    color: var(--text-dim);
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    transition: border-color 160ms ease, color 160ms ease;
+    min-height: 36px;
+    display: inline-flex;
+    align-items: center;
+}
+@media (hover: hover) {
+    .nav-logout:hover {
+        border-color: var(--accent);
+        color: var(--text);
+    }
+}
+.nav-logout:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+    border-color: var(--accent);
+}
+
+/* —————————————————————————————————————————————————————
+   Layout shell
+   ————————————————————————————————————————————————————— */
+
+.shell {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 2.5rem 1.25rem 5rem;
+}
+@media (max-width: 768px) {
+    .shell { padding: 1.75rem 1rem 6rem; }
+}
+
+.crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 1.25rem;
+}
+.crumb a { color: var(--text-dim); }
+.crumb .sep { color: var(--text-mute); }
+@media (hover: hover) {
+    .crumb a:hover { color: var(--text); }
+}
+
+.page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-soft);
+    flex-wrap: wrap;
+}
+.page-title {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 800;
+    font-size: clamp(2rem, 6vw, 2.75rem);
+    line-height: 1;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    margin: 0;
+    color: var(--text);
+}
+.page-sub {
+    color: var(--text-dim);
+    font-size: 0.95rem;
+    margin: 0.5rem 0 0;
+    max-width: 50ch;
+}
+
+/* —————————————————————————————————————————————————————
+   Microtype label
+   ————————————————————————————————————————————————————— */
+
+.eyebrow {
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin: 0 0 0.6rem;
+}
+
+.section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 2.5rem 0 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-soft);
+}
+.section-head h2 {
+    font-family: 'Inter', sans-serif;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    font-weight: 600;
+    margin: 0;
+}
+.section-head .section-count {
+    font-feature-settings: 'tnum';
+    color: var(--text-mute);
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+/* —————————————————————————————————————————————————————
+   Buttons
+   ————————————————————————————————————————————————————— */
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 44px;
+    padding: 0.7rem 1.2rem;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-family: 'Inter', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: border-color 160ms ease, background 160ms ease, transform 120ms ease;
+}
+.btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+    border-color: var(--accent);
+}
+@media (hover: hover) {
+    .btn:hover {
+        border-color: var(--accent);
+        background: var(--surface-2);
+    }
+}
+.btn:active { transform: translateY(1px); }
+
+.btn-primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+    font-weight: 600;
+    box-shadow: 0 0 0 1px transparent, 0 8px 20px -10px var(--accent);
+    transition: border-color 160ms ease, background 160ms ease, transform 120ms ease, box-shadow 200ms ease;
+}
+@media (hover: hover) {
+    .btn-primary:hover {
+        background: var(--accent-deep);
+        border-color: var(--accent-deep);
+        box-shadow: 0 0 0 3px var(--accent-soft), 0 0 24px -6px var(--accent), 0 8px 20px -10px var(--accent);
+    }
+}
+
+.btn-ghost {
+    background: transparent;
+    border-color: transparent;
+    color: var(--text-dim);
+}
+@media (hover: hover) {
+    .btn-ghost:hover {
+        color: var(--text);
+        background: var(--surface);
+    }
+}
+
+.btn-danger { color: var(--danger); }
+@media (hover: hover) {
+    .btn-danger:hover { border-color: var(--danger); color: var(--danger); }
+}
+
+.icon-btn {
+    width: 38px;
+    height: 38px;
+    min-height: 38px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--text-dim);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+@media (hover: hover) {
+    .icon-btn:hover:not([disabled]) {
+        color: var(--text);
+        border-color: var(--border);
+        background: var(--surface);
+    }
+}
+.icon-btn[disabled] {
+    color: var(--text-mute);
+    cursor: not-allowed;
+}
+.icon-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+    border-color: var(--accent);
+}
+.icon-btn svg { width: 16px; height: 16px; }
+
+/* —————————————————————————————————————————————————————
+   Quiz list — card grid
+   ————————————————————————————————————————————————————— */
+
+.quiz-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: 1fr;
+}
+@media (min-width: 768px) {
+    .quiz-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1040px) {
+    .quiz-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.quiz-card {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius);
+    padding: 1.5rem 1.5rem 1rem;
+    transition: border-color 200ms ease, transform 200ms ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 220px;
+}
+@media (hover: hover) {
+    .quiz-card:hover {
+        border-color: var(--border);
+        transform: translateY(-2px);
+    }
+    .quiz-card:hover::before {
+        background: var(--accent);
+    }
+}
+.quiz-card::before {
+    content: "";
+    position: absolute;
+    left: -1px;
+    top: 1.5rem;
+    bottom: 1.5rem;
+    width: 2px;
+    background: transparent;
+    border-radius: 2px;
+    transition: background 200ms ease;
+}
+
+.quiz-card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+    font-weight: 600;
+}
+.quiz-card-meta .when {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-dim);
+}
+.quiz-card-title {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 700;
+    font-size: 1.2rem;
+    line-height: 1.2;
+    letter-spacing: 0.005em;
+    text-transform: uppercase;
+    margin: 0;
+    color: var(--text);
+}
+.quiz-card-slug {
+    font-family: ui-monospace, 'JetBrains Mono', Menlo, monospace;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+.quiz-card-desc {
+    color: var(--text-dim);
+    font-size: 0.92rem;
+    line-height: 1.55;
+    margin: 0;
+    flex: 1;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.quiz-card-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding-top: 1rem;
+    border-top: 1px dashed var(--border-soft);
+}
+.quiz-card-counts {
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.quiz-card-counts strong {
+    color: var(--text);
+    font-weight: 600;
+}
+.quiz-card-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+/* —————————————————————————————————————————————————————
+   Empty state
+   ————————————————————————————————————————————————————— */
+
+.empty {
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-lg);
+    padding: 4rem 2rem;
+    text-align: center;
+    background: rgba(21, 21, 28, 0.4);
+}
+.empty-title {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 700;
+    font-size: 1.5rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text);
+    margin: 0 0 0.5rem;
+}
+.empty-sub {
+    color: var(--text-dim);
+    margin: 0 0 1.5rem;
+    max-width: 36ch;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* —————————————————————————————————————————————————————
+   Quiz view — header
+   ————————————————————————————————————————————————————— */
+
+.quiz-hero {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-soft);
+}
+.quiz-hero-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+.pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+}
+.pill::before {
+    content: "";
+    width: 6px; height: 6px; border-radius: 999px;
+    background: var(--text-mute);
+}
+.pill-public::before { background: var(--cyan); }
+.pill-unlisted::before { background: var(--warning); }
+.pill-private::before { background: var(--text-mute); }
+
+.quiz-hero-title {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 800;
+    font-size: clamp(1.85rem, 5.5vw, 2.5rem);
+    line-height: 1.05;
+    letter-spacing: 0.005em;
+    text-transform: uppercase;
+    margin: 0.5rem 0 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+.quiz-hero-title .quiz-edit {
+    color: var(--text-mute);
+    transition: color 160ms ease;
+}
+@media (hover: hover) {
+    .quiz-hero-title .quiz-edit:hover { color: var(--accent); }
+}
+.quiz-hero-desc {
+    color: var(--text-dim);
+    margin: 0 0 1.25rem;
+    max-width: 58ch;
+}
+.quiz-hero-share {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: ui-monospace, 'JetBrains Mono', Menlo, monospace;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    padding: 0.5rem 0.75rem;
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-sm);
+    max-width: max-content;
+    margin-bottom: 1rem;
+}
+.quiz-hero-share .copy-link {
+    color: var(--cyan);
+    font-family: 'Inter', sans-serif;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-left: 0.5rem;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+}
+.quiz-hero-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+/* —————————————————————————————————————————————————————
+   Questions — cards on mobile, table on desktop
+   ————————————————————————————————————————————————————— */
+
+.q-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.q-row {
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+}
+@media (min-width: 768px) {
+    .q-row {
+        grid-template-columns: 48px 80px 1fr auto auto;
+        align-items: center;
+        padding: 1rem 1.25rem;
+    }
+}
+
+.q-position {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 800;
+    font-size: 2rem;
+    line-height: 1;
+    letter-spacing: 0.02em;
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+    width: 48px;
+    text-align: center;
+    opacity: 0.9;
+}
+.q-thumb {
+    width: 64px;
+    height: 64px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border: 1px solid var(--border-soft);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-mute);
+    font-size: 0.65rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+@media (max-width: 767px) {
+    .q-thumb {
+        grid-column: 1;
+        grid-row: 2;
+        width: 48px;
+        height: 48px;
+    }
+    .q-position {
+        grid-column: 1;
+        grid-row: 1;
+        text-align: left;
+        font-size: 1.75rem;
+    }
+}
+.q-body {
+    grid-column: 2 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 0;
+}
+@media (min-width: 768px) {
+    .q-body {
+        grid-column: 3;
+    }
+}
+.q-text {
+    font-size: 1rem;
+    color: var(--text);
+    line-height: 1.45;
+    margin: 0;
+}
+.q-options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    color: var(--text-dim);
+}
+.q-options li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.q-options li::before {
+    content: "";
+    width: 14px; height: 14px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    flex-shrink: 0;
+}
+.q-options li.correct {
+    color: var(--cyan);
+}
+.q-options li.correct::before {
+    background: var(--cyan);
+    border-color: var(--cyan);
+    box-shadow: inset 0 0 0 3px var(--surface);
+}
+.q-reorder {
+    display: flex;
+    gap: 0.25rem;
+    grid-column: 1 / -1;
+    justify-self: end;
+}
+@media (min-width: 768px) {
+    .q-reorder { grid-column: 4; }
+}
+.q-actions {
+    display: flex;
+    gap: 0.25rem;
+    grid-column: 1 / -1;
+    justify-self: end;
+    border-top: 1px dashed var(--border-soft);
+    padding-top: 0.75rem;
+    margin-top: 0.25rem;
+    width: 100%;
+    justify-content: flex-end;
+}
+@media (min-width: 768px) {
+    .q-actions {
+        grid-column: 5;
+        border-top: 0;
+        padding-top: 0;
+        margin-top: 0;
+        width: auto;
+    }
+}
+
+/* —————————————————————————————————————————————————————
+   Players list
+   ————————————————————————————————————————————————————— */
+
+.player-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+.player-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.9rem 1.25rem;
+    border-bottom: 1px solid var(--border-soft);
+    background: var(--surface);
+}
+.player-row:last-child { border-bottom: 0; }
+.player-row:nth-child(even) { background: var(--surface-2); }
+.player-name {
+    font-size: 0.95rem;
+    color: var(--text);
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.player-name .username-meta {
+    color: var(--text-dim);
+    font-size: 0.75rem;
+    margin-left: 0.5rem;
+    font-weight: 400;
+}
+.player-score {
+    font-variant-numeric: tabular-nums;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text);
+    min-width: 4ch;
+    text-align: right;
+}
+.player-reset {
+    background: transparent;
+    border: 0;
+    color: var(--text-mute);
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 160ms ease;
+    padding: 0.5rem;
+}
+@media (hover: hover) {
+    .player-reset:hover { color: var(--warning); }
+}
+
+/* —————————————————————————————————————————————————————
+   Question form
+   ————————————————————————————————————————————————————— */
+
+.form-shell {
+    max-width: 640px;
+    margin: 0 auto;
+}
+.form-field {
+    margin-bottom: 1.75rem;
+}
+.label {
+    display: block;
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 0.55rem;
+}
+.label-hint {
+    color: var(--text-mute);
+    font-size: 0.78rem;
+    letter-spacing: 0;
+    text-transform: none;
+    font-weight: 400;
+    margin-left: 0.5rem;
+}
+.input, .textarea {
+    width: 100%;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.7rem 0.85rem;
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 160ms ease;
+}
+.input:focus, .textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: var(--shadow-focus);
+}
+.input-readonly {
+    background: var(--surface-2);
+    color: var(--text-dim);
+    border-style: dashed;
+}
+.textarea { min-height: 100px; resize: vertical; }
+
+.dropzone {
+    border: 2px dashed var(--border);
+    border-radius: var(--radius);
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    color: var(--text-dim);
+    transition: border-color 200ms ease, background 200ms ease;
+    background: rgba(21, 21, 28, 0.4);
+}
+.dropzone:hover { border-color: var(--accent); }
+.dropzone-icon {
+    width: 44px; height: 44px;
+    margin: 0 auto 0.75rem;
+    border-radius: 999px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    display: flex; align-items: center; justify-content: center;
+    color: var(--text-dim);
+}
+.dropzone-strong {
+    color: var(--text);
+    font-weight: 500;
+    display: block;
+    margin-bottom: 0.25rem;
+}
+.dropzone-alt {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    color: var(--text-mute);
+    font-size: 0.78rem;
+}
+.dropzone-alt input {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius-sm);
+    font-family: ui-monospace, 'JetBrains Mono', Menlo, monospace;
+    font-size: 0.78rem;
+}
+.dropzone-alt input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: var(--shadow-focus);
+}
+
+.option-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border-soft);
+}
+.option-row:last-child { border-bottom: 0; }
+.option-letter {
+    font-family: 'Orbitron', system-ui, sans-serif;
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--accent);
+    line-height: 1;
+    width: 1.5rem;
+    text-align: center;
+    opacity: 0.75;
+    letter-spacing: 0.04em;
+}
+.option-input {
+    width: 100%;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.6rem 0.8rem;
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 160ms ease;
+}
+.option-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: var(--shadow-focus);
+}
+.option-check {
+    cursor: pointer;
+    user-select: none;
+}
+.option-check input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.option-check-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--text-dim);
+    background: var(--surface);
+    transition: all 160ms ease;
+    min-height: 32px;
+}
+.option-check input:checked ~ .option-check-pill {
+    background: var(--cyan-soft);
+    border-color: var(--cyan);
+    color: var(--cyan);
+}
+.option-check input:focus-visible ~ .option-check-pill {
+    box-shadow: 0 0 0 3px var(--cyan-soft);
+}
+.option-check-pill::before {
+    content: "";
+    width: 8px; height: 8px;
+    border-radius: 999px;
+    border: 1px solid currentColor;
+    transition: background 160ms ease;
+}
+.option-check input:checked ~ .option-check-pill::before {
+    background: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-soft);
+}
+@media (max-width: 768px) {
+    .form-actions {
+        position: sticky;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: linear-gradient(180deg, transparent, var(--bg) 30%);
+        padding: 1rem 1rem 1.25rem;
+        margin: 2.5rem -1rem -6rem;
+        z-index: 5;
+        border-top: 1px solid var(--border-soft);
+    }
+    .form-actions .btn-primary { flex: 1; }
+}
+
+/* —————————————————————————————————————————————————————
+   Stagger reveal on page load — restraint, not flair.
+   ————————————————————————————————————————————————————— */
+
+@keyframes rise {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+.shell > * {
+    opacity: 0;
+    animation: rise 460ms cubic-bezier(0.2, 0.6, 0.2, 1) forwards;
+}
+.shell > *:nth-child(1) { animation-delay: 60ms; }
+.shell > *:nth-child(2) { animation-delay: 120ms; }
+.shell > *:nth-child(3) { animation-delay: 180ms; }
+.shell > *:nth-child(4) { animation-delay: 240ms; }
+.shell > *:nth-child(5) { animation-delay: 300ms; }
+@media (prefers-reduced-motion: reduce) {
+    .shell > * { animation: none; opacity: 1; }
+}


### PR DESCRIPTION
## Summary

Lays the groundwork for the admin redesign tracked in #207 and ships the brand colour migration that came out of the design exploration. Three commits, in order:

- **`0ca03d8`** — Extracts the player client's `:root` design tokens into a shared `internal/client/static/css/tokens.css`. Both surfaces (player + admin) now `<link>` the same file. Adds three mockup pages under `mockups/admin-redesign/` (quiz list, quiz view, question form) so we have a fixed reference for what the rebuilt admin will look like.
- **`79e1305`** — Swaps the brand accent from magenta `#ff2d95` to banana yellow `#ffd23f`. One token change + one hardcoded rgba in `synthwave.css` (the leaderboard's selected-row border). Every other consumer (`.button:focus`, `.notification`, `.claim-cta`, the pencil icon, etc.) cascades for free.
- **`0e9f284`** — Updates the `CLAUDE.md` "Commits" rule to allow Claude to commit after explicit user sign-off, replacing the previous "never commit" stance.

This is phase 1 of the multi-PR redesign plan in #207. Phases 2–5 (layout primitives → page-by-page reskin → mobile refinements → future-feature placeholders) land on follow-up branches once this is merged.

## Test plan

- [x] `make check` — 0 issues, 14 packages PASS
- [x] `make test-e2e` — 16 passed (tests assert on classes/text, not pixel colour, so the swap is transparent)
- [ ] Manual: play through as anonymous player; verify the `.claim-cta`, leaderboard's selected row, pencil icon, primary buttons, focus rings are all yellow; "correct" feedback stays cyan; "wrong" stays red; "Time out!" stays amber
- [x] Manual: open `mockups/admin-redesign/index.html` for the design reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)