### PR TITLE
Carry anonymous game history onto the account on sign in

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -137,7 +137,9 @@ func HandleGoogleCallback(
 	authn *GoogleAuthenticator,
 	csrfMgr *csrf.Manager,
 	identities OAuthIdentityStore,
+	players PlayerStore,
 	sessions *session.Manager,
+	games AnonymousGameMigrator,
 	registrationEnabled bool,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
@@ -181,6 +183,7 @@ func HandleGoogleCallback(
 		}
 
 		sessions.Set(w, player.ID)
+		migrateGamesAfterSignIn(r.Context(), logger, players, games, sessionPlayerID, player.ID)
 		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 	})
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -303,11 +303,17 @@ func redirectIfSignedIn(
 // credentials, signs the player in, and redirects to the admin landing page.
 // registrationEnabled controls whether error renders show the "No account? Register" link.
 // googleEnabled controls whether error renders show the "Sign in with Google" button.
+// games is the post-login migration hook (#406): when the request
+// arrives with a session pointing at an anonymous row, that row's
+// game history is carried onto the signed-in account. Nil disables
+// the migration — accepted by callers (tests) that don't care about
+// the migration path.
 func HandleLoginSubmit(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
 	players PlayerStore,
 	sessions *session.Manager,
+	games AnonymousGameMigrator,
 	registrationEnabled, googleEnabled bool,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
@@ -371,7 +377,12 @@ func HandleLoginSubmit(
 			return
 		}
 
+		var priorSessionPlayerID *int64
+		if id, ok := sessions.PlayerID(r); ok {
+			priorSessionPlayerID = &id
+		}
 		sessions.Set(w, player.ID)
+		migrateGamesAfterSignIn(r.Context(), logger, players, games, priorSessionPlayerID, player.ID)
 		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 	})
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -793,7 +793,7 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false, false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -827,7 +827,7 @@ func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false, false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"bob"},
 		"password": {"correctbattery"},
@@ -845,7 +845,7 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false, false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"ghost"},
@@ -872,7 +872,7 @@ func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false, false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"wrong-password-no"},
@@ -895,7 +895,7 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), false, false)
+	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"legacy"},
 		"password": {"anything-goes-here-13"},

--- a/internal/auth/migrate.go
+++ b/internal/auth/migrate.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// migrateGamesAfterSignIn is the post-auth hook that carries an
+// anonymous visitor's pre-sign-in game history onto the account they
+// just signed into (#406).
+//
+// Runs after sessions.Set in HandleLoginSubmit and
+// HandleGoogleCallback. The four short-circuits keep the migration
+// limited to the case it was designed for:
+//
+//  1. priorSessionPlayerID is nil — visitor arrived without a session,
+//     nothing to migrate from.
+//  2. priorSessionPlayerID equals signedInPlayerID — the auth flow
+//     claimed the visitor's existing row in place (the password-claim
+//     path in HandleRegisterSubmit, the session-claim path in
+//     linkOrCreateGooglePlayer); the data is already on the right
+//     player, no move needed.
+//  3. The prior row no longer exists — race with another callback that
+//     already cleaned it up, or a manual admin delete.
+//  4. The prior row is NOT anonymous — visitor switched between two
+//     credentialled accounts on purpose; moving the previous account's
+//     game history would be data corruption, not a migration.
+//
+// Silent on success: no UI prompt today. The ticket's recommended
+// "Yes, move it?" confirm modal is a follow-up that lives on top of
+// this backend. Failure here is logged but does NOT fail the sign-in
+// — the visitor is already authenticated; refusing to redirect them
+// because an unrelated cleanup failed would be worse UX than the
+// orphaned-games state itself.
+func migrateGamesAfterSignIn(
+	ctx context.Context,
+	logger *slog.Logger,
+	players PlayerStore,
+	games AnonymousGameMigrator,
+	priorSessionPlayerID *int64,
+	signedInPlayerID int64,
+) {
+	if games == nil || priorSessionPlayerID == nil {
+		return
+	}
+	if *priorSessionPlayerID == signedInPlayerID {
+		return
+	}
+
+	prior, err := players.GetPlayerByID(ctx, *priorSessionPlayerID)
+	if err != nil {
+		if !errors.Is(err, ErrPlayerNotFound) {
+			logger.ErrorContext(ctx, "post-signin migrate: lookup prior session player",
+				slog.Int64("prior_player_id", *priorSessionPlayerID),
+				slog.Any("err", err),
+			)
+		}
+
+		return
+	}
+	if !prior.IsAnonymous() {
+		return
+	}
+
+	moved, err := games.ReattributeGames(ctx, *priorSessionPlayerID, signedInPlayerID)
+	if err != nil {
+		logger.ErrorContext(ctx, "post-signin migrate: reattribute games",
+			slog.Int64("from", *priorSessionPlayerID),
+			slog.Int64("to", signedInPlayerID),
+			slog.Any("err", err),
+		)
+
+		return
+	}
+	if moved > 0 {
+		logger.InfoContext(ctx, "post-signin migrate: reattributed anonymous games",
+			slog.Int64("from", *priorSessionPlayerID),
+			slog.Int64("to", signedInPlayerID),
+			slog.Int64("participants_moved", moved),
+		)
+	}
+}

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -87,6 +87,22 @@ func (p *Player) IsAuthenticated() bool {
 	return p.PasswordHash != "" || p.Email != "" || p.Role == RoleAdmin
 }
 
