### PR TITLE
Reskin admin navbar and quiz list (Bulma variable-first) (#214)

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -313,8 +313,9 @@ func TestHandleQuizList(t *testing.T) {
 		if got, want := body, "Quiz Two"; !strings.Contains(got, want) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
 		}
-		if got, want := body, "Last edited"; !strings.Contains(got, want) {
-			t.Fatalf("body should contain column header %q, got: %q", want, got)
+		// Populated path renders the Bulma card grid (see #207).
+		if got, want := body, `class="card quiz-card"`; !strings.Contains(got, want) {
+			t.Fatalf("body should contain quiz-card markup %q, got: %q", want, got)
 		}
 		// Quiz One: 2 hr ago. Quiz Two: just now.
 		if got, want := body, "2 hr ago"; !strings.Contains(got, want) {
@@ -353,14 +354,14 @@ func TestHandleQuizList(t *testing.T) {
 		}
 
 		body := rr.Body.String()
-		// The count for Quiz One (id=1) should appear inside its row's
-		// linked count cell. Anchor on the href so we don't accidentally
-		// match unrelated digits elsewhere on the page.
-		if got, want := body, `href="/admin/quizzes/1">5</a>`; !strings.Contains(got, want) {
-			t.Errorf("body should contain count cell %q, got %q", want, got)
+		// The count for Quiz One (id=1) renders in the card-footer as
+		// "<strong>5</strong>&nbsp;questions". Anchor on the surrounding
+		// markup so unrelated digits don't accidentally match.
+		if got, want := body, `<strong>5</strong>&nbsp;questions`; !strings.Contains(got, want) {
+			t.Errorf("body should contain count %q, got %q", want, got)
 		}
-		if got, want := body, `href="/admin/quizzes/2">0</a>`; !strings.Contains(got, want) {
-			t.Errorf("body should contain zero-count cell %q (missing key → 0), got %q", want, got)
+		if got, want := body, `<strong>0</strong>&nbsp;questions`; !strings.Contains(got, want) {
+			t.Errorf("body should contain zero count %q (missing key → 0), got %q", want, got)
 		}
 	})
 
@@ -413,7 +414,11 @@ func TestHandleQuizList(t *testing.T) {
 		if got, want := body, "Admin Dashboard - Quiz List"; !strings.Contains(got, want) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
 		}
-		if got, want := body, "No quizzes found."; !strings.Contains(got, want) {
+		// Empty path renders the Bulma .empty.notification panel (see #207).
+		if got, want := body, `class="empty notification`; !strings.Contains(got, want) {
+			t.Fatalf("got: %q, should contain empty-state markup: %q", got, want)
+		}
+		if got, want := body, "No quizzes yet"; !strings.Contains(got, want) {
 			t.Fatalf("got: %q, should contain: %q", got, want)
 		}
 	})
@@ -1202,7 +1207,9 @@ func TestHandleQuestionCreate(t *testing.T) {
 	if got, want := rr.Code, http.StatusOK; got != want {
 		t.Fatalf("got status code %v, want %v, log:\n%v", got, want, buf.String())
 	}
-	if got, want := rr.Body.String(), "List of Quizzes"; !strings.Contains(got, want) {
+	// Sanity check that the navbar brand renders so we know the layout
+	// rendered end-to-end and not just a fragment.
+	if got, want := rr.Body.String(), `class="navbar-item brand"`; !strings.Contains(got, want) {
 		t.Fatalf("got: %v, should contain: %q", got, want)
 	}
 }

--- a/internal/client/static/css/admin.css
+++ b/internal/client/static/css/admin.css
@@ -1,0 +1,390 @@
+/* topbanana admin — Bulma variable-first skin.
+   Customises Bulma v1 by overriding --bulma-* CSS custom properties at
+   :root. Bespoke CSS is reserved for things Bulma doesn't model at all
+   (body vignette, brand wordmark, in-card editorial layout, hover
+   transforms). No !important anywhere — variable overrides cascade
+   through Bulma's compiled rules. See #207. */
+
+/* ─── Our design tokens (referenced by Bulma overrides + custom CSS) ─── */
+:root {
+    --bg: hsl(240, 18%, 5%);
+    --surface: hsl(240, 15%, 9%);
+    --surface-2: hsl(240, 14%, 13%);
+    --border: hsl(240, 11%, 19%);
+    --border-soft: hsl(240, 13%, 14%);
+    --text: hsl(240, 11%, 91%);
+    --text-dim: hsl(240, 5%, 50%);
+    --text-mute: hsl(240, 7%, 31%);
+    --accent: hsl(47, 100%, 62%);
+    --accent-soft: hsla(47, 100%, 62%, 0.14);
+    --accent-line: hsla(47, 100%, 62%, 0.4);
+    --accent-deep: hsl(45, 100%, 48%);
+    --cyan: hsl(190, 100%, 70%);
+    --danger: hsl(0, 100%, 68%);
+}
+
+/* ─── Bulma variable overrides (the heavy lifting) ─────────────────── */
+:root {
+    /* Scheme — flip Bulma to our dark palette. These cascade into card,
+       box, dropdown, notification, etc. backgrounds + text. */
+    --bulma-scheme-main: var(--bg);
+    --bulma-scheme-main-bis: var(--surface);
+    --bulma-scheme-main-ter: var(--surface-2);
+    --bulma-scheme-invert: var(--text);
+    --bulma-scheme-invert-bis: var(--text);
+    --bulma-scheme-invert-ter: var(--text);
+    --bulma-background: var(--surface);
+    --bulma-background-hover: var(--surface-2);
+    --bulma-border: var(--border);
+    --bulma-border-weak: var(--border-soft);
+    --bulma-border-hover: var(--accent-line);
+    --bulma-text: var(--text);
+    --bulma-text-strong: var(--text);
+    --bulma-text-weak: var(--text-dim);
+
+    /* Body — Bulma uses these for the document baseline. */
+    --bulma-body-background-color: var(--bg);
+    --bulma-body-color: var(--text);
+    --bulma-body-family: 'Inter', system-ui, -apple-system, sans-serif;
+    --bulma-body-line-height: 1.55;
+
+    /* Type families. .title takes secondary, body takes primary. */
+    --bulma-family-primary: 'Inter', system-ui, -apple-system, sans-serif;
+    --bulma-family-secondary: 'Orbitron', system-ui, sans-serif;
+    --bulma-family-code: ui-monospace, 'JetBrains Mono', Menlo, monospace;
+
+    /* Radii — synthwave look prefers small/tight corners. */
+    --bulma-radius-small: 4px;
+    --bulma-radius: 4px;
+    --bulma-radius-medium: 6px;
+    --bulma-radius-large: 8px;
+    --bulma-control-radius: 4px;
+    --bulma-control-radius-small: 3px;
+
+    /* Primary → banana yellow. The HSL components feed every
+       derived shade (.is-primary-light, -dark, -soft, etc.). */
+    --bulma-primary-h: 47;
+    --bulma-primary-s: 100%;
+    --bulma-primary-l: 62%;
+
+    /* Danger → tuned red. */
+    --bulma-danger-h: 0;
+    --bulma-danger-s: 100%;
+    --bulma-danger-l: 68%;
+
+    /* Title / subtitle typography. */
+    --bulma-title-color: var(--text);
+    --bulma-title-family: 'Orbitron', system-ui, sans-serif;
+    --bulma-title-weight: 700;
+    --bulma-title-line-height: 1.15;
+    --bulma-subtitle-color: var(--text-dim);
+    --bulma-subtitle-family: 'Inter', system-ui, sans-serif;
+    --bulma-subtitle-weight: 400;
+
+    /* Navbar. Sticky behaviour is set on .navbar directly (Bulma has
+       no variable for position). */
+    --bulma-navbar-background-color: hsla(240, 18%, 5%, 0.86);
+    --bulma-navbar-item-color: var(--text-dim);
+    --bulma-navbar-item-hover-background-color: transparent;
+    --bulma-navbar-item-hover-color: var(--text);
+    --bulma-navbar-item-active-background-color: transparent;
+    --bulma-navbar-item-active-color: var(--text);
+    --bulma-navbar-box-shadow-size: 0;
+    --bulma-navbar-height: 3.5rem;
+    --bulma-navbar-padding-vertical: 0.5rem;
+    --bulma-navbar-padding-horizontal: 1.25rem;
+
+    /* Breadcrumb. */
+    --bulma-breadcrumb-item-color: var(--text-dim);
+    --bulma-breadcrumb-item-hover-color: var(--text);
+    --bulma-breadcrumb-item-active-color: var(--text);
+    --bulma-breadcrumb-item-separator-color: var(--text-mute);
+
+    /* Card. */
+    --bulma-card-background-color: var(--surface);
+    --bulma-card-color: var(--text);
+    --bulma-card-shadow: none;
+    --bulma-card-radius: 8px;
+    --bulma-card-content-background-color: transparent;
+    --bulma-card-content-padding: 1.25rem 1.25rem 0.5rem;
+    --bulma-card-footer-background-color: transparent;
+    --bulma-card-footer-border-top: 1px solid var(--border-soft);
+    --bulma-card-footer-padding: 0.85rem 1.25rem;
+
+    /* Modal. */
+    --bulma-modal-background-background-color: hsla(240, 18%, 5%, 0.78);
+    --bulma-modal-card-head-background-color: transparent;
+    --bulma-modal-card-foot-background-color: transparent;
+    --bulma-modal-card-body-background-color: var(--surface);
+    --bulma-modal-card-title-color: var(--text);
+    --bulma-modal-card-title-size: 0.9rem;
+    --bulma-modal-card-title-line-height: 1.4;
+    --bulma-modal-card-head-padding: 1.25rem 1.5rem;
+    --bulma-modal-card-head-radius: 8px;
+    --bulma-modal-card-foot-radius: 8px;
+    --bulma-modal-card-body-padding: 1.25rem 1.5rem;
+
+    /* Notification (used by our empty state container). Zero out
+       Bulma's colored fill so the empty-state custom rules drive the look. */
+    --bulma-notification-background-l: 0%;
+    --bulma-notification-color-l: 100%;
+    --bulma-notification-radius: 12px;
+    --bulma-notification-padding: 3rem 1.5rem;
+
+    /* Buttons. Ghost gets the icon-button treatment for free. */
+    --bulma-button-family: 'Inter', system-ui, sans-serif;
+    --bulma-button-weight: 600;
+    --bulma-button-padding-horizontal: 1.1em;
+    --bulma-button-padding-vertical: 0.65em;
+    --bulma-button-ghost-color: var(--text-dim);
+    --bulma-button-ghost-hover-color: var(--text);
+    --bulma-button-ghost-background: transparent;
+    --bulma-button-ghost-decoration: none;
+    --bulma-button-ghost-hover-decoration: none;
+    --bulma-button-focus-box-shadow-size: 0 0 0 3px;
+    --bulma-button-disabled-opacity: 0.4;
+
+    /* Control (inputs share these). */
+    --bulma-control-border-width: 1px;
+}
+
+/* ─── Body atmosphere (Bulma has no variable for this) ─────────────── */
+
+html, body {
+    background: var(--bg);
+    color: var(--text);
+}
+
+body {
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: 'cv11', 'ss01', 'tnum';
+    min-height: 100vh;
+    background-color: var(--bg);
+    background-image:
+        radial-gradient(ellipse 80% 600px at 50% -200px, hsla(47, 100%, 62%, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 400px at 50% -100px, hsla(190, 100%, 70%, 0.04), transparent 70%),
+        radial-gradient(circle at 1px 1px, hsla(0, 0%, 100%, 0.025) 1px, transparent 0);
+    background-size: 100% 100%, 100% 100%, 24px 24px;
+    background-repeat: no-repeat, no-repeat, repeat;
+    background-attachment: fixed, fixed, fixed;
+}
+
+/* Bulma .section is opaque by default; let the body atmosphere show through. */
+.section { background: transparent; }
+
+.container.is-max-desktop { max-width: 1080px; }
+
+/* ─── Navbar — bespoke bits Bulma has no variable for ──────────────── */
+
+.navbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-soft);
+}
+
+/* Keep the menu visible on every viewport — our meta is tiny and we
+   don't want Bulma's burger toggle pattern. */
+@media screen and (max-width: 1023px) {
+    .navbar-burger { display: none; }
+    .navbar-menu.is-active {
+        background: transparent;
+        box-shadow: none;
+        padding: 0;
+    }
+    .navbar-menu .navbar-end {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+    }
+}
+
+/* Brand wordmark — synthwave-flavored, no Bulma equivalent. */
+.navbar-item.brand {
+    font-family: var(--bulma-family-secondary);
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    color: var(--text);
+    text-transform: uppercase;
+}
+.navbar-item.brand:focus,
+.navbar-item.brand:hover {
+    background: transparent;
+    color: var(--text);
+}
+.brand-accent { color: var(--accent); font-weight: 800; }
+.brand-icon {
+    width: 22px; height: 22px;
+    margin-right: 0.55rem;
+    color: var(--accent);
+    filter: drop-shadow(0 0 8px hsla(47, 100%, 62%, 0.45));
+    display: inline-flex;
+    flex-shrink: 0;
+}
+.brand-icon svg { width: 100%; height: 100%; display: block; }
+
+.navbar-item.is-meta { font-size: 0.85rem; }
+.navbar-item.is-meta strong { color: var(--text); font-weight: 500; }
+
+/* "Log out" — outlined ghost variant. Lives on .button.is-logout (our
+   custom modifier). */
+.button.is-logout {
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    background: transparent;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    min-height: 36px;
+}
+.button.is-logout:hover {
+    border-color: var(--accent);
+    color: var(--text);
+    background: transparent;
+}
+
+/* ─── Breadcrumb — micro-typography Bulma doesn't variable-ize ─────── */
+.breadcrumb {
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 2rem;
+}
+
+/* ─── Page header (Bulma .level) ───────────────────────────────────── */
+.level.page-header { margin-bottom: 2.5rem; align-items: flex-start; }
+.level.page-header .subtitle {
+    margin-top: 0.35rem;
+    margin-bottom: 0;
+    max-width: 540px;
+}
+@media screen and (max-width: 768px) {
+    .level.page-header { flex-direction: column; align-items: stretch; gap: 1.25rem; }
+    .level.page-header .level-right { justify-content: flex-start; }
+}
+
+/* ─── Title sizes (Bulma's defaults are large for our editorial feel) ─ */
+.title.is-3 { font-size: 2rem; letter-spacing: -0.01em; }
+.title.is-4 { font-size: 1.4rem; letter-spacing: 0.005em; }
+.subtitle.is-6 { font-size: 0.95rem; line-height: 1.6; }
+
+/* ─── Buttons — primary needs uppercase wordmark treatment ─────────── */
+.button.is-primary {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    font-size: 0.78rem;
+    min-height: 44px;
+}
+
+/* Icon-only ghost button: 36px square, no padding. */
+.button.is-small.is-ghost {
+    width: 36px;
+    height: 36px;
+    min-height: 36px;
+    padding: 0;
+    border-radius: var(--bulma-radius-small);
+}
+.button.is-small.is-ghost:hover { background: var(--surface-2); }
+.button.is-small.is-ghost .icon svg { width: 16px; height: 16px; }
+
+/* Delete-variant icon button — turns red on hover. Custom modifier
+   avoids Bulma's .has-text-danger utility (which ships with !important). */
+.button.is-ghost.is-delete { color: var(--danger); }
+.button.is-ghost.is-delete:hover {
+    color: var(--danger);
+    background: hsla(0, 100%, 68%, 0.08);
+}
+
+/* ─── Card hover + top accent bar (no Bulma variable for these) ────── */
+.card.quiz-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-soft);
+    position: relative;
+    overflow: hidden;
+    transition: border-color 200ms ease, transform 200ms ease;
+}
+.card.quiz-card::before {
+    content: '';
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border), transparent);
+    opacity: 0.8;
+}
+@media (hover: hover) {
+    .card.quiz-card:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-1px);
+    }
+    .card.quiz-card:hover::before {
+        background: linear-gradient(90deg, transparent, var(--accent), transparent);
+        opacity: 1;
+    }
+}
+.card-content { flex: 1 1 auto; }
+.card-footer-item { color: var(--text-dim); font-size: 0.85rem; }
+.card-footer-item:first-child { justify-content: flex-start; }
+.card-footer-item:last-child { justify-content: flex-end; }
+
+/* ─── Quiz-card internals (genuinely custom — Bulma has no equivalent) ─ */
+.quiz-card-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+    margin-bottom: 0.75rem;
+}
+.quiz-card-kind { color: var(--text-dim); }
+.quiz-card-when { color: var(--text-mute); }
+.quiz-card-title {
+    font-family: var(--bulma-family-secondary);
+    font-size: 1.1rem;
+    line-height: 1.25;
+    margin: 0 0 0.5rem;
+    color: var(--text);
+    font-weight: 600;
+}
+.quiz-card-title a { color: inherit; }
+.quiz-card-title a:hover { color: var(--accent); }
+.quiz-card-slug {
+    display: inline-block;
+    font-family: var(--bulma-family-code);
+    font-size: 0.72rem;
+    color: var(--cyan);
+    background: hsla(190, 100%, 70%, 0.08);
+    padding: 0.18rem 0.5rem;
+    border-radius: var(--bulma-radius-small);
+    margin-bottom: 0.85rem;
+}
+.quiz-card-desc {
+    color: var(--text-dim);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0 0 1rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.quiz-card-counts strong { color: var(--text); font-weight: 600; margin-right: 0.25rem; }
+.quiz-card-actions { gap: 0.25rem; display: flex; }
+
+/* ─── Empty state — re-skins Bulma's .notification for our framing ──── */
+.empty.notification {
+    background: transparent;
+    border: 1px dashed var(--border);
+    color: var(--text);
+}
+.empty.notification .title { margin-bottom: 0.5rem; }
+.empty.notification .subtitle { margin-bottom: 1.5rem; }

--- a/internal/web/tmpl/admin/layouts/base.gohtml
+++ b/internal/web/tmpl/admin/layouts/base.gohtml
@@ -4,8 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Title}} - Admin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
     <link rel="stylesheet" href="/client/css/tokens.css">
