### PR TITLE
Sweep unit tests to blackbox plus dot import convention

### DIFF
--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -10,7 +10,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/starquake/topbanana/cmd/server/app"
+	. "github.com/starquake/topbanana/cmd/server/app"
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/database"
 	"github.com/starquake/topbanana/internal/dbtest"
@@ -35,7 +35,7 @@ func TestCheck_FreshDB_Succeeds(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	if err := app.Check(t.Context(), getenv, &stdout); err != nil {
+	if err := Check(t.Context(), getenv, &stdout); err != nil {
 		t.Fatalf("Check err = %v, want nil", err)
 	}
 	if got, want := stdout.String(), "startup ok"; !strings.Contains(got, want) {
@@ -52,7 +52,7 @@ func TestCheck_BadDBURI_ReturnsError(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	err := app.Check(t.Context(), getenv, &stdout)
+	err := Check(t.Context(), getenv, &stdout)
 	if err == nil {
 		t.Fatal("Check err = nil, want non-nil for unreachable DB_URI")
 	}
@@ -145,7 +145,7 @@ func TestResetPassword_HappyPath_RotatesHash(t *testing.T) {
 
 	stdin := strings.NewReader(newPassword + "\n" + newPassword + "\n")
 	var stdout, stderr bytes.Buffer
-	if err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, username); err != nil {
+	if err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, username); err != nil {
 		t.Fatalf("ResetPassword err = %v, want nil", err)
 	}
 
@@ -190,7 +190,7 @@ func TestResetPassword_UsernameWhitespaceTrimmed_RotatesHash(t *testing.T) {
 
 	stdin := strings.NewReader(newPassword + "\n" + newPassword + "\n")
 	var stdout, stderr bytes.Buffer
-	if err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "  alice  "); err != nil {
+	if err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "  alice  "); err != nil {
 		t.Fatalf("ResetPassword err = %v, want nil", err)
 	}
 
@@ -213,11 +213,11 @@ func TestResetPassword_UnknownUsername_ReturnsError(t *testing.T) {
 
 	stdin := strings.NewReader("new-correct-battery\nnew-correct-battery\n")
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "ghost")
+	err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "ghost")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for unknown username")
 	}
-	if got, want := err, app.ErrResetUserNotFound; !errors.Is(got, want) {
+	if got, want := err, ErrResetUserNotFound; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -237,11 +237,11 @@ func TestResetPassword_PasswordTooShort_ReturnsError(t *testing.T) {
 
 	stdin := strings.NewReader("short\n")
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
+	err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for too-short password")
 	}
-	if got, want := err, app.ErrResetPasswordTooShort; !errors.Is(got, want) {
+	if got, want := err, ErrResetPasswordTooShort; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -266,11 +266,11 @@ func TestResetPassword_PasswordTooLong_ReturnsError(t *testing.T) {
 	tooLong := strings.Repeat("a", auth.MaxPasswordLength+1)
 	stdin := strings.NewReader(tooLong + "\n")
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
+	err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for too-long password")
 	}
-	if got, want := err, app.ErrResetPasswordTooLong; !errors.Is(got, want) {
+	if got, want := err, ErrResetPasswordTooLong; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -290,11 +290,11 @@ func TestResetPassword_ConfirmationMismatch_ReturnsError(t *testing.T) {
 	// Two lines, both long enough to pass the length check, but different.
 	stdin := strings.NewReader("new-correct-battery\nnew-correct-typo-here\n")
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
+	err := ResetPassword(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for mismatching confirmation")
 	}
-	if got, want := err, app.ErrResetPasswordsDontMatch; !errors.Is(got, want) {
+	if got, want := err, ErrResetPasswordsDontMatch; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -316,11 +316,11 @@ func TestResetPassword_EmptyUsername_ReturnsError(t *testing.T) {
 	getenv := func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), getenv, strings.NewReader(""), &stdout, &stderr, "   ")
+	err := ResetPassword(t.Context(), getenv, strings.NewReader(""), &stdout, &stderr, "   ")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for whitespace-only username")
 	}
-	if got, want := err, app.ErrResetUsernameRequired; !errors.Is(got, want) {
+	if got, want := err, ErrResetUsernameRequired; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 	if got := stdout.String(); got != "" {
@@ -340,11 +340,11 @@ func TestResetPassword_ClosedStdin_ReturnsError(t *testing.T) {
 	seedPlayer(t, dbURI, "alice")
 
 	var stdout, stderr bytes.Buffer
-	err := app.ResetPassword(t.Context(), envFor(dbURI), strings.NewReader(""), &stdout, &stderr, "alice")
+	err := ResetPassword(t.Context(), envFor(dbURI), strings.NewReader(""), &stdout, &stderr, "alice")
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for empty stdin")
 	}
-	if got, want := err, app.ErrResetEmptyInput; !errors.Is(got, want) {
+	if got, want := err, ErrResetEmptyInput; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 

--- a/internal/absurl/absurl_test.go
+++ b/internal/absurl/absurl_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/absurl"
+	. "github.com/starquake/topbanana/internal/absurl"
 )
 
 func TestBaseURL(t *testing.T) {
@@ -70,7 +70,7 @@ func TestBaseURL(t *testing.T) {
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}
-			if got, want := absurl.BaseURL(req), tc.want; got != want {
+			if got, want := BaseURL(req), tc.want; got != want {
 				t.Errorf("BaseURL = %q, want %q", got, want)
 			}
 		})

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,21 +7,21 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 )
 
 func TestHashPassword_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	plain := "correct horse battery staple"
-	hashed, err := auth.HashPassword(plain)
+	hashed, err := HashPassword(plain)
 	if err != nil {
 		t.Fatalf("HashPassword(%q) err = %v, want nil", plain, err)
 	}
 	if hashed == plain {
 		t.Errorf("HashPassword(%q) = %q, want a value different from the plaintext", plain, hashed)
 	}
-	if err := auth.CheckPassword(hashed, plain); err != nil {
+	if err := CheckPassword(hashed, plain); err != nil {
 		t.Errorf("CheckPassword(_, %q) = %v, want nil", plain, err)
 	}
 }
@@ -29,11 +29,11 @@ func TestHashPassword_RoundTrip(t *testing.T) {
 func TestCheckPassword_WrongPassword(t *testing.T) {
 	t.Parallel()
 
-	hashed, err := auth.HashPassword("right")
+	hashed, err := HashPassword("right")
 	if err != nil {
 		t.Fatalf("HashPassword: %v", err)
 	}
-	checkErr := auth.CheckPassword(hashed, "wrong")
+	checkErr := CheckPassword(hashed, "wrong")
 	if got, want := checkErr, bcrypt.ErrMismatchedHashAndPassword; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -45,7 +45,7 @@ func TestCheckPassword_WrongPassword(t *testing.T) {
 func TestCheckPassword_MalformedHash(t *testing.T) {
 	t.Parallel()
 
-	if got, want := auth.CheckPassword("not-a-bcrypt-hash", "anything"), bcrypt.ErrHashTooShort; !errors.Is(got, want) {
+	if got, want := CheckPassword("not-a-bcrypt-hash", "anything"), bcrypt.ErrHashTooShort; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }

--- a/internal/auth/context_test.go
+++ b/internal/auth/context_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 )
 
 func TestPlayerFromContext_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	want := &auth.Player{ID: 7, Username: "alice", Role: auth.RoleAdmin}
-	ctx := auth.WithPlayer(t.Context(), want)
+	want := &Player{ID: 7, Username: "alice", Role: RoleAdmin}
+	ctx := WithPlayer(t.Context(), want)
 
-	got, ok := auth.PlayerFromContext(ctx)
+	got, ok := PlayerFromContext(ctx)
 	if !ok {
 		t.Fatal("PlayerFromContext ok = false, want true")
 	}
@@ -25,7 +25,7 @@ func TestPlayerFromContext_RoundTrip(t *testing.T) {
 func TestPlayerFromContext_Missing(t *testing.T) {
 	t.Parallel()
 
-	got, ok := auth.PlayerFromContext(context.Background())
+	got, ok := PlayerFromContext(context.Background())
 	if ok {
 		t.Error("PlayerFromContext ok = true, want false")
 	}

--- a/internal/auth/google_test.go
+++ b/internal/auth/google_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 )
 
 // stubOAuthStore is an in-memory OAuthIdentityStore for unit tests
@@ -15,8 +15,8 @@ import (
 // PlayerStore methods because the OAuth flow does not touch them.
 type stubOAuthStore struct {
 	mu             sync.Mutex
-	players        map[int64]*auth.Player
-	byEmail        map[string]*auth.Player
+	players        map[int64]*Player
+	byEmail        map[string]*Player
 	identities     map[identityKey]int64
 	nextID         int64
 	createErr      error
@@ -33,14 +33,14 @@ type identityKey struct {
 
 func newStubOAuthStore() *stubOAuthStore {
 	return &stubOAuthStore{
-		players:    map[int64]*auth.Player{},
-		byEmail:    map[string]*auth.Player{},
+		players:    map[int64]*Player{},
+		byEmail:    map[string]*Player{},
 		identities: map[identityKey]int64{},
 		nextID:     1,
 	}
 }
 
-func (s *stubOAuthStore) GetPlayerByProviderSubject(_ context.Context, provider, subject string) (*auth.Player, error) {
+func (s *stubOAuthStore) GetPlayerByProviderSubject(_ context.Context, provider, subject string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -49,13 +49,13 @@ func (s *stubOAuthStore) GetPlayerByProviderSubject(_ context.Context, provider,
 	}
 	id, ok := s.identities[identityKey{Provider: provider, Subject: subject}]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 
 	return s.players[id], nil
 }
 
-func (s *stubOAuthStore) GetPlayerByEmail(_ context.Context, email string) (*auth.Player, error) {
+func (s *stubOAuthStore) GetPlayerByEmail(_ context.Context, email string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -64,13 +64,13 @@ func (s *stubOAuthStore) GetPlayerByEmail(_ context.Context, email string) (*aut
 	}
 	p, ok := s.byEmail[email]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 
 	return p, nil
 }
 
-func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, email string) (*auth.Player, error) {
+func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, email string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -80,17 +80,17 @@ func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, emai
 	if s.createColl > 0 {
 		s.createColl--
 
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 	if _, exists := s.byEmail[email]; exists && email != "" {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
-	p := &auth.Player{
+	p := &Player{
 		ID:       s.nextID,
 		Username: username,
 		Email:    email,
-		Role:     auth.RolePlayer,
+		Role:     RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -110,26 +110,26 @@ func (s *stubOAuthStore) LinkProviderIdentity(_ context.Context, playerID int64,
 	}
 	key := identityKey{Provider: provider, Subject: subject}
 	if _, exists := s.identities[key]; exists {
-		return auth.ErrIdentityAlreadyLinked
+		return ErrIdentityAlreadyLinked
 	}
 	s.identities[key] = playerID
 
 	return nil
 }
 
-func (s *stubOAuthStore) ClaimPlayerForOAuth(_ context.Context, playerID int64, email string) (*auth.Player, error) {
+func (s *stubOAuthStore) ClaimPlayerForOAuth(_ context.Context, playerID int64, email string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	p, ok := s.players[playerID]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 	// Mirror the SQL's "anonymous only" guard so the stub fails the
 	// same way the production query would when the row has already
 	// been credentialled or carries an email.
 	if p.PasswordHash != "" || p.Email != "" {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 	p.Email = email
 	if email != "" {
@@ -142,14 +142,14 @@ func (s *stubOAuthStore) ClaimPlayerForOAuth(_ context.Context, playerID int64, 
 // seedAnonymous inserts a fully anonymous players row (no password,
 // no email) so the session-claim test has a target the
 // ClaimPlayerForOAuth guard accepts.
-func (s *stubOAuthStore) seedAnonymous(username string) *auth.Player {
+func (s *stubOAuthStore) seedAnonymous(username string) *Player {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	p := &auth.Player{
+	p := &Player{
 		ID:       s.nextID,
 		Username: username,
-		Role:     auth.RolePlayer,
+		Role:     RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -161,15 +161,15 @@ func (s *stubOAuthStore) seedAnonymous(username string) *auth.Player {
 // existing target without going through CreatePlayerFromOAuth. Always
 // inserts as a plain "player" — the OAuth race-recovery tests don't
 // exercise admin-promotion paths, so the role is fixed.
-func (s *stubOAuthStore) seed(email, username string) *auth.Player {
+func (s *stubOAuthStore) seed(email, username string) *Player {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	p := &auth.Player{
+	p := &Player{
 		ID:       s.nextID,
 		Username: username,
 		Email:    email,
-		Role:     auth.RolePlayer,
+		Role:     RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -187,7 +187,7 @@ func TestLinkOrCreateGooglePlayer_NewPlayer(t *testing.T) {
 	t.Parallel()
 
 	store := newStubOAuthStore()
-	player, err := auth.ExportLinkOrCreateGooglePlayer(
+	player, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-1", "fresh@example.test", nil,
 	)
 	if err != nil {
@@ -207,7 +207,7 @@ func TestLinkOrCreateGooglePlayer_NewPlayer(t *testing.T) {
 
 	// A second call with the same subject reads the existing identity
 	// row and returns the same player.
-	again, err := auth.ExportLinkOrCreateGooglePlayer(
+	again, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-1", "fresh@example.test", nil,
 	)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestLinkOrCreateGooglePlayer_LinkExistingEmail(t *testing.T) {
 	store := newStubOAuthStore()
 	existing := store.seed("alice@example.test", "alice")
 
-	player, err := auth.ExportLinkOrCreateGooglePlayer(
+	player, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-2", "alice@example.test", nil,
 	)
 	if err != nil {
@@ -242,7 +242,7 @@ func TestLinkOrCreateGooglePlayer_LinkExistingEmail(t *testing.T) {
 	}
 
 	// Lookup by subject now resolves to the same row.
-	bySubject, err := store.GetPlayerByProviderSubject(t.Context(), auth.ProviderGoogle, "google-sub-2")
+	bySubject, err := store.GetPlayerByProviderSubject(t.Context(), ProviderGoogle, "google-sub-2")
 	if err != nil {
 		t.Fatalf("GetPlayerByProviderSubject err = %v, want nil", err)
 	}
@@ -261,7 +261,7 @@ func TestLinkOrCreateGooglePlayer_RetriesPetnameCollision(t *testing.T) {
 	store := newStubOAuthStore()
 	store.createColl = 2
 
-	player, err := auth.ExportLinkOrCreateGooglePlayer(
+	player, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-retry", "retry@example.test", nil,
 	)
 	if err != nil {
@@ -284,13 +284,13 @@ func TestLinkOrCreateGooglePlayer_ExhaustsRetries(t *testing.T) {
 	store := newStubOAuthStore()
 	store.createColl = 100 // far more than the loop allows
 
-	_, err := auth.ExportLinkOrCreateGooglePlayer(
+	_, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-exhaust", "exhaust@example.test", nil,
 	)
 	if err == nil {
 		t.Fatal("ExportLinkOrCreateGooglePlayer err = nil, want non-nil after exhausting retries")
 	}
-	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+	if got, want := err, ErrUsernameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want it to wrap %v", got, want)
 	}
 }
@@ -306,7 +306,7 @@ func TestLinkOrCreateGooglePlayer_ClaimsAnonymousSession(t *testing.T) {
 	store := newStubOAuthStore()
 	anon := store.seedAnonymous("happy-banana")
 
-	player, err := auth.ExportLinkOrCreateGooglePlayer(
+	player, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-claim", "claim@example.test", &anon.ID,
 	)
 	if err != nil {
@@ -324,7 +324,7 @@ func TestLinkOrCreateGooglePlayer_ClaimsAnonymousSession(t *testing.T) {
 
 	// A subsequent sign-in with the same subject resolves through the
 	// identity lookup and lands on the same row.
-	bySubject, err := store.GetPlayerByProviderSubject(t.Context(), auth.ProviderGoogle, "google-sub-claim")
+	bySubject, err := store.GetPlayerByProviderSubject(t.Context(), ProviderGoogle, "google-sub-claim")
 	if err != nil {
 		t.Fatalf("GetPlayerByProviderSubject err = %v, want nil", err)
 	}
@@ -344,7 +344,7 @@ func TestLinkOrCreateGooglePlayer_SessionWithNonAnonymousRowFallsThrough(t *test
 	store := newStubOAuthStore()
 	credentialled := store.seed("settled@example.test", "settled")
 
-	player, err := auth.ExportLinkOrCreateGooglePlayer(
+	player, err := ExportLinkOrCreateGooglePlayer(
 		t.Context(), store, "google-sub-fallthrough", "newcomer@example.test", &credentialled.ID,
 	)
 	if err != nil {
@@ -379,14 +379,14 @@ func TestClaimAnonymousSessionPlayer_RecoversFromConcurrentLink(t *testing.T) {
 	winner := store.seed("winner@example.test", "winner")
 	// Pre-link the identity to the winning row so the recovery
 	// lookup finds it.
-	if err := store.LinkProviderIdentity(t.Context(), winner.ID, auth.ProviderGoogle, "google-sub-race"); err != nil {
+	if err := store.LinkProviderIdentity(t.Context(), winner.ID, ProviderGoogle, "google-sub-race"); err != nil {
 		t.Fatalf("seed LinkProviderIdentity err = %v, want nil", err)
 	}
 
 	// The loser passes its own session player id (also pointing at
 	// "winner.ID" because both callbacks share the cookie) and the
 	// same email + subject the winner used.
-	got, err := auth.ExportClaimAnonymousSessionPlayer(
+	got, err := ExportClaimAnonymousSessionPlayer(
 		t.Context(), store, winner.ID, "google-sub-race", "winner@example.test",
 	)
 	if err != nil {
@@ -409,13 +409,13 @@ func TestClaimAnonymousSessionPlayer_NoRaceFallsThrough(t *testing.T) {
 	// nothing has linked the subject yet.
 	row := store.seed("stale@example.test", "stale")
 
-	got, err := auth.ExportClaimAnonymousSessionPlayer(
+	got, err := ExportClaimAnonymousSessionPlayer(
 		t.Context(), store, row.ID, "google-sub-unlinked", "stale@example.test",
 	)
 	if err == nil {
 		t.Fatalf("err = nil, want ErrPlayerNotFound (got player=%v)", got)
 	}
-	if !errors.Is(err, auth.ErrPlayerNotFound) {
+	if !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("err = %v, want it to wrap ErrPlayerNotFound", err)
 	}
 }
@@ -434,13 +434,13 @@ func TestCreateGooglePlayer_RecoversFromConcurrentLink(t *testing.T) {
 	if err := store.LinkProviderIdentity(
 		t.Context(),
 		winner.ID,
-		auth.ProviderGoogle,
+		ProviderGoogle,
 		"google-sub-create-race",
 	); err != nil {
 		t.Fatalf("seed LinkProviderIdentity err = %v, want nil", err)
 	}
 
-	got, err := auth.ExportCreateGooglePlayer(
+	got, err := ExportCreateGooglePlayer(
 		t.Context(), store, "google-sub-create-race", "newcomer@example.test",
 	)
 	if err != nil {
@@ -464,32 +464,32 @@ func TestSignAndValidateState_RoundTrip(t *testing.T) {
 	const nonce = "deterministic-nonce-for-testing"
 	key := []byte("session-key-for-tests")
 
-	signed := auth.ExportSignState(key, nonce)
+	signed := ExportSignState(key, nonce)
 	if signed == "" {
 		t.Fatal("signState returned empty string")
 	}
 
 	// Same key, same nonce in the cookie, same value in the query =>
 	// valid.
-	if err := auth.ExportVerifySignedState(key, signed, signed); err != nil {
+	if err := ExportVerifySignedState(key, signed, signed); err != nil {
 		t.Errorf("validateState(matching) err = %v, want nil", err)
 	}
 
 	// Different key => invalid signature.
-	if err := auth.ExportVerifySignedState(
+	if err := ExportVerifySignedState(
 		[]byte("other"),
 		signed,
 		signed,
 	); !errors.Is(
 		err,
-		auth.ErrGoogleStateMismatch,
+		ErrGoogleStateMismatch,
 	) {
-		t.Errorf("validateState(other key) err = %v, want %v", err, auth.ErrGoogleStateMismatch)
+		t.Errorf("validateState(other key) err = %v, want %v", err, ErrGoogleStateMismatch)
 	}
 
 	// Mismatched cookie vs query => invalid.
 	tampered := signed[:len(signed)-1] + "x"
-	if err := auth.ExportVerifySignedState(key, signed, tampered); !errors.Is(err, auth.ErrGoogleStateMismatch) {
-		t.Errorf("validateState(mismatch) err = %v, want %v", err, auth.ErrGoogleStateMismatch)
+	if err := ExportVerifySignedState(key, signed, tampered); !errors.Is(err, ErrGoogleStateMismatch) {
+		t.Errorf("validateState(mismatch) err = %v, want %v", err, ErrGoogleStateMismatch)
 	}
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -12,15 +12,15 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/session"
 )
 
 // stubPlayerStore is an in-memory PlayerStore for tests.
 type stubPlayerStore struct {
 	mu      sync.Mutex
-	byID    map[int64]*auth.Player
-	byName  map[string]*auth.Player
+	byID    map[int64]*Player
+	byName  map[string]*Player
 	nextID  int64
 	failGet bool
 	// forceAnonCollisions, when > 0, makes the next N CreateAnonymousPlayer
@@ -41,25 +41,25 @@ type stubPlayerStore struct {
 
 func newStubPlayerStore() *stubPlayerStore {
 	return &stubPlayerStore{
-		byID:   map[int64]*auth.Player{},
-		byName: map[string]*auth.Player{},
+		byID:   map[int64]*Player{},
+		byName: map[string]*Player{},
 		nextID: 1,
 	}
 }
 
-func (s *stubPlayerStore) GetPlayerByUsername(_ context.Context, username string) (*auth.Player, error) {
+func (s *stubPlayerStore) GetPlayerByUsername(_ context.Context, username string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	p, ok := s.byName[username]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 
 	return p, nil
 }
 
-func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*auth.Player, error) {
+func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -68,7 +68,7 @@ func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*auth.Play
 	}
 	p, ok := s.byID[id]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 
 	return p, nil
@@ -81,17 +81,17 @@ func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*auth.Play
 func (s *stubPlayerStore) CreatePlayer(
 	_ context.Context,
 	username, passwordHash, requestedRole string,
-) (*auth.Player, error) {
+) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, exists := s.byName[username]; exists {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
 	role := s.resolveRoleLocked(requestedRole)
 
-	p := &auth.Player{
+	p := &Player{
 		ID:           s.nextID,
 		Username:     username,
 		PasswordHash: passwordHash,
@@ -106,7 +106,7 @@ func (s *stubPlayerStore) CreatePlayer(
 
 // CreateAnonymousPlayer mirrors store.CreateAnonymousPlayer: insert a row
 // with the given username, no password_hash, role = "player".
-func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username string) (*auth.Player, error) {
+func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -119,17 +119,17 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 	if s.forceAnonCollisions > 0 {
 		s.forceAnonCollisions--
 
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
 	if _, exists := s.byName[username]; exists {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
-	p := &auth.Player{
+	p := &Player{
 		ID:       s.nextID,
 		Username: username,
-		Role:     auth.RolePlayer,
+		Role:     RolePlayer,
 	}
 	s.nextID++
 	s.byID[p.ID] = p
@@ -139,25 +139,25 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 }
 
 // ClaimPlayer mirrors store.ClaimPlayer: upgrades an anonymous row in place
-// or fails with auth.ErrPlayerAlreadyClaimed / ErrPlayerNotFound /
+// or fails with ErrPlayerAlreadyClaimed / ErrPlayerNotFound /
 // ErrUsernameTaken.
 func (s *stubPlayerStore) ClaimPlayer(
 	_ context.Context,
 	playerID int64,
 	username, passwordHash, requestedRole string,
-) (*auth.Player, error) {
+) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	existing, ok := s.byID[playerID]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 	if existing.PasswordHash != "" {
-		return nil, auth.ErrPlayerAlreadyClaimed
+		return nil, ErrPlayerAlreadyClaimed
 	}
 	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
 	delete(s.byName, existing.Username)
@@ -171,19 +171,19 @@ func (s *stubPlayerStore) ClaimPlayer(
 
 func (s *stubPlayerStore) UpdatePlayerUsername(
 	_ context.Context, playerID int64, username string,
-) (*auth.Player, error) {
+) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	existing, ok := s.byID[playerID]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 	if existing.PasswordHash != "" {
-		return nil, auth.ErrPlayerNotAnonymous
+		return nil, ErrPlayerNotAnonymous
 	}
 	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
 	delete(s.byName, existing.Username)
@@ -195,19 +195,19 @@ func (s *stubPlayerStore) UpdatePlayerUsername(
 
 func (s *stubPlayerStore) RenamePlayer(
 	_ context.Context, playerID int64, username string,
-) (*auth.Player, error) {
+) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if strings.TrimSpace(username) == "" {
-		return nil, auth.ErrUsernameEmpty
+		return nil, ErrUsernameEmpty
 	}
 	existing, ok := s.byID[playerID]
 	if !ok {
-		return nil, auth.ErrPlayerNotFound
+		return nil, ErrPlayerNotFound
 	}
 	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, auth.ErrUsernameTaken
+		return nil, ErrUsernameTaken
 	}
 
 	delete(s.byName, existing.Username)
@@ -223,7 +223,7 @@ func (s *stubPlayerStore) SetPlayerPasswordHash(_ context.Context, username, pas
 
 	p, ok := s.byName[username]
 	if !ok {
-		return auth.ErrPlayerNotFound
+		return ErrPlayerNotFound
 	}
 	p.PasswordHash = passwordHash
 
@@ -233,16 +233,16 @@ func (s *stubPlayerStore) SetPlayerPasswordHash(_ context.Context, username, pas
 // resolveRoleLocked applies the same "first password-bearing registrant
 // becomes admin" rule as the production SQL. Caller must hold s.mu.
 func (s *stubPlayerStore) resolveRoleLocked(requestedRole string) string {
-	if requestedRole == auth.RoleAdmin {
-		return auth.RoleAdmin
+	if requestedRole == RoleAdmin {
+		return RoleAdmin
 	}
 	for _, existing := range s.byID {
 		if existing.PasswordHash != "" {
-			return auth.RolePlayer
+			return RolePlayer
 		}
 	}
 
-	return auth.RoleAdmin
+	return RoleAdmin
 }
 
 func discardLogger() *slog.Logger {
@@ -263,7 +263,7 @@ func postForm(t *testing.T, handler http.Handler, path string, values url.Values
 func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleRegisterForm(
+	handler := HandleRegisterForm(
 		discardLogger(),
 		nil,
 		newStubPlayerStore(),
@@ -286,7 +286,7 @@ func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 	// MinPasswordLength/MaxPasswordLength constants. Asserting the
 	// rendered output keeps the func bound to the constants and the
 	// validator-side error messages.
-	helpWant := fmt.Sprintf("Must be %d–%d characters.", auth.MinPasswordLength, auth.MaxPasswordLength)
+	helpWant := fmt.Sprintf("Must be %d–%d characters.", MinPasswordLength, MaxPasswordLength)
 	if !strings.Contains(body, helpWant) {
 		t.Errorf("body = %q, want password-help substring %q", body, helpWant)
 	}
@@ -296,7 +296,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -314,7 +314,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
 	}
-	if got, want := p.Role, auth.RoleAdmin; got != want {
+	if got, want := p.Role, RoleAdmin; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
 	}
 
@@ -336,11 +336,11 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 
 	store := newStubPlayerStore()
 	// Pre-seed first admin.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "hash", auth.RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "admin", "hash", RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
 		"password": {"correctbattery"},
@@ -359,7 +359,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
 	}
-	if got, want := p.Role, auth.RolePlayer; got != want {
+	if got, want := p.Role, RolePlayer; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
 	}
 }
@@ -369,11 +369,11 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 
 	store := newStubPlayerStore()
 	// Pre-seed first user so the count > 0 and the env var path is exercised.
-	if _, err := store.CreatePlayer(t.Context(), "first", "h", auth.RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "first", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(
+	handler := HandleRegisterSubmit(
 		discardLogger(),
 		nil,
 		store,
@@ -394,7 +394,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
 	}
-	if got, want := p.Role, auth.RoleAdmin; got != want {
+	if got, want := p.Role, RoleAdmin; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
 	}
 }
@@ -403,7 +403,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -413,11 +413,11 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	if got, want := rec.Code, http.StatusBadRequest; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	want := fmt.Sprintf("at least %d characters", auth.MinPasswordLength)
+	want := fmt.Sprintf("at least %d characters", MinPasswordLength)
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, auth.ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, GetPlayerByUsername err = %v", err)
 	}
 }
@@ -430,21 +430,21 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
-		"password": {strings.Repeat("a", auth.MaxPasswordLength+1)},
+		"password": {strings.Repeat("a", MaxPasswordLength+1)},
 	})
 
 	if got, want := rec.Code, http.StatusBadRequest; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	want := fmt.Sprintf("at most %d characters", auth.MaxPasswordLength)
+	want := fmt.Sprintf("at most %d characters", MaxPasswordLength)
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, auth.ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, GetPlayerByUsername err = %v", err)
 	}
 }
@@ -453,11 +453,11 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "h", auth.RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -486,7 +486,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
 
 	// Build a request that already carries the anonymous session cookie.
 	rec := httptest.NewRecorder()
@@ -521,7 +521,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	if upgraded.PasswordHash == "" {
 		t.Error("upgraded.PasswordHash is empty, want bcrypt hash from claim")
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "anon-existing"); !errors.Is(err, auth.ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByUsername(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("anonymous row still resolvable by old username; err = %v, want ErrPlayerNotFound", err)
 	}
 }
@@ -534,7 +534,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "previousHash", auth.RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "previousHash", RolePlayer); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-claimer")
@@ -543,7 +543,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID)
@@ -596,13 +596,13 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 		anon.ID,
 		"winner",
 		"winnerHash",
-		auth.RolePlayer,
+		RolePlayer,
 	); claimErr != nil {
 		t.Fatalf("ClaimPlayer err = %v, want nil", claimErr)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID) // cookie still points at the now-claimed row
@@ -636,7 +636,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(
+	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
 		newStubPlayerStore(),
@@ -660,7 +660,7 @@ func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(
+	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
 		newStubPlayerStore(),
@@ -684,7 +684,7 @@ func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLoginForm(
+	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
 		newStubPlayerStore(),
@@ -713,7 +713,7 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	hash, err := auth.HashPassword("correctbattery")
+	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
@@ -721,16 +721,16 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	// registrant becomes admin" rule (mirroring the production SQL)
 	// promotes that row, not carol. Carol then stays as a plain
 	// player and the redirect lands on / instead of /admin/quizzes.
-	if _, seedErr := store.CreatePlayer(t.Context(), "first-admin", hash, auth.RoleAdmin); seedErr != nil {
+	if _, seedErr := store.CreatePlayer(t.Context(), "first-admin", hash, RoleAdmin); seedErr != nil {
 		t.Fatalf("seed admin err = %v, want nil", seedErr)
 	}
-	player, err := store.CreatePlayer(t.Context(), "carol", hash, auth.RolePlayer)
+	player, err := store.CreatePlayer(t.Context(), "carol", hash, RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := auth.HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID)
@@ -762,7 +762,7 @@ func TestHandleLoginForm_AnonymousSession_RendersForm(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := auth.HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID)
@@ -785,15 +785,15 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	hash, err := auth.HashPassword("correctbattery")
+	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, auth.RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
+	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"correctbattery"},
@@ -816,18 +816,18 @@ func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 	store := newStubPlayerStore()
 	// Pre-seed an admin so the "first password-bearing registrant
 	// becomes admin" rule doesn't accidentally promote bob.
-	if _, err := store.CreatePlayer(t.Context(), "first-admin", "h", auth.RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "first-admin", "h", RoleAdmin); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
-	hash, err := auth.HashPassword("correctbattery")
+	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "bob", hash, auth.RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "bob", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
+	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"bob"},
 		"password": {"correctbattery"},
@@ -845,7 +845,7 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
+	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"ghost"},
@@ -864,15 +864,15 @@ func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	hash, err := auth.HashPassword("right-password-yes")
+	hash, err := HashPassword("right-password-yes")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, auth.RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
+	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
 		"password": {"wrong-password-no"},
@@ -891,11 +891,11 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 
 	// Seed a player with no password hash (legacy admin from migration).
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "legacy", "", auth.RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "legacy", "", RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := auth.HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
+	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"legacy"},
 		"password": {"anything-goes-here-13"},
@@ -910,7 +910,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"   "},
@@ -924,7 +924,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 		t.Errorf("body did not mention required username, got %q", got)
 	}
 	// Whitespace-trimmed name should not have been created.
-	if _, err := store.GetPlayerByUsername(t.Context(), ""); !errors.Is(err, auth.ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByUsername(t.Context(), ""); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("empty player should not exist, err = %v", err)
 	}
 }
@@ -933,9 +933,9 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := auth.HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 
-	password := strings.Repeat("a", auth.MinPasswordLength) // exactly 13 characters
+	password := strings.Repeat("a", MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"password": {password},
@@ -952,7 +952,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 func TestHandleLogout_NoCookie(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLogout(session.New([]byte("k"), true))
+	handler := HandleLogout(session.New([]byte("k"), true))
 
 	// No session cookie attached to the request.
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
@@ -970,7 +970,7 @@ func TestHandleLogout_NoCookie(t *testing.T) {
 func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 	t.Parallel()
 
-	handler := auth.HandleLogout(session.New([]byte("k"), true))
+	handler := HandleLogout(session.New([]byte("k"), true))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/logout", nil)
 	rec := httptest.NewRecorder()

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/session"
 )
 
@@ -28,22 +28,22 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "h", auth.RoleAdmin)
+	admin, err := store.CreatePlayer(t.Context(), "alice", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	called := false
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	var seenOK bool
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		seenPlayer, seenOK = auth.PlayerFromContext(r.Context())
+		seenPlayer, seenOK = PlayerFromContext(r.Context())
 		w.WriteHeader(http.StatusTeapot)
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
+	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID)
@@ -77,10 +77,10 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	store := newStubPlayerStore()
 	// Pre-seed an admin so the next CreatePlayer call is not auto-promoted to admin
 	// by the "first password-bearing registrant becomes admin" rule.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "h", auth.RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "admin", "h", RoleAdmin); err != nil {
 		t.Fatalf("seed admin err = %v, want nil", err)
 	}
-	player, err := store.CreatePlayer(t.Context(), "bob", "h", auth.RolePlayer)
+	player, err := store.CreatePlayer(t.Context(), "bob", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -90,7 +90,7 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
+	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID)
@@ -120,7 +120,7 @@ func TestRequireAdmin_NoCookie_RedirectsToLogin(t *testing.T) {
 		t.Error("next should not be called without cookie")
 	})
 
-	mw := auth.RequireAdmin(next, store, session.New([]byte("k"), true), nil, discardLogger())
+	mw := RequireAdmin(next, store, session.New([]byte("k"), true), nil, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -143,7 +143,7 @@ func TestRequireAdmin_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
+	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, 9999)
@@ -163,7 +163,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "h", auth.RoleAdmin)
+	admin, err := store.CreatePlayer(t.Context(), "alice", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -174,7 +174,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := auth.RequireAdmin(next, store, sessions, nil, discardLogger())
+	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID)
@@ -196,15 +196,15 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 	store := newStubPlayerStore()
 	sessions := session.New([]byte("k"), true)
 
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		seenPlayer, _ = PlayerFromContext(r.Context())
 		w.WriteHeader(http.StatusTeapot)
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -251,12 +251,12 @@ func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 
 	sessions := session.New([]byte("k"), true)
 
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, existing.ID)
@@ -284,12 +284,12 @@ func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 	store := newStubPlayerStore()
 	sessions := session.New([]byte("k"), true)
 
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	// Issue a cookie pointing at an ID that does not exist in the store.
 	rec := httptest.NewRecorder()
@@ -323,11 +323,11 @@ func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 
 	var seenIDs []int64
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		p, _ := auth.PlayerFromContext(r.Context())
+		p, _ := PlayerFromContext(r.Context())
 		seenIDs = append(seenIDs, p.ID)
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	for range 2 {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
@@ -352,12 +352,12 @@ func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
 	store.forceAnonCollisions = 3
 	sessions := session.New([]byte("k"), true)
 
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -383,12 +383,12 @@ func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
 	store.forceAnonCollisions = 5
 	sessions := session.New([]byte("k"), true)
 
-	var seenPlayer *auth.Player
+	var seenPlayer *Player
 	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = auth.PlayerFromContext(r.Context())
+		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -413,7 +413,7 @@ func TestEnsurePlayer_CreateAnonymousNonCollisionError_500(t *testing.T) {
 		t.Error("next should not be called when CreateAnonymousPlayer returns a non-collision error")
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -440,7 +440,7 @@ func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
 		t.Error("next should not be called on store error")
 	})
 
-	mw := auth.EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, existing.ID)

--- a/internal/auth/petname_test.go
+++ b/internal/auth/petname_test.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 )
 
 func TestGeneratePetname_Shape(t *testing.T) {
 	t.Parallel()
 
 	for range 100 {
-		name := auth.GeneratePetname()
+		name := GeneratePetname()
 		if name == "" {
 			t.Fatal("GeneratePetname() = empty string, want non-empty")
 		}
@@ -36,7 +36,7 @@ func TestGeneratePetname_Distinct(t *testing.T) {
 
 	seen := make(map[string]struct{}, 1000)
 	for range 1000 {
-		seen[auth.GeneratePetname()] = struct{}{}
+		seen[GeneratePetname()] = struct{}{}
 	}
 	// With ~15M combinations, the birthday-problem expectation on 1000 draws
 	// is ~999 distinct outcomes. Allow generous slack to keep the test stable

--- a/internal/auth/player_test.go
+++ b/internal/auth/player_test.go
@@ -3,7 +3,7 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/auth"
 )
 
 func TestPlayer_IsAnonymous(t *testing.T) {
@@ -11,27 +11,27 @@ func TestPlayer_IsAnonymous(t *testing.T) {
 
 	tests := []struct {
 		name string
-		p    auth.Player
+		p    Player
 		want bool
 	}{
 		{
 			name: "anonymous player (empty hash, player role)",
-			p:    auth.Player{PasswordHash: "", Role: auth.RolePlayer},
+			p:    Player{PasswordHash: "", Role: RolePlayer},
 			want: true,
 		},
 		{
 			name: "credentialled player",
-			p:    auth.Player{PasswordHash: "$2a$bcrypted", Role: auth.RolePlayer},
+			p:    Player{PasswordHash: "$2a$bcrypted", Role: RolePlayer},
 			want: false,
 		},
 		{
 			name: "seeded admin row (empty hash but admin role) is not anonymous",
-			p:    auth.Player{PasswordHash: "", Role: auth.RoleAdmin},
+			p:    Player{PasswordHash: "", Role: RoleAdmin},
 			want: false,
 		},
 		{
 			name: "credentialled admin",
-			p:    auth.Player{PasswordHash: "$2a$bcrypted", Role: auth.RoleAdmin},
+			p:    Player{PasswordHash: "$2a$bcrypted", Role: RoleAdmin},
 			want: false,
 		},
 	}

--- a/internal/clientapi/export_test.go
+++ b/internal/clientapi/export_test.go
@@ -1,0 +1,6 @@
+package clientapi
+
+// ExportShuffleByGame exposes the unexported shuffleByGame helper so
+// the external clientapi_test package can pin its determinism and
+// permutation contracts without becoming a whitebox test.
+var ExportShuffleByGame = shuffleByGame

--- a/internal/clientapi/shuffle_test.go
+++ b/internal/clientapi/shuffle_test.go
@@ -1,9 +1,11 @@
-package clientapi
+package clientapi_test
 
 import (
 	"fmt"
 	"slices"
 	"testing"
+
+	. "github.com/starquake/topbanana/internal/clientapi"
 )
 
 // TestShuffleByGame_Deterministic pins the contract the player client
@@ -14,12 +16,12 @@ func TestShuffleByGame_Deterministic(t *testing.T) {
 	t.Parallel()
 
 	first := []int{1, 2, 3, 4}
-	shuffleByGame("game-abc", 42, len(first), func(i, j int) {
+	ExportShuffleByGame("game-abc", 42, len(first), func(i, j int) {
 		first[i], first[j] = first[j], first[i]
 	})
 
 	second := []int{1, 2, 3, 4}
-	shuffleByGame("game-abc", 42, len(second), func(i, j int) {
+	ExportShuffleByGame("game-abc", 42, len(second), func(i, j int) {
 		second[i], second[j] = second[j], second[i]
 	})
 
@@ -34,7 +36,7 @@ func TestShuffleByGame_PreservesElements(t *testing.T) {
 	t.Parallel()
 
 	got := []int{1, 2, 3, 4, 5, 6, 7, 8}
-	shuffleByGame("any-game", 1, len(got), func(i, j int) {
+	ExportShuffleByGame("any-game", 1, len(got), func(i, j int) {
 		got[i], got[j] = got[j], got[i]
 	})
 
@@ -60,7 +62,7 @@ func TestShuffleByGame_DifferentGamesDiffer(t *testing.T) {
 	for i := range trials {
 		opts := []int{1, 2, 3, 4}
 		gameID := "game-" + string(rune('a'+i))
-		shuffleByGame(gameID, 1, len(opts), func(a, b int) {
+		ExportShuffleByGame(gameID, 1, len(opts), func(a, b int) {
 			opts[a], opts[b] = opts[b], opts[a]
 		})
 		seen[fmt.Sprintf("%v", opts)] = struct{}{}

--- a/internal/csrf/csrf_test.go
+++ b/internal/csrf/csrf_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/csrf"
+	. "github.com/starquake/topbanana/internal/csrf"
 )
 
 // newGetRequest builds a GET request with the test context attached so
@@ -40,7 +40,7 @@ func newPostFormRequest(t *testing.T, values url.Values) *http.Request {
 // the response, or an empty string if no such cookie was set.
 func nonceCookieFromResponse(rec *httptest.ResponseRecorder) string {
 	for _, c := range rec.Result().Cookies() {
-		if c.Name == csrf.CookieName {
+		if c.Name == CookieName {
 			return c.Value
 		}
 	}
@@ -51,7 +51,7 @@ func nonceCookieFromResponse(rec *httptest.ResponseRecorder) string {
 func TestToken_SetsCookieWhenAbsent(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
@@ -63,7 +63,7 @@ func TestToken_SetsCookieWhenAbsent(t *testing.T) {
 
 	nonce := nonceCookieFromResponse(rec)
 	if nonce == "" {
-		t.Fatalf("expected %q cookie to be set, got none", csrf.CookieName)
+		t.Fatalf("expected %q cookie to be set, got none", CookieName)
 	}
 }
 
@@ -76,7 +76,7 @@ func TestToken_CookieFlags_RespectSecureCookies(t *testing.T) {
 
 	t.Run("production sets Secure", func(t *testing.T) {
 		t.Parallel()
-		m := csrf.New([]byte("test-key"), true)
+		m := New([]byte("test-key"), true)
 		rec := httptest.NewRecorder()
 		_ = m.Token(rec, newGetRequest(t, "/"))
 
@@ -94,7 +94,7 @@ func TestToken_CookieFlags_RespectSecureCookies(t *testing.T) {
 
 	t.Run("development drops Secure", func(t *testing.T) {
 		t.Parallel()
-		m := csrf.New([]byte("test-key"), false)
+		m := New([]byte("test-key"), false)
 		rec := httptest.NewRecorder()
 		_ = m.Token(rec, newGetRequest(t, "/"))
 
@@ -116,7 +116,7 @@ func TestToken_CookieFlags_RespectSecureCookies(t *testing.T) {
 func TestToken_ReusesExistingCookie(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	// Issue a nonce first so we have a stable cookie value.
 	rec1 := httptest.NewRecorder()
@@ -125,13 +125,13 @@ func TestToken_ReusesExistingCookie(t *testing.T) {
 
 	nonce := nonceCookieFromResponse(rec1)
 	if nonce == "" {
-		t.Fatalf("expected %q cookie to be set on first call", csrf.CookieName)
+		t.Fatalf("expected %q cookie to be set on first call", CookieName)
 	}
 
 	// Second request with the cookie attached should reuse it.
 	rec2 := httptest.NewRecorder()
 	req2 := newGetRequest(t, "/login")
-	req2.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: nonce})
+	req2.AddCookie(&http.Cookie{Name: CookieName, Value: nonce})
 
 	tok2 := m.Token(rec2, req2)
 
@@ -146,11 +146,11 @@ func TestToken_ReusesExistingCookie(t *testing.T) {
 func TestToken_DeterministicForSameNonce(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "fixed-nonce-value"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "fixed-nonce-value"})
 
 	t1 := m.Token(rec, req)
 	t2 := m.Token(rec, req)
@@ -163,10 +163,10 @@ func TestToken_DeterministicForSameNonce(t *testing.T) {
 func TestValidate_NoCookie(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
-	req := newPostFormRequest(t, url.Values{csrf.FormField: {"anything"}})
+	m := New([]byte("test-key"), true)
+	req := newPostFormRequest(t, url.Values{FormField: {"anything"}})
 
-	if got, want := m.Validate(req), csrf.ErrInvalidToken; !errors.Is(got, want) {
+	if got, want := m.Validate(req), ErrInvalidToken; !errors.Is(got, want) {
 		t.Errorf("Validate err = %v, want %v", got, want)
 	}
 }
@@ -174,11 +174,11 @@ func TestValidate_NoCookie(t *testing.T) {
 func TestValidate_NoFormField(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 	req := newPostFormRequest(t, url.Values{})
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "some-nonce"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "some-nonce"})
 
-	if got, want := m.Validate(req), csrf.ErrInvalidToken; !errors.Is(got, want) {
+	if got, want := m.Validate(req), ErrInvalidToken; !errors.Is(got, want) {
 		t.Errorf("Validate err = %v, want %v", got, want)
 	}
 }
@@ -186,12 +186,12 @@ func TestValidate_NoFormField(t *testing.T) {
 func TestValidate_TamperedToken(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	// Get a valid token.
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "real-nonce"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "real-nonce"})
 	valid := m.Token(rec, req)
 
 	// Flip the last character to produce something that is still
@@ -203,10 +203,10 @@ func TestValidate_TamperedToken(t *testing.T) {
 	}
 	tampered := valid[:len(valid)-1] + string(flipped)
 
-	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tampered}})
-	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "real-nonce"})
+	postReq := newPostFormRequest(t, url.Values{FormField: {tampered}})
+	postReq.AddCookie(&http.Cookie{Name: CookieName, Value: "real-nonce"})
 
-	if got, want := m.Validate(postReq), csrf.ErrInvalidToken; !errors.Is(got, want) {
+	if got, want := m.Validate(postReq), ErrInvalidToken; !errors.Is(got, want) {
 		t.Errorf("Validate err = %v, want %v", got, want)
 	}
 }
@@ -214,18 +214,18 @@ func TestValidate_TamperedToken(t *testing.T) {
 func TestValidate_DifferentKey(t *testing.T) {
 	t.Parallel()
 
-	managerA := csrf.New([]byte("key-a"), true)
-	managerB := csrf.New([]byte("key-b"), true)
+	managerA := New([]byte("key-a"), true)
+	managerB := New([]byte("key-b"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "shared-nonce"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "shared-nonce"})
 	tokenFromA := managerA.Token(rec, req)
 
-	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tokenFromA}})
-	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "shared-nonce"})
+	postReq := newPostFormRequest(t, url.Values{FormField: {tokenFromA}})
+	postReq.AddCookie(&http.Cookie{Name: CookieName, Value: "shared-nonce"})
 
-	if got, want := managerB.Validate(postReq), csrf.ErrInvalidToken; !errors.Is(got, want) {
+	if got, want := managerB.Validate(postReq), ErrInvalidToken; !errors.Is(got, want) {
 		t.Errorf("Validate err = %v, want %v", got, want)
 	}
 }
@@ -233,15 +233,15 @@ func TestValidate_DifferentKey(t *testing.T) {
 func TestValidate_ValidToken(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "happy-path-nonce"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "happy-path-nonce"})
 	tok := m.Token(rec, req)
 
-	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tok}})
-	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "happy-path-nonce"})
+	postReq := newPostFormRequest(t, url.Values{FormField: {tok}})
+	postReq.AddCookie(&http.Cookie{Name: CookieName, Value: "happy-path-nonce"})
 
 	if err := m.Validate(postReq); err != nil {
 		t.Errorf("Validate err = %v, want nil", err)
@@ -251,7 +251,7 @@ func TestValidate_ValidToken(t *testing.T) {
 func TestMiddleware_GET_PassesThrough(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	called := false
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -274,7 +274,7 @@ func TestMiddleware_GET_PassesThrough(t *testing.T) {
 func TestMiddleware_POST_NoToken_403(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	called := false
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -297,12 +297,12 @@ func TestMiddleware_POST_NoToken_403(t *testing.T) {
 func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	// Issue a token first so we know the nonce/token pair is valid.
 	rec := httptest.NewRecorder()
 	req := newGetRequest(t, "/login")
-	req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "post-nonce"})
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "post-nonce"})
 	tok := m.Token(rec, req)
 
 	called := false
@@ -313,8 +313,8 @@ func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
 	handler := m.Middleware(next)
 
 	postRec := httptest.NewRecorder()
-	postReq := newPostFormRequest(t, url.Values{csrf.FormField: {tok}})
-	postReq.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "post-nonce"})
+	postReq := newPostFormRequest(t, url.Values{FormField: {tok}})
+	postReq.AddCookie(&http.Cookie{Name: CookieName, Value: "post-nonce"})
 	handler.ServeHTTP(postRec, postReq)
 
 	if !called {
@@ -328,7 +328,7 @@ func TestMiddleware_POST_ValidToken_CallsNext(t *testing.T) {
 func TestMiddleware_UnsafeMethods_AreValidated(t *testing.T) {
 	t.Parallel()
 
-	m := csrf.New([]byte("test-key"), true)
+	m := New([]byte("test-key"), true)
 
 	tests := []struct {
 		name   string

--- a/internal/game/clamp_test.go
+++ b/internal/game/clamp_test.go
@@ -1,8 +1,10 @@
-package game
+package game_test
 
 import (
 	"testing"
 	"time"
+
+	. "github.com/starquake/topbanana/internal/game"
 )
 
 // TestClampTappedAt pins the #237 trust window. The recorded AnsweredAt
@@ -55,7 +57,7 @@ func TestClampTappedAt(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got, want := clampTappedAt(tc.tappedAt, startedAt, serverNow), tc.want; !got.Equal(want) {
+			if got, want := ExportClampTappedAt(tc.tappedAt, startedAt, serverNow), tc.want; !got.Equal(want) {
 				t.Errorf("clampTappedAt(%v, %v, %v) = %v, want %v", tc.tappedAt, startedAt, serverNow, got, want)
 			}
 		})

--- a/internal/game/export_test.go
+++ b/internal/game/export_test.go
@@ -1,0 +1,12 @@
+package game
+
+// Test-only re-exports of internal helpers (#: blackbox-test sweep
+// against the "prefer dot-import blackbox tests" rule in the
+// backend-dev agent). The wrapped identifiers stay unexported so the
+// production surface is unchanged; only the external game_test
+// package sees the Export* names.
+var (
+	ExportClampTappedAt       = clampTappedAt
+	ExportResolveAnswerWindow = resolveAnswerWindow
+	ExportDefaultExpiration   = defaultExpiration
+)

--- a/internal/game/time_limit_test.go
+++ b/internal/game/time_limit_test.go
@@ -1,9 +1,10 @@
-package game
+package game_test
 
 import (
 	"testing"
 	"time"
 
+	. "github.com/starquake/topbanana/internal/game"
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
@@ -38,7 +39,7 @@ func TestResolveAnswerWindow(t *testing.T) {
 			name: "both unset falls through to defaultExpiration",
 			q:    &quiz.Question{TimeLimitSeconds: nil},
 			qz:   &quiz.Quiz{TimeLimitSeconds: 0},
-			want: defaultExpiration,
+			want: ExportDefaultExpiration,
 		},
 		{
 			name: "zero question override is treated as unset",
@@ -50,13 +51,13 @@ func TestResolveAnswerWindow(t *testing.T) {
 			name: "nil question + nil quiz still resolves",
 			q:    nil,
 			qz:   nil,
-			want: defaultExpiration,
+			want: ExportDefaultExpiration,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got, want := resolveAnswerWindow(tc.q, tc.qz), tc.want; got != want {
+			if got, want := ExportResolveAnswerWindow(tc.q, tc.qz), tc.want; got != want {
 				t.Errorf("resolveAnswerWindow(%+v, %+v) = %v, want %v", tc.q, tc.qz, got, want)
 			}
 		})

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/starquake/topbanana/internal/game"
-	"github.com/starquake/topbanana/internal/health"
+	. "github.com/starquake/topbanana/internal/health"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
 )
@@ -115,7 +115,7 @@ func TestHandleHealthz(t *testing.T) {
 		}
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 		w := httptest.NewRecorder()
-		health.HandleHealthz(slog.Default(), stores)(w, req)
+		HandleHealthz(slog.Default(), stores)(w, req)
 
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("status = %d, want %d", got, want)
@@ -143,7 +143,7 @@ func TestHandleHealthz(t *testing.T) {
 		}
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 		w := httptest.NewRecorder()
-		health.HandleHealthz(slog.Default(), stores)(w, req)
+		HandleHealthz(slog.Default(), stores)(w, req)
 
 		if got, want := w.Code, http.StatusServiceUnavailable; got != want {
 			t.Errorf("status = %d, want %d", got, want)

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/starquake/topbanana/internal/home"
+	. "github.com/starquake/topbanana/internal/home"
 )
 
 // stubStore feeds the handler canned rows so the render path is the
@@ -18,17 +18,17 @@ import (
 // independently; the err fields exercise the degraded-render branch
 // (the page should still render, with the failing section empty).
 type stubStore struct {
-	popular    []*home.PopularQuiz
-	active     []*home.ActivePlayer
+	popular    []*PopularQuiz
+	active     []*ActivePlayer
 	popularErr error
 	activeErr  error
 }
 
-func (s *stubStore) ListPopularQuizzes(_ context.Context) ([]*home.PopularQuiz, error) {
+func (s *stubStore) ListPopularQuizzes(_ context.Context) ([]*PopularQuiz, error) {
 	return s.popular, s.popularErr
 }
 
-func (s *stubStore) ListMostActivePlayers(_ context.Context) ([]*home.ActivePlayer, error) {
+func (s *stubStore) ListMostActivePlayers(_ context.Context) ([]*ActivePlayer, error) {
 	return s.active, s.activeErr
 }
 
@@ -36,7 +36,7 @@ func TestHandle_RendersPopularAndActiveSections(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{
-		popular: []*home.PopularQuiz{
+		popular: []*PopularQuiz{
 			{
 				ID:          7,
 				Title:       "Bananas of the World",
@@ -46,7 +46,7 @@ func TestHandle_RendersPopularAndActiveSections(t *testing.T) {
 			},
 			{ID: 9, Title: "Capital Cities", Slug: "capital-cities", Description: "Quickfire geography.", PlayCount: 3},
 		},
-		active: []*home.ActivePlayer{
+		active: []*ActivePlayer{
 			{ID: 1, Username: "alice", FinishedCount: 4},
 			{ID: 2, Username: "bob", FinishedCount: 2},
 		},
@@ -77,10 +77,10 @@ func TestHandle_SingularPlayAndQuizPluralization(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{
-		popular: []*home.PopularQuiz{
+		popular: []*PopularQuiz{
 			{ID: 11, Title: "Solo", Slug: "solo", PlayCount: 1},
 		},
-		active: []*home.ActivePlayer{
+		active: []*ActivePlayer{
 			{ID: 1, Username: "carol", FinishedCount: 1},
 		},
 	}
@@ -123,7 +123,7 @@ func TestHandle_StoreErrorsDegradeToEmptyState(t *testing.T) {
 		activeErr:  errors.New("boom"),
 	}
 	rec := httptest.NewRecorder()
-	handler := home.Handle(slog.New(slog.DiscardHandler), store, nil, nil)
+	handler := Handle(slog.New(slog.DiscardHandler), store, nil, nil)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	handler.ServeHTTP(rec, req)
 
@@ -144,9 +144,9 @@ func TestHandle_TruncatesToTopN(t *testing.T) {
 
 	// Feed more than the page-level cap of 6 to confirm the handler
 	// slices instead of dumping the full list into the template.
-	popular := make([]*home.PopularQuiz, 0, 10)
+	popular := make([]*PopularQuiz, 0, 10)
 	for i := range 10 {
-		popular = append(popular, &home.PopularQuiz{
+		popular = append(popular, &PopularQuiz{
 			ID:        int64(i + 1),
 			Title:     "T" + string(rune('A'+i)),
 			Slug:      "t" + string(rune('a'+i)),
@@ -170,7 +170,7 @@ func TestHandle_TruncatesToTopN(t *testing.T) {
 func serve(t *testing.T, store *stubStore) string {
 	t.Helper()
 
-	handler := home.Handle(slog.New(slog.DiscardHandler), store, nil, nil)
+	handler := Handle(slog.New(slog.DiscardHandler), store, nil, nil)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	handler.ServeHTTP(rec, req)

--- a/internal/leaderboard/hub_test.go
+++ b/internal/leaderboard/hub_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/starquake/topbanana/internal/leaderboard"
+	. "github.com/starquake/topbanana/internal/leaderboard"
 )
 
 func TestHub_PublishWithoutSubscribers(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	// Publish must not panic or deadlock when no one is listening.
 	h.Publish(1)
 }
@@ -19,7 +19,7 @@ func TestHub_PublishWithoutSubscribers(t *testing.T) {
 func TestHub_DeliversToSubscriber(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	ch, unsub := h.Subscribe(7)
 	defer unsub()
 
@@ -36,7 +36,7 @@ func TestHub_DeliversToSubscriber(t *testing.T) {
 func TestHub_ScopedByQuizID(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	chA, unsubA := h.Subscribe(1)
 	defer unsubA()
 	chB, unsubB := h.Subscribe(2)
@@ -62,7 +62,7 @@ func TestHub_ScopedByQuizID(t *testing.T) {
 func TestHub_CoalescesBackPressure(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	ch, unsub := h.Subscribe(3)
 	defer unsub()
 
@@ -81,7 +81,7 @@ func TestHub_CoalescesBackPressure(t *testing.T) {
 func TestHub_UnsubscribeStopsDelivery(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	ch, unsub := h.Subscribe(5)
 	unsub()
 
@@ -102,7 +102,7 @@ func TestHub_UnsubscribeStopsDelivery(t *testing.T) {
 func TestHub_UnsubscribeIsIdempotent(t *testing.T) {
 	t.Parallel()
 
-	h := leaderboard.NewHub()
+	h := NewHub()
 	_, unsub := h.Subscribe(9)
 
 	unsub()
@@ -116,7 +116,7 @@ func TestHub_ConcurrentPublishAndSubscribe(t *testing.T) {
 	// Sanity check that the mutex pattern doesn't deadlock under contention.
 	// Not a strict race test (use `go test -race` for that); just a smoke
 	// for "no goroutine blocks indefinitely."
-	h := leaderboard.NewHub()
+	h := NewHub()
 	const quizID int64 = 11
 	const workers = 8
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -8,21 +8,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/starquake/topbanana/internal/session"
+	. "github.com/starquake/topbanana/internal/session"
 )
 
 // newManagerAt returns a Manager whose clock is fixed at the given time.
 // Used by clock-sensitive tests that need deterministic issuedAt and expiry.
-func newManagerAt(t *testing.T, when time.Time) *session.Manager {
+func newManagerAt(t *testing.T, when time.Time) *Manager {
 	t.Helper()
 
-	return session.ExportNewWithClock([]byte("k"), true, func() time.Time { return when })
+	return ExportNewWithClock([]byte("k"), true, func() time.Time { return when })
 }
 
 func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("test-key"), true)
+	mgr := New([]byte("test-key"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 42)
 
@@ -32,7 +32,7 @@ func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 	}
 
 	c := cookies[0]
-	if got, want := c.Name, session.CookieName; got != want {
+	if got, want := c.Name, CookieName; got != want {
 		t.Errorf("cookie name = %q, want %q", got, want)
 	}
 	if !c.HttpOnly {
@@ -47,7 +47,7 @@ func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 	if got, want := c.Path, "/"; got != want {
 		t.Errorf("cookie Path = %q, want %q", got, want)
 	}
-	if got, want := c.MaxAge, session.MaxAge; got != want {
+	if got, want := c.MaxAge, MaxAge; got != want {
 		t.Errorf("cookie MaxAge = %d, want %d", got, want)
 	}
 
@@ -69,7 +69,7 @@ func TestSet_SecureFlag_DroppedInDevelopment(t *testing.T) {
 	// — see #205. The TestSet_AndPlayerID_RoundTrip test above covers
 	// the secureCookies=true path.
 
-	mgr := session.New([]byte("k"), false)
+	mgr := New([]byte("k"), false)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 42)
 
@@ -89,7 +89,7 @@ func TestSet_SecureFlag_DroppedInDevelopment(t *testing.T) {
 func TestPlayerID_MissingCookie(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 
 	_, ok := mgr.PlayerID(req)
@@ -101,7 +101,7 @@ func TestPlayerID_MissingCookie(t *testing.T) {
 func TestPlayerID_TamperedSignature(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -123,7 +123,7 @@ func TestPlayerID_TamperedSignature(t *testing.T) {
 func TestPlayerID_TamperedPayload(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -147,7 +147,7 @@ func TestPlayerID_TamperedPayload(t *testing.T) {
 func TestPlayerID_TamperedTimestamp(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Set(rec, 7)
 
@@ -172,7 +172,7 @@ func TestPlayerID_TamperedTimestamp(t *testing.T) {
 func TestPlayerID_MalformedCookie(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 
 	// base64url("not-an-int|123") and base64url("123|not-an-int") for the parse-error paths.
 	badPlayerID := base64.RawURLEncoding.EncodeToString([]byte("not-an-int|123"))
@@ -190,7 +190,7 @@ func TestPlayerID_MalformedCookie(t *testing.T) {
 	}
 	for _, value := range tests {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
-		req.AddCookie(&http.Cookie{Name: session.CookieName, Value: value})
+		req.AddCookie(&http.Cookie{Name: CookieName, Value: value})
 
 		if _, ok := mgr.PlayerID(req); ok {
 			t.Errorf("PlayerID(%q) ok = true, want false", value)
@@ -201,11 +201,11 @@ func TestPlayerID_MalformedCookie(t *testing.T) {
 func TestPlayerID_DifferentKey(t *testing.T) {
 	t.Parallel()
 
-	signer := session.New([]byte("real-key"), true)
+	signer := New([]byte("real-key"), true)
 	rec := httptest.NewRecorder()
 	signer.Set(rec, 1)
 
-	verifier := session.New([]byte("other-key"), true)
+	verifier := New([]byte("other-key"), true)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.AddCookie(rec.Result().Cookies()[0])
 
@@ -225,7 +225,7 @@ func TestPlayerID_ExpiredCookie(t *testing.T) {
 	c := rec.Result().Cookies()[0]
 
 	// Advance past MaxAge by 1 second.
-	verifier := newManagerAt(t, issuedAt.Add(time.Duration(session.MaxAge+1)*time.Second))
+	verifier := newManagerAt(t, issuedAt.Add(time.Duration(MaxAge+1)*time.Second))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.AddCookie(c)
@@ -246,7 +246,7 @@ func TestPlayerID_BoundaryAgeIsValid(t *testing.T) {
 	signer.Set(rec, 5)
 	c := rec.Result().Cookies()[0]
 
-	verifier := newManagerAt(t, issuedAt.Add(time.Duration(session.MaxAge)*time.Second))
+	verifier := newManagerAt(t, issuedAt.Add(time.Duration(MaxAge)*time.Second))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	req.AddCookie(c)
@@ -263,7 +263,7 @@ func TestPlayerID_BoundaryAgeIsValid(t *testing.T) {
 func TestClear(t *testing.T) {
 	t.Parallel()
 
-	mgr := session.New([]byte("k"), true)
+	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
 	mgr.Clear(rec)
 
@@ -273,7 +273,7 @@ func TestClear(t *testing.T) {
 	}
 
 	c := cookies[0]
-	if got, want := c.Name, session.CookieName; got != want {
+	if got, want := c.Name, CookieName; got != want {
 		t.Errorf("cookie name = %q, want %q", got, want)
 	}
 	if got, want := c.MaxAge, -1; got != want {


### PR DESCRIPTION
Brings the rest of the unit tests under \`internal/\` and \`cmd/\` onto the testing convention codified in #420:
- External \`<pkg>_test\` package with dot import.
- Unexported access via \`export_test.go\` instead of whitebox tests or \`*_internal_test.go\`.

## Changes

**Whitebox → blackbox conversions (3 files):**

- \`internal/clientapi/shuffle_internal_test.go\` → \`shuffle_test.go\` + new \`internal/clientapi/export_test.go\`.
- \`internal/game/clamp_internal_test.go\` → \`clamp_test.go\`.
- \`internal/game/time_limit_internal_test.go\` → \`time_limit_test.go\` + new \`internal/game/export_test.go\` (carrying \`ExportClampTappedAt\`, \`ExportResolveAnswerWindow\`, \`ExportDefaultExpiration\`).

**Dot-import rewrites (14 files):**

\`cmd/server/app/app_test.go\`, \`internal/absurl\`, \`internal/csrf\`, \`internal/health\`, \`internal/home\`, \`internal/leaderboard\`, \`internal/session\`, plus all seven \`internal/auth/*_test.go\` files.

Each file swapped its named import for a dot import and dropped the package prefix at every call site. Same Go behaviour, shorter call sites, no remaining drift from the convention.

## Verified

\`make lint-fix\`, \`make check\`, \`make smoke\`, \`make test-e2e\` all clean.