+// AnonymousGameMigrator carries an anonymous visitor's game data onto
+// the account they just signed into. Implemented by store.GameStore;
+// defined here so the auth package can call into it without importing
+// internal/game or internal/store, keeping the dep graph narrow and
+// the post-login migration testable with a small stub.
+//
+// ReattributeGames moves every game_answers + game_participants row
+// from fromPlayerID onto toPlayerID, skipping quizzes the destination
+// player has already played (UNIQUE (player_id, quiz_id) on
+// game_participants). Both moves run in a single transaction; the
+// return value is the number of participant rows that actually
+// moved (zero is a valid "nothing to do" outcome).
+type AnonymousGameMigrator interface {
+	ReattributeGames(ctx context.Context, fromPlayerID, toPlayerID int64) (int64, error)
+}
+
 // PlayerStore is the persistence interface used by the auth package.
 type PlayerStore interface {
 	// GetPlayerByUsername returns the player with the given username.

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -777,6 +777,77 @@ func (q *Queries) ListQuizIDsForPlayer(ctx context.Context, playerID int64) ([]i
 	return items, nil
 }
 
+const reattributeGameAnswers = `-- name: ReattributeGameAnswers :execrows
+UPDATE game_answers
+SET player_id = ?1
+WHERE game_answers.player_id = ?2
+  AND game_answers.game_id IN (
+      SELECT gp.game_id FROM game_participants gp
+      WHERE gp.player_id = ?2
+        AND NOT EXISTS (
+            SELECT 1 FROM game_participants gp2
+            WHERE gp2.player_id = ?1
+              AND gp2.quiz_id = gp.quiz_id
+        )
+  )
+`
+
+type ReattributeGameAnswersParams struct {
+	ToPlayerID   int64
+	FromPlayerID int64
+}
+
+// Re-assigns game_answers rows from from_player_id to to_player_id for
+// the games belonging to from_player_id whose quizzes the destination
+// player has not yet played. Skipping the conflict cases keeps the
+// UNIQUE INDEX on game_participants (player_id, quiz_id) satisfied
+// when ReattributeGameParticipants runs immediately after.
+//
+// Used by the post-login migration (#406) that carries an anonymous
+// visitor's game history onto the account they just signed into.
+// Returns the affected row count so the caller can decide whether to
+// broadcast an SSE refresh or skip the no-op case.
+//
+// The two queries are called inside a single transaction at the
+// service layer so a partial migration cannot leave answers
+// attributed to a player who has no participant row for that game.
+func (q *Queries) ReattributeGameAnswers(ctx context.Context, arg ReattributeGameAnswersParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reattributeGameAnswers, arg.ToPlayerID, arg.FromPlayerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const reattributeGameParticipants = `-- name: ReattributeGameParticipants :execrows
+UPDATE game_participants
+SET player_id = ?1
+WHERE game_participants.player_id = ?2
+  AND NOT EXISTS (
+      SELECT 1 FROM game_participants gp2
+      WHERE gp2.player_id = ?1
+        AND gp2.quiz_id = game_participants.quiz_id
+  )
+`
+
+type ReattributeGameParticipantsParams struct {
+	ToPlayerID   int64
+	FromPlayerID int64
+}
+
+// Re-assigns the participant rows themselves, skipping any quiz the
+// destination player has already played (UNIQUE (player_id, quiz_id)
+// would otherwise reject the UPDATE). Run after
+// ReattributeGameAnswers inside the same transaction so the answers
+// are moved while the source participation still exists.
+func (q *Queries) ReattributeGameParticipants(ctx context.Context, arg ReattributeGameParticipantsParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, reattributeGameParticipants, arg.ToPlayerID, arg.FromPlayerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const startGame = `-- name: StartGame :execresult
 UPDATE games
 SET started_at = CURRENT_TIMESTAMP

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -235,3 +235,46 @@ WHERE game_id IN (sqlc.slice('game_ids'));
 DELETE
 FROM games
 WHERE id IN (sqlc.slice('ids'));
+
+-- name: ReattributeGameAnswers :execrows
+-- Re-assigns game_answers rows from from_player_id to to_player_id for
+-- the games belonging to from_player_id whose quizzes the destination
+-- player has not yet played. Skipping the conflict cases keeps the
+-- UNIQUE INDEX on game_participants (player_id, quiz_id) satisfied
+-- when ReattributeGameParticipants runs immediately after.
+--
+-- Used by the post-login migration (#406) that carries an anonymous
+-- visitor's game history onto the account they just signed into.
+-- Returns the affected row count so the caller can decide whether to
+-- broadcast an SSE refresh or skip the no-op case.
+--
+-- The two queries are called inside a single transaction at the
+-- service layer so a partial migration cannot leave answers
+-- attributed to a player who has no participant row for that game.
+UPDATE game_answers
+SET player_id = sqlc.arg('to_player_id')
+WHERE game_answers.player_id = sqlc.arg('from_player_id')
+  AND game_answers.game_id IN (
+      SELECT gp.game_id FROM game_participants gp
+      WHERE gp.player_id = sqlc.arg('from_player_id')
+        AND NOT EXISTS (
+            SELECT 1 FROM game_participants gp2
+            WHERE gp2.player_id = sqlc.arg('to_player_id')
+              AND gp2.quiz_id = gp.quiz_id
+        )
+  );
+
+-- name: ReattributeGameParticipants :execrows
+-- Re-assigns the participant rows themselves, skipping any quiz the
+-- destination player has already played (UNIQUE (player_id, quiz_id)
+-- would otherwise reject the UPDATE). Run after
+-- ReattributeGameAnswers inside the same transaction so the answers
+-- are moved while the source participation still exists.
+UPDATE game_participants
+SET player_id = sqlc.arg('to_player_id')
+WHERE game_participants.player_id = sqlc.arg('from_player_id')
+  AND NOT EXISTS (
+      SELECT 1 FROM game_participants gp2
+      WHERE gp2.player_id = sqlc.arg('to_player_id')
+        AND gp2.quiz_id = game_participants.quiz_id
+  );

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -124,7 +124,8 @@ func addAuthRoutes(
 	mux.Handle(
 		"POST /login",
 		csrfMW(auth.HandleLoginSubmit(
-			logger, csrfMgr, stores.Players, sessions, cfg.RegistrationEnabled, googleEnabled,
+			logger, csrfMgr, stores.Players, sessions, stores.GameMigrator,
+			cfg.RegistrationEnabled, googleEnabled,
 		)),
 	)
 	mux.Handle("POST /logout", csrfMW(auth.HandleLogout(sessions)))
@@ -140,7 +141,10 @@ func addAuthRoutes(
 		mux.Handle("GET /login/google", auth.HandleGoogleLogin(logger, googleAuth))
 		mux.Handle(
 			"GET /login/google/callback",
-			auth.HandleGoogleCallback(logger, googleAuth, csrfMgr, stores.OAuth, sessions, cfg.RegistrationEnabled),
+			auth.HandleGoogleCallback(
+				logger, googleAuth, csrfMgr, stores.OAuth, stores.Players, sessions, stores.GameMigrator,
+				cfg.RegistrationEnabled,
+			),
 		)
 	} else {
 		logger.Info(

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -406,6 +406,53 @@ func (s *GameStore) ListQuizIDsForPlayer(ctx context.Context, playerID int64) ([
 	return ids, nil
 }
 
+// ReattributeGames moves every game_answers + game_participants row
+// from fromPlayerID onto toPlayerID, skipping quizzes the destination
+// player has already played (the UNIQUE (player_id, quiz_id) index on
+// game_participants would otherwise reject the move). The two
+// statements run in a single transaction so a crash in the middle
+// cannot leave answers attributed to a player who has no participant
+// row for the same game.
+//
+// Returns the participant-row count that moved. Zero is a valid
+// "nothing to do" outcome — callers can short-circuit any post-move
+// work (SSE refresh, orphan cleanup) on it.
+//
+// Used by the post-login migration (#406) when a visitor's session
+// flipped from an anonymous row to a different signed-in account; the
+// anonymous row's game history is carried onto the signed-in account
+// so a leaderboard entry the visitor just earned does not disappear.
+func (s *GameStore) ReattributeGames(ctx context.Context, fromPlayerID, toPlayerID int64) (int64, error) {
+	var movedParticipants int64
+	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		// Move answers first while the participant rows on
+		// fromPlayerID still exist — the answers query joins through
+		// game_participants to scope which games are eligible.
+		if _, aErr := q.ReattributeGameAnswers(ctx, db.ReattributeGameAnswersParams{
+			ToPlayerID:   toPlayerID,
+			FromPlayerID: fromPlayerID,
+		}); aErr != nil {
+			return fmt.Errorf("reattribute game_answers: %w", aErr)
+		}
+
+		moved, pErr := q.ReattributeGameParticipants(ctx, db.ReattributeGameParticipantsParams{
+			ToPlayerID:   toPlayerID,
+			FromPlayerID: fromPlayerID,
+		})
+		if pErr != nil {
+			return fmt.Errorf("reattribute game_participants: %w", pErr)
+		}
+		movedParticipants = moved
+
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to reattribute games from %d to %d: %w", fromPlayerID, toPlayerID, err)
+	}
+
+	return movedParticipants, nil
+}
+
 func (s *GameStore) deleteGamesForPlayerOnQuizTx(
 	ctx context.Context, tx *sql.Tx, playerID, quizID int64,
 ) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,12 +12,18 @@ import (
 )
 
 // Stores is a collection of stores for the application.
+//
+// GameStore satisfies both game.Store (the broad interface the game
+// service uses) and auth.AnonymousGameMigrator (the narrow one the
+// post-sign-in migration uses); both slots point at the same concrete
+// instance so consumers only see the methods relevant to their flow.
 type Stores struct {
-	Quizzes quiz.Store
-	Games   game.Store
-	Players auth.PlayerStore
-	OAuth   auth.OAuthIdentityStore
-	Home    home.Store
+	Quizzes      quiz.Store
+	Games        game.Store
+	GameMigrator auth.AnonymousGameMigrator
+	Players      auth.PlayerStore
+	OAuth        auth.OAuthIdentityStore
+	Home         home.Store
 }
 
 // New initializes a new Stores instance with the provided database connection.
@@ -27,12 +33,14 @@ type Stores struct {
 // so they only see the methods relevant to their flow.
 func New(conn *sql.DB, logger *slog.Logger) *Stores {
 	players := NewPlayerStore(conn, logger)
+	games := NewGameStore(conn, logger)
 
 	return &Stores{
-		Quizzes: NewQuizStore(conn, logger),
-		Games:   NewGameStore(conn, logger),
-		Players: players,
-		OAuth:   players,
-		Home:    NewHomeStore(conn, logger),
+		Quizzes:      NewQuizStore(conn, logger),
+		Games:        games,
+		GameMigrator: games,
+		Players:      players,
+		OAuth:        players,
+		Home:         NewHomeStore(conn, logger),
 	}
 }

--- a/test/integration/anon_migration_test.go
+++ b/test/integration/anon_migration_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// TestAnonMigration_Integration covers #406: an anonymous visitor's
+// game history follows them onto the account they sign into. Drives
+// the full HTTP stack against a real server: register an admin,
+// publish a quiz, log out, play through anonymously, then log back
+// in as an existing player and verify the just-played game now
+// belongs to the signed-in player.
+func TestAnonMigration_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegration(t)
+	baseURL := setup.BaseURL
+	stores := setup.Stores
+
+	// Seed an admin + a quiz the anonymous visitor will play.
+	quizRow := &quiz.Quiz{
+		Title: "Migration Test Quiz", Slug: "migration-test-quiz",
+		Description:       "Carry me across the auth boundary.",
+		CreatedByPlayerID: seededAdminID,
+		Questions: []*quiz.Question{
+			{Text: "Q1", Position: 1, Options: []*quiz.Option{{Text: "a", Correct: true}, {Text: "b"}}},
+		},
+	}
+	if err := stores.Quizzes.CreateQuiz(ctx, quizRow); err != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", err)
+	}
+
+	// Register the destination account directly so the anonymous
+	// visitor can sign INTO it later. Need a separate client so its
+	// cookie jar doesn't carry the destination's session into the
+	// anonymous-play step below.
+	destClient := authClient(t)
+	registerForRedirect(ctx, t, destClient, baseURL, "migration-dest", "correct-battery-13")
+	destPlayer, err := stores.Players.GetPlayerByUsername(ctx, "migration-dest")
+	if err != nil {
+		t.Fatalf("lookup destination player err = %v, want nil", err)
+	}
+
+	// Anonymous play. A fresh client gets an EnsurePlayer petname row
+	// the first time it hits the API.
+	anonClient := authClient(t)
+	primeAnonymousPlayer(ctx, t, anonClient, baseURL)
+	anonPlayer := lookupAnonPlayer(ctx, t, setup.Stores.Players, "migration-dest", "admin")
+	if anonPlayer.ID == destPlayer.ID || anonPlayer.ID == seededAdminID {
+		t.Fatalf("anonymous player id (%d) clashed with a known seeded id", anonPlayer.ID)
+	}
+	finishGameInt(t, stores.Games, anonPlayer.ID, quizRow)
+
+	// Anonymous now has one finished game on quizRow; destination has zero.
+	requirePlayerGameCount(t, setup.DBURI, anonPlayer.ID, 1)
+	requirePlayerGameCount(t, setup.DBURI, destPlayer.ID, 0)
+
+	// Sign anonClient in as the destination account via POST /login.
+	loginAnonAsDest(ctx, t, anonClient, baseURL, "migration-dest", "correct-battery-13")
+
+	// After sign-in: the game should now belong to destination.
+	requirePlayerGameCount(t, setup.DBURI, anonPlayer.ID, 0)
+	requirePlayerGameCount(t, setup.DBURI, destPlayer.ID, 1)
+}
+
+// primeAnonymousPlayer touches GET /api/players/me so EnsurePlayer
+// mints an anonymous row + sets the session cookie on the client's
+// jar. The body is drained + closed inside.
+func primeAnonymousPlayer(ctx context.Context, t *testing.T, client *http.Client, baseURL string) {
+	t.Helper()
+	resp := httpGet(ctx, t, client, baseURL+"/api/players/me")
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("prime /api/players/me status = %d, want %d", got, want)
+	}
+}
+
+// lookupAnonPlayer finds the most recently created players row that
+// is not one of the names the test already knows (seed admin + the
+// destination account). Used because EnsurePlayer assigns a random
+// petname, so the test can't ask for it by name.
+func lookupAnonPlayer(ctx context.Context, t *testing.T, players auth.PlayerStore, excluded ...string) *auth.Player {
+	t.Helper()
+	// The seed admin is always id=1 and the destination is id=2 in
+	// this test's narrow universe; the anonymous row is therefore
+	// id=3 (or higher if the test grows). Probe by ascending id
+	// until we hit a row whose username is not in the excluded set.
+	for id := int64(2); id <= 20; id++ {
+		p, err := players.GetPlayerByID(ctx, id)
+		if err != nil {
+			continue
+		}
+		known := slices.Contains(excluded, p.Username)
+		if !known {
+			return p
+		}
+	}
+	t.Fatal("could not find an anonymous player row to migrate from")
+
+	return nil
+}
+
+// loginAnonAsDest POSTs the credentials with the anonymous client's
+// jar carrying the EnsurePlayer session cookie, so the login handler
+// sees a prior anonymous session and triggers the migration.
+func loginAnonAsDest(ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string) {
+	t.Helper()
+
+	csrfToken := primeLoginCSRF(ctx, t, client, baseURL)
+
+	form := url.Values{
+		"csrf_token": {csrfToken},
+		"username":   {username},
+		"password":   {password},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, baseURL+"/login", strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("login Do err = %v, want nil", err)
+	}
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("login status = %d, want %d", got, want)
+	}
+}
+
+// primeLoginCSRF GETs /login on the supplied client (so the nonce
+// cookie lands on its jar) and returns the csrf_token value rendered
+// on the form. Body is drained and closed inside the helper so
+// callers don't have to manage the Response lifetime.
+func primeLoginCSRF(ctx context.Context, t *testing.T, client *http.Client, baseURL string) string {
+	t.Helper()
+	resp := httpGet(ctx, t, client, baseURL+"/login")
+	defer closeBody(t, resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /login body err = %v, want nil", err)
+	}
+	matches := regexp.MustCompile(`name="csrf_token" value="([^"]+)"`).FindStringSubmatch(string(body))
+	if len(matches) < 2 {
+		t.Fatalf("csrf token missing from /login body (excerpt: %.200q)", string(body))
+	}
+
+	return matches[1]
+}
+
+// requirePlayerGameCount opens the test DB and asserts the
+// game_participants count for the given player matches want.
+func requirePlayerGameCount(t *testing.T, dbURI string, playerID int64, want int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	var got int
+	if err := db.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM game_participants WHERE player_id = ?`, playerID,
+	).Scan(&got); err != nil {
+		t.Fatalf("count game_participants err = %v, want nil", err)
+	}
+	if got != want {
+		t.Errorf("game_participants for player %d = %d, want %d", playerID, got, want)
+	}
+}

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -241,6 +241,7 @@ func registerGameplayAdmin(ctx context.Context, t *testing.T, client *http.Clien
 // out of setupIntegration as the first return value) to avoid containedctx.
 type integrationSetup struct {
 	BaseURL string
+	DBURI   string
 	Stores  *store.Stores
 }
 
@@ -268,6 +269,7 @@ func setupIntegration(t *testing.T) (context.Context, integrationSetup) {
 
 	return ctx, integrationSetup{
 		BaseURL: srv.BaseURL,
+		DBURI:   srv.DBURI,
 		Stores:  store.New(db, slog.Default()),
 	}
 }


### PR DESCRIPTION
Closes #406

## Notes

- **Silent migration for the first cut.** The ticket recommended a "Yes, move it?" confirm modal; building it would require a return-to-page query param plus a new UI surface. The backend here is the prerequisite either way — a follow-up PR can add the prompt without changing this code. Failure logs but does not block the sign-in.
- **Conflict handling.** UNIQUE (player_id, quiz_id) on game_participants would reject any move where the destination has already played the same quiz; the SQL skips those rows explicitly so the visitor still signs in cleanly and only the non-conflicting games migrate.
- **Symmetric coverage.** Wired into both \`HandleLoginSubmit\` (password) and \`HandleGoogleCallback\` (OAuth) — the migration is a post-auth hook independent of the credential type.
- **Narrow dependency**, not a wholesale game-store import in the auth package: \`auth.AnonymousGameMigrator\` is a one-method interface that \`store.GameStore\` satisfies; the wiring layer threads it through.

## Out of scope (separate follow-up tickets if needed)

- The confirm-before-migrate UI prompt.
- Cleanup of the orphaned anonymous \`players\` row (it has no game data left after the move; harmless, but a sweep job could collect them).
- Per-quiz SSE refresh on the destination quizzes (today the next answer triggers a re-render naturally).