### PR TITLE
Correct client countdown against server clock

### DIFF
--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -108,6 +108,12 @@ export class GameApp {
         // element across the whole question lifetime.
         this.revealing = false;
         this.revealTimer = null;
+        // Offset between the server clock and Date.now() in ms,
+        // refreshed from `serverNow` in every question payload (#180).
+        // serverTime() applies it so the per-question countdown runs
+        // against the server's view of "now" instead of the device's,
+        // which can be minutes off on phones with stale time.
+        this.clockOffset = 0;
         // Server-Sent Events handle for the leaderboard live stream
         // (#239). Opened when the leaderboard becomes visible; closed on
         // navigation away. Null when no subscription is active.
@@ -507,9 +513,34 @@ export class GameApp {
             return;
         }
         this.imageError = false;
+        this.syncClockFrom(question);
         this.question = question;
         this.startRevealCountdown();
         this.animateQuestionEntrance();
+    }
+
+    // syncClockFrom recomputes clockOffset from the serverNow that
+    // travels with every question payload. A per-question reset keeps
+    // drift bounded without needing a separate clock-sync endpoint;
+    // the only remaining error is one-way network delay (RTT/2), which
+    // is negligible against a 10-second answer window. A missing
+    // serverNow (older server) leaves clockOffset at 0 — the existing
+    // skew-vulnerable behaviour, not a regression.
+    syncClockFrom(question) {
+        if (!question || !question.serverNow) return;
+        const serverMs = new Date(question.serverNow).getTime();
+        if (!Number.isFinite(serverMs)) return;
+        this.clockOffset = serverMs - Date.now();
+    }
+
+    // serverTime returns the current time in ms as the server sees it,
+    // using clockOffset captured on the last question payload. All
+    // per-question countdown math goes through this helper so a
+    // skewed device clock can't push the timer past expiredAt
+    // (forward skew) or hold it open past the server window (backward
+    // skew) — see #180.
+    serverTime() {
+        return Date.now() + this.clockOffset;
     }
 
     // startRevealCountdown drives the pre-answer beat (#247) by filling
@@ -525,7 +556,7 @@ export class GameApp {
     // had.
     startRevealCountdown() {
         const startAt = new Date(this.question.startedAt).getTime();
-        const revealStart = Date.now();
+        const revealStart = this.serverTime();
         if (revealStart >= startAt) {
             this.revealing = false;
             this.startCountdown();
@@ -535,7 +566,7 @@ export class GameApp {
         this.revealing = true;
         this.progress = 0;
         this.revealTimer = setInterval(() => {
-            const now = Date.now();
+            const now = this.serverTime();
             if (now >= startAt) {
                 this.progress = 100;
                 clearInterval(this.revealTimer);
@@ -701,7 +732,7 @@ export class GameApp {
         this.progress = 100;
 
         this.timer = setInterval(() => {
-            const now = new Date().getTime();
+            const now = this.serverTime();
             const remaining = end - now;
             this.progress = Math.max(0, (remaining / total) * 100);
 

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -646,7 +646,8 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 		Text string `json:"text"`
 	}
 
-	// Position/Total drive the in-game HUD chip (#253).
+	// Position/Total drive the in-game HUD chip (#253); ServerNow
+	// drives the client clock-offset correction (#180).
 	type questionResponse struct {
 		ID        int64            `json:"id"`
 		Text      string           `json:"text"`
@@ -654,6 +655,7 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 		Options   []optionResponse `json:"options"`
 		StartedAt time.Time        `json:"startedAt"`
 		ExpiredAt time.Time        `json:"expiredAt"`
+		ServerNow time.Time        `json:"serverNow"`
 		Position  int              `json:"position"`
 		Total     int              `json:"total"`
 	}
@@ -666,22 +668,14 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 
 		gq, err := service.GetNextQuestion(r.Context(), gameID, playerID)
 		if err != nil {
-			if errors.Is(err, game.ErrGameNotFound) {
+			switch {
+			case errors.Is(err, game.ErrGameNotFound),
+				errors.Is(err, quiz.ErrQuizNotFound),
+				errors.Is(err, game.ErrNoMoreQuestions):
 				http.Error(w, err.Error(), http.StatusNotFound)
-
-				return
+			default:
+				writeInternalError(w, r, logger, "error retrieving next question", err)
 			}
-			if errors.Is(err, quiz.ErrQuizNotFound) {
-				http.Error(w, err.Error(), http.StatusNotFound)
-
-				return
-			}
-			if errors.Is(err, game.ErrNoMoreQuestions) {
-				http.Error(w, err.Error(), http.StatusNotFound)
-
-				return
-			}
-			writeInternalError(w, r, logger, "error retrieving next question", err)
 
 			return
 		}
@@ -705,6 +699,7 @@ func HandleQuestionNext(logger *slog.Logger, service *game.Service) http.Handler
 			Options:   resOptions,
 			StartedAt: gq.StartedAt,
 			ExpiredAt: gq.ExpiredAt,
+			ServerNow: time.Now().UTC(),
 			Position:  gq.Position,
 			Total:     gq.Total,
 		}

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -67,6 +67,7 @@ type nextQuestionRes struct {
 	Text      string               `json:"text"`
 	Options   []nextQuestionOption `json:"options"`
 	StartedAt time.Time            `json:"startedAt"`
+	ServerNow time.Time            `json:"serverNow"`
 }
 
 // playerScoreRes mirrors one player_scores entry in the GET .../results
@@ -453,6 +454,7 @@ func TestGameplay_Integration(t *testing.T) {
 		// Walk through questions
 		for i := range 3 {
 			// Get Next Question
+			before := time.Now()
 			resp = httpGet(ctx, t, client, fmt.Sprintf("%s/api/games/%s/questions/next", baseURL, gameID))
 			if got, want := resp.StatusCode, http.StatusOK; got != want {
 				t.Fatalf("next question status = %d, want %d", got, want)
@@ -465,6 +467,16 @@ func TestGameplay_Integration(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("failed to decode next question response: %v", err)
+			}
+			// invariant pinned by #180: the server stamps a fresh
+			// serverNow on every question so the client can correct
+			// for system-clock skew. It must land between the
+			// pre-request "before" and a tolerant upper bound past
+			// the HTTP round-trip — anything outside that window
+			// means the server is sending a stale or wrong field.
+			after := time.Now().Add(5 * time.Second)
+			if got := nextQsRes.ServerNow; got.Before(before) || got.After(after) {
+				t.Errorf("ServerNow = %v, want within [%v, %v]", got, before, after)
 			}
 
 			// Find correct or incorrect option


### PR DESCRIPTION
Closes #180

Drive-by: folded the three identical `errors.Is + http.Error(404)` branches in `HandleQuestionNext` into one switch — was needed to keep the function under revive's 75-line cap after adding `ServerNow`. Same behaviour.