+    <link rel="stylesheet" href="/client/css/admin.css">
     <script src="https://cdn.jsdelivr.net/npm/fontawesome-free@1.0.4/js/all.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fontawesome-free@1.0.4/css/fontawesome.min.css">
 </head>

--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -1,37 +1,18 @@
 {{ define "navbar" }}
-    <nav class="navbar" role="navigation" aria-label="main navigation">
+    <nav class="navbar" role="navigation" aria-label="Primary">
         <div class="navbar-brand">
-
-            <a class="navbar-item" href="/admin">
-                Top Banana!
-            </a>
-
-            <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false"
-               data-target="navbarBasicExample">
-                <span aria-hidden="true"></span>
-                <span aria-hidden="true"></span>
-                <span aria-hidden="true"></span>
-                <span aria-hidden="true"></span>
+            <a class="navbar-item brand" href="/admin">
+                <span class="brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>
+                TOP<span class="brand-accent">BANANA</span>
             </a>
         </div>
-
-        <div class="navbar-menu">
-            <div class="navbar-start">
-                <a class="navbar-item" href="/admin/quizzes">
-                    List of Quizzes
-                </a>
-            </div>
-
+        <div class="navbar-menu is-active">
             <div class="navbar-end">
-                <div class="navbar-item">
-                    Signed in as&nbsp;<strong>{{currentUser}}</strong>
-                </div>
+                <div class="navbar-item is-meta">Signed in as&nbsp;<strong>{{currentUser}}</strong></div>
                 <div class="navbar-item">
                     <form action="/logout" method="POST">
                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-                        <button type="submit" class="button is-light">
