### PR TITLE
Gate session and CSRF cookie Secure flag on APP_ENV=production (#205)

### DIFF
--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -266,7 +266,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -310,7 +310,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
 		"password": {"correctbattery"},
@@ -342,7 +342,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 		discardLogger(),
 		nil,
 		store,
-		session.New([]byte("k")),
+		session.New([]byte("k"), true),
 		[]string{"alice", "carol"},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
@@ -367,7 +367,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -394,7 +394,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -421,7 +421,7 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -449,7 +449,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
 
 	// Build a request that already carries the anonymous session cookie.
@@ -506,7 +506,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
 
 	rec := httptest.NewRecorder()
@@ -565,7 +565,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 		t.Fatalf("ClaimPlayer err = %v, want nil", claimErr)
 	}
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil)
 
 	rec := httptest.NewRecorder()
@@ -660,7 +660,7 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -678,7 +678,7 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false)
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"ghost"},
@@ -705,7 +705,7 @@ func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"wrong-password-no"},
@@ -728,7 +728,7 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k")), false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"legacy"},
 		"password": {"anything-goes-here-13"},
@@ -743,7 +743,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"   "},
@@ -766,7 +766,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k")), nil)
+	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil)
 
 	password := strings.Repeat("a", auth.MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{
@@ -785,7 +785,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 func TestHandleLogout_NoCookie(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLogout(session.New([]byte("k")))
+	handler := auth.HandleLogout(session.New([]byte("k"), true))
 
 	// No session cookie attached to the request.
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
@@ -803,7 +803,7 @@ func TestHandleLogout_NoCookie(t *testing.T) {
 func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLogout(session.New([]byte("k")))
+	handler := auth.HandleLogout(session.New([]byte("k"), true))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
 	rec := httptest.NewRecorder()

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -42,7 +42,7 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	})
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
@@ -89,7 +89,7 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 		t.Error("next should not be called for player role")
 	})
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
@@ -120,7 +120,7 @@ func TestRequireAdmin_NoCookie_RedirectsToLogin(t *testing.T) {
 		t.Error("next should not be called without cookie")
 	})
 
-	mw := auth.RequireAdmin(next, store, session.New([]byte("k")), nil, discardLogger())
+	mw := auth.RequireAdmin(next, store, session.New([]byte("k"), true), nil, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -142,7 +142,7 @@ func TestRequireAdmin_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 		t.Error("next should not be called for unknown player")
 	})
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
@@ -173,7 +173,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 		t.Error("next should not be called when store errors")
 	})
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
@@ -194,7 +194,7 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *auth.Player
 	called := false
@@ -249,7 +249,7 @@ func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *auth.Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -282,7 +282,7 @@ func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *auth.Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -319,7 +319,7 @@ func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenIDs []int64
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -350,7 +350,7 @@ func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
 	// ErrUsernameTaken; the fourth attempt should succeed and produce a
 	// regular petname row.
 	store.forceAnonCollisions = 3
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *auth.Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
 	// Force every petname attempt (5) to collide so the fallback xid path
 	// has to run.
 	store.forceAnonCollisions = 5
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *auth.Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -407,7 +407,7 @@ func TestEnsurePlayer_CreateAnonymousNonCollisionError_500(t *testing.T) {
 
 	store := newStubPlayerStore()
 	store.forceAnonErr = errors.New("boom")
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called when CreateAnonymousPlayer returns a non-collision error")
@@ -434,7 +434,7 @@ func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
 	}
 	store.failGet = true
 
