### PR TITLE
Harden SESSION_KEY handling and deploy workflow (#217)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,9 +55,13 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
-          envs: IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
+            if [ -z "$SESSION_KEY" ]; then
+              echo "ERROR: SESSION_KEY is empty or unset; refusing to deploy" >&2
+              exit 1
+            fi
             mkdir -p ~/topbanana-staging
             cd ~/topbanana-staging
             umask 077
@@ -75,8 +79,16 @@ jobs:
 
       - name: Verify staging deployment
         run: |
-          sleep 10
-          curl -f "${{ secrets.HEALTH_URL }}" || echo "Health check failed, but deployment may still be starting up"
+          for i in $(seq 1 12); do
+            if curl -fsS "${{ secrets.HEALTH_URL }}" >/dev/null; then
+              echo "Health check passed (attempt $i)"
+              exit 0
+            fi
+            echo "Health check attempt $i/12 failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "Health check failed after 12 attempts (60s); failing the deploy" >&2
+          exit 1
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -123,11 +135,16 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
-          envs: IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
+            if [ -z "$SESSION_KEY" ]; then
+              echo "ERROR: SESSION_KEY is empty or unset; refusing to deploy" >&2
+              exit 1
+            fi
             mkdir -p ~/topbanana-production
             cd ~/topbanana-production
+            umask 077
             cat > .env <<EOF
             SESSION_KEY=${SESSION_KEY}
             IMAGE_NAME=${IMAGE_NAME}
@@ -142,5 +159,13 @@ jobs:
 
       - name: Verify production deployment
         run: |
-          sleep 10
-          curl -f "${{ secrets.HEALTH_URL }}" || echo "Health check failed, but deployment may still be starting up"
+          for i in $(seq 1 12); do
+            if curl -fsS "${{ secrets.HEALTH_URL }}" >/dev/null; then
+              echo "Health check passed (attempt $i)"
+              exit 0
+            fi
+            echo "Health check attempt $i/12 failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "Health check failed after 12 attempts (60s); failing the deploy" >&2
+          exit 1

--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -9,7 +9,7 @@ services:
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
       - REGISTRATION_ENABLED=true
       - ADMIN_USERNAMES=admin
-      - SESSION_KEY=${SESSION_KEY}
+      - SESSION_KEY=${SESSION_KEY:?SESSION_KEY must be set in .env or environment}
     volumes:
       - topbanana_production_data:/home/nonroot/data
     networks:

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -9,7 +9,7 @@ services:
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
       - REGISTRATION_ENABLED=true
       - ADMIN_USERNAMES=admin
-      - SESSION_KEY=${SESSION_KEY}
+      - SESSION_KEY=${SESSION_KEY:?SESSION_KEY must be set in .env or environment}
     volumes:
       - topbanana_staging_data:/home/nonroot/data
     networks:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,9 +15,11 @@ import (
 // production deployments without a database.
 var ErrDBURINotSetInProduction = errors.New("DB_URI must be set in production")
 
-// ErrSessionKeyNotSetInProduction is returned when SESSION_KEY is not set in production. A stable key is required so
-// session cookies survive process restarts.
-var ErrSessionKeyNotSetInProduction = errors.New("SESSION_KEY must be set in production")
+// ErrSessionKeyRequired is returned when SESSION_KEY is not set in an
+// environment that requires an explicit key. Every APP_ENV except development
+// requires one so session cookies survive process restarts; development falls
+// back to an ephemeral random key so localhost runs need no configuration.
+var ErrSessionKeyRequired = errors.New("SESSION_KEY must be set")
 
 const (
 	// AppEnvironmentDefault is the default application environment.
@@ -195,14 +197,18 @@ func parseAdminUsernames(raw string) []string {
 	return out
 }
 
-// resolveSessionKey returns the session key for cookie signing. In production an explicit value is required; in
-// development a random ephemeral key is generated when none is provided.
+// resolveSessionKey returns the session key for cookie signing. An explicit
+// value is required in every environment except development; development
+// generates a random ephemeral key so localhost runs need no configuration.
+// The previous policy only enforced this in production, which let staging
+// silently rotate keys on every container restart and invalidate active
+// sessions. See #217.
 func resolveSessionKey(envValue, appEnvironment string) (string, error) {
 	if envValue != "" {
 		return envValue, nil
 	}
-	if appEnvironment == AppEnvironmentProduction {
-		return "", ErrSessionKeyNotSetInProduction
+	if appEnvironment != AppEnvironmentDefault {
+		return "", fmt.Errorf("%w: APP_ENV=%q", ErrSessionKeyRequired, appEnvironment)
 	}
 
 	b := make([]byte, sessionKeyByteLength)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,8 +216,33 @@ func TestParse(t *testing.T) {
 		if err == nil {
 			t.Fatal("Parse() with empty SESSION_KEY in production: err = nil, want non-nil")
 		}
-		if got, want := err, ErrSessionKeyNotSetInProduction; !errors.Is(got, want) {
+		if got, want := err, ErrSessionKeyRequired; !errors.Is(got, want) {
 			t.Fatalf("Parse() err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("empty SESSION_KEY in staging requires explicit key", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(key string) string {
+			envs := map[string]string{
+				"APP_ENV":     "staging",
+				"DB_URI":      "file:test.sqlite",
+				"SESSION_KEY": "",
+			}
+
+			return envs[key]
+		}
+
+		_, err := Parse(getenv)
+		if err == nil {
+			t.Fatal("Parse() with empty SESSION_KEY in staging: err = nil, want non-nil")
+		}
+		if got, want := err, ErrSessionKeyRequired; !errors.Is(got, want) {
+			t.Fatalf("Parse() err = %v, want %v", got, want)
+		}
+		if got, want := err.Error(), `APP_ENV="staging"`; !strings.Contains(got, want) {
+			t.Errorf("Parse() err.Error() = %q, should contain %q", got, want)
 		}
 	})
 


### PR DESCRIPTION
Closes #217.

## Summary
- **Compose layer**: both `docker-compose.production.yml` and `docker-compose.staging.yml` now use `${SESSION_KEY:?…}` so docker-compose refuses to start the container when SESSION_KEY is unset, instead of silently substituting empty string.
- **Go layer**: `resolveSessionKey` now requires an explicit `SESSION_KEY` in every `APP_ENV` except `development`. Closes the silent-ephemeral-key trap on staging (every restart was rotating the key and invalidating active sessions). Renamed `ErrSessionKeyNotSetInProduction` → `ErrSessionKeyRequired` with a generic message; the error is wrapped with the offending `APP_ENV` value at the call site.
- **Deploy workflow fixes (audit caught three more)**:
  - `SESSION_KEY` was defined at `env:` but missing from `with.envs:` in both jobs — `appleboy/ssh-action` wasn't forwarding it to the remote SSH shell, so `.env` got `SESSION_KEY=` empty. Added to both `envs:` lists.
  - Added an empty-string guard at the top of each remote script so a missing/blank GH secret aborts the deploy explicitly.
  - Production was missing `umask 077`, so its `.env` (containing the SESSION_KEY) was world-readable. Staging already had it.
  - Both verify steps were single curl + `|| echo …`, which masked failed deploys as green. Replaced with a 12-attempt × 5s polling loop (60s budget) that exits non-zero on persistent failure.

## Test plan
- [x] `make lint-fix` clean
- [x] `make check` green (new `staging` sub-test asserts `ErrSessionKeyRequired` is returned and the error message names the env)
- [x] `make smoke` green
- [ ] Manual: `SESSION_KEY=  docker compose -f deployments/demo/docker-compose.production.yml config` should fail with a clear `SESSION_KEY must be set` error
- [ ] Manual: same for the staging compose file
- [ ] Manual: trigger a staging deploy with the GH secret intact and confirm the verify step's polling loop logs attempts and the deploy passes