-                            Log out
-                        </button>
+                        <button type="submit" class="button is-small is-logout">Log out</button>
                     </form>
                 </div>
             </div>

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -1,82 +1,92 @@
 {{define "content"}}
-    <div class="quiz-list">
-        <h1 class="title is-1">{{.Title}}</h1>
+    <div class="container is-max-desktop">
+            <nav class="breadcrumb" aria-label="breadcrumbs">
+                <ul>
+                    <li><a href="/admin">Admin</a></li>
+                    <li class="is-active"><a href="#" aria-current="page">Quizzes</a></li>
+                </ul>
+            </nav>
 
-        <a href="/admin/quizzes/new">
-            <span class="icon-text">
-                <span class="icon"><i class="fas fa-plus"></i></span>
-                <span>Create New Quiz</span>
-            </span>
-        </a>
-
-        {{if .Quizzes}}
-            <table class="table">
-                <thead>
-                <tr>
-                    <th>ID</th>
-                    <th>Title</th>
-                    <th>Slug</th>
-                    <th>Description</th>
-                    <th>Last edited</th>
-                    <th>Questions</th>
-                    <th>Actions</th>
-                </tr>
-                </thead>
-                <tbody>
-                {{range .Quizzes}}
-                    <tr>
-                        <td>{{.ID}}</td>
-                        <td><a href="/admin/quizzes/{{.ID}}">{{.Title}}</a></td>
-                        <td>{{.Slug}}</td>
-                        <td>{{.Description}}</td>
-                        <td title="{{.UpdatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .UpdatedAt}}</td>
-                        <td><a href="/admin/quizzes/{{.ID}}">{{.QuestionCount}}</a></td>
-                        <td>
-                            <a href="/admin/quizzes/{{.ID}}/edit">
-                                <span class="icon-text">
-                                    <span class="icon"><i class="fas fa-pen"></i></span>
-                                    <span>Edit quiz</span>
-                                </span>
-                            </a>
-                            &nbsp;
-                            <a href="#" onclick="openModal('modal-delete-quiz-{{.ID}}'); return false;">
-                                <span class="icon-text has-text-danger">
-                                    <span class="icon"><i class="fas fa-trash"></i></span>
-                                    <span>Delete quiz</span>
-                                </span>
-                            </a>
-                        </td>
-                    </tr>
-                {{end}}
-                </tbody>
-            </table>
-
-            {{range .Quizzes}}
-                <div class="modal" id="modal-delete-quiz-{{.ID}}">
-                    <div class="modal-background" onclick="closeModal('modal-delete-quiz-{{.ID}}')"></div>
-                    <div class="modal-card">
-                        <header class="modal-card-head">
-                            <p class="modal-card-title">Delete Quiz</p>
-                            <button class="delete" aria-label="close" onclick="closeModal('modal-delete-quiz-{{.ID}}')"></button>
-                        </header>
-                        <section class="modal-card-body">
-                            Are you sure you want to delete quiz <strong>&#34;{{.Title}}&#34;</strong>? This will also delete all its questions and options. This action cannot be undone.
-                        </section>
-                        <footer class="modal-card-foot">
-                            <div class="buttons">
-                                <form method="post" action="/admin/quizzes/{{.ID}}/delete">
-                                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-                                    <button class="button is-danger" type="submit">Delete</button>
-                                </form>
-                                <button class="button" onclick="closeModal('modal-delete-quiz-{{.ID}}')">Cancel</button>
-                            </div>
-                        </footer>
+            <div class="level page-header">
+                <div class="level-left">
+                    <div>
+                        <h1 class="title is-3">Quizzes</h1>
+                        <p class="subtitle is-6">Author, share, and review quizzes. Tap a card to manage questions.</p>
                     </div>
                 </div>
