### PR TITLE
Codify workflow rules in CLAUDE.md so they survive memory drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ gh api -X PUT repos/starquake/topbanana/branches/main/protection --input <payloa
 
 When removing a workflow job, drop its context from the required list too — leaving a stale required-context name makes every PR mergeable-blocked indefinitely.
 
+## Comments
+
+Only add a comment when the intent can't be understood from the surrounding context, the function name, or the code in the function. A well-named function whose body reads as its own explanation doesn't need a docstring. A non-obvious tradeoff, workaround, or constraint does.
+
 ## Comments that reach across files
 
 WHY comments are encouraged when the rationale isn't obvious from the code. But a WHY that explains *what the other side of the system expects* is fragile — if the other side changes, the comment silently lies. The reader trusts it, and is misled.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Pick the right layer:
 
 One-off scripts are reserved for genuinely interactive debugging that can't be expressed as a test (e.g. eyeballing a visual layout, attaching a debugger). If you find yourself writing the same `curl` twice, it's a test.
 
+**New HTTP handler tests are integration tests, not stub-driven unit tests.** A handler whose contract is "wire the request to the store and render" is better pinned end-to-end (router → middleware → handler → store → DB) than against a stub that re-states what the store should return. Existing stub-driven unit tests stay until they break during an unrelated refactor — porting them wholesale isn't worth the CI-runtime hit. Decided in #30.
+
 ## Workflow
 
 When starting work on a new ticket: switch to `main`, run `git pull`, then create a new branch. Branch names use dashes (not slashes) and are prefixed with the ticket number — e.g. `1-fix-bugs`. Ask for the ticket number if not provided. Omit the prefix if there is no ticket.


### PR DESCRIPTION
CLAUDE.md's "Commits and PRs" section describes the per-change workflow at a high level, but several rules I rely on live only in my memory today. When that memory drifts they get re-litigated mid-task. Move the load-bearing ones into CLAUDE.md so the canonical project doc is the source of truth.

## Rules to add (or tighten)

1. **Per-change order of operations.** Make explicit:

   ```
   implement
     -> make lint-fix && make check && make smoke && make test-e2e
     -> /review + /go-style-review loop until both clean (fix findings)
     -> stage explicit paths
     -> commit
     -> push
     -> open draft PR
     -> ask for sign-off (user reviews diff on GitHub)
   ```

   The review loop is *before* commit, not after, so the diff that ships to GitHub is already clean.

2. **Comment-only-when-needed.** Comments are for WHY, not WHAT. Only add one when the rationale is non-obvious from the code. Original #425 scope.

3. **Sign-off does not carry.** A "looks good" on one diff does not extend to follow-up commits; re-ask after each new commit on the same branch.

4. **Stage explicit paths.** `git add <paths>`, never `-A` / `.`, so secrets and binaries don't sneak in.

5. **Rebase to update a branch.** `git rebase origin/main`, never merge.

6. **PR body empty by default.** `--body ""` unless the PR closes a tracked ticket, in which case the body is exactly `Closes #N`.

7. **New-ticket flow.** Switch to main -> `git pull` -> create a dash-named branch with the ticket-number prefix before starting any work.

## Out of scope

- Rules already covered in CLAUDE.md (commit message style, ASCII-only source, no SQL in Go files, etc.) - those are working as documented.
- Rules that are purely about Claude's internal behaviour (e.g. "don't kill processes you didn't start") - those stay in memory, not CLAUDE.md.