### PR TITLE
Add --minify to make tailwind-watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,12 @@ $(TAILWIND_BIN):
 tailwind: $(TAILWIND_BIN)
 	$(TAILWIND_BIN) -i $(TAILWIND_INPUT) -o $(TAILWIND_OUTPUT) --minify
 
+# --watch + --minify so every rebuild matches what `make tailwind` would
+# produce — without --minify the watcher emits pretty-printed CSS that
+# would diverge from the committed admin.css and fail tailwind-check.
 .PHONY: tailwind-watch
 tailwind-watch: $(TAILWIND_BIN)
-	$(TAILWIND_BIN) -i $(TAILWIND_INPUT) -o $(TAILWIND_OUTPUT) --watch
+	$(TAILWIND_BIN) -i $(TAILWIND_INPUT) -o $(TAILWIND_OUTPUT) --watch --minify
 
 # Regenerate into a temp file and diff against the committed admin.css. Wired
 # into `make check` so a template class change without `make tailwind` fails


### PR DESCRIPTION
## Summary
- `make tailwind-watch` runs the Tailwind CLI without `--minify`, so each rebuild writes pretty-printed CSS over the committed `admin.css`. This drifts the working tree on every template save, breaks `make tailwind-check`, and conflicts with `git pull` / `git checkout`.
- Adding `--minify` to the watch target makes its output byte-identical to what `make tailwind` produces, so the committed file stays consistent across dev iterations.
- Minified output is no harder to debug — browser DevTools still attribute styles by class name. The single-file minify adds ~30ms to each watch rebuild.

## Test plan
- [x] `make tailwind-check` passes after running `make tailwind-watch` briefly + touching a template (the watcher's rebuilt output matches the committed file).
- [x] Existing `tailwind-check` in `make check` already guards against future regressions of this kind.