+                <div class="level-right">
+                    <a class="button is-primary" href="/admin/quizzes/new">
+                        <span class="icon is-small">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.5.5 0 0 1 .5.5v5.5H14a.5.5 0 0 1 0 1H8.5V14a.5.5 0 0 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 .5-.5z"/></svg>
+                        </span>
+                        <span>New quiz</span>
+                    </a>
+                </div>
+            </div>
+
+            {{if .Quizzes}}
+                <div class="columns is-multiline">
+                    {{range .Quizzes}}
+                        <div class="column is-half-tablet is-one-third-desktop">
+                            <article class="card quiz-card">
+                                <div class="card-content">
+                                    <div class="quiz-card-meta">
+                                        <span class="quiz-card-kind">Quiz</span>
+                                        <time class="quiz-card-when" title="{{.UpdatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .UpdatedAt}}</time>
+                                    </div>
+                                    <h3 class="quiz-card-title"><a href="/admin/quizzes/{{.ID}}">{{.Title}}</a></h3>
+                                    <code class="quiz-card-slug">/play/{{.Slug}}</code>
+                                    <p class="quiz-card-desc">{{.Description}}</p>
+                                </div>
+                                <footer class="card-footer">
+                                    <span class="card-footer-item quiz-card-counts"><strong>{{.QuestionCount}}</strong>&nbsp;questions</span>
+                                    <span class="card-footer-item quiz-card-actions">
+                                        <a class="button is-small is-ghost" href="/admin/quizzes/{{.ID}}" aria-label="View" title="View">
+                                            <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg></span>
+                                        </a>
+                                        <a class="button is-small is-ghost" href="/admin/quizzes/{{.ID}}/edit" aria-label="Edit" title="Edit">
+                                            <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg></span>
+                                        </a>
+                                        <button type="button" class="button is-small is-ghost is-delete" onclick="openModal('modal-delete-quiz-{{.ID}}')" aria-label="Delete" title="Delete">
+                                            <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg></span>
+                                        </button>
+                                    </span>
+                                </footer>
+                            </article>
+                        </div>
+                    {{end}}
+                </div>
+
+                {{range .Quizzes}}
+                    <div class="modal" id="modal-delete-quiz-{{.ID}}">
+                        <div class="modal-background" onclick="closeModal('modal-delete-quiz-{{.ID}}')"></div>
+                        <div class="modal-card">
+                            <header class="modal-card-head">
+                                <p class="modal-card-title">Delete quiz</p>
+                                <button class="delete" aria-label="close" onclick="closeModal('modal-delete-quiz-{{.ID}}')"></button>
+                            </header>
+                            <section class="modal-card-body">
+                                Are you sure you want to delete quiz <strong>&#34;{{.Title}}&#34;</strong>? This will also delete all its questions and options. This action cannot be undone.
+                            </section>
+                            <footer class="modal-card-foot">
+                                <form method="post" action="/admin/quizzes/{{.ID}}/delete">
+                                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                                    <div class="buttons is-justify-content-flex-end">
+                                        <button type="button" class="button" onclick="closeModal('modal-delete-quiz-{{.ID}}')">Cancel</button>
+                                        <button type="submit" class="button is-danger">Delete</button>
+                                    </div>
+                                </form>
+                            </footer>
+                        </div>
+                    </div>
+                {{end}}
+            {{else}}
+                <div class="empty notification has-text-centered">
+                    <h2 class="title is-4">No quizzes yet</h2>
+                    <p class="subtitle is-6">Create your first quiz to get going. You can add questions, share a link, and watch the leaderboard fill in.</p>
+                    <a class="button is-primary" href="/admin/quizzes/new">Create your first quiz</a>
+                </div>
             {{end}}
-        {{else}}
-            <p>No quizzes found. <a href="/admin/quizzes/new">Create one now!</a></p>
-        {{end}}
     </div>
 
     <script>

