### PR TITLE
Wire SMTP, BASE_URL, and REGISTRATION_ENABLED through staging and production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,24 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URL: ${{ secrets.GOOGLE_REDIRECT_URL }}
+          # SMTP_* are optional: if none are set, the no-op mailer in
+          # the app stays in place and the /admin/email diagnostics
+          # page renders "disabled (no-op)". The Go config layer
+          # enforces consistency (partial SMTP errors at boot).
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          SMTP_TLS: ${{ secrets.SMTP_TLS }}
+          # BASE_URL is the absolute URL prefix for verify / invite
+          # links embedded in outbound email (#290, #318). Optional
+          # today; required when those features ship.
+          BASE_URL: ${{ secrets.BASE_URL }}
+          # REGISTRATION_ENABLED is an env-driven toggle so the
+          # operator can flip it without a redeploy. Defaults true on
+          # the compose side when unset here.
+          REGISTRATION_ENABLED: ${{ vars.REGISTRATION_ENABLED }}
           IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           IMAGE_TAG: edge
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +81,7 @@ jobs:
           # bakes in a blank, which the compose ${VAR:?…} guard then
           # rejects on boot. Keep this list in lockstep with the env block
           # above and the .env heredoc below.
-          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
             if [ -z "$SESSION_KEY" ]; then
@@ -84,6 +102,14 @@ jobs:
             GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
             GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
             GOOGLE_REDIRECT_URL=${GOOGLE_REDIRECT_URL}
+            SMTP_HOST=${SMTP_HOST}
+            SMTP_PORT=${SMTP_PORT}
+            SMTP_USERNAME=${SMTP_USERNAME}
+            SMTP_PASSWORD=${SMTP_PASSWORD}
+            SMTP_FROM=${SMTP_FROM}
+            SMTP_TLS=${SMTP_TLS}
+            BASE_URL=${BASE_URL}
+            REGISTRATION_ENABLED=${REGISTRATION_ENABLED}
             IMAGE_NAME=${IMAGE_NAME}
             IMAGE_TAG=${IMAGE_TAG}
             EOF
@@ -147,6 +173,24 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URL: ${{ secrets.GOOGLE_REDIRECT_URL }}
+          # SMTP_* are optional: if none are set, the no-op mailer in
+          # the app stays in place and the /admin/email diagnostics
+          # page renders "disabled (no-op)". The Go config layer
+          # enforces consistency (partial SMTP errors at boot).
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          SMTP_TLS: ${{ secrets.SMTP_TLS }}
+          # BASE_URL is the absolute URL prefix for verify / invite
+          # links embedded in outbound email (#290, #318). Optional
+          # today; required when those features ship.
+          BASE_URL: ${{ secrets.BASE_URL }}
+          # REGISTRATION_ENABLED is an env-driven toggle so the
+          # operator can flip it without a redeploy. Defaults true on
+          # the compose side when unset here.
+          REGISTRATION_ENABLED: ${{ vars.REGISTRATION_ENABLED }}
           IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -160,7 +204,7 @@ jobs:
           # bakes in a blank, which the compose ${VAR:?…} guard then
           # rejects on boot. Keep this list in lockstep with the env block
           # above and the .env heredoc below.
-          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
             if [ -z "$SESSION_KEY" ]; then
@@ -181,6 +225,14 @@ jobs:
             GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
             GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
             GOOGLE_REDIRECT_URL=${GOOGLE_REDIRECT_URL}
+            SMTP_HOST=${SMTP_HOST}
+            SMTP_PORT=${SMTP_PORT}
+            SMTP_USERNAME=${SMTP_USERNAME}
+            SMTP_PASSWORD=${SMTP_PASSWORD}
+            SMTP_FROM=${SMTP_FROM}
+            SMTP_TLS=${SMTP_TLS}
+            BASE_URL=${BASE_URL}
+            REGISTRATION_ENABLED=${REGISTRATION_ENABLED}
             IMAGE_NAME=${IMAGE_NAME}
             IMAGE_TAG=${IMAGE_TAG}
             EOF

--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -38,6 +38,17 @@ services:
       # without port, etc.) is rejected by the Go config layer with
       # a clear error. Same three-place-edit rule as the GOOGLE_*
       # block above applies in deploy.yml.
+      #
+      # SMTP_PORT and SMTP_TLS must be paired by the operator; nothing
+      # auto-picks the port. The supported pairings:
+      #   - SMTP_PORT=587 + SMTP_TLS=true  -> STARTTLS, the standard
+      #     "TLS on" path (most providers).
+      #   - SMTP_PORT=25  + SMTP_TLS=false -> plain SMTP (usually
+      #     only for internal relays).
+      #   - SMTP_PORT=1025 + SMTP_TLS=false -> local Mailpit dev.
+      # Port 465 (implicit TLS / SMTPS) is NOT supported: go-mail's
+      # TLS path issues STARTTLS, which fails on a port the server
+      # expects to be TLS-wrapped from byte zero.
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-}
       - SMTP_USERNAME=${SMTP_USERNAME:-}

--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -7,7 +7,11 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
-      - REGISTRATION_ENABLED=true
+      # REGISTRATION_ENABLED is now env-driven so the operator can
+      # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
+      # without a redeploy. Defaults true when unset so a fresh stack
+      # behaves the way the previously-hardcoded value did.
+      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
       - ADMIN_USERNAMES=admin
       - SESSION_KEY=${SESSION_KEY:?SESSION_KEY must be set in .env or environment}
       # Google sign-in is part of the standard production deployment.