-	sessions := session.New([]byte("k"))
+	sessions := session.New([]byte("k"), true)
 
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called on store error")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,10 @@ var ErrSessionKeyNotSetInProduction = errors.New("SESSION_KEY must be set in pro
 const (
 	// AppEnvironmentDefault is the default application environment.
 	AppEnvironmentDefault = "development"
+	// AppEnvironmentProduction is the production environment value. Several
+	// behaviours flip on this (see [Config.SecureCookies] and the DB_URI /
+	// SESSION_KEY validation in [Parse]).
+	AppEnvironmentProduction = "production"
 	// ClientDirDefault specifies the default directory for client-side static files.
 	ClientDirDefault = ""
 
@@ -72,6 +76,17 @@ type Config struct {
 	RegistrationEnabled bool
 }
 
+// SecureCookies reports whether session and CSRF cookies should be issued
+// with the Secure attribute. Returns true only in production. In
+// development the flag is dropped so the dev server is reachable from any
+// LAN hostname over plain HTTP (chip.local, 192.168.x.x, devtunnels, …) —
+// browsers reject Secure cookies on non-HTTPS contexts and the rejection
+// cascades into "forbidden: invalid CSRF token" failures otherwise. See
+// #205.
+func (c *Config) SecureCookies() bool {
+	return c.IsProduction()
+}
+
 // Parse parses environment variables into the config.
 func Parse(getenv func(string) string) (*Config, error) {
 	c := Config{
@@ -109,7 +124,7 @@ func Parse(getenv func(string) string) (*Config, error) {
 	}
 
 	// Mandatory fields
-	if c.AppEnvironment == "production" && getenv("DB_URI") == "" {
+	if c.AppEnvironment == AppEnvironmentProduction && getenv("DB_URI") == "" {
 		return nil, ErrDBURINotSetInProduction
 	}
 
@@ -186,7 +201,7 @@ func resolveSessionKey(envValue, appEnvironment string) (string, error) {
 	if envValue != "" {
 		return envValue, nil
 	}
-	if appEnvironment == "production" {
+	if appEnvironment == AppEnvironmentProduction {
 		return "", ErrSessionKeyNotSetInProduction
 	}
 
@@ -200,5 +215,5 @@ func resolveSessionKey(envValue, appEnvironment string) (string, error) {
 
 // IsProduction returns true if the application is running in production.
 func (c *Config) IsProduction() bool {
-	return c.AppEnvironment == "production"
+	return c.AppEnvironment == AppEnvironmentProduction
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -344,3 +344,31 @@ func TestParse_AdminUsernames(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_SecureCookies(t *testing.T) {
+	t.Parallel()
+	// SecureCookies decides whether session + CSRF cookies get the
+	// Secure attribute. Production must, development must not — see
+	// #205 for why dev drops the flag.
+
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "production", env: "production", want: true},
+		{name: "development", env: "development", want: false},
+		{name: "unset", env: "", want: false},          // empty env never matches production
+		{name: "staging", env: "staging", want: false}, // anything-other-than-production is dev-shaped
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &Config{AppEnvironment: tt.env}
+			if got, want := c.SecureCookies(), tt.want; got != want {
+				t.Errorf("SecureCookies() = %v, want %v (AppEnvironment=%q)", got, want, tt.env)
+			}
+		})
+	}
+}

--- a/internal/csrf/csrf.go
+++ b/internal/csrf/csrf.go
@@ -15,7 +15,10 @@
 // HMAC-SHA256(sessionKey, "csrf-v1") so deployments do not need to manage a
 // second secret, and the two keys cannot be confused with each other.
 //
-// Cookies use Path=/, Secure, SameSite=Lax, and HttpOnly=true. The cookie
+// Cookies use Path=/, SameSite=Lax, and HttpOnly=true. The Secure attribute
+// is controlled per Manager via [New]'s secureCookies argument: production
+// callers pass true; development callers pass false so the dev server is
+// reachable over plain HTTP from any LAN hostname (see #205). The cookie
 // rides along automatically on same-origin form submits regardless of
 // HttpOnly, so making it readable from JavaScript would only add risk
 // without enabling any current flow.
@@ -56,18 +59,22 @@ var ErrInvalidToken = errors.New("csrf: invalid or missing token")
 // Manager issues CSRF nonce cookies and validates tokens submitted with unsafe
 // requests. A single instance is safe for concurrent use.
 type Manager struct {
-	key []byte
+	key           []byte
+	secureCookies bool
 }
 
 // New returns a Manager whose signing key is derived from the given session
 // key using HMAC-SHA256. Passing the same SESSION_KEY produces the same CSRF
 // key so the manager survives process restarts without invalidating tokens.
-func New(sessionKey []byte) *Manager {
+// secureCookies controls the Secure attribute on issued nonce cookies — see
+// Config.SecureCookies in internal/config for the policy and #205 for why
+// it is gated.
+func New(sessionKey []byte, secureCookies bool) *Manager {
 	h := hmac.New(sha256.New, sessionKey)
 	// hash.Hash.Write never returns an error.
 	_, _ = h.Write([]byte(keyDerivationLabel))
 
-	return &Manager{key: h.Sum(nil)}
+	return &Manager{key: h.Sum(nil), secureCookies: secureCookies}
 }
 
 // Token returns a CSRF token for the current request, ensuring a nonce cookie
@@ -85,7 +92,7 @@ func (m *Manager) Token(w http.ResponseWriter, r *http.Request) string {
 	}
 
 	nonce := newNonce()
-	http.SetCookie(w, newCookie(nonce))
+	http.SetCookie(w, m.newCookie(nonce))
 
 	return tokenFromNonce(m.key, nonce)
 }
@@ -178,15 +185,20 @@ func newNonce() string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
-// newCookie returns a fresh CSRF nonce cookie with the safe defaults applied.
-func newCookie(value string) *http.Cookie {
+// newCookie returns a fresh CSRF nonce cookie. HttpOnly and SameSite=Lax
+// are always set; the Secure attribute follows the Manager's
+// secureCookies field — see [New]'s doc comment for the rationale.
+func (m *Manager) newCookie(value string) *http.Cookie {
+	//nolint:gosec // G124: Secure is intentionally policy-driven (production
+	// passes true via cfg.SecureCookies(); dev passes false so plain-HTTP
+	// LAN access works). See #205.
 	return &http.Cookie{
 		Name:     CookieName,
 		Value:    value,
 		Path:     "/",
 		MaxAge:   MaxAge,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   m.secureCookies,
 		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/internal/csrf/csrf_test.go
+++ b/internal/csrf/csrf_test.go
@@ -51,7 +51,7 @@ func nonceCookieFromResponse(rec *httptest.ResponseRecorder) string {
 func TestToken_SetsCookieWhenAbsent(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
@@ -67,10 +67,56 @@ func TestToken_SetsCookieWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestToken_CookieFlags_RespectSecureCookies(t *testing.T) {
+	t.Parallel()
+	// secureCookies=true (production) must set the Secure attribute;
+	// secureCookies=false (development) must drop it so browsers accept
+	// the cookie over plain HTTP from LAN hostnames — see #205. The
+	// HttpOnly + SameSite=Lax flags stay on regardless of mode.
+
+	t.Run("production sets Secure", func(t *testing.T) {
+		t.Parallel()
+		m := csrf.New([]byte("test-key"), true)
+		rec := httptest.NewRecorder()
+		_ = m.Token(rec, newGetRequest(t, "/"))
+
+		c := rec.Result().Cookies()[0]
+		if !c.Secure {
+			t.Error("cookie Secure = false, want true in production")
+		}
+		if !c.HttpOnly {
+			t.Error("cookie HttpOnly = false, want true")
+		}
+		if got, want := c.SameSite, http.SameSiteLaxMode; got != want {
+			t.Errorf("cookie SameSite = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("development drops Secure", func(t *testing.T) {
+		t.Parallel()
+		m := csrf.New([]byte("test-key"), false)
+		rec := httptest.NewRecorder()
+		_ = m.Token(rec, newGetRequest(t, "/"))
+
+		c := rec.Result().Cookies()[0]
+		if c.Secure {
+			t.Error("cookie Secure = true, want false in dev")
+		}
+		// HttpOnly and SameSite must still be set even in dev — only
+		// the Secure attribute is environment-gated.
+		if !c.HttpOnly {
+			t.Error("cookie HttpOnly = false, want true even in dev")
+		}
+		if got, want := c.SameSite, http.SameSiteLaxMode; got != want {
+			t.Errorf("cookie SameSite = %v, want %v even in dev", got, want)
+		}
+	})
+}
+
 func TestToken_ReusesExistingCookie(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	// Issue a nonce first so we have a stable cookie value.
 	rec1 := httptest.NewRecorder()
@@ -100,7 +146,7 @@ func TestToken_ReusesExistingCookie(t *testing.T) {
 func TestToken_DeterministicForSameNonce(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
@@ -117,7 +163,7 @@ func TestToken_DeterministicForSameNonce(t *testing.T) {
 func TestValidate_NoCookie(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 	req := newPostFormRequest(t, url.Values{csrf.FormField: {"anything"}})
 
 	if got, want := m.Validate(req), csrf.ErrInvalidToken; !errors.Is(got, want) {
@@ -128,7 +174,7 @@ func TestValidate_NoCookie(t *testing.T) {
 func TestValidate_NoFormField(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 	req := newPostFormRequest(t, url.Values{})
 	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "some-nonce"})
 
@@ -140,7 +186,7 @@ func TestValidate_NoFormField(t *testing.T) {
 func TestValidate_TamperedToken(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	// Get a valid token.
 	rec := httptest.NewRecorder()
@@ -168,8 +214,8 @@ func TestValidate_TamperedToken(t *testing.T) {
 func TestValidate_DifferentKey(t *testing.T) {
 	t.Parallel()
 
-	managerA := csrf.New([]byte("key-a"))
-	managerB := csrf.New([]byte("key-b"))
+	managerA := csrf.New([]byte("key-a"), true)
+	managerB := csrf.New([]byte("key-b"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
@@ -187,7 +233,7 @@ func TestValidate_DifferentKey(t *testing.T) {
 func TestValidate_ValidToken(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
@@ -205,7 +251,7 @@ func TestValidate_ValidToken(t *testing.T) {
 func TestMiddleware_GET_PassesThrough(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	called := false
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -228,7 +274,7 @@ func TestMiddleware_GET_PassesThrough(t *testing.T) {
 func TestMiddleware_POST_NoToken_403(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	called := false
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -251,7 +297,7 @@ func TestMiddleware_POST_NoToken_403(t *testing.T) {
 func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	// Issue a token first so we know the nonce/token pair is valid.
 	rec := httptest.NewRecorder()
@@ -282,7 +328,7 @@ func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
 func TestMiddleware_UnsafeMethods_AreValidated(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"))
+	m := csrf.New([]byte("test-key"), true)
 
 	tests := []struct {
 		name   string

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -23,8 +23,8 @@ func addRoutes(
 	gameService *game.Service,
 	cfg *config.Config,
 ) {
-	sessions := session.New([]byte(cfg.SessionKey))
-	csrfMgr := csrf.New([]byte(cfg.SessionKey))
+	sessions := session.New([]byte(cfg.SessionKey), cfg.SecureCookies())
+	csrfMgr := csrf.New([]byte(cfg.SessionKey), cfg.SecureCookies())
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
 	addAdminRoutes(mux, logger, stores, gameService, sessions, csrfMgr)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -5,8 +5,10 @@
 //
 //	base64url(playerID|issuedAt) + "." + base64url(hmac_sha256(key, playerID|issuedAt))
 //
-// The cookie is HttpOnly, SameSite=Lax, and Secure. Browsers treat http://localhost as a
-// secure context, so Secure cookies still work in local development without TLS.
+// The cookie is always HttpOnly and SameSite=Lax. The Secure attribute is
+// controlled per Manager via [New]'s secureCookies argument: production
+// callers pass true; development callers pass false so the dev server is
+// reachable over plain HTTP from any LAN hostname (see #205).
 //
 // MaxAge serves double duty: it is both the client-side cookie lifetime and the
 // server-side accept window. A cookie whose issuedAt is older than MaxAge seconds
@@ -47,30 +49,34 @@ const issuedAtBitSize = 64
 // the clock so callers do not have to thread these parameters through every
 // call site, and so tests can fix the clock without touching package-level state.
 type Manager struct {
-	key []byte
-	now func() time.Time
+	key           []byte
+	now           func() time.Time
+	secureCookies bool
 }
 
-// New returns a Manager that signs cookies with the given key.
-func New(key []byte) *Manager {
-	return newWithClock(key, time.Now)
+// New returns a Manager that signs cookies with the given key. secureCookies
+// controls the Secure attribute on issued cookies — see Config.SecureCookies
+// in internal/config for the dev-versus-production policy and #205 for why
+// this is gated.
+func New(key []byte, secureCookies bool) *Manager {
+	return newWithClock(key, secureCookies, time.Now)
 }
 
 // newWithClock returns a Manager with a caller-supplied clock. It exists for
 // internal tests that need to fix time without depending on a package-level
 // variable.
-func newWithClock(key []byte, now func() time.Time) *Manager {
-	return &Manager{key: key, now: now}
+func newWithClock(key []byte, secureCookies bool, now func() time.Time) *Manager {
+	return &Manager{key: key, now: now, secureCookies: secureCookies}
 }
 
 // Set writes a signed session cookie containing the given player ID to w.
 func (m *Manager) Set(w http.ResponseWriter, playerID int64) {
-	http.SetCookie(w, newCookie(encode(playerID, m.now().Unix(), m.key), MaxAge))
+	http.SetCookie(w, m.newCookie(encode(playerID, m.now().Unix(), m.key), MaxAge))
 }
 
 // Clear deletes the session cookie by setting it with an empty value and a negative MaxAge.
-func (*Manager) Clear(w http.ResponseWriter) {
-	http.SetCookie(w, newCookie("", clearedMaxAge))
+func (m *Manager) Clear(w http.ResponseWriter) {
+	http.SetCookie(w, m.newCookie("", clearedMaxAge))
 }
 
 // PlayerID returns the player ID encoded in the request's session cookie.
@@ -86,16 +92,19 @@ func (m *Manager) PlayerID(r *http.Request) (int64, bool) {
 }
 
 // newCookie returns the session cookie with the safe defaults always applied:
-// HttpOnly, SameSite=Lax, and Secure. Browsers treat http://localhost as a
-// secure context, so the Secure flag does not break local development.
-func newCookie(value string, maxAge int) *http.Cookie {
+// HttpOnly and SameSite=Lax. The Secure attribute follows the Manager's
+// secureCookies field — see [New]'s doc comment for the rationale.
+func (m *Manager) newCookie(value string, maxAge int) *http.Cookie {
+	//nolint:gosec // G124: Secure is intentionally policy-driven (production
+	// passes true via cfg.SecureCookies(); dev passes false so plain-HTTP
+	// LAN access works). See #205.
 	return &http.Cookie{
 		Name:     CookieName,
 		Value:    value,
 		Path:     "/",
 		MaxAge:   maxAge,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   m.secureCookies,
 		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -16,13 +16,13 @@ import (
 func newManagerAt(t *testing.T, when time.Time) *session.Manager {
 	t.Helper()
 
-	return session.ExportNewWithClock([]byte("k"), func() time.Time { return when })
+	return session.ExportNewWithClock([]byte("k"), true, func() time.Time { return when })
 }
 
 func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("test-key"))
+	mgr := session.New([]byte("test-key"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 42)
 
@@ -62,10 +62,34 @@ func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestSet_SecureFlag_DroppedInDevelopment(t *testing.T) {
+	t.Parallel()
+	// In dev (secureCookies=false) the Secure attribute is dropped so
+	// browsers accept the cookie over plain HTTP from any LAN hostname
+	// — see #205. The TestSet_AndPlayerID_RoundTrip test above covers
+	// the secureCookies=true path.
+
+	mgr := session.New([]byte("k"), false)
+	rec := httptest.NewRecorder()
+	mgr.Set(rec, 42)
+
+	c := rec.Result().Cookies()[0]
+	if c.Secure {
+		t.Error("cookie Secure = true, want false in dev")
+	}
+	// Other safe defaults must still apply regardless of dev/prod.
+	if !c.HttpOnly {
+		t.Error("cookie HttpOnly = false, want true even in dev")
+	}
+	if got, want := c.SameSite, http.SameSiteLaxMode; got != want {
+		t.Errorf("cookie SameSite = %v, want %v even in dev", got, want)
+	}
+}
+
 func TestPlayerID_MissingCookie(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 
 	_, ok := mgr.PlayerID(req)
@@ -77,7 +101,7 @@ func TestPlayerID_MissingCookie(t *testing.T) {
 func TestPlayerID_TamperedSignature(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -99,7 +123,7 @@ func TestPlayerID_TamperedSignature(t *testing.T) {
 func TestPlayerID_TamperedPayload(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -123,7 +147,7 @@ func TestPlayerID_TamperedPayload(t *testing.T) {
 func TestPlayerID_TamperedTimestamp(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -148,7 +172,7 @@ func TestPlayerID_TamperedTimestamp(t *testing.T) {
 func TestPlayerID_MalformedCookie(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 
 	// base64url("not-an-int|123") and base64url("123|not-an-int") for the parse-error paths.
 	badPlayerID := base64.RawURLEncoding.EncodeToString([]byte("not-an-int|123"))
@@ -177,11 +201,11 @@ func TestPlayerID_MalformedCookie(t *testing.T) {
 func TestPlayerID_DifferentKey(t *testing.T) {
 	t.Parallel()
 
-	signer := session.New([]byte("real-key"))
+	signer := session.New([]byte("real-key"), true)
 	rec := httptest.NewRecorder()
 	signer.Set(rec, 1)
 
-	verifier := session.New([]byte("other-key"))
+	verifier := session.New([]byte("other-key"), true)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.AddCookie(rec.Result().Cookies()[0])
 
@@ -239,7 +263,7 @@ func TestPlayerID_BoundaryAgeIsValid(t *testing.T) {
 func TestClear(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"))
+	mgr := session.New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Clear(rec)
 


### PR DESCRIPTION
## Summary
- Cookies kept the `Secure` attribute unconditionally, which broke local testing from LAN hostnames like `chip.local` over plain HTTP — browsers reject `Secure` cookies on non-HTTPS contexts and the rejection surfaced as `forbidden: invalid CSRF token`.
- `session.Manager` and `csrf.Manager` now take a `secureCookies bool` so the `Secure` attribute is policy-driven rather than hardcoded.
- The policy lives in `Config.SecureCookies()`, a thin wrapper over `IsProduction()`. Production opts in; development, staging, and any other env value drop the flag. `HttpOnly` and `SameSite=Lax` stay on regardless of mode.

Closes #205.

## Test plan
- [x] `make lint-fix` clean
- [x] `make check` green (unit + integration)
- [ ] Manual: access dev server from a LAN hostname (e.g. `chip.local:8080`) and confirm login / quiz creation no longer 403 on CSRF
- [ ] Manual: confirm production deploy still issues `Secure` cookies (DevTools → Application → Cookies)