--- a/mockups/admin-redesign-bulma-vars/quiz-list.html
+++ b/mockups/admin-redesign-bulma-vars/quiz-list.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quizzes — top banana admin (Bulma variable-first skin)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav class="navbar" role="navigation" aria-label="Primary">
+        <div class="navbar-brand">
+            <a class="navbar-item brand" href="index.html">
+                <span class="brand-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg></span>
+                TOP<span class="brand-accent">BANANA</span>
+            </a>
+        </div>
+        <div class="navbar-menu is-active">
+            <div class="navbar-end">
+                <div class="navbar-item is-meta">Signed in as&nbsp;<strong>alice</strong></div>
+                <div class="navbar-item">
+                    <a class="button is-small is-logout" href="#" aria-label="Log out">Log out</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="section">
+        <div class="container is-max-desktop">
+            <nav class="breadcrumb" aria-label="breadcrumbs">
+                <ul>
+                    <li><a href="index.html">Admin</a></li>
+                    <li class="is-active"><a href="#" aria-current="page">Quizzes</a></li>
+                </ul>
+            </nav>
+
+            <div class="level page-header">
+                <div class="level-left">
+                    <div>
+                        <h1 class="title is-3">Quizzes</h1>
+                        <p class="subtitle is-6">Author, share, and review quizzes. Tap a card to manage questions.</p>
+                    </div>
+                </div>
+                <div class="level-right">
+                    <a class="button is-primary" href="#">
+                        <span class="icon is-small">
+                            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.5.5 0 0 1 .5.5v5.5H14a.5.5 0 0 1 0 1H8.5V14a.5.5 0 0 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 .5-.5z"/></svg>
+                        </span>
+                        <span>New quiz</span>
+                    </a>
+                </div>
+            </div>
+
+            <div class="columns is-multiline">
+                <div class="column is-half-tablet is-one-third-desktop">
+                    <article class="card quiz-card">
+                        <div class="card-content">
+                            <div class="quiz-card-meta">
+                                <span class="quiz-card-kind">Quiz · 12 plays</span>
+                                <time class="quiz-card-when">3 hr ago</time>
+                            </div>
+                            <h3 class="quiz-card-title"><a href="#">Capital Cities of Europe</a></h3>
+                            <code class="quiz-card-slug">/play/capital-cities-of-europe-7</code>
+                            <p class="quiz-card-desc">A geography refresher. Twelve quick-fire questions covering EU capitals, with one curveball about a country that joined in 2007.</p>
+                        </div>
+                        <footer class="card-footer">
+                            <span class="card-footer-item quiz-card-counts"><strong>12</strong>&nbsp;questions</span>
+                            <span class="card-footer-item quiz-card-actions">
+                                <a class="button is-small is-ghost" aria-label="View" title="View">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg></span>
+                                </a>
+                                <a class="button is-small is-ghost" aria-label="Edit" title="Edit">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg></span>
+                                </a>
+                                <button class="button is-small is-ghost is-delete" aria-label="Delete" title="Delete">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg></span>
+                                </button>
+                            </span>
+                        </footer>
+                    </article>
+                </div>
+
+                <div class="column is-half-tablet is-one-third-desktop">
+                    <article class="card quiz-card">
+                        <div class="card-content">
+                            <div class="quiz-card-meta">
+                                <span class="quiz-card-kind">Quiz · 47 plays</span>
+                                <time class="quiz-card-when">2 days ago</time>
+                            </div>
+                            <h3 class="quiz-card-title"><a href="#">Films of the 90s</a></h3>
+                            <code class="quiz-card-slug">/play/films-of-the-90s-3</code>
+                            <p class="quiz-card-desc">Working titles, taglines, and one director identification round. Built for the office quiz night — light on trivia, heavy on visuals.</p>
+                        </div>
+                        <footer class="card-footer">
+                            <span class="card-footer-item quiz-card-counts"><strong>8</strong>&nbsp;questions</span>
+                            <span class="card-footer-item quiz-card-actions">
+                                <a class="button is-small is-ghost" aria-label="View" title="View">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg></span>
+                                </a>
+                                <a class="button is-small is-ghost" aria-label="Edit" title="Edit">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg></span>
+                                </a>
+                                <button class="button is-small is-ghost is-delete" aria-label="Delete" title="Delete">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg></span>
+                                </button>
+                            </span>
+                        </footer>
+                    </article>
+                </div>
+
+                <div class="column is-half-tablet is-one-third-desktop">
+                    <article class="card quiz-card">
+                        <div class="card-content">
+                            <div class="quiz-card-meta">
+                                <span class="quiz-card-kind">Quiz · 0 plays</span>
+                                <time class="quiz-card-when">Just now</time>
+                            </div>
+                            <h3 class="quiz-card-title"><a href="#">Pub Quiz: Half&nbsp;1</a></h3>
+                            <code class="quiz-card-slug">/play/pub-quiz-half-1-12</code>
+                            <p class="quiz-card-desc">Draft. Geography, music from 1965–1985, two picture rounds. Aiming for fifteen questions before Thursday.</p>
+                        </div>
+                        <footer class="card-footer">
+                            <span class="card-footer-item quiz-card-counts"><strong>3</strong>&nbsp;questions</span>
+                            <span class="card-footer-item quiz-card-actions">
+                                <a class="button is-small is-ghost" aria-label="View" title="View">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.13 13.13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.13 13.13 0 0 1 14.828 8a13.13 13.13 0 0 1-1.66 2.043C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.13 13.13 0 0 1 1.172 8z"/><path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z"/></svg></span>
+                                </a>
+                                <a class="button is-small is-ghost" aria-label="Edit" title="Edit">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg></span>
+                                </a>
+                                <button class="button is-small is-ghost is-delete" aria-label="Delete" title="Delete">
+                                    <span class="icon"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg></span>
+                                </button>
+                            </span>
+                        </footer>
+                    </article>
+                </div>
+            </div>
+
+            <section class="empty-preview">
+                <p class="eyebrow">Empty state · preview</p>
+                <div class="empty notification has-text-centered">
+                    <h2 class="title is-4">No quizzes yet</h2>
+                    <p class="subtitle is-6">Create your first quiz to get going. You can add questions, share a link, and watch the leaderboard fill in.</p>
+                    <a class="button is-primary" href="#">Create your first quiz</a>
+                </div>
+            </section>
+
+            <section class="modal-preview">
+                <p class="eyebrow">Delete modal · preview</p>
+                <div class="modal is-active is-static-preview" aria-label="Delete confirmation preview">
+                    <div class="modal-background"></div>
+                    <div class="modal-card">
+                        <header class="modal-card-head">
+                            <p class="modal-card-title">Delete quiz</p>
+                            <button class="delete" aria-label="close"></button>
+                        </header>
+                        <section class="modal-card-body">
+                            Are you sure you want to delete quiz <strong>&ldquo;Capital Cities of Europe&rdquo;</strong>? This will also delete all its questions and options. This action cannot be undone.
+                        </section>
+                        <footer class="modal-card-foot">
+                            <div class="buttons is-justify-content-flex-end">
+                                <button class="button">Cancel</button>
+                                <button class="button is-danger">Delete</button>
+                            </div>
+                        </footer>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </section>
+</body>
+</html>