@@ -27,6 +31,23 @@ services:
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:?GOOGLE_CLIENT_ID must be set in .env or environment}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:?GOOGLE_CLIENT_SECRET must be set in .env or environment}
       - GOOGLE_REDIRECT_URL=${GOOGLE_REDIRECT_URL:?GOOGLE_REDIRECT_URL must be set in .env or environment}
+      # SMTP_* are optional. If the production environment doesn't
+      # define any of them, the app falls back to the no-op mailer
+      # and the /admin/email diagnostics page renders the "disabled
+      # (no-op)" badge - no boot failure. Partial wiring (host
+      # without port, etc.) is rejected by the Go config layer with
+      # a clear error. Same three-place-edit rule as the GOOGLE_*
+      # block above applies in deploy.yml.
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_FROM=${SMTP_FROM:-}
+      - SMTP_TLS=${SMTP_TLS:-}
+      # BASE_URL is the absolute URL prefix for verify / invite links
+      # in outbound email. Optional until #111 PR2 ships; the mailer
+      # falls back to an empty prefix when unset.
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - topbanana_production_data:/home/nonroot/data
     networks:

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -38,6 +38,17 @@ services:
       # etc.) is rejected by the Go config layer with a clear error.
       # Same three-place-edit rule as the GOOGLE_* block above applies
       # in deploy.yml.
+      #
+      # SMTP_PORT and SMTP_TLS must be paired by the operator; nothing
+      # auto-picks the port. The supported pairings:
+      #   - SMTP_PORT=587 + SMTP_TLS=true  -> STARTTLS, the standard
+      #     "TLS on" path (most providers).
+      #   - SMTP_PORT=25  + SMTP_TLS=false -> plain SMTP (usually
+      #     only for internal relays).
+      #   - SMTP_PORT=1025 + SMTP_TLS=false -> local Mailpit dev.
+      # Port 465 (implicit TLS / SMTPS) is NOT supported: go-mail's
+      # TLS path issues STARTTLS, which fails on a port the server
+      # expects to be TLS-wrapped from byte zero.
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-}
       - SMTP_USERNAME=${SMTP_USERNAME:-}

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -7,7 +7,11 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
-      - REGISTRATION_ENABLED=true
+      # REGISTRATION_ENABLED is now env-driven so the operator can
+      # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
+      # without a redeploy. Defaults true when unset so a fresh stack
+      # behaves the way the previously-hardcoded value did.
+      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
       - ADMIN_USERNAMES=admin
       - SESSION_KEY=${SESSION_KEY:?SESSION_KEY must be set in .env or environment}
       # Google sign-in is part of the standard staging deployment.
@@ -27,6 +31,23 @@ services:
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:?GOOGLE_CLIENT_ID must be set in .env or environment}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:?GOOGLE_CLIENT_SECRET must be set in .env or environment}
       - GOOGLE_REDIRECT_URL=${GOOGLE_REDIRECT_URL:?GOOGLE_REDIRECT_URL must be set in .env or environment}
+      # SMTP_* are optional. If the staging environment doesn't define
+      # any of them, the app falls back to the no-op mailer and the
+      # /admin/email diagnostics page renders the "disabled (no-op)"
+      # badge - no boot failure. Partial wiring (host without port,
+      # etc.) is rejected by the Go config layer with a clear error.
+      # Same three-place-edit rule as the GOOGLE_* block above applies
+      # in deploy.yml.
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_FROM=${SMTP_FROM:-}
+      - SMTP_TLS=${SMTP_TLS:-}
+      # BASE_URL is the absolute URL prefix for verify / invite links
+      # in outbound email. Optional until #111 PR2 ships; the mailer
+      # falls back to an empty prefix when unset.
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - topbanana_staging_data:/home/nonroot/data
     networks:


### PR DESCRIPTION
Adds the env-var plumbing without a ticket.

## What lands

**deploy.yml** (both `deploy-staging` and `deploy-production`):
- New entries in the `env:` block: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_TLS`, `BASE_URL`, `REGISTRATION_ENABLED`.
- New entries in the `envs:` allowlist (appleboy/ssh-action) so the values are actually forwarded.
- New lines in the `.env` heredoc so the host's compose stack receives them.
- `REGISTRATION_ENABLED` is sourced from `vars.REGISTRATION_ENABLED` (a GitHub Actions variable you can flip without a redeploy). The other new vars come from `secrets.*`.

**docker-compose.staging.yml + docker-compose.production.yml**:
- New `SMTP_*` and `BASE_URL` env entries with `${VAR:-}` (empty-when-unset) so a fresh deploy without those secrets still boots; the Go config layer falls back to the no-op mailer and partial-config errors fire at startup if you set some but not all.
- `REGISTRATION_ENABLED` moved from hardcoded `true` to `${REGISTRATION_ENABLED:-true}` so flipping the GitHub variable takes effect without a code change.

## Operator notes

After this merges you can set on the staging / production GitHub environments:

- **Secrets**: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_TLS`, `BASE_URL`
- **Variables**: `REGISTRATION_ENABLED` (`true` or `false`; defaults `true` when unset)

None are required. Leaving all the `SMTP_*` blank keeps the no-op mailer in place and the `/admin/email` diagnostics page renders "disabled (no-op)". Setting some but not all of `SMTP_HOST` / `SMTP_PORT` / `SMTP_FROM` is rejected at boot via `ErrSMTPConfigIncomplete` (#321).