### PR TITLE
Drop the in-progress dot on the leaderboard for abandoned players

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -95,7 +95,7 @@ func (s stubGameStore) ListAnswersForQuizLeaderboard(
 // (seeded with answers only) keep passing. The participants list is
 // the canonical entry source post-#335.
 func (s stubGameStore) ListParticipantsForQuizLeaderboard(
-	ctx context.Context, quizID int64,
+	ctx context.Context, quizID int64, _ time.Time,
 ) ([]*game.LeaderboardParticipant, error) {
 	if s.listAnswersForQuizLeaderboard == nil {
 		return nil, nil

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -294,7 +294,7 @@ func toEntryResponse(e game.LeaderboardEntry) quizLeaderboardEntryResponse {
 		Score:           e.Score,
 		Rank:            e.Rank,
 		IsCurrentPlayer: e.IsCurrentPlayer,
-		InProgress:      !e.Completed,
+		InProgress:      e.InProgress,
 	}
 }
 

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -124,7 +124,7 @@ type stubGameStore struct {
 	createQuestion                     func(ctx context.Context, gq *game.Question) error
 	createAnswer                       func(ctx context.Context, a *game.Answer) error
 	listAnswersForQuizLeaderboard      func(ctx context.Context, quizID int64) ([]*game.LeaderboardAnswer, error)
-	listParticipantsForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*game.LeaderboardParticipant, error)
+	listParticipantsForQuizLeaderboard func(ctx context.Context, quizID int64, staleBefore time.Time) ([]*game.LeaderboardParticipant, error)
 	deleteGamesForPlayerOnQuiz         func(ctx context.Context, playerID, quizID int64) error
 	listQuizIDsForPlayer               func(ctx context.Context, playerID int64) ([]int64, error)
 }
@@ -258,10 +258,10 @@ func (s stubGameStore) ListAnswersForQuizLeaderboard(
 // that need to exercise the no-answer-participant path (#335) set the
 // participants stub explicitly.
 func (s stubGameStore) ListParticipantsForQuizLeaderboard(
-	ctx context.Context, quizID int64,
+	ctx context.Context, quizID int64, staleBefore time.Time,
 ) ([]*game.LeaderboardParticipant, error) {
 	if s.listParticipantsForQuizLeaderboard != nil {
-		return s.listParticipantsForQuizLeaderboard(ctx, quizID)
+		return s.listParticipantsForQuizLeaderboard(ctx, quizID, staleBefore)
 	}
 	if s.listAnswersForQuizLeaderboard == nil {
 		return nil, errStub

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -675,32 +675,42 @@ SELECT gp.player_id AS player_id,
        CASE WHEN (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id) > 0
              AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = gp.game_id) >=
                  (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
-            THEN 1 ELSE 0 END AS is_completed
+            THEN 1 ELSE 0 END AS is_completed,
+       CASE WHEN EXISTS (
+              SELECT 1 FROM game_questions gq
+              WHERE gq.game_id = gp.game_id
+                AND gq.expired_at < ?
+                AND NOT EXISTS (SELECT 1 FROM game_answers ga WHERE ga.game_question_id = gq.id)
+                AND NOT EXISTS (SELECT 1 FROM game_questions gqn WHERE gqn.game_id = gp.game_id AND gqn.id > gq.id)
+            ) THEN 1 ELSE 0 END AS is_stale
 FROM game_participants gp
          JOIN games g   ON g.id = gp.game_id
          JOIN players p ON p.id = gp.player_id
 WHERE g.quiz_id = ?
 `
 
+type ListParticipantsForQuizLeaderboardParams struct {
+	ExpiredAt time.Time
+	QuizID    int64
+}
+
 type ListParticipantsForQuizLeaderboardRow struct {
 	PlayerID    int64
 	Username    string
 	IsCompleted int64
+	IsStale     int64
 }
 
-// Lists every player who has joined a game for the given quiz, with the
-// same is_completed predicate ListAnswersForQuizLeaderboard carries on
-// the answer rows. The Service uses this list as the canonical set of
-// leaderboard entries (#335) so a player who clicked Start but has not
-// yet submitted an answer still appears with a 0 score and the
-// in-progress dot, instead of being invisible until their first answer
-// commits. The answers query then contributes the per-row scoring
-// inputs used to roll up each entry's running total.
+// One row per player joined to the quiz, flagged with is_completed
+// (every quiz question issued) and is_stale (#336: latest
+// game_question unanswered and expired before stale_before).
+// Canonical entry set per #335 so a joined-but-unanswered player
+// still appears at 0.
 // Joins through `games` so the WHERE filters on games.quiz_id (NOT
 // NULL); game_participants.quiz_id is nullable in the schema, which
 // would otherwise force sqlc to infer sql.NullInt64 for the parameter.
-func (q *Queries) ListParticipantsForQuizLeaderboard(ctx context.Context, quizID int64) ([]ListParticipantsForQuizLeaderboardRow, error) {
-	rows, err := q.db.QueryContext(ctx, listParticipantsForQuizLeaderboard, quizID)
+func (q *Queries) ListParticipantsForQuizLeaderboard(ctx context.Context, arg ListParticipantsForQuizLeaderboardParams) ([]ListParticipantsForQuizLeaderboardRow, error) {
+	rows, err := q.db.QueryContext(ctx, listParticipantsForQuizLeaderboard, arg.ExpiredAt, arg.QuizID)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +718,12 @@ func (q *Queries) ListParticipantsForQuizLeaderboard(ctx context.Context, quizID
 	var items []ListParticipantsForQuizLeaderboardRow
 	for rows.Next() {
 		var i ListParticipantsForQuizLeaderboardRow
-		if err := rows.Scan(&i.PlayerID, &i.Username, &i.IsCompleted); err != nil {
+		if err := rows.Scan(
+			&i.PlayerID,
+			&i.Username,
+			&i.IsCompleted,
+			&i.IsStale,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -26,6 +26,10 @@ const (
 	defaultRevealDelay      = 3 * time.Second
 	maxPoints               = 1000
 	defaultLeaderboardLimit = 10
+	// defaultStalePeriod is the grace window for the in-progress dot
+	// (#336): a 10s answer window plus slack for reveal beats and
+	// mobile network jitter.
+	defaultStalePeriod = 30 * time.Second
 )
 
 var (
@@ -169,9 +173,13 @@ type LeaderboardAnswer struct {
 // in the per-answer scoring inputs from
 // [Store.ListAnswersForQuizLeaderboard].
 type LeaderboardParticipant struct {
-	PlayerID    int64
-	Username    string
+	PlayerID int64
+	Username string
+	// IsCompleted: every quiz question has been issued to this game.
 	IsCompleted bool
+	// IsStale: latest game_question is unanswered and expired before
+	// the store's stale_before threshold (#336).
+	IsStale bool
 }
 
 // LeaderboardEntry is a single row of a per-quiz leaderboard: the player's
@@ -181,10 +189,10 @@ type LeaderboardParticipant struct {
 // entry belongs to the player making the request, which lets the client
 // highlight the row.
 //
-// Completed is false when the player is still mid-quiz: the Score may
-// be a partial running total (#244) or zero if the player has clicked
-// Start but not yet submitted their first answer (#335). The client
-// surfaces these rows as in-progress on the wire (`inProgress: true`).
+// Completed is true once every quiz question has been issued.
+// InProgress is true when the player is actively mid-quiz: not
+// completed AND not stale (#336). Wire renders the live dot from
+// InProgress; admin "Played by" filters on Completed.
 type LeaderboardEntry struct {
 	PlayerID        int64
 	Username        string
@@ -192,6 +200,7 @@ type LeaderboardEntry struct {
 	Rank            int
 	IsCurrentPlayer bool
 	Completed       bool
+	InProgress      bool
 }
 
 // LeaderboardResult bundles the truncated top-N entries with the requesting
@@ -235,13 +244,15 @@ type Store interface {
 	// LeaderboardAnswer.IsCompleted flag tells the caller whether the
 	// row belongs to a game that has issued every quiz question (#244).
 	ListAnswersForQuizLeaderboard(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
-	// ListParticipantsForQuizLeaderboard returns one row per player who
-	// joined a game for the given quiz, with the same is_completed flag
-	// that ListAnswersForQuizLeaderboard carries. The Service uses this
-	// list as the canonical set of leaderboard entries (#335) so a
-	// player who has clicked Start but not yet submitted an answer
-	// still appears with a 0 score and the in-progress dot.
-	ListParticipantsForQuizLeaderboard(ctx context.Context, quizID int64) ([]*LeaderboardParticipant, error)
+	// ListParticipantsForQuizLeaderboard returns one row per player
+	// joined to the quiz, flagged with IsCompleted and IsStale (#336).
+	// Canonical entry set per #335 so a joined-but-unanswered player
+	// still appears at 0.
+	ListParticipantsForQuizLeaderboard(
+		ctx context.Context,
+		quizID int64,
+		staleBefore time.Time,
+	) ([]*LeaderboardParticipant, error)
 	// DeleteGamesForPlayerOnQuiz hard-deletes every game (and dependent
 	// rows) that belongs to the given player on the given quiz. No error
 	// when the player has no games for the quiz: the admin reset flow is
@@ -270,6 +281,7 @@ type Service struct {
 	logger               *slog.Logger
 	leaderboardPublisher LeaderboardPublisher
 	revealDelay          time.Duration
+	stalePeriod          time.Duration
 }
 
 // NewService initializes and returns a new instance of Service with the provided game and quiz stores.
@@ -279,7 +291,14 @@ func NewService(gameStore Store, quizStore quiz.Store, logger *slog.Logger) *Ser
 		quizStore:   quizStore,
 		logger:      logger,
 		revealDelay: defaultRevealDelay,
+		stalePeriod: defaultStalePeriod,
 	}
+}
+
+// SetStalePeriod overrides the in-progress dot grace window (#336).
+// Not safe for concurrent use; call during startup wiring.
+func (s *Service) SetStalePeriod(d time.Duration) {
+	s.stalePeriod = d
 }
 
 // GetQuiz proxies to the wrapped quiz store. Exposed so clientapi
@@ -818,7 +837,7 @@ func (s *Service) GetQuizLeaderboard(
 	// have not submitted an answer yet. The answers query below only
 	// contributes per-row scoring inputs that roll up into each entry's
 	// running total.
-	participants, err := s.store.ListParticipantsForQuizLeaderboard(ctx, quizID)
+	participants, err := s.store.ListParticipantsForQuizLeaderboard(ctx, quizID, time.Now().Add(-s.stalePeriod))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list leaderboard participants: %w", err)
 	}
@@ -852,6 +871,8 @@ func (s *Service) GetQuizLeaderboard(
 			Score:           playerTotals[p.PlayerID],
 			IsCurrentPlayer: p.PlayerID == currentPlayerID,
 			Completed:       p.IsCompleted,
+			// Stale rows stay on the board (#336) but drop the dot.
+			InProgress: !p.IsCompleted && !p.IsStale,
 		})
 	}
 

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -27,7 +27,7 @@ var errStub = errors.New("stub error")
 // so the existing CreateGame happy-path tests do not have to opt in.
 type stubStore struct {
 	listAnswersForQuizLeaderboard      func(ctx context.Context, quizID int64) ([]*LeaderboardAnswer, error)
-	listParticipantsForQuizLeaderboard func(ctx context.Context, quizID int64) ([]*LeaderboardParticipant, error)
+	listParticipantsForQuizLeaderboard func(ctx context.Context, quizID int64, staleBefore time.Time) ([]*LeaderboardParticipant, error)
 	getGameByPlayerAndQuiz             func(ctx context.Context, playerID, quizID int64) (*Game, error)
 	deleteGamesForPlayerOnQuiz         func(ctx context.Context, playerID, quizID int64) error
 	listQuizIDsForPlayer               func(ctx context.Context, playerID int64) ([]int64, error)
@@ -74,10 +74,10 @@ func (s stubStore) ListAnswersForQuizLeaderboard(
 // explicitly to exercise the no-answer-participant path the fallback
 // can't represent.
 func (s stubStore) ListParticipantsForQuizLeaderboard(
-	ctx context.Context, quizID int64,
+	ctx context.Context, quizID int64, staleBefore time.Time,
 ) ([]*LeaderboardParticipant, error) {
 	if s.listParticipantsForQuizLeaderboard != nil {
-		return s.listParticipantsForQuizLeaderboard(ctx, quizID)
+		return s.listParticipantsForQuizLeaderboard(ctx, quizID, staleBefore)
 	}
 	if s.listAnswersForQuizLeaderboard == nil {
 		return nil, errStub
@@ -1248,7 +1248,7 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 						makeAnswerCompleted(2, "bob", true, false),
 					}, nil
 				},
-				listParticipantsForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardParticipant, error) {
+				listParticipantsForQuizLeaderboard: func(_ context.Context, _ int64, _ time.Time) ([]*LeaderboardParticipant, error) {
 					return []*LeaderboardParticipant{
 						{PlayerID: 1, Username: "alice", IsCompleted: false},
 						{PlayerID: 2, Username: "bob", IsCompleted: false},
@@ -1626,6 +1626,73 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		}
 		if result.CurrentPlayer != nil {
 			t.Errorf("CurrentPlayer = %+v, want nil (player has no row)", result.CurrentPlayer)
+		}
+	})
+
+	t.Run("stale participant has InProgress=false but stays on the board (#336)", func(t *testing.T) {
+		t.Parallel()
+
+		// Three participants: alice (active, mid-quiz), bob (completed),
+		// carol (stale: not completed but flagged abandoned by the
+		// store). The wire-shape consumer renders the live dot from
+		// InProgress, so carol must drop the dot even though her game
+		// is technically still open.
+		svc := NewService(
+			stubStore{
+				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
+					return nil, nil
+				},
+				listParticipantsForQuizLeaderboard: func(_ context.Context, _ int64, _ time.Time) ([]*LeaderboardParticipant, error) {
+					return []*LeaderboardParticipant{
+						{PlayerID: 1, Username: "alice", IsCompleted: false, IsStale: false},
+						{PlayerID: 2, Username: "bob", IsCompleted: true, IsStale: false},
+						{PlayerID: 3, Username: "carol", IsCompleted: false, IsStale: true},
+					}, nil
+				},
+			},
+			stubQuizStore{
+				quizExists: func(_ context.Context, _ int64) (bool, error) {
+					return true, nil
+				},
+			},
+			slog.New(slog.DiscardHandler),
+		)
+
+		result, err := svc.GetQuizLeaderboard(t.Context(), 1, 0, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := len(result.Entries), 3; got != want {
+			t.Fatalf("len(entries) = %d, want %d (stale participants stay on the board)", got, want)
+		}
+
+		byName := make(map[string]LeaderboardEntry, len(result.Entries))
+		for _, e := range result.Entries {
+			byName[e.Username] = e
+		}
+
+		alice := byName["alice"]
+		if got, want := alice.InProgress, true; got != want {
+			t.Errorf("alice.InProgress = %v, want %v (active mid-quiz)", got, want)
+		}
+		if got, want := alice.Completed, false; got != want {
+			t.Errorf("alice.Completed = %v, want %v", got, want)
+		}
+
+		bob := byName["bob"]
+		if got, want := bob.InProgress, false; got != want {
+			t.Errorf("bob.InProgress = %v, want %v (completed)", got, want)
+		}
+		if got, want := bob.Completed, true; got != want {
+			t.Errorf("bob.Completed = %v, want %v", got, want)
+		}
+
+		carol := byName["carol"]
+		if got, want := carol.InProgress, false; got != want {
+			t.Errorf("carol.InProgress = %v, want %v (stale: abandoned mid-quiz)", got, want)
+		}
+		if got, want := carol.Completed, false; got != want {
+			t.Errorf("carol.Completed = %v, want %v (stale != completed)", got, want)
 		}
 	})
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/health"
@@ -90,7 +91,7 @@ func (*stubGameStore) ListAnswersForQuizLeaderboard(
 }
 
 func (*stubGameStore) ListParticipantsForQuizLeaderboard(
-	_ context.Context, _ int64,
+	_ context.Context, _ int64, _ time.Time,
 ) ([]*game.LeaderboardParticipant, error) {
 	return nil, nil
 }

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -103,14 +103,11 @@ FROM game_answers ga
 WHERE g.quiz_id = ?;
 
 -- name: ListParticipantsForQuizLeaderboard :many
--- Lists every player who has joined a game for the given quiz, with the
--- same is_completed predicate ListAnswersForQuizLeaderboard carries on
--- the answer rows. The Service uses this list as the canonical set of
--- leaderboard entries (#335) so a player who clicked Start but has not
--- yet submitted an answer still appears with a 0 score and the
--- in-progress dot, instead of being invisible until their first answer
--- commits. The answers query then contributes the per-row scoring
--- inputs used to roll up each entry's running total.
+-- One row per player joined to the quiz, flagged with is_completed
+-- (every quiz question issued) and is_stale (#336: latest
+-- game_question unanswered and expired before stale_before).
+-- Canonical entry set per #335 so a joined-but-unanswered player
+-- still appears at 0.
 -- Joins through `games` so the WHERE filters on games.quiz_id (NOT
 -- NULL); game_participants.quiz_id is nullable in the schema, which
 -- would otherwise force sqlc to infer sql.NullInt64 for the parameter.
@@ -119,7 +116,14 @@ SELECT gp.player_id AS player_id,
        CASE WHEN (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id) > 0
              AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = gp.game_id) >=
                  (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
-            THEN 1 ELSE 0 END AS is_completed
+            THEN 1 ELSE 0 END AS is_completed,
+       CASE WHEN EXISTS (
+              SELECT 1 FROM game_questions gq
+              WHERE gq.game_id = gp.game_id
+                AND gq.expired_at < ?
+                AND NOT EXISTS (SELECT 1 FROM game_answers ga WHERE ga.game_question_id = gq.id)
+                AND NOT EXISTS (SELECT 1 FROM game_questions gqn WHERE gqn.game_id = gp.game_id AND gqn.id > gq.id)
+            ) THEN 1 ELSE 0 END AS is_stale
 FROM game_participants gp
          JOIN games g   ON g.id = gp.game_id
          JOIN players p ON p.id = gp.player_id

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/config"
@@ -173,7 +174,7 @@ func (stubGameStore) ListAnswersForQuizLeaderboard(
 }
 
 func (stubGameStore) ListParticipantsForQuizLeaderboard(
-	_ context.Context, _ int64,
+	_ context.Context, _ int64, _ time.Time,
 ) ([]*game.LeaderboardParticipant, error) {
 	return nil, nil
 }

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/rs/xid"
 	"modernc.org/sqlite"
@@ -360,15 +361,16 @@ func (s *GameStore) ListAnswersForQuizLeaderboard(
 	return answers, nil
 }
 
-// ListParticipantsForQuizLeaderboard returns one row per player who
-// joined a game for the given quiz, with the same is_completed flag the
-// answer rows carry. The Service uses this list as the canonical set of
-// leaderboard entries so a player who clicked Start but has not yet
-// submitted an answer still appears on the live leaderboard (#335).
+// ListParticipantsForQuizLeaderboard returns one row per player joined
+// to the quiz, flagged with IsCompleted and IsStale (#336). Pass
+// [time.Now]-stalePeriod for staleBefore. Canonical entry set per #335.
 func (s *GameStore) ListParticipantsForQuizLeaderboard(
-	ctx context.Context, quizID int64,
+	ctx context.Context, quizID int64, staleBefore time.Time,
 ) ([]*game.LeaderboardParticipant, error) {
-	rows, err := s.q.ListParticipantsForQuizLeaderboard(ctx, quizID)
+	rows, err := s.q.ListParticipantsForQuizLeaderboard(ctx, db.ListParticipantsForQuizLeaderboardParams{
+		ExpiredAt: staleBefore,
+		QuizID:    quizID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list leaderboard participants for quiz %d: %w", quizID, err)
 	}
@@ -378,9 +380,9 @@ func (s *GameStore) ListParticipantsForQuizLeaderboard(
 		participants = append(participants, &game.LeaderboardParticipant{
 			PlayerID: r.PlayerID,
 			Username: r.Username,
-			// CASE returns 1/0; treat non-zero as "every quiz question
-			// has been issued for this participant's game".
+			// CASE returns 1/0.
 			IsCompleted: r.IsCompleted != 0,
+			IsStale:     r.IsStale != 0,
 		})
 	}
 

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -736,7 +736,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 			t.Fatalf("failed to create participant: %v", err)
 		}
 
-		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID)
+		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID, time.Now())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -798,7 +798,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 			}
 		}
 
-		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID)
+		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID, time.Now())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -844,7 +844,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 			t.Fatalf("failed to create participant: %v", err)
 		}
 
-		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), emptyQuiz.ID)
+		rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), emptyQuiz.ID, time.Now())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -855,6 +855,82 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 			t.Errorf("rows[0].IsCompleted = %v, want %v (no questions defined)", got, want)
 		}
 	})
+
+	t.Run(
+		"returns IsStale=true when the latest game_question is unanswered and expired before staleBefore (#336)",
+		func(t *testing.T) {
+			t.Parallel()
+
+			// Insert a game_question whose expired_at is well in the past
+			// with no game_answer rows referencing it. With staleBefore set
+			// to now, the predicate should fire and surface the participant
+			// as stale even though they have not finished the quiz.
+			db := dbtest.Open(t)
+			quizStore := NewQuizStore(db, slog.Default())
+			testQuiz := newTestQuizzes()[0]
+			if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+				t.Fatalf("failed to create quiz: %v", err)
+			}
+
+			playerStore := NewPlayerStore(db, slog.Default())
+			player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-participant-stale")
+			if err != nil {
+				t.Fatalf("failed to create player: %v", err)
+			}
+
+			gameStore := NewGameStore(db, slog.Default())
+			g := &game.Game{QuizID: testQuiz.ID}
+			if err = gameStore.CreateGame(t.Context(), g); err != nil {
+				t.Fatalf("failed to create game: %v", err)
+			}
+			if err = gameStore.CreateParticipant(
+				t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID, QuizID: testQuiz.ID},
+			); err != nil {
+				t.Fatalf("failed to create participant: %v", err)
+			}
+
+			// Issue the first quiz question with an expired_at far in the
+			// past, and skip the matching game_answer. The remaining quiz
+			// questions stay unissued so the participant is not Completed.
+			past := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+			gq := &game.Question{
+				GameID:     g.ID,
+				QuestionID: testQuiz.Questions[0].ID,
+				StartedAt:  past.Add(-10 * time.Second),
+				ExpiredAt:  past,
+			}
+			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+				t.Fatalf("failed to create game question: %v", err)
+			}
+
+			// staleBefore = now: gq.expired_at (2 min ago) is before this,
+			// so the predicate fires.
+			rows, err := gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID, time.Now())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got, want := len(rows), 1; got != want {
+				t.Fatalf("len(rows) = %d, want %d", got, want)
+			}
+			if got, want := rows[0].IsStale, true; got != want {
+				t.Errorf("rows[0].IsStale = %v, want %v (latest game_question expired without answer)", got, want)
+			}
+			if got, want := rows[0].IsCompleted, false; got != want {
+				t.Errorf("rows[0].IsCompleted = %v, want %v (only 1 of 3 questions issued)", got, want)
+			}
+
+			// staleBefore far enough in the past that gq's expiry is AFTER
+			// it: the predicate should not fire, confirming the threshold
+			// is honoured rather than the field's existence.
+			rows, err = gameStore.ListParticipantsForQuizLeaderboard(t.Context(), testQuiz.ID, past.Add(-time.Hour))
+			if err != nil {
+				t.Fatalf("unexpected error on past staleBefore: %v", err)
+			}
+			if got, want := rows[0].IsStale, false; got != want {
+				t.Errorf("rows[0].IsStale = %v, want %v (staleBefore predates the expiry)", got, want)
+			}
+		},
+	)
 }
 
 // TestGameStore_ListQuizIDsForPlayer_IncludesJoinedButUnanswered pins


### PR DESCRIPTION
Server-side half of #336 (the client-side SSE-heartbeat-loss self-dot drop will land as a follow-up PR).