--- a/mockups/admin-redesign-bulma-vars/styles.css
+++ b/mockups/admin-redesign-bulma-vars/styles.css
@@ -1,0 +1,422 @@
+/* topbanana admin — redesign mockup, Bulma variable-first variant.
+   Visual goal identical to ../admin-redesign/ and ../admin-redesign-bulma/.
+   The technique here is the v1-blessed customisation path: override
+   Bulma's CSS custom properties at :root and let the cascade do the work.
+   No `!important`. Component-level overrides only where Bulma exposes
+   no variable for the value we need. Bespoke CSS reserved for things
+   Bulma doesn't model at all (vignette, brand wordmark, in-card
+   editorial layout). */
+
+/* ─── Our design tokens (referenced by Bulma overrides + custom CSS) ── */
+:root {
+    --bg: hsl(240, 18%, 5%);
+    --surface: hsl(240, 15%, 9%);
+    --surface-2: hsl(240, 14%, 13%);
+    --border: hsl(240, 11%, 19%);
+    --border-soft: hsl(240, 13%, 14%);
+    --text: hsl(240, 11%, 91%);
+    --text-dim: hsl(240, 5%, 50%);
+    --text-mute: hsl(240, 7%, 31%);
+    --accent: hsl(47, 100%, 62%);
+    --accent-soft: hsla(47, 100%, 62%, 0.14);
+    --accent-line: hsla(47, 100%, 62%, 0.4);
+    --accent-deep: hsl(45, 100%, 48%);
+    --cyan: hsl(190, 100%, 70%);
+    --danger: hsl(0, 100%, 68%);
+}
+
+/* ─── Bulma variable overrides (the heavy lifting) ─────────────────── */
+:root {
+    /* Scheme — flip Bulma to our dark palette. These cascade into card,
+       box, dropdown, notification, etc. backgrounds + text. */
+    --bulma-scheme-main: var(--bg);
+    --bulma-scheme-main-bis: var(--surface);
+    --bulma-scheme-main-ter: var(--surface-2);
+    --bulma-scheme-invert: var(--text);
+    --bulma-scheme-invert-bis: var(--text);
+    --bulma-scheme-invert-ter: var(--text);
+    --bulma-background: var(--surface);
+    --bulma-background-hover: var(--surface-2);
+    --bulma-border: var(--border);
+    --bulma-border-weak: var(--border-soft);
+    --bulma-border-hover: var(--accent-line);
+    --bulma-text: var(--text);
+    --bulma-text-strong: var(--text);
+    --bulma-text-weak: var(--text-dim);
+
+    /* Body — Bulma uses these for the document baseline. */
+    --bulma-body-background-color: var(--bg);
+    --bulma-body-color: var(--text);
+    --bulma-body-family: 'Inter', system-ui, -apple-system, sans-serif;
+    --bulma-body-line-height: 1.55;
+
+    /* Type families. .title takes secondary, body takes primary. */
+    --bulma-family-primary: 'Inter', system-ui, -apple-system, sans-serif;
+    --bulma-family-secondary: 'Orbitron', system-ui, sans-serif;
+    --bulma-family-code: ui-monospace, 'JetBrains Mono', Menlo, monospace;
+
+    /* Radii — synthwave look prefers small/tight corners. */
+    --bulma-radius-small: 4px;
+    --bulma-radius: 4px;
+    --bulma-radius-medium: 6px;
+    --bulma-radius-large: 8px;
+    --bulma-control-radius: 4px;
+    --bulma-control-radius-small: 3px;
+
+    /* Primary → banana yellow. The HSL components feed every
+       derived shade (.is-primary-light, -dark, -soft, etc.). */
+    --bulma-primary-h: 47;
+    --bulma-primary-s: 100%;
+    --bulma-primary-l: 62%;
+
+    /* Danger → tuned red. */
+    --bulma-danger-h: 0;
+    --bulma-danger-s: 100%;
+    --bulma-danger-l: 68%;
+
+    /* Title / subtitle typography. */
+    --bulma-title-color: var(--text);
+    --bulma-title-family: 'Orbitron', system-ui, sans-serif;
+    --bulma-title-weight: 700;
+    --bulma-title-line-height: 1.15;
+    --bulma-subtitle-color: var(--text-dim);
+    --bulma-subtitle-family: 'Inter', system-ui, sans-serif;
+    --bulma-subtitle-weight: 400;
+
+    /* Navbar. Sticky behaviour is set on .navbar directly (Bulma has
+       no variable for position). */
+    --bulma-navbar-background-color: hsla(240, 18%, 5%, 0.86);
+    --bulma-navbar-item-color: var(--text-dim);
+    --bulma-navbar-item-hover-background-color: transparent;
+    --bulma-navbar-item-hover-color: var(--text);
+    --bulma-navbar-item-active-background-color: transparent;
+    --bulma-navbar-item-active-color: var(--text);
+    --bulma-navbar-box-shadow-size: 0;
+    --bulma-navbar-height: 3.5rem;
+    --bulma-navbar-padding-vertical: 0.5rem;
+    --bulma-navbar-padding-horizontal: 1.25rem;
+
+    /* Breadcrumb. */
+    --bulma-breadcrumb-item-color: var(--text-dim);
+    --bulma-breadcrumb-item-hover-color: var(--text);
+    --bulma-breadcrumb-item-active-color: var(--text);
+    --bulma-breadcrumb-item-separator-color: var(--text-mute);
+
+    /* Card. */
+    --bulma-card-background-color: var(--surface);
+    --bulma-card-color: var(--text);
+    --bulma-card-shadow: none;
+    --bulma-card-radius: 8px;
+    --bulma-card-content-background-color: transparent;
+    --bulma-card-content-padding: 1.25rem 1.25rem 0.5rem;
+    --bulma-card-footer-background-color: transparent;
+    --bulma-card-footer-border-top: 1px solid var(--border-soft);
+    --bulma-card-footer-padding: 0.85rem 1.25rem;
+
+    /* Modal. */
+    --bulma-modal-background-background-color: hsla(240, 18%, 5%, 0.78);
+    --bulma-modal-card-head-background-color: transparent;
+    --bulma-modal-card-foot-background-color: transparent;
+    --bulma-modal-card-body-background-color: var(--surface);
+    --bulma-modal-card-title-color: var(--text);
+    --bulma-modal-card-title-size: 0.9rem;
+    --bulma-modal-card-title-line-height: 1.4;
+    --bulma-modal-card-head-padding: 1.25rem 1.5rem;
+    --bulma-modal-card-head-radius: 8px;
+    --bulma-modal-card-foot-radius: 8px;
+    --bulma-modal-card-body-padding: 1.25rem 1.5rem;
+
+    /* Notification (used by our empty state container). We zero out
+       Bulma's colored fill so the empty-state custom rules drive the look. */
+    --bulma-notification-background-l: 0%;
+    --bulma-notification-color-l: 100%;
+    --bulma-notification-radius: 12px;
+    --bulma-notification-padding: 3rem 1.5rem;
+
+    /* Buttons. Ghost gets the icon-button treatment for free. */
+    --bulma-button-family: 'Inter', system-ui, sans-serif;
+    --bulma-button-weight: 600;
+    --bulma-button-padding-horizontal: 1.1em;
+    --bulma-button-padding-vertical: 0.65em;
+    --bulma-button-ghost-color: var(--text-dim);
+    --bulma-button-ghost-hover-color: var(--text);
+    --bulma-button-ghost-background: transparent;
+    --bulma-button-ghost-decoration: none;
+    --bulma-button-ghost-hover-decoration: none;
+    --bulma-button-focus-box-shadow-size: 0 0 0 3px;
+    --bulma-button-disabled-opacity: 0.4;
+
+    /* Control (inputs share these). */
+    --bulma-control-border-width: 1px;
+}
+
+/* ─── Body atmosphere (Bulma has no variable for this) ─────────────── */
+
+html, body {
+    background: var(--bg);
+    color: var(--text);
+}
+
+body {
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: 'cv11', 'ss01', 'tnum';
+    min-height: 100vh;
+    background-color: var(--bg);
+    background-image:
+        radial-gradient(ellipse 80% 600px at 50% -200px, hsla(47, 100%, 62%, 0.10), transparent 60%),
+        radial-gradient(ellipse 60% 400px at 50% -100px, hsla(190, 100%, 70%, 0.04), transparent 70%),
+        radial-gradient(circle at 1px 1px, hsla(0, 0%, 100%, 0.025) 1px, transparent 0);
+    background-size: 100% 100%, 100% 100%, 24px 24px;
+    background-repeat: no-repeat, no-repeat, repeat;
+    background-attachment: fixed, fixed, fixed;
+}
+
+/* Bulma .section is opaque by default; let the body atmosphere show through. */
+.section { background: transparent; }
+
+.container.is-max-desktop { max-width: 1080px; }
+
+/* ─── Navbar — bespoke bits Bulma has no variable for ──────────────── */
+
+.navbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-soft);
+}
+
+/* Keep the menu visible on every viewport — our meta is tiny and we
+   don't want Bulma's burger toggle pattern. */
+@media screen and (max-width: 1023px) {
+    .navbar-burger { display: none; }
+    .navbar-menu.is-active {
+        background: transparent;
+        box-shadow: none;
+        padding: 0;
+    }
+    .navbar-menu .navbar-end {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+    }
+}
+
+/* Brand wordmark — synthwave-flavored, no Bulma equivalent. */
+.navbar-item.brand {
+    font-family: var(--bulma-family-secondary);
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    color: var(--text);
+    text-transform: uppercase;
+}
+.navbar-item.brand:focus,
+.navbar-item.brand:hover {
+    background: transparent;
+    color: var(--text);
+}
+.brand-accent { color: var(--accent); font-weight: 800; }
+.brand-icon {
+    width: 22px; height: 22px;
+    margin-right: 0.55rem;
+    color: var(--accent);
+    filter: drop-shadow(0 0 8px hsla(47, 100%, 62%, 0.45));
+    display: inline-flex;
+    flex-shrink: 0;
+}
+.brand-icon svg { width: 100%; height: 100%; display: block; }
+
+.navbar-item.is-meta { font-size: 0.85rem; }
+.navbar-item.is-meta strong { color: var(--text); font-weight: 500; }
+
+/* "Log out" — outlined ghost variant. Lives on .button.is-logout (our
+   custom modifier). */
+.button.is-logout {
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    background: transparent;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    min-height: 36px;
+}
+.button.is-logout:hover {
+    border-color: var(--accent);
+    color: var(--text);
+    background: transparent;
+}
+
+/* ─── Breadcrumb — micro-typography Bulma doesn't variable-ize ─────── */
+.breadcrumb {
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 2rem;
+}
+
+/* ─── Page header (Bulma .level) ───────────────────────────────────── */
+.level.page-header { margin-bottom: 2.5rem; align-items: flex-start; }
+.level.page-header .subtitle {
+    margin-top: 0.35rem;
+    margin-bottom: 0;
+    max-width: 540px;
+}
+@media screen and (max-width: 768px) {
+    .level.page-header { flex-direction: column; align-items: stretch; gap: 1.25rem; }
+    .level.page-header .level-right { justify-content: flex-start; }
+}
+
+/* ─── Title sizes (Bulma's defaults are large for our editorial feel) ─ */
+.title.is-3 { font-size: 2rem; letter-spacing: -0.01em; }
+.title.is-4 { font-size: 1.4rem; letter-spacing: 0.005em; }
+.subtitle.is-6 { font-size: 0.95rem; line-height: 1.6; }
+
+/* ─── Buttons — primary needs uppercase wordmark treatment ─────────── */
+.button.is-primary {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    font-size: 0.78rem;
+    min-height: 44px;
+}
+
+/* Icon-only ghost button: 36px square, no padding. */
+.button.is-small.is-ghost {
+    width: 36px;
+    height: 36px;
+    min-height: 36px;
+    padding: 0;
+    border-radius: var(--bulma-radius-small);
+}
+.button.is-small.is-ghost:hover { background: var(--surface-2); }
+.button.is-small.is-ghost .icon svg { width: 16px; height: 16px; }
+
+/* Delete-variant icon button — turns red on hover. Custom modifier
+   avoids Bulma's .has-text-danger utility (which ships with !important). */
+.button.is-ghost.is-delete { color: var(--danger); }
+.button.is-ghost.is-delete:hover {
+    color: var(--danger);
+    background: hsla(0, 100%, 68%, 0.08);
+}
+
+/* ─── Card hover + top accent bar (no Bulma variable for these) ────── */
+.card.quiz-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-soft);
+    position: relative;
+    overflow: hidden;
+    transition: border-color 200ms ease, transform 200ms ease;
+}
+.card.quiz-card::before {
+    content: '';
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border), transparent);
+    opacity: 0.8;
+}
+@media (hover: hover) {
+    .card.quiz-card:hover {
+        border-color: var(--accent-line);
+        transform: translateY(-1px);
+    }
+    .card.quiz-card:hover::before {
+        background: linear-gradient(90deg, transparent, var(--accent), transparent);
+        opacity: 1;
+    }
+}
+.card-content { flex: 1 1 auto; }
+.card-footer-item { color: var(--text-dim); font-size: 0.85rem; }
+.card-footer-item:first-child { justify-content: flex-start; }
+.card-footer-item:last-child { justify-content: flex-end; }
+
+/* ─── Quiz-card internals (genuinely custom — Bulma has no equivalent) ─ */
+.quiz-card-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+    margin-bottom: 0.75rem;
+}
+.quiz-card-kind { color: var(--text-dim); }
+.quiz-card-when { color: var(--text-mute); }
+.quiz-card-title {
+    font-family: var(--bulma-family-secondary);
+    font-size: 1.1rem;
+    line-height: 1.25;
+    margin: 0 0 0.5rem;
+    color: var(--text);
+    font-weight: 600;
+}
+.quiz-card-title a { color: inherit; }
+.quiz-card-title a:hover { color: var(--accent); }
+.quiz-card-slug {
+    display: inline-block;
+    font-family: var(--bulma-family-code);
+    font-size: 0.72rem;
+    color: var(--cyan);
+    background: hsla(190, 100%, 70%, 0.08);
+    padding: 0.18rem 0.5rem;
+    border-radius: var(--bulma-radius-small);
+    margin-bottom: 0.85rem;
+}
+.quiz-card-desc {
+    color: var(--text-dim);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0 0 1rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.quiz-card-counts strong { color: var(--text); font-weight: 600; margin-right: 0.25rem; }
+.quiz-card-actions { gap: 0.25rem; display: flex; }
+
+/* ─── Empty state — re-skins Bulma's .notification for our framing ──── */
+.empty.notification {
+    background: transparent;
+    border: 1px dashed var(--border);
+    color: var(--text);
+}
+.empty.notification .title { margin-bottom: 0.5rem; }
+.empty.notification .subtitle { margin-bottom: 1.5rem; }
+
+/* ─── Mockup-only helpers ─────────────────────────────────────────── */
+
+.eyebrow {
+    margin: 4rem 0 1rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-mute);
+}
+
+/* Static-preview modal: keeps it open inline (no JS) so the reviewer
+   can see it in context. */
+.modal.is-static-preview {
+    position: relative;
+    display: block;
+    height: auto;
+    width: 100%;
+    z-index: auto;
+}
+.modal.is-static-preview .modal-background {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+}
+.modal.is-static-preview .modal-card {
+    position: relative;
+    margin: 1.5rem auto;
+    z-index: 1;
+}

