### PR TITLE
Add make test-one target for running a single test by name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,16 @@ test-integration:
 test-all:
 	go test -v -race -tags=integration ./...
 
+# Run tests matching the given name regex. Pass NAME=TestFoo to filter, or
+# NAME='TestFoo/sub-case' for a sub-test. The integration build tag is set
+# so both unit and integration tests are reachable.
+#
+# Example: make test-one NAME=TestConfig_SecureCookies
+.PHONY: test-one
+test-one:
+	@test -n "$(NAME)" || { echo "Usage: make test-one NAME=TestFoo"; exit 1; }
+	go test -v -race -tags=integration -run '$(NAME)' ./...
+
 .PHONY: test-coverage
 test-coverage:
 	mkdir -p $(COV_DIR)


### PR DESCRIPTION
## Summary
- Adds a `test-one` Make target so a single Go test (or sub-test) can be run by name regex without remembering the full `go test -v -race -tags=integration -run …` incantation.
- Includes the `integration` build tag so both unit and integration tests are reachable through the same target.
- Empty-NAME guard prints a usage line and exits 1, avoiding an accidental "run everything" when the variable is forgotten.

Example: `make test-one NAME=TestConfig_SecureCookies`.

## Test plan
- [x] `make test-one` (no NAME) → prints usage, exits 1
- [x] `make test-one NAME=TestConfig_SecureCookies` → runs only that test + its sub-tests, all pass