--- a/test/e2e/tests/admin.spec.ts
+++ b/test/e2e/tests/admin.spec.ts
@@ -20,22 +20,22 @@ test('register, create a quiz with varied questions, and see them on the quiz vi
     await expect(row.locator('.has-text-success')).toHaveCount(q.correctIndices.length);
   }
 
-  // The new quiz title should appear in the admin quiz list. Match by cell
-  // (rather than by row position) so the assertion is stable across runs that
-  // share a long-lived SQLite file.
+  // The new quiz title should appear in the admin quiz list. The redesigned
+  // list (#207) renders each quiz as a card whose title is a link, so match
+  // the link by name rather than a table cell.
   await page.goto('/admin/quizzes');
-  await expect(page.getByRole('cell', { name: quizTitle })).toBeVisible();
+  await expect(page.locator('.card.quiz-card').getByRole('link', { name: quizTitle })).toBeVisible();
 
-  // The "Top Banana!" brand in the navbar should be a real link that lands
-  // on /admin — guards against regressing back to href="#".
-  await page.getByRole('link', { name: 'Top Banana!' }).click();
+  // The "TOPBANANA" brand wordmark in the navbar should be a real link
+  // that lands on /admin — guards against regressing back to href="#".
+  await page.locator('.navbar-item.brand').click();
   await expect(page).toHaveURL(/\/admin$/);
 
   // Open the share modal on the quiz view and confirm the rendered share
   // URL points at /play/<slug>-<id>. Don't try to verify the clipboard
   // (browser permission model varies); just check the user-visible link.
   await page.goto('/admin/quizzes');
-  await page.getByRole('cell', { name: quizTitle }).click();
+  await page.locator('.card.quiz-card').getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('link', { name: 'Share quiz' }).click();
   const shareLinkText = await page.locator('.share-link').textContent();

--- a/test/e2e/tests/auth.spec.ts
+++ b/test/e2e/tests/auth.spec.ts
@@ -13,9 +13,10 @@ test('register, log out, log back in, and reach the admin dashboard', async ({ p
   await page.locator('input[name=password]').fill(password);
   await page.locator('button[type=submit]').click();
 
-  // Successful registration redirects to /admin/quizzes.
+  // Successful registration redirects to /admin/quizzes — the redesigned
+  // page header (#207) renders the heading "Quizzes" inside h1.title.is-3.
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
-  await expect(page.locator('h1.title')).toContainText('Admin Dashboard');
+  await expect(page.locator('h1.title')).toContainText('Quizzes');
 
   // Log out via the navbar button. The form posts to /logout, the server
   // clears the cookie and 303s to /login, and the browser follows the redirect.
@@ -35,5 +36,5 @@ test('register, log out, log back in, and reach the admin dashboard', async ({ p
   await page.locator('button[type=submit]').click();
 
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
-  await expect(page.locator('h1.title')).toContainText('Admin Dashboard');
+  await expect(page.locator('h1.title')).toContainText('Quizzes');
 });

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -226,6 +226,14 @@ func TestAdmin_Integration(t *testing.T) {
 	if got, want := string(body), quizTitle; !strings.Contains(got, want) {
 		t.Errorf("string(body) = %q, should contain %q", got, want)
 	}
+	// Pin the new Bulma navbar + quiz-card markup so regressions to the
+	// old table/page-title layout are caught here (see #207).
+	if got, want := string(body), `class="navbar-brand"`; !strings.Contains(got, want) {
+		t.Errorf("string(body) = %q, should contain %q", got, want)
+	}
+	if got, want := string(body), `class="card quiz-card"`; !strings.Contains(got, want) {
+		t.Errorf("string(body) = %q, should contain %q", got, want)
+	}
 
 	// Verify quiz details
 	req, err = http.NewRequestWithContext(


### PR DESCRIPTION
Closes #214. First reviewable slice of #207.

## Summary
- New `internal/client/static/css/admin.css` (390 lines, zero `!important`) — design tokens, `--bulma-*` variable overrides, bespoke CSS only for what Bulma doesn't model.
- Reskinned navbar (`navbar.gohtml`) using Bulma's `.navbar` markup with the dark sticky synthwave look, Orbitron `TOPBANANA` wordmark, banana-leaf SVG icon, and the logout POST form.
- Reskinned `/admin/quizzes` (`quizlist.gohtml`) from Bulma's table to a `.columns > .column > .card.quiz-card` grid with editorial in-card typography. Empty state via `.notification`. Delete modal keeps Bulma's `.modal-card` markup; admin.css overrides the colors.
- Mockup added at `mockups/admin-redesign-bulma-vars/` as the design + technique contract (zero `!important`, variable-first overrides).
- Integration + unit + e2e tests updated to pin the new markup.

## Test plan
- [x] `make lint-fix` clean
- [x] `make check` green
- [x] `make test-e2e` green (16 tests, all browsers)
- [x] `make smoke` green
- [x] `grep -cE '!important\s*;' internal/client/static/css/admin.css` → 0
- [ ] Browse `/admin/quizzes` after login and confirm it matches `mockups/admin-redesign-bulma-vars/quiz-list.html`
- [ ] Verify mobile (360px) reads single-column without horizontal scroll
- [ ] Verify the existing CRUD flows still work end-to-end (create quiz, edit quiz, delete quiz via modal)

## Out of scope (follow-up tickets under #207)
Quiz view, quiz form, question form, login, register, access-denied — those pages still use Bulma's default light skin and inherit the dark page background only.