### PR TITLE
Capture email at register (#111 PR1 of 3)

### DIFF
--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -89,7 +89,13 @@ func seedPlayer(t *testing.T, dbURI, username string) string {
 	}
 
 	players := store.NewPlayerStore(conn, slog.Default())
-	if _, err := players.CreatePlayer(t.Context(), username, hashed, auth.RolePlayer); err != nil {
+	if _, err := players.CreatePlayer(
+		t.Context(),
+		username,
+		username+"@example.test",
+		hashed,
+		auth.RolePlayer,
+	); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -74,3 +74,8 @@ func ExportReadGoogleNext(r *http.Request, key []byte) string {
 // integration / unit tests can assert it without re-declaring the
 // constant.
 const GoogleNextCookieName = googleNextCookieName
+
+// LooksLikeEmail exposes the unexported register-form email validator
+// so the external auth_test package can pin its branch table without
+// going through the full register handler (#111 PR1).
+var LooksLikeEmail = looksLikeEmail

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -75,7 +75,5 @@ func ExportReadGoogleNext(r *http.Request, key []byte) string {
 // constant.
 const GoogleNextCookieName = googleNextCookieName
 
-// LooksLikeEmail exposes the unexported register-form email validator
-// so the external auth_test package can pin its branch table without
-// going through the full register handler (#111 PR1).
+// LooksLikeEmail exposes looksLikeEmail for the external test package.
 var LooksLikeEmail = looksLikeEmail

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -469,6 +470,19 @@ func linkExistingPlayerByEmail(
 		}
 
 		return nil, fmt.Errorf("link identity to existing player: %w", linkErr)
+	}
+
+	// Google has just attested the player's ownership of this email
+	// address. Stamp email_verified_at if it was still NULL (a
+	// password-registered row from #111 PR1 starts unverified) so the
+	// gate landing in PR3 does not keep bouncing a linked account to
+	// the resend page.
+	if err := identities.MarkPlayerEmailVerifiedIfNew(ctx, player.ID); err != nil {
+		return nil, fmt.Errorf("mark email verified after link: %w", err)
+	}
+	if player.EmailVerifiedAt == nil {
+		now := time.Now().UTC()
+		player.EmailVerifiedAt = &now
 	}
 
 	return player, nil

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -472,11 +472,7 @@ func linkExistingPlayerByEmail(
 		return nil, fmt.Errorf("link identity to existing player: %w", linkErr)
 	}
 
-	// Google has just attested the player's ownership of this email
-	// address. Stamp email_verified_at if it was still NULL (a
-	// password-registered row from #111 PR1 starts unverified) so the
-	// gate landing in PR3 does not keep bouncing a linked account to
-	// the resend page.
+	// Google attests the address; stamp email_verified_at if not already set.
 	if err := identities.MarkPlayerEmailVerifiedIfNew(ctx, player.ID); err != nil {
 		return nil, fmt.Errorf("mark email verified after link: %w", err)
 	}

--- a/internal/auth/google_test.go
+++ b/internal/auth/google_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
 )
@@ -137,6 +138,24 @@ func (s *stubOAuthStore) ClaimPlayerForOAuth(_ context.Context, playerID int64, 
 	}
 
 	return p, nil
+}
+
+// MarkPlayerEmailVerifiedIfNew mirrors the SQL by stamping
+// EmailVerifiedAt on the row when it is currently nil. Idempotent.
+func (s *stubOAuthStore) MarkPlayerEmailVerifiedIfNew(_ context.Context, playerID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.players[playerID]
+	if !ok {
+		return nil
+	}
+	if p.EmailVerifiedAt == nil {
+		now := time.Now().UTC()
+		p.EmailVerifiedAt = &now
+	}
+
+	return nil
 }
 
 // seedAnonymous inserts a fully anonymous players row (no password,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -60,7 +60,11 @@ const maxFormBodySize = 64 * 1024
 type formData struct {
 	Title    string
 	Username string
-	Message  string
+	// Email is the trimmed+lowercased value the registrant submitted.
+	// Preserved across form re-renders so a failed validation does not
+	// drop the email the visitor typed (#111 PR1).
+	Email   string
+	Message string
 	// ShowRegister controls whether the login template renders the
 	// "No account? Register" link. False when REGISTRATION_ENABLED is unset/false.
 	ShowRegister bool
@@ -137,13 +141,15 @@ func HandleRegisterSubmit(
 		}
 
 		rawUsername := r.PostFormValue("username")
+		rawEmail := r.PostFormValue("email")
 		password := r.PostFormValue("password")
 
-		input := validateRegisterInput(rawUsername, password)
+		input := validateRegisterInput(rawUsername, rawEmail, password)
 		if !input.OK {
 			render.render(w, r, http.StatusBadRequest, formData{
 				Title:      "Register",
 				Username:   input.Cleaned,
+				Email:      input.CleanedEmail,
 				Message:    input.ErrMsg,
 				ShowGoogle: googleEnabled,
 			})
@@ -164,13 +170,25 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		player, err := claimOrCreatePlayer(r, players, sessions, input.Cleaned, hashed, role)
+		player, err := claimOrCreatePlayer(r, players, sessions, input.Cleaned, input.CleanedEmail, hashed, role)
 		if err != nil {
 			if errors.Is(err, ErrUsernameTaken) {
 				render.render(w, r, http.StatusConflict, formData{
 					Title:      "Register",
 					Username:   input.Cleaned,
+					Email:      input.CleanedEmail,
 					Message:    "Username is already taken.",
+					ShowGoogle: googleEnabled,
+				})
+
+				return
+			}
+			if errors.Is(err, ErrEmailTaken) {
+				render.render(w, r, http.StatusConflict, formData{
+					Title:      "Register",
+					Username:   input.Cleaned,
+					Email:      input.CleanedEmail,
+					Message:    "Email is already registered. Try logging in.",
 					ShowGoogle: googleEnabled,
 				})
 
@@ -205,17 +223,17 @@ func claimOrCreatePlayer(
 	r *http.Request,
 	players PlayerStore,
 	sessions *session.Manager,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	playerID, ok := sessions.PlayerID(r)
 	if !ok {
-		return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+		return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
 	}
 
 	existing, err := players.GetPlayerByID(r.Context(), playerID)
 	if err != nil {
 		if errors.Is(err, ErrPlayerNotFound) {
-			return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+			return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
 		}
 
 		return nil, fmt.Errorf("get player by id for claim: %w", err)
@@ -224,13 +242,13 @@ func claimOrCreatePlayer(
 		// Session already belongs to a credentialled account. Treat this as a
 		// fresh registration so the new account is created independently;
 		// the existing session is replaced when the caller resets the cookie.
-		return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+		return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
 	}
 
-	claimed, err := players.ClaimPlayer(r.Context(), playerID, username, passwordHash, requestedRole)
+	claimed, err := players.ClaimPlayer(r.Context(), playerID, username, email, passwordHash, requestedRole)
 	if err != nil {
 		if errors.Is(err, ErrPlayerAlreadyClaimed) || errors.Is(err, ErrPlayerNotFound) {
-			return createPlayerWrapped(r, players, username, passwordHash, requestedRole)
+			return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
 		}
 
 		return nil, fmt.Errorf("claim player: %w", err)
@@ -244,9 +262,9 @@ func claimOrCreatePlayer(
 func createPlayerWrapped(
 	r *http.Request,
 	players PlayerStore,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*Player, error) {
-	p, err := players.CreatePlayer(r.Context(), username, passwordHash, requestedRole)
+	p, err := players.CreatePlayer(r.Context(), username, email, passwordHash, requestedRole)
 	if err != nil {
 		return nil, fmt.Errorf("create player: %w", err)
 	}
@@ -431,23 +449,38 @@ type registerInput struct {
 	// Cleaned is the username with surrounding whitespace removed. Callers use it for
 	// both storage and lookup so `" alice "` and `"alice"` cannot be treated as different users.
 	Cleaned string
+	// CleanedEmail is the email with surrounding whitespace removed and
+	// the entire value lowercased so case variants do not produce
+	// duplicate accounts (#111 PR1).
+	CleanedEmail string
 	// ErrMsg is a user-facing error message, populated only when OK is false.
 	ErrMsg string
 	// OK reports whether the inputs are valid.
 	OK bool
 }
 
-// validateRegisterInput trims the username and validates the inputs.
-func validateRegisterInput(username, password string) registerInput {
+// validateRegisterInput trims the username and email, lowercases the
+// email, and validates the inputs.
+func validateRegisterInput(username, email, password string) registerInput {
 	cleaned := strings.TrimSpace(username)
+	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	if cleaned == "" {
-		return registerInput{Cleaned: cleaned, ErrMsg: "Username is required.", OK: false}
+		return registerInput{
+			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			ErrMsg: "Username is required.", OK: false,
+		}
+	}
+	if !looksLikeEmail(cleanedEmail) {
+		return registerInput{
+			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			ErrMsg: "Enter a valid email address.", OK: false,
+		}
 	}
 	if len(password) < MinPasswordLength {
 		return registerInput{
-			Cleaned: cleaned,
-			ErrMsg:  fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength),
-			OK:      false,
+			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			ErrMsg: fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength),
+			OK:     false,
 		}
 	}
 	if len(password) > MaxPasswordLength {
@@ -455,13 +488,40 @@ func validateRegisterInput(username, password string) registerInput {
 		// turns a wrapped 500 into a normal form-validation error with a
 		// user-friendly message.
 		return registerInput{
-			Cleaned: cleaned,
-			ErrMsg:  fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength),
-			OK:      false,
+			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			ErrMsg: fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength),
+			OK:     false,
 		}
 	}
 
-	return registerInput{Cleaned: cleaned, OK: true}
+	return registerInput{Cleaned: cleaned, CleanedEmail: cleanedEmail, OK: true}
+}
+
+// looksLikeEmail is a deliberately loose check: exactly one '@', a
+// non-empty local part, a host that contains a dot but does not start
+// or end with one. Tight validation belongs at the SMTP / DNS layer;
+// this exists only to reject obvious typos at the form so the
+// duplicate-email path remains the rare exception rather than the
+// common error (#111 PR1).
+func looksLikeEmail(s string) bool {
+	if s == "" {
+		return false
+	}
+	local, host, ok := strings.Cut(s, "@")
+	if !ok || local == "" || host == "" {
+		return false
+	}
+	if strings.Count(s, "@") > 1 {
+		return false
+	}
+	if strings.HasPrefix(host, ".") || strings.HasSuffix(host, ".") {
+		return false
+	}
+	if !strings.Contains(host, ".") {
+		return false
+	}
+
+	return true
 }
 
 // renderInvalidCredentials re-renders the login form with the generic

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -148,7 +148,7 @@ func HandleRegisterSubmit(
 		if !input.OK {
 			render.render(w, r, http.StatusBadRequest, formData{
 				Title:      "Register",
-				Username:   input.Cleaned,
+				Username:   input.CleanedUsername,
 				Email:      input.CleanedEmail,
 				Message:    input.ErrMsg,
 				ShowGoogle: googleEnabled,
@@ -158,7 +158,7 @@ func HandleRegisterSubmit(
 		}
 
 		role := RolePlayer
-		if slices.Contains(adminUsernames, input.Cleaned) {
+		if slices.Contains(adminUsernames, input.CleanedUsername) {
 			role = RoleAdmin
 		}
 
@@ -170,12 +170,20 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		player, err := claimOrCreatePlayer(r, players, sessions, input.Cleaned, input.CleanedEmail, hashed, role)
+		player, err := claimOrCreatePlayer(
+			r,
+			players,
+			sessions,
+			input.CleanedUsername,
+			input.CleanedEmail,
+			hashed,
+			role,
+		)
 		if err != nil {
 			if errors.Is(err, ErrUsernameTaken) {
 				render.render(w, r, http.StatusConflict, formData{
 					Title:      "Register",
-					Username:   input.Cleaned,
+					Username:   input.CleanedUsername,
 					Email:      input.CleanedEmail,
 					Message:    "Username is already taken.",
 					ShowGoogle: googleEnabled,
@@ -186,7 +194,7 @@ func HandleRegisterSubmit(
 			if errors.Is(err, ErrEmailTaken) {
 				render.render(w, r, http.StatusConflict, formData{
 					Title:      "Register",
-					Username:   input.Cleaned,
+					Username:   input.CleanedUsername,
 					Email:      input.CleanedEmail,
 					Message:    "Email is already registered. Try logging in.",
 					ShowGoogle: googleEnabled,
@@ -446,9 +454,9 @@ func HandleLogout(sessions *session.Manager) http.Handler {
 
 // registerInput is the result of validateRegisterInput.
 type registerInput struct {
-	// Cleaned is the username with surrounding whitespace removed. Callers use it for
+	// CleanedUsername is the username with surrounding whitespace removed. Callers use it for
 	// both storage and lookup so `" alice "` and `"alice"` cannot be treated as different users.
-	Cleaned string
+	CleanedUsername string
 	// CleanedEmail is the email with surrounding whitespace removed and
 	// the entire value lowercased so case variants do not produce
 	// duplicate accounts (#111 PR1).
@@ -462,23 +470,23 @@ type registerInput struct {
 // validateRegisterInput trims the username and email, lowercases the
 // email, and validates the inputs.
 func validateRegisterInput(username, email, password string) registerInput {
-	cleaned := strings.TrimSpace(username)
+	cleanedUsername := strings.TrimSpace(username)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
-	if cleaned == "" {
+	if cleanedUsername == "" {
 		return registerInput{
-			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
 			ErrMsg: "Username is required.", OK: false,
 		}
 	}
 	if !looksLikeEmail(cleanedEmail) {
 		return registerInput{
-			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
 			ErrMsg: "Enter a valid email address.", OK: false,
 		}
 	}
 	if len(password) < MinPasswordLength {
 		return registerInput{
-			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
 			ErrMsg: fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength),
 			OK:     false,
 		}
@@ -488,13 +496,13 @@ func validateRegisterInput(username, email, password string) registerInput {
 		// turns a wrapped 500 into a normal form-validation error with a
 		// user-friendly message.
 		return registerInput{
-			Cleaned: cleaned, CleanedEmail: cleanedEmail,
+			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
 			ErrMsg: fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength),
 			OK:     false,
 		}
 	}
 
-	return registerInput{Cleaned: cleaned, CleanedEmail: cleanedEmail, OK: true}
+	return registerInput{CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail, OK: true}
 }
 
 // looksLikeEmail is a deliberately loose check: exactly one '@', a

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -60,9 +60,8 @@ const maxFormBodySize = 64 * 1024
 type formData struct {
 	Title    string
 	Username string
-	// Email is the trimmed+lowercased value the registrant submitted.
-	// Preserved across form re-renders so a failed validation does not
-	// drop the email the visitor typed (#111 PR1).
+	// Email is the trimmed+lowercased value; preserved across form
+	// re-renders so a failed validation doesn't drop it.
 	Email   string
 	Message string
 	// ShowRegister controls whether the login template renders the
@@ -171,32 +170,15 @@ func HandleRegisterSubmit(
 		}
 
 		player, err := claimOrCreatePlayer(
-			r,
-			players,
-			sessions,
-			input.CleanedUsername,
-			input.CleanedEmail,
-			hashed,
-			role,
+			r, players, sessions, input.CleanedUsername, input.CleanedEmail, hashed, role,
 		)
 		if err != nil {
-			if errors.Is(err, ErrUsernameTaken) {
+			if msg, ok := registerCollisionMessage(err); ok {
 				render.render(w, r, http.StatusConflict, formData{
 					Title:      "Register",
 					Username:   input.CleanedUsername,
 					Email:      input.CleanedEmail,
-					Message:    "Username is already taken.",
-					ShowGoogle: googleEnabled,
-				})
-
-				return
-			}
-			if errors.Is(err, ErrEmailTaken) {
-				render.render(w, r, http.StatusConflict, formData{
-					Title:      "Register",
-					Username:   input.CleanedUsername,
-					Email:      input.CleanedEmail,
-					Message:    "Email is already registered. Try logging in.",
+					Message:    msg,
 					ShowGoogle: googleEnabled,
 				})
 
@@ -211,6 +193,20 @@ func HandleRegisterSubmit(
 		sessions.Set(w, player.ID)
 		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 	})
+}
+
+// registerCollisionMessage maps the register-time conflict sentinels
+// onto the user-facing banner. ok=false when err is something else
+// and the caller should treat it as a 500.
+func registerCollisionMessage(err error) (string, bool) {
+	switch {
+	case errors.Is(err, ErrUsernameTaken):
+		return "Username is already taken.", true
+	case errors.Is(err, ErrEmailTaken):
+		return "Email is already registered. Try logging in.", true
+	}
+
+	return "", false
 }
 
 // claimOrCreatePlayer is the storage-side branch of HandleRegisterSubmit. If
@@ -454,12 +450,10 @@ func HandleLogout(sessions *session.Manager) http.Handler {
 
 // registerInput is the result of validateRegisterInput.
 type registerInput struct {
-	// CleanedUsername is the username with surrounding whitespace removed. Callers use it for
-	// both storage and lookup so `" alice "` and `"alice"` cannot be treated as different users.
+	// CleanedUsername is the username, whitespace-trimmed.
 	CleanedUsername string
-	// CleanedEmail is the email with surrounding whitespace removed and
-	// the entire value lowercased so case variants do not produce
-	// duplicate accounts (#111 PR1).
+	// CleanedEmail is the email, whitespace-trimmed and lowercased so
+	// case variants cannot create duplicate accounts.
 	CleanedEmail string
 	// ErrMsg is a user-facing error message, populated only when OK is false.
 	ErrMsg string
@@ -505,12 +499,9 @@ func validateRegisterInput(username, email, password string) registerInput {
 	return registerInput{CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail, OK: true}
 }
 
-// looksLikeEmail is a deliberately loose check: exactly one '@', a
-// non-empty local part, a host that contains a dot but does not start
-// or end with one. Tight validation belongs at the SMTP / DNS layer;
-// this exists only to reject obvious typos at the form so the
-// duplicate-email path remains the rare exception rather than the
-// common error (#111 PR1).
+// looksLikeEmail is a deliberately loose check: one '@', non-empty
+// local part, host with a dot that does not start or end with one.
+// Tight validation belongs at the SMTP / DNS layer.
 func looksLikeEmail(s string) bool {
 	if s == "" {
 		return false

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -80,7 +80,7 @@ func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*Player, e
 // rule is observed atomically.
 func (s *stubPlayerStore) CreatePlayer(
 	_ context.Context,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -88,12 +88,20 @@ func (s *stubPlayerStore) CreatePlayer(
 	if _, exists := s.byName[username]; exists {
 		return nil, ErrUsernameTaken
 	}
+	if email != "" {
+		for _, p := range s.byID {
+			if p.Email == email {
+				return nil, ErrEmailTaken
+			}
+		}
+	}
 
 	role := s.resolveRoleLocked(requestedRole)
 
 	p := &Player{
 		ID:           s.nextID,
 		Username:     username,
+		Email:        email,
 		PasswordHash: passwordHash,
 		Role:         role,
 	}
@@ -144,7 +152,7 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 func (s *stubPlayerStore) ClaimPlayer(
 	_ context.Context,
 	playerID int64,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -159,8 +167,16 @@ func (s *stubPlayerStore) ClaimPlayer(
 	if other, exists := s.byName[username]; exists && other.ID != playerID {
 		return nil, ErrUsernameTaken
 	}
+	if email != "" {
+		for _, p := range s.byID {
+			if p.ID != playerID && p.Email == email {
+				return nil, ErrEmailTaken
+			}
+		}
+	}
 
 	delete(s.byName, existing.Username)
+	existing.Email = email
 	existing.Username = username
 	existing.PasswordHash = passwordHash
 	existing.Role = s.resolveRoleLocked(requestedRole)
@@ -300,6 +316,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -336,13 +353,14 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 
 	store := newStubPlayerStore()
 	// Pre-seed first admin.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "hash", RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "hash", RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
+		"email":    {"bob@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -369,7 +387,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 
 	store := newStubPlayerStore()
 	// Pre-seed first user so the count > 0 and the env var path is exercised.
-	if _, err := store.CreatePlayer(t.Context(), "first", "h", RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "first", "first@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
@@ -383,6 +401,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 	)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"carol"},
+		"email":    {"carol@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -407,6 +426,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"short"},
 	})
 
@@ -434,6 +454,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {strings.Repeat("a", MaxPasswordLength+1)},
 	})
 
@@ -453,13 +474,14 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "h", RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -468,6 +490,81 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	}
 	if got, want := rec.Body.String(), "already taken"; !strings.Contains(got, want) {
 		t.Errorf("body did not mention duplicate, got %q", got)
+	}
+}
+
+// TestHandleRegisterSubmit_DuplicateEmail pins #111 PR1: a second
+// register with the same email as an existing row gets a 409 with the
+// "already registered" banner instead of the generic 500.
+func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	if _, err := store.CreatePlayer(t.Context(), "alice", "shared@example.test", "h", RolePlayer); err != nil {
+		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
+	}
+
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	rec := postForm(t, handler, "/register", url.Values{
+		"username": {"bob"},
+		"email":    {"shared@example.test"},
+		"password": {"correctbattery"},
+	})
+
+	if got, want := rec.Code, http.StatusConflict; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), "already registered"; !strings.Contains(got, want) {
+		t.Errorf("body did not mention duplicate email, got %q", got)
+	}
+}
+
+// TestHandleRegisterSubmit_RejectsInvalidEmail pins the form-level
+// validator: a malformed email surfaces as a 400 with the "Enter a
+// valid email address" banner, without hitting the store at all.
+func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	rec := postForm(t, handler, "/register", url.Values{
+		"username": {"alice"},
+		"email":    {"not-an-email"},
+		"password": {"correctbattery"},
+	})
+
+	if got, want := rec.Code, http.StatusBadRequest; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), "Enter a valid email address"; !strings.Contains(got, want) {
+		t.Errorf("body did not surface the email validator banner, got %q", got)
+	}
+}
+
+// TestHandleRegisterSubmit_LowercasesAndTrimsEmail pins the
+// normalisation rule: "  ALICE@Example.Test " round-trips as
+// "alice@example.test" on the stored row so case/whitespace variants
+// cannot create duplicate accounts.
+func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
+	t.Parallel()
+
+	store := newStubPlayerStore()
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	rec := postForm(t, handler, "/register", url.Values{
+		"username": {"alice"},
+		"email":    {"  ALICE@Example.Test "},
+		"password": {"correctbattery"},
+	})
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
+	}
+	p, err := store.GetPlayerByUsername(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	if got, want := p.Email, "alice@example.test"; got != want {
+		t.Errorf("stored email = %q, want %q", got, want)
 	}
 }
 
@@ -495,6 +592,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 
 	form := url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 	}
 	req := httptest.NewRequestWithContext(
@@ -534,7 +632,13 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "previousHash", RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(
+		t.Context(),
+		"alice",
+		"alice@example.test",
+		"previousHash",
+		RolePlayer,
+	); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-claimer")
@@ -551,6 +655,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 
 	form := url.Values{
 		"username": {"alice"}, // already taken by the seeded credentialled row
+		"email":    {"new-alice@example.test"},
 		"password": {"correctbattery"},
 	}
 	req := httptest.NewRequestWithContext(
@@ -595,6 +700,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 		t.Context(),
 		anon.ID,
 		"winner",
+		"winner@example.test",
 		"winnerHash",
 		RolePlayer,
 	); claimErr != nil {
@@ -610,6 +716,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 
 	form := url.Values{
 		"username": {"latecomer"},
+		"email":    {"latecomer@example.test"},
 		"password": {"correctbattery"},
 	}
 	req := httptest.NewRequestWithContext(
@@ -721,10 +828,16 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	// registrant becomes admin" rule (mirroring the production SQL)
 	// promotes that row, not carol. Carol then stays as a plain
 	// player and the redirect lands on / instead of /admin/quizzes.
-	if _, seedErr := store.CreatePlayer(t.Context(), "first-admin", hash, RoleAdmin); seedErr != nil {
+	if _, seedErr := store.CreatePlayer(
+		t.Context(),
+		"first-admin",
+		"first-admin@example.test",
+		hash,
+		RoleAdmin,
+	); seedErr != nil {
 		t.Fatalf("seed admin err = %v, want nil", seedErr)
 	}
-	player, err := store.CreatePlayer(t.Context(), "carol", hash, RolePlayer)
+	player, err := store.CreatePlayer(t.Context(), "carol", "carol@example.test", hash, RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -789,13 +902,14 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -818,13 +932,14 @@ func TestHandleLoginSubmit_HonoursNext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 		"next":     {"/admin/email"},
 	})
@@ -848,13 +963,14 @@ func TestHandleLoginSubmit_RejectsUnsafeNext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
 		"next":     {"//evil.com/"},
 	})
@@ -876,20 +992,27 @@ func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 	store := newStubPlayerStore()
 	// Pre-seed an admin so the "first password-bearing registrant
 	// becomes admin" rule doesn't accidentally promote bob.
-	if _, err := store.CreatePlayer(t.Context(), "first-admin", "h", RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(
+		t.Context(),
+		"first-admin",
+		"first-admin@example.test",
+		"h",
+		RoleAdmin,
+	); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "bob", hash, RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "bob", "bob@example.test", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"bob"},
+		"email":    {"bob@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -909,6 +1032,7 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"ghost"},
+		"email":    {"ghost@example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -928,13 +1052,14 @@ func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", hash, RolePlayer); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {"wrong-password-no"},
 	})
 
@@ -951,13 +1076,14 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 
 	// Seed a player with no password hash (legacy admin from migration).
 	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "legacy", "", RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "legacy", "legacy@example.test", "", RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false, false)
 	rec := postForm(t, handler, "/login", url.Values{
 		"username": {"legacy"},
+		"email":    {"legacy@example.test"},
 		"password": {"anything-goes-here-13"},
 	})
 
@@ -974,6 +1100,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"   "},
+		"email":    {"   @example.test"},
 		"password": {"correctbattery"},
 	})
 
@@ -998,6 +1125,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	password := strings.Repeat("a", MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
+		"email":    {"alice@example.test"},
 		"password": {password},
 	})
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -493,9 +493,6 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterSubmit_DuplicateEmail pins #111 PR1: a second
-// register with the same email as an existing row gets a 409 with the
-// "already registered" banner instead of the generic 500.
 func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	t.Parallel()
 
@@ -519,9 +516,6 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterSubmit_RejectsInvalidEmail pins the form-level
-// validator: a malformed email surfaces as a 400 with the "Enter a
-// valid email address" banner, without hitting the store at all.
 func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 	t.Parallel()
 
@@ -541,10 +535,6 @@ func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterSubmit_LowercasesAndTrimsEmail pins the
-// normalisation rule: "  ALICE@Example.Test " round-trips as
-// "alice@example.test" on the stored row so case/whitespace variants
-// cannot create duplicate accounts.
 func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -28,7 +28,7 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "h", RoleAdmin)
+	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -77,10 +77,10 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	store := newStubPlayerStore()
 	// Pre-seed an admin so the next CreatePlayer call is not auto-promoted to admin
 	// by the "first password-bearing registrant becomes admin" rule.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "h", RoleAdmin); err != nil {
+	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "h", RoleAdmin); err != nil {
 		t.Fatalf("seed admin err = %v, want nil", err)
 	}
-	player, err := store.CreatePlayer(t.Context(), "bob", "h", RolePlayer)
+	player, err := store.CreatePlayer(t.Context(), "bob", "bob@example.test", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -192,7 +192,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "h", RoleAdmin)
+	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}

--- a/internal/auth/oauth_store.go
+++ b/internal/auth/oauth_store.go
@@ -41,10 +41,7 @@ type OAuthIdentityStore interface {
 	// each case the caller falls through to the create-fresh-player
 	// path. The username on the row is left untouched.
 	ClaimPlayerForOAuth(ctx context.Context, playerID int64, email string) (*Player, error)
-	// MarkPlayerEmailVerifiedIfNew flips email_verified_at to now() on
-	// the row when it is currently NULL. Idempotent. Called by the
-	// link-by-email path so a password-registered row that later signs
-	// in with the same Google address picks up the verified flag the
-	// gate (#111 PR3) will check.
+	// MarkPlayerEmailVerifiedIfNew stamps email_verified_at when
+	// currently NULL. Idempotent.
 	MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID int64) error
 }

--- a/internal/auth/oauth_store.go
+++ b/internal/auth/oauth_store.go
@@ -41,4 +41,10 @@ type OAuthIdentityStore interface {
 	// each case the caller falls through to the create-fresh-player
 	// path. The username on the row is left untouched.
 	ClaimPlayerForOAuth(ctx context.Context, playerID int64, email string) (*Player, error)
+	// MarkPlayerEmailVerifiedIfNew flips email_verified_at to now() on
+	// the row when it is currently NULL. Idempotent. Called by the
+	// link-by-email path so a password-registered row that later signs
+	// in with the same Google address picks up the verified flag the
+	// gate (#111 PR3) will check.
+	MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID int64) error
 }

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -12,6 +12,12 @@ var ErrPlayerNotFound = errors.New("player not found")
 // ErrUsernameTaken is returned when a username is already in use.
 var ErrUsernameTaken = errors.New("username taken")
 
+// ErrEmailTaken is returned when an email is already in use by another
+// player. The register handler maps it to a 409 + form re-render with
+// the email-field error so a registrant whose chosen email collides
+// can fix it without re-typing the rest of the form (#111 PR1).
+var ErrEmailTaken = errors.New("email taken")
+
 // ErrPlayerAlreadyClaimed is returned by ClaimPlayer when the target row
 // already has a password_hash set, so it cannot be upgraded again.
 var ErrPlayerAlreadyClaimed = errors.New("player already claimed")
@@ -36,13 +42,26 @@ var ErrIdentityAlreadyLinked = errors.New("identity already linked")
 
 // Player represents an authenticated user (admin or player).
 type Player struct {
-	ID              int64
-	Username        string
-	Email           string
+	ID       int64
+	Username string
+	Email    string
+	// EmailVerifiedAt is nil until the player consumes a verify token
+	// (#111). OAuth-linked rows are stamped at link time because Google
+	// attests the email. The gate added in #111 PR3 refuses routes for
+	// password-bearing rows with EmailVerifiedAt == nil.
+	EmailVerifiedAt *time.Time
 	PasswordHash    string
 	Role            string
 	CreatedAt       time.Time
 	UsernameClaimed bool
+}
+
+// IsEmailVerified reports whether the player has cleared the verify
+// gate. True for OAuth-linked rows (stamped at link time) and password
+// rows that consumed a verify token. False for the pre-#111 legacy
+// state of password rows with no email.
+func (p *Player) IsEmailVerified() bool {
+	return p.EmailVerifiedAt != nil
 }
 
 // IsAnonymous reports whether the player has no credentials set yet (no
@@ -68,21 +87,21 @@ func (p *Player) HasCustomName() bool {
 	return p.UsernameClaimed
 }
 
-// IsAuthenticated reports whether the visitor is known to the system —
-// they have a password hash, an OAuth-verified email, or the seeded
-// admin role. Distinct from !IsAnonymous() because an OAuth-only
-// player has no password hash yet is still authenticated; flipping
-// the existing IsAnonymous definition would change the semantics of
-// the claim-flow code paths that depend on it. Used by surfaces that
-// gate on "is the visitor signed in?" rather than "is the row a
-// fresh claimable stub?", e.g. /login's already-signed-in redirect.
+// IsAuthenticated reports whether the visitor is known to the system -
+// they have a password hash, a linked OAuth identity (carrying an
+// email), or the seeded admin role. Distinct from !IsAnonymous()
+// because an OAuth-only player has no password hash yet is still
+// authenticated; flipping the existing IsAnonymous definition would
+// change the semantics of the claim-flow code paths that depend on
+// it. Used by surfaces that gate on "is the visitor signed in?"
+// rather than "is the row a fresh claimable stub?", e.g. /login's
+// already-signed-in redirect.
 //
-// The Email != "" branch is safe today because password registration
-// does not write an email; the only rows with email set are OAuth-
-// linked. When #111 starts capturing email on password registration,
-// revisit this predicate so an unverified password account does not
-// count as authenticated. See the footnote on #111 for the parallel
-// concern on linkExistingPlayerByEmail.
+// "Authenticated" intentionally does NOT mean "email-verified". The
+// gate landing in #111 PR3 checks [Player.IsEmailVerified] as a
+// separate predicate so an unverified password row can still be
+// session-bearing (the post-login interstitial / resend page needs to
+// run as that user) without being granted the protected routes.
 func (p *Player) IsAuthenticated() bool {
 	return p.PasswordHash != "" || p.Email != "" || p.Role == RoleAdmin
 }
@@ -155,13 +174,16 @@ type PlayerStore interface {
 	// GetPlayerByID returns the player with the given ID.
 	// Returns ErrPlayerNotFound when there is no match.
 	GetPlayerByID(ctx context.Context, id int64) (*Player, error)
-	// CreatePlayer creates a new player with the given username, password hash,
-	// and requested role. The store may promote the stored role to admin when
-	// the requested role is not "admin" but there are no other password-bearing
-	// players yet — making the "first registrant becomes admin" rule atomic
-	// against concurrent registrations.
-	// Returns ErrUsernameTaken when the username is already in use.
-	CreatePlayer(ctx context.Context, username, passwordHash, requestedRole string) (*Player, error)
+	// CreatePlayer creates a new player with the given username, email,
+	// password hash, and requested role. The store may promote the stored
+	// role to admin when the requested role is not "admin" but there are
+	// no other password-bearing players yet - making the "first
+	// registrant becomes admin" rule atomic against concurrent
+	// registrations.
+	// email is required (#111 PR1); the store trims + lowercases it
+	// before insert. Returns ErrUsernameTaken when the username is
+	// already in use and ErrEmailTaken when the email is already in use.
+	CreatePlayer(ctx context.Context, username, email, passwordHash, requestedRole string) (*Player, error)
 	// CreateAnonymousPlayer creates a row with the given username, no email,
 	// no password_hash, and role = "player". Used by EnsurePlayer to back a
 	// brand-new visitor with a real row before they can play. The caller
@@ -179,7 +201,11 @@ type PlayerStore interface {
 	// Returns ErrPlayerAlreadyClaimed when the target row already has a
 	// password_hash, ErrUsernameTaken when the requested username collides
 	// with another row, and ErrPlayerNotFound when the id does not exist.
-	ClaimPlayer(ctx context.Context, playerID int64, username, passwordHash, requestedRole string) (*Player, error)
+	ClaimPlayer(
+		ctx context.Context,
+		playerID int64,
+		username, email, passwordHash, requestedRole string,
+	) (*Player, error)
 	// SetPlayerPasswordHash overwrites the password_hash on the row identified
 	// by username. Used by the operator-only -reset-password tool to rotate a
 	// forgotten admin password. Returns ErrPlayerNotFound when no row matches.

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -12,10 +12,7 @@ var ErrPlayerNotFound = errors.New("player not found")
 // ErrUsernameTaken is returned when a username is already in use.
 var ErrUsernameTaken = errors.New("username taken")
 
-// ErrEmailTaken is returned when an email is already in use by another
-// player. The register handler maps it to a 409 + form re-render with
-// the email-field error so a registrant whose chosen email collides
-// can fix it without re-typing the rest of the form (#111 PR1).
+// ErrEmailTaken is returned when an email is already in use.
 var ErrEmailTaken = errors.New("email taken")
 
 // ErrPlayerAlreadyClaimed is returned by ClaimPlayer when the target row
@@ -45,10 +42,8 @@ type Player struct {
 	ID       int64
 	Username string
 	Email    string
-	// EmailVerifiedAt is nil until the player consumes a verify token
-	// (#111). OAuth-linked rows are stamped at link time because Google
-	// attests the email. The gate added in #111 PR3 refuses routes for
-	// password-bearing rows with EmailVerifiedAt == nil.
+	// EmailVerifiedAt is nil until the address is verified. OAuth-linked
+	// rows are stamped at link time because the provider attests the email.
 	EmailVerifiedAt *time.Time
 	PasswordHash    string
 	Role            string
@@ -56,10 +51,7 @@ type Player struct {
 	UsernameClaimed bool
 }
 
-// IsEmailVerified reports whether the player has cleared the verify
-// gate. True for OAuth-linked rows (stamped at link time) and password
-// rows that consumed a verify token. False for the pre-#111 legacy
-// state of password rows with no email.
+// IsEmailVerified reports whether the player's email has been verified.
 func (p *Player) IsEmailVerified() bool {
 	return p.EmailVerifiedAt != nil
 }
@@ -87,21 +79,10 @@ func (p *Player) HasCustomName() bool {
 	return p.UsernameClaimed
 }
 
-// IsAuthenticated reports whether the visitor is known to the system -
-// they have a password hash, a linked OAuth identity (carrying an
-// email), or the seeded admin role. Distinct from !IsAnonymous()
-// because an OAuth-only player has no password hash yet is still
-// authenticated; flipping the existing IsAnonymous definition would
-// change the semantics of the claim-flow code paths that depend on
-// it. Used by surfaces that gate on "is the visitor signed in?"
-// rather than "is the row a fresh claimable stub?", e.g. /login's
-// already-signed-in redirect.
-//
-// "Authenticated" intentionally does NOT mean "email-verified". The
-// gate landing in #111 PR3 checks [Player.IsEmailVerified] as a
-// separate predicate so an unverified password row can still be
-// session-bearing (the post-login interstitial / resend page needs to
-// run as that user) without being granted the protected routes.
+// IsAuthenticated reports whether the visitor has signed in. True for
+// password rows, OAuth-linked rows, and the seeded admin. Distinct
+// from [Player.IsEmailVerified] - the email-verify gate is a separate
+// predicate so an unverified password row can still be session-bearing.
 func (p *Player) IsAuthenticated() bool {
 	return p.PasswordHash != "" || p.Email != "" || p.Role == RoleAdmin
 }
@@ -174,15 +155,10 @@ type PlayerStore interface {
 	// GetPlayerByID returns the player with the given ID.
 	// Returns ErrPlayerNotFound when there is no match.
 	GetPlayerByID(ctx context.Context, id int64) (*Player, error)
-	// CreatePlayer creates a new player with the given username, email,
-	// password hash, and requested role. The store may promote the stored
-	// role to admin when the requested role is not "admin" but there are
-	// no other password-bearing players yet - making the "first
-	// registrant becomes admin" rule atomic against concurrent
-	// registrations.
-	// email is required (#111 PR1); the store trims + lowercases it
-	// before insert. Returns ErrUsernameTaken when the username is
-	// already in use and ErrEmailTaken when the email is already in use.
+	// CreatePlayer creates a player with the given credentials. The
+	// store trims + lowercases the email and atomically promotes the
+	// first password-bearing registrant to admin. Returns
+	// ErrUsernameTaken / ErrEmailTaken on UNIQUE collisions.
 	CreatePlayer(ctx context.Context, username, email, passwordHash, requestedRole string) (*Player, error)
 	// CreateAnonymousPlayer creates a row with the given username, no email,
 	// no password_hash, and role = "player". Used by EnsurePlayer to back a

--- a/internal/auth/register_email_test.go
+++ b/internal/auth/register_email_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/starquake/topbanana/internal/auth"
 )
 
-// TestLooksLikeEmail pins the validator the register form runs before
-// hitting the store (#111 PR1). Loose by design - tight validation
-// belongs at the SMTP / DNS layer - but tight enough to catch the
-// obvious typos.
 func TestLooksLikeEmail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/register_email_test.go
+++ b/internal/auth/register_email_test.go
@@ -1,0 +1,43 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+// TestLooksLikeEmail pins the validator the register form runs before
+// hitting the store (#111 PR1). Loose by design - tight validation
+// belongs at the SMTP / DNS layer - but tight enough to catch the
+// obvious typos.
+func TestLooksLikeEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"simple", "alice@example.test", true},
+		{"subdomain", "alice@mail.example.test", true},
+		{"plus addressing", "alice+work@example.test", true},
+		{"numeric local", "12345@example.test", true},
+		{"empty", "", false},
+		{"no at sign", "aliceexample.test", false},
+		{"two at signs", "alice@@example.test", false},
+		{"local missing", "@example.test", false},
+		{"host missing", "alice@", false},
+		{"no dot in host", "alice@localhost", false},
+		{"dot at start of host", "alice@.example", false},
+		{"dot at start of multi-label host", "alice@.example.com", false},
+		{"empty TLD", "alice@example.", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := auth.LooksLikeEmail(tt.in), tt.want; got != want {
+				t.Errorf("LooksLikeEmail(%q) = %v, want %v", tt.in, got, want)
+			}
+		})
+	}
+}

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -317,7 +317,7 @@ func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlaye
 }
 
 const getPlayer = `-- name: GetPlayer :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 FROM players
 WHERE id = ?
 `
@@ -333,6 +333,7 @@ func (q *Queries) GetPlayer(ctx context.Context, id int64) (Player, error) {
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -71,6 +71,7 @@ type Player struct {
 	Role            string
 	CreatedAt       time.Time
 	UsernameClaimed int64
+	EmailVerifiedAt sql.NullTime
 }
 
 type PlayerIdentity struct {

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -16,8 +16,9 @@ const claimPlayer = `-- name: ClaimPlayer :one
 UPDATE players
 SET username = ?1,
     password_hash = ?2,
+    email = ?3,
     role = CASE
-        WHEN CAST(?3 AS TEXT) = 'admin' THEN 'admin'
+        WHEN CAST(?4 AS TEXT) = 'admin' THEN 'admin'
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
             WHERE p.password_hash IS NOT NULL
@@ -26,14 +27,16 @@ SET username = ?1,
         ELSE 'player'
     END,
     username_claimed = 1
-WHERE players.id = ?4
+WHERE players.id = ?5
   AND players.password_hash IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+  AND players.email IS NULL
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type ClaimPlayerParams struct {
 	Username      string
 	PasswordHash  sql.NullString
+	Email         sql.NullString
 	RequestedRole string
 	ID            int64
 }
@@ -62,6 +65,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 	row := q.db.QueryRowContext(ctx, claimPlayer,
 		arg.Username,
 		arg.PasswordHash,
+		arg.Email,
 		arg.RequestedRole,
 		arg.ID,
 	)
@@ -74,6 +78,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
@@ -81,6 +86,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 const claimPlayerForOAuth = `-- name: ClaimPlayerForOAuth :one
 UPDATE players
 SET email = ?1,
+    email_verified_at = CURRENT_TIMESTAMP,
     role = CASE
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
@@ -92,7 +98,7 @@ SET email = ?1,
 WHERE players.id = ?2
   AND players.password_hash IS NULL
   AND players.email IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type ClaimPlayerForOAuthParams struct {
@@ -131,6 +137,7 @@ func (q *Queries) ClaimPlayerForOAuth(ctx context.Context, arg ClaimPlayerForOAu
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
@@ -150,7 +157,7 @@ func (q *Queries) CountAllPlayers(ctx context.Context) (int64, error) {
 const createAnonymousPlayer = `-- name: CreateAnonymousPlayer :one
 INSERT INTO players (username, role)
 VALUES (?1, 'player')
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 // Used by the EnsurePlayer middleware to back a fresh visitor with a real
@@ -173,15 +180,17 @@ func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (P
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
 
 const createPlayerFromOAuth = `-- name: CreatePlayerFromOAuth :one
-INSERT INTO players (username, email, role, username_claimed)
+INSERT INTO players (username, email, email_verified_at, role, username_claimed)
 VALUES (
     ?1,
     ?2,
+    CURRENT_TIMESTAMP,
     CASE
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
@@ -192,7 +201,7 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type CreatePlayerFromOAuthParams struct {
@@ -226,17 +235,19 @@ func (q *Queries) CreatePlayerFromOAuth(ctx context.Context, arg CreatePlayerFro
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
 
 const createPlayerWithCredentials = `-- name: CreatePlayerWithCredentials :one
-INSERT INTO players (username, password_hash, role, username_claimed)
+INSERT INTO players (username, password_hash, email, role, username_claimed)
 VALUES (
     ?1,
     ?2,
+    ?3,
     CASE
-        WHEN CAST(?3 AS TEXT) = 'admin' THEN 'admin'
+        WHEN CAST(?4 AS TEXT) = 'admin' THEN 'admin'
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
             WHERE p.password_hash IS NOT NULL
@@ -246,12 +257,13 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type CreatePlayerWithCredentialsParams struct {
 	Username      string
 	PasswordHash  sql.NullString
+	Email         sql.NullString
 	RequestedRole string
 }
 
@@ -273,8 +285,17 @@ type CreatePlayerWithCredentialsParams struct {
 // their username at the register form. The column tracks "did the player
 // pick this name themselves" (vs auto-generated petname), so a fresh
 // registrant must be marked as claimed from the moment the row is written.
+//
+// email is required at register time (#111). email_verified_at stays NULL
+// until the player consumes their verify token; the auth gate denies
+// routes for password-bearing rows in that state.
 func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePlayerWithCredentialsParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, createPlayerWithCredentials, arg.Username, arg.PasswordHash, arg.RequestedRole)
+	row := q.db.QueryRowContext(ctx, createPlayerWithCredentials,
+		arg.Username,
+		arg.PasswordHash,
+		arg.Email,
+		arg.RequestedRole,
+	)
 	var i Player
 	err := row.Scan(
 		&i.ID,
@@ -284,12 +305,13 @@ func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePla
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
 
 const getPlayerByEmail = `-- name: GetPlayerByEmail :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 FROM players
 WHERE email = ?
 LIMIT 1
@@ -310,12 +332,13 @@ func (q *Queries) GetPlayerByEmail(ctx context.Context, email sql.NullString) (P
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
 
 const getPlayerByProviderSubject = `-- name: GetPlayerByProviderSubject :one
-SELECT p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed
+SELECT p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at
 FROM players p
 JOIN player_identities pi ON pi.player_id = p.id
 WHERE pi.provider = ? AND pi.subject = ?
@@ -342,12 +365,13 @@ func (q *Queries) GetPlayerByProviderSubject(ctx context.Context, arg GetPlayerB
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
 
 const getPlayerByUsername = `-- name: GetPlayerByUsername :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 FROM players
 WHERE username = ?
 LIMIT 1
@@ -364,6 +388,7 @@ func (q *Queries) GetPlayerByUsername(ctx context.Context, username string) (Pla
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
@@ -391,7 +416,7 @@ func (q *Queries) LinkProviderIdentity(ctx context.Context, arg LinkProviderIden
 
 const listAllPlayers = `-- name: ListAllPlayers :many
 SELECT
-    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed,
+    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at,
     EXISTS (SELECT 1 FROM player_identities pi WHERE pi.player_id = p.id) AS has_oauth,
     CAST(COALESCE((SELECT pi.provider FROM player_identities pi WHERE pi.player_id = p.id ORDER BY pi.provider LIMIT 1), '') AS TEXT) AS oauth_provider
 FROM players p
@@ -412,6 +437,7 @@ type ListAllPlayersRow struct {
 	Role            string
 	CreatedAt       time.Time
 	UsernameClaimed int64
+	EmailVerifiedAt sql.NullTime
 	HasOauth        bool
 	OauthProvider   string
 }
@@ -445,6 +471,7 @@ func (q *Queries) ListAllPlayers(ctx context.Context, arg ListAllPlayersParams) 
 			&i.Role,
 			&i.CreatedAt,
 			&i.UsernameClaimed,
+			&i.EmailVerifiedAt,
 			&i.HasOauth,
 			&i.OauthProvider,
 		); err != nil {
@@ -527,12 +554,34 @@ func (q *Queries) ListPlayerFinishStats(ctx context.Context, playerIds []int64) 
 	return items, nil
 }
 
+const markPlayerEmailVerifiedIfNew = `-- name: MarkPlayerEmailVerifiedIfNew :execrows
+UPDATE players
+SET email_verified_at = CURRENT_TIMESTAMP
+WHERE id = ?1
+  AND email_verified_at IS NULL
+`
+
+// Stamps email_verified_at = now() on the row when it is currently
+// NULL. Idempotent: a second call against an already-verified row is
+// a no-op (rows-affected stays 0). Called by the OAuth link-by-email
+// path so a password-registered row that later signs in with the same
+// Google address gets the "verified" flag flipped, otherwise PR3's
+// gate would keep blocking the user even though Google has now
+// attested the address (#111 PR1 review finding).
+func (q *Queries) MarkPlayerEmailVerifiedIfNew(ctx context.Context, id int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markPlayerEmailVerifiedIfNew, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const renamePlayer = `-- name: RenamePlayer :one
 UPDATE players
 SET username = ?1,
     username_claimed = 1
 WHERE id = ?2
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type RenamePlayerParams struct {
@@ -563,6 +612,7 @@ func (q *Queries) RenamePlayer(ctx context.Context, arg RenamePlayerParams) (Pla
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }
@@ -604,7 +654,7 @@ UPDATE players
 SET username = ?1,
     username_claimed = 1
 WHERE id = ?2 AND password_hash IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
 `
 
 type UpdatePlayerUsernameParams struct {
@@ -635,6 +685,7 @@ func (q *Queries) UpdatePlayerUsername(ctx context.Context, arg UpdatePlayerUser
 		&i.Role,
 		&i.CreatedAt,
 		&i.UsernameClaimed,
+		&i.EmailVerifiedAt,
 	)
 	return i, err
 }

--- a/internal/migrations/20260527000000_add_email_verification.sql
+++ b/internal/migrations/20260527000000_add_email_verification.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- players.email_verified_at flips to the verify timestamp once the
+-- player consumes a verify token (#111 PR2). NULL until verified; the
+-- gate added in #111 PR3 redirects unverified password-bearing rows
+-- to the resend page. OAuth-linked rows are stamped at link time so
+-- the gate treats them as verified (Google attests the email).
+-- +goose StatementBegin
+ALTER TABLE players ADD COLUMN email_verified_at DATETIME;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE players DROP COLUMN email_verified_at;
+-- +goose StatementEnd

--- a/internal/migrations/20260527000000_add_email_verification.sql
+++ b/internal/migrations/20260527000000_add_email_verification.sql
@@ -1,10 +1,4 @@
 -- +goose Up
-
--- players.email_verified_at flips to the verify timestamp once the
--- player consumes a verify token (#111 PR2). NULL until verified; the
--- gate added in #111 PR3 redirects unverified password-bearing rows
--- to the resend page. OAuth-linked rows are stamped at link time so
--- the gate treats them as verified (Google attests the email).
 -- +goose StatementBegin
 ALTER TABLE players ADD COLUMN email_verified_at DATETIME;
 -- +goose StatementEnd

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -23,10 +23,6 @@ LIMIT 1;
 -- their username at the register form. The column tracks "did the player
 -- pick this name themselves" (vs auto-generated petname), so a fresh
 -- registrant must be marked as claimed from the moment the row is written.
---
--- email is required at register time (#111). email_verified_at stays NULL
--- until the player consumes their verify token; the auth gate denies
--- routes for password-bearing rows in that state.
 INSERT INTO players (username, password_hash, email, role, username_claimed)
 VALUES (
     sqlc.arg('username'),
@@ -307,13 +303,7 @@ WHERE id = sqlc.arg('id')
 RETURNING *;
 
 -- name: MarkPlayerEmailVerifiedIfNew :execrows
--- Stamps email_verified_at = now() on the row when it is currently
--- NULL. Idempotent: a second call against an already-verified row is
--- a no-op (rows-affected stays 0). Called by the OAuth link-by-email
--- path so a password-registered row that later signs in with the same
--- Google address gets the "verified" flag flipped, otherwise PR3's
--- gate would keep blocking the user even though Google has now
--- attested the address (#111 PR1 review finding).
+-- Stamps email_verified_at when currently NULL. Idempotent.
 UPDATE players
 SET email_verified_at = CURRENT_TIMESTAMP
 WHERE id = sqlc.arg('id')

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -23,10 +23,15 @@ LIMIT 1;
 -- their username at the register form. The column tracks "did the player
 -- pick this name themselves" (vs auto-generated petname), so a fresh
 -- registrant must be marked as claimed from the moment the row is written.
-INSERT INTO players (username, password_hash, role, username_claimed)
+--
+-- email is required at register time (#111). email_verified_at stays NULL
+-- until the player consumes their verify token; the auth gate denies
+-- routes for password-bearing rows in that state.
+INSERT INTO players (username, password_hash, email, role, username_claimed)
 VALUES (
     sqlc.arg('username'),
     sqlc.arg('password_hash'),
+    sqlc.arg('email'),
     CASE
         WHEN CAST(sqlc.arg('requested_role') AS TEXT) = 'admin' THEN 'admin'
         WHEN NOT EXISTS (
@@ -78,6 +83,7 @@ RETURNING *;
 UPDATE players
 SET username = sqlc.arg('username'),
     password_hash = sqlc.arg('password_hash'),
+    email = sqlc.arg('email'),
     role = CASE
         WHEN CAST(sqlc.arg('requested_role') AS TEXT) = 'admin' THEN 'admin'
         WHEN NOT EXISTS (
@@ -90,6 +96,7 @@ SET username = sqlc.arg('username'),
     username_claimed = 1
 WHERE players.id = sqlc.arg('id')
   AND players.password_hash IS NULL
+  AND players.email IS NULL
 RETURNING *;
 
 -- name: SetPlayerPasswordHash :execrows
@@ -147,10 +154,11 @@ LIMIT 1;
 -- deployments from promoting *every* sign-in to admin. Without this,
 -- the second-and-onward Google sign-ins on a fresh DB would all see
 -- count(password_hash IS NOT NULL) == 0 and become admin.
-INSERT INTO players (username, email, role, username_claimed)
+INSERT INTO players (username, email, email_verified_at, role, username_claimed)
 VALUES (
     sqlc.arg('username'),
     sqlc.arg('email'),
+    CURRENT_TIMESTAMP,
     CASE
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
@@ -195,6 +203,7 @@ VALUES (?, ?, ?);
 -- petname-collision retry it uses for cookieless visitors.
 UPDATE players
 SET email = sqlc.arg('email'),
+    email_verified_at = CURRENT_TIMESTAMP,
     role = CASE
         WHEN NOT EXISTS (
             SELECT 1 FROM players p
@@ -296,3 +305,16 @@ SET username = sqlc.arg('username'),
     username_claimed = 1
 WHERE id = sqlc.arg('id')
 RETURNING *;
+
+-- name: MarkPlayerEmailVerifiedIfNew :execrows
+-- Stamps email_verified_at = now() on the row when it is currently
+-- NULL. Idempotent: a second call against an already-verified row is
+-- a no-op (rows-affected stays 0). Called by the OAuth link-by-email
+-- path so a password-registered row that later signs in with the same
+-- Google address gets the "verified" flag flipped, otherwise PR3's
+-- gate would keep blocking the user even though Google has now
+-- attested the address (#111 PR1 review finding).
+UPDATE players
+SET email_verified_at = CURRENT_TIMESTAMP
+WHERE id = sqlc.arg('id')
+  AND email_verified_at IS NULL;

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -34,7 +34,7 @@ func (stubPlayerStore) GetPlayerByID(_ context.Context, _ int64) (*auth.Player, 
 	return nil, auth.ErrPlayerNotFound
 }
 
-func (stubPlayerStore) CreatePlayer(_ context.Context, _, _, _ string) (*auth.Player, error) {
+func (stubPlayerStore) CreatePlayer(_ context.Context, _, _, _, _ string) (*auth.Player, error) {
 	return nil, errRouteStub
 }
 
@@ -42,7 +42,7 @@ func (stubPlayerStore) CreateAnonymousPlayer(_ context.Context, _ string) (*auth
 	return nil, errRouteStub
 }
 
-func (stubPlayerStore) ClaimPlayer(_ context.Context, _ int64, _, _, _ string) (*auth.Player, error) {
+func (stubPlayerStore) ClaimPlayer(_ context.Context, _ int64, _, _, _, _ string) (*auth.Player, error) {
 	return nil, errRouteStub
 }
 

--- a/internal/store/home_test.go
+++ b/internal/store/home_test.go
@@ -87,11 +87,11 @@ func seedHomeDB(t *testing.T) homeSeed {
 		t.Fatalf("CreateQuiz q2 err = %v, want nil", err)
 	}
 
-	alice, err := players.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer)
+	alice, err := players.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer alice err = %v, want nil", err)
 	}
-	bob, err := players.CreatePlayer(t.Context(), "bob", "hash", auth.RolePlayer)
+	bob, err := players.CreatePlayer(t.Context(), "bob", "bob"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer bob err = %v, want nil", err)
 	}
@@ -248,11 +248,23 @@ func TestHomeStore_ListMostActivePlayers_AppliesThirtyDayWindow(t *testing.T) {
 		t.Fatalf("CreateQuiz err = %v, want nil", err)
 	}
 
-	stale, err := players.CreatePlayer(t.Context(), "stale-winner", "hash", auth.RolePlayer)
+	stale, err := players.CreatePlayer(
+		t.Context(),
+		"stale-winner",
+		"stale-winner"+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	)
 	if err != nil {
 		t.Fatalf("CreatePlayer stale err = %v, want nil", err)
 	}
-	recent, err := players.CreatePlayer(t.Context(), "recent-winner", "hash", auth.RolePlayer)
+	recent, err := players.CreatePlayer(
+		t.Context(),
+		"recent-winner",
+		"recent-winner"+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	)
 	if err != nil {
 		t.Fatalf("CreatePlayer recent err = %v, want nil", err)
 	}
@@ -314,7 +326,7 @@ func TestHomeStore_ExcludesEmptyQuizFromRankings(t *testing.T) {
 	if err := quizzes.CreateQuiz(t.Context(), emptyQuiz); err != nil {
 		t.Fatalf("CreateQuiz empty err = %v, want nil", err)
 	}
-	player, err := players.CreatePlayer(t.Context(), "lonely", "hash", auth.RolePlayer)
+	player, err := players.CreatePlayer(t.Context(), "lonely", "lonely"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -71,30 +71,36 @@ func (s *PlayerStore) GetPlayerByID(ctx context.Context, id int64) (*auth.Player
 	return playerFromRow(row), nil
 }
 
-// CreatePlayer creates a new player with the given username, password hash, and
-// requested role. The role stored may be promoted to admin by the underlying
-// query: if the requested role is "admin" it is honoured directly, and if the
-// requested role is anything else it is promoted to admin only when no other
-// password-bearing player exists yet (so the first registrant always becomes
-// admin atomically — see the SQL for why).
+// CreatePlayer creates a new player with the given username, email,
+// password hash, and requested role. The role stored may be promoted
+// to admin by the underlying query: if the requested role is "admin"
+// it is honoured directly, and if the requested role is anything else
+// it is promoted to admin only when no other password-bearing player
+// exists yet (so the first registrant always becomes admin atomically -
+// see the SQL for why).
 //
-// Returns auth.ErrUsernameTaken if the username is already in use.
+// email is required at register time (#111 PR1). It is trimmed and
+// lowercased here so case/whitespace variants cannot create duplicate
+// accounts; the UNIQUE index on players.email enforces the rest.
+//
+// Returns auth.ErrUsernameTaken when the username is taken and
+// auth.ErrEmailTaken when the email is taken; both are surfaced via
+// the same SQLITE_CONSTRAINT_UNIQUE error code, so classifyUniqueErr
+// distinguishes them by checking which column survived the conflict.
 func (s *PlayerStore) CreatePlayer(
 	ctx context.Context,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
+	cleanedUsername := strings.TrimSpace(username)
+	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.CreatePlayerWithCredentials(ctx, db.CreatePlayerWithCredentialsParams{
-		Username:      strings.TrimSpace(username),
+		Username:      cleanedUsername,
 		PasswordHash:  sql.NullString{String: passwordHash, Valid: true},
+		Email:         sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		RequestedRole: requestedRole,
 	})
 	if err != nil {
-		var sqliteErr *sqlite.Error
-		if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-			return nil, auth.ErrUsernameTaken
-		}
-
-		return nil, fmt.Errorf("failed to create player: %w", err)
+		return nil, s.classifyCredentialConflict(ctx, cleanedUsername, cleanedEmail, err)
 	}
 
 	return playerFromRow(row), nil
@@ -131,16 +137,19 @@ func (s *PlayerStore) CreateAnonymousPlayer(ctx context.Context, username string
 func (s *PlayerStore) ClaimPlayer(
 	ctx context.Context,
 	playerID int64,
-	username, passwordHash, requestedRole string,
+	username, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
+	cleanedUsername := strings.TrimSpace(username)
+	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.ClaimPlayer(ctx, db.ClaimPlayerParams{
-		Username:      strings.TrimSpace(username),
+		Username:      cleanedUsername,
 		PasswordHash:  sql.NullString{String: passwordHash, Valid: true},
+		Email:         sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		RequestedRole: requestedRole,
 		ID:            playerID,
 	})
 	if err != nil {
-		return nil, s.classifyClaimErr(ctx, playerID, err)
+		return nil, s.classifyClaimErr(ctx, playerID, cleanedUsername, cleanedEmail, err)
 	}
 
 	return playerFromRow(row), nil
@@ -308,6 +317,20 @@ func (s *PlayerStore) ClaimPlayerForOAuth(
 	return playerFromRow(row), nil
 }
 
+// MarkPlayerEmailVerifiedIfNew flips email_verified_at to now() when
+// the row is currently unverified. Idempotent: a second call against
+// an already-verified row affects 0 rows and returns nil. Used by the
+// OAuth link-by-email path so a password-registered row that later
+// gets a Google identity attached picks up the "verified" stamp
+// (#111 PR1).
+func (s *PlayerStore) MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID int64) error {
+	if _, err := s.q.MarkPlayerEmailVerifiedIfNew(ctx, playerID); err != nil {
+		return fmt.Errorf("failed to mark player email verified: %w", err)
+	}
+
+	return nil
+}
+
 // LinkProviderIdentity inserts a player_identities row tying the given
 // player to the (provider, subject) pair. Returns
 // auth.ErrIdentityAlreadyLinked when the UNIQUE (provider, subject)
@@ -460,11 +483,14 @@ func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID in
 // classifyClaimErr maps a ClaimPlayer storage error onto the auth-package
 // sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous (the id might
 // not exist OR the row has already been claimed), so it re-queries by id
-// to disambiguate.
-func (s *PlayerStore) classifyClaimErr(ctx context.Context, playerID int64, err error) error {
+// to disambiguate. UNIQUE conflicts re-use classifyCredentialConflict
+// to distinguish a username-taken from an email-taken collision (#111).
+func (s *PlayerStore) classifyClaimErr(
+	ctx context.Context, playerID int64, cleanedUsername, cleanedEmail string, err error,
+) error {
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-		return auth.ErrUsernameTaken
+		return s.classifyCredentialConflict(ctx, cleanedUsername, cleanedEmail, err)
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to claim player: %w", err)
@@ -481,6 +507,41 @@ func (s *PlayerStore) classifyClaimErr(ctx context.Context, playerID int64, err 
 	return auth.ErrPlayerAlreadyClaimed
 }
 
+// classifyCredentialConflict maps a SQLITE UNIQUE-constraint failure
+// from a CreatePlayer / ClaimPlayer insert onto the right auth-package
+// sentinel. SQLite surfaces every UNIQUE violation with the same error
+// code, so the wrapper has to look up which of (username, email) is
+// already taken to pick between ErrUsernameTaken and ErrEmailTaken.
+// On any non-UNIQUE error or any lookup failure during classification
+// the original error is wrapped through so the caller sees the
+// underlying cause.
+func (s *PlayerStore) classifyCredentialConflict(
+	ctx context.Context, cleanedUsername, cleanedEmail string, err error,
+) error {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) || sqliteErr.Code() != sqlite3.SQLITE_CONSTRAINT_UNIQUE {
+		return fmt.Errorf("failed to create player: %w", err)
+	}
+	// Look up by username first because the username conflict is the
+	// historical default; ErrEmailTaken is the new branch added by
+	// #111.
+	if _, lookupErr := s.q.GetPlayerByUsername(ctx, cleanedUsername); lookupErr == nil {
+		return auth.ErrUsernameTaken
+	}
+	if cleanedEmail != "" {
+		if _, lookupErr := s.q.GetPlayerByEmail(
+			ctx,
+			sql.NullString{String: cleanedEmail, Valid: true},
+		); lookupErr == nil {
+			return auth.ErrEmailTaken
+		}
+	}
+	// Constraint fired but neither column matches now (rare: a
+	// concurrent delete between the failed insert and this lookup).
+	// Fall back to the generic message rather than misclassify.
+	return fmt.Errorf("failed to create player: %w", err)
+}
+
 func playerFromRow(row db.Player) *auth.Player {
 	p := &auth.Player{
 		ID:              row.ID,
@@ -494,6 +555,10 @@ func playerFromRow(row db.Player) *auth.Player {
 	}
 	if row.PasswordHash.Valid {
 		p.PasswordHash = row.PasswordHash.String
+	}
+	if row.EmailVerifiedAt.Valid {
+		verified := row.EmailVerifiedAt.Time
+		p.EmailVerifiedAt = &verified
 	}
 
 	return p

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -71,22 +71,10 @@ func (s *PlayerStore) GetPlayerByID(ctx context.Context, id int64) (*auth.Player
 	return playerFromRow(row), nil
 }
 
-// CreatePlayer creates a new player with the given username, email,
-// password hash, and requested role. The role stored may be promoted
-// to admin by the underlying query: if the requested role is "admin"
-// it is honoured directly, and if the requested role is anything else
-// it is promoted to admin only when no other password-bearing player
-// exists yet (so the first registrant always becomes admin atomically -
-// see the SQL for why).
-//
-// email is required at register time (#111 PR1). It is trimmed and
-// lowercased here so case/whitespace variants cannot create duplicate
-// accounts; the UNIQUE index on players.email enforces the rest.
-//
-// Returns auth.ErrUsernameTaken when the username is taken and
-// auth.ErrEmailTaken when the email is taken; both are surfaced via
-// the same SQLITE_CONSTRAINT_UNIQUE error code, so classifyUniqueErr
-// distinguishes them by checking which column survived the conflict.
+// CreatePlayer creates a credentialled player. Email is trimmed and
+// lowercased before insert. Returns auth.ErrUsernameTaken or
+// auth.ErrEmailTaken on UNIQUE collisions; the underlying SQL
+// promotes the first password-bearing registrant to admin.
 func (s *PlayerStore) CreatePlayer(
 	ctx context.Context,
 	username, email, passwordHash, requestedRole string,
@@ -317,12 +305,8 @@ func (s *PlayerStore) ClaimPlayerForOAuth(
 	return playerFromRow(row), nil
 }
 
-// MarkPlayerEmailVerifiedIfNew flips email_verified_at to now() when
-// the row is currently unverified. Idempotent: a second call against
-// an already-verified row affects 0 rows and returns nil. Used by the
-// OAuth link-by-email path so a password-registered row that later
-// gets a Google identity attached picks up the "verified" stamp
-// (#111 PR1).
+// MarkPlayerEmailVerifiedIfNew stamps email_verified_at when it is
+// currently NULL. Idempotent.
 func (s *PlayerStore) MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID int64) error {
 	if _, err := s.q.MarkPlayerEmailVerifiedIfNew(ctx, playerID); err != nil {
 		return fmt.Errorf("failed to mark player email verified: %w", err)
@@ -483,8 +467,7 @@ func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID in
 // classifyClaimErr maps a ClaimPlayer storage error onto the auth-package
 // sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous (the id might
 // not exist OR the row has already been claimed), so it re-queries by id
-// to disambiguate. UNIQUE conflicts re-use classifyCredentialConflict
-// to distinguish a username-taken from an email-taken collision (#111).
+// to disambiguate.
 func (s *PlayerStore) classifyClaimErr(
 	ctx context.Context, playerID int64, cleanedUsername, cleanedEmail string, err error,
 ) error {
@@ -507,14 +490,9 @@ func (s *PlayerStore) classifyClaimErr(
 	return auth.ErrPlayerAlreadyClaimed
 }
 
-// classifyCredentialConflict maps a SQLITE UNIQUE-constraint failure
-// from a CreatePlayer / ClaimPlayer insert onto the right auth-package
-// sentinel. SQLite surfaces every UNIQUE violation with the same error
-// code, so the wrapper has to look up which of (username, email) is
-// already taken to pick between ErrUsernameTaken and ErrEmailTaken.
-// On any non-UNIQUE error or any lookup failure during classification
-// the original error is wrapped through so the caller sees the
-// underlying cause.
+// classifyCredentialConflict maps a SQLITE UNIQUE violation onto
+// ErrUsernameTaken or ErrEmailTaken by looking up which column the
+// caller already took. Any other error wraps through unchanged.
 func (s *PlayerStore) classifyCredentialConflict(
 	ctx context.Context, cleanedUsername, cleanedEmail string, err error,
 ) error {
@@ -522,9 +500,6 @@ func (s *PlayerStore) classifyCredentialConflict(
 	if !errors.As(err, &sqliteErr) || sqliteErr.Code() != sqlite3.SQLITE_CONSTRAINT_UNIQUE {
 		return fmt.Errorf("failed to create player: %w", err)
 	}
-	// Look up by username first because the username conflict is the
-	// historical default; ErrEmailTaken is the new branch added by
-	// #111.
 	if _, lookupErr := s.q.GetPlayerByUsername(ctx, cleanedUsername); lookupErr == nil {
 		return auth.ErrUsernameTaken
 	}
@@ -536,9 +511,7 @@ func (s *PlayerStore) classifyCredentialConflict(
 			return auth.ErrEmailTaken
 		}
 	}
-	// Constraint fired but neither column matches now (rare: a
-	// concurrent delete between the failed insert and this lookup).
-	// Fall back to the generic message rather than misclassify.
+
 	return fmt.Errorf("failed to create player: %w", err)
 }
 

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -52,7 +52,7 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	created, err := ps.CreatePlayer(t.Context(), "alice", "hashed-secret", auth.RoleAdmin)
+	created, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hashed-secret", auth.RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -94,7 +94,7 @@ func TestPlayerStore_CreatePlayer_FirstPasswordBearer_PromotedToAdmin(t *testing
 
 	// Even when the caller asks for "player", the first password-bearing
 	// registrant is promoted to admin atomically by the SQL CASE expression.
-	created, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer)
+	created, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -109,11 +109,11 @@ func TestPlayerStore_CreatePlayer_SecondPasswordBearer_StaysPlayer(t *testing.T)
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	if _, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer); err != nil {
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 
-	created, err := ps.CreatePlayer(t.Context(), "bob", "hash", auth.RolePlayer)
+	created, err := ps.CreatePlayer(t.Context(), "bob", "bob"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -128,11 +128,11 @@ func TestPlayerStore_CreatePlayer_ExplicitAdmin_HonouredEvenWhenNotFirst(t *test
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	if _, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer); err != nil {
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 
-	created, err := ps.CreatePlayer(t.Context(), "carol", "hash", auth.RoleAdmin)
+	created, err := ps.CreatePlayer(t.Context(), "carol", "carol"+"@example.test", "hash", auth.RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -147,7 +147,13 @@ func TestPlayerStore_TrimsWhitespaceOnCreateAndLookup(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	if _, err := ps.CreatePlayer(t.Context(), "  alice  ", "hash", auth.RolePlayer); err != nil {
+	if _, err := ps.CreatePlayer(
+		t.Context(),
+		"  alice  ",
+		"  alice  "+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
@@ -179,13 +185,63 @@ func TestPlayerStore_CreatePlayer_DuplicateUsername(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	if _, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer); err != nil {
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer first call err = %v, want nil", err)
 	}
 
-	_, err := ps.CreatePlayer(t.Context(), "alice", "other", auth.RolePlayer)
+	// Different email, same username: must classify as ErrUsernameTaken
+	// rather than the generic SQLITE wrap. classifyCredentialConflict
+	// looks up by username first and returns the sentinel that maps to
+	// the user-facing "username is already taken" banner (#111 PR1).
+	_, err := ps.CreatePlayer(t.Context(), "alice", "alice-other@example.test", "other", auth.RolePlayer)
 	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+// TestPlayerStore_CreatePlayer_DuplicateEmail pins the email-side of
+// classifyCredentialConflict (#111 PR1): a second create with the
+// same email but a different username surfaces ErrEmailTaken, not the
+// generic SQLITE wrap.
+func TestPlayerStore_CreatePlayer_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "shared@example.test", "hash", auth.RolePlayer); err != nil {
+		t.Fatalf("CreatePlayer first call err = %v, want nil", err)
+	}
+
+	_, err := ps.CreatePlayer(t.Context(), "bob", "shared@example.test", "other", auth.RolePlayer)
+	if got, want := err, auth.ErrEmailTaken; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+// TestPlayerStore_CreatePlayer_LowercasesAndTrimsEmail pins the
+// store-layer normalisation rule so "  ALICE@Example.Test " round-
+// trips as "alice@example.test" on the persisted row, blocking
+// case/whitespace variants from creating duplicate accounts (#111 PR1).
+func TestPlayerStore_CreatePlayer_LowercasesAndTrimsEmail(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	created, err := ps.CreatePlayer(t.Context(), "alice", "  ALICE@Example.Test ", "hash", auth.RolePlayer)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	if got, want := created.Email, "alice@example.test"; got != want {
+		t.Errorf("stored Email = %q, want %q", got, want)
+	}
+
+	// A second create with a case/whitespace variant must still trip
+	// the email-unique guard so users cannot end-run case-folding.
+	_, dupErr := ps.CreatePlayer(t.Context(), "bob", "alice@EXAMPLE.test", "h", auth.RolePlayer)
+	if got, want := dupErr, auth.ErrEmailTaken; !errors.Is(got, want) {
+		t.Errorf("case-variant duplicate err = %v, want %v", got, want)
 	}
 }
 
@@ -248,7 +304,7 @@ func TestPlayerStore_CreateAnonymousPlayer_DoesNotBlockFirstAdmin(t *testing.T) 
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	created, err := ps.CreatePlayer(t.Context(), "alice", "hash", auth.RolePlayer)
+	created, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -268,7 +324,7 @@ func TestPlayerStore_ClaimPlayer_UpgradesAnonymousRow(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	claimed, err := ps.ClaimPlayer(t.Context(), anon.ID, "alice", "hash", auth.RolePlayer)
+	claimed, err := ps.ClaimPlayer(t.Context(), anon.ID, "alice", "alice"+"@example.test", "hash", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("ClaimPlayer err = %v, want nil", err)
 	}
@@ -302,11 +358,18 @@ func TestPlayerStore_ClaimPlayer_AlreadyClaimed_ReturnsSentinel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
-	if _, claimErr := ps.ClaimPlayer(t.Context(), anon.ID, "alice", "hash", auth.RolePlayer); claimErr != nil {
+	if _, claimErr := ps.ClaimPlayer(
+		t.Context(),
+		anon.ID,
+		"alice",
+		"alice"+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	); claimErr != nil {
 		t.Fatalf("first ClaimPlayer err = %v, want nil", claimErr)
 	}
 
-	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "bob", "other", auth.RolePlayer)
+	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "bob", "bob"+"@example.test", "other", auth.RolePlayer)
 	if got, want := err, auth.ErrPlayerAlreadyClaimed; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -327,7 +390,7 @@ func TestPlayerStore_ClaimPlayer_UnknownPlayerID_ReturnsNotFound(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	_, err := ps.ClaimPlayer(t.Context(), 9999, "ghost", "hash", auth.RolePlayer)
+	_, err := ps.ClaimPlayer(t.Context(), 9999, "ghost", "ghost"+"@example.test", "hash", auth.RolePlayer)
 	if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -339,7 +402,7 @@ func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	if _, err := ps.CreatePlayer(t.Context(), "alice", "h", auth.RolePlayer); err != nil {
+	if _, err := ps.CreatePlayer(t.Context(), "alice", "alice"+"@example.test", "h", auth.RolePlayer); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 	anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-rival")
@@ -347,7 +410,7 @@ func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
-	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "alice", "h", auth.RolePlayer)
+	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "alice", "alice"+"@example.test", "h", auth.RolePlayer)
 	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -443,7 +506,13 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
 
-		if _, err := ps.CreatePlayer(t.Context(), "claimed", "h", auth.RolePlayer); err != nil {
+		if _, err := ps.CreatePlayer(
+			t.Context(),
+			"claimed",
+			"claimed"+"@example.test",
+			"h",
+			auth.RolePlayer,
+		); err != nil {
 			t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 		}
 		anon, err := ps.CreateAnonymousPlayer(t.Context(), "anon-collider")
@@ -462,7 +531,13 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
 
-		credentialled, err := ps.CreatePlayer(t.Context(), "credentialled", "h", auth.RolePlayer)
+		credentialled, err := ps.CreatePlayer(
+			t.Context(),
+			"credentialled",
+			"credentialled"+"@example.test",
+			"h",
+			auth.RolePlayer,
+		)
 		if err != nil {
 			t.Fatalf("CreatePlayer err = %v, want nil", err)
 		}
@@ -498,7 +573,7 @@ func TestPlayerStore_ListAllPlayers_AndCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
-	pw, err := ps.CreatePlayer(t.Context(), "pw-list-1", "h", auth.RolePlayer)
+	pw, err := ps.CreatePlayer(t.Context(), "pw-list-1", "pw-list-1"+"@example.test", "h", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -189,20 +189,13 @@ func TestPlayerStore_CreatePlayer_DuplicateUsername(t *testing.T) {
 		t.Fatalf("CreatePlayer first call err = %v, want nil", err)
 	}
 
-	// Different email, same username: must classify as ErrUsernameTaken
-	// rather than the generic SQLITE wrap. classifyCredentialConflict
-	// looks up by username first and returns the sentinel that maps to
-	// the user-facing "username is already taken" banner (#111 PR1).
+	// Different email, same username -> ErrUsernameTaken.
 	_, err := ps.CreatePlayer(t.Context(), "alice", "alice-other@example.test", "other", auth.RolePlayer)
 	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }
 
-// TestPlayerStore_CreatePlayer_DuplicateEmail pins the email-side of
-// classifyCredentialConflict (#111 PR1): a second create with the
-// same email but a different username surfaces ErrEmailTaken, not the
-// generic SQLITE wrap.
 func TestPlayerStore_CreatePlayer_DuplicateEmail(t *testing.T) {
 	t.Parallel()
 
@@ -219,10 +212,6 @@ func TestPlayerStore_CreatePlayer_DuplicateEmail(t *testing.T) {
 	}
 }
 
-// TestPlayerStore_CreatePlayer_LowercasesAndTrimsEmail pins the
-// store-layer normalisation rule so "  ALICE@Example.Test " round-
-// trips as "alice@example.test" on the persisted row, blocking
-// case/whitespace variants from creating duplicate accounts (#111 PR1).
 func TestPlayerStore_CreatePlayer_LowercasesAndTrimsEmail(t *testing.T) {
 	t.Parallel()
 
@@ -237,8 +226,7 @@ func TestPlayerStore_CreatePlayer_LowercasesAndTrimsEmail(t *testing.T) {
 		t.Errorf("stored Email = %q, want %q", got, want)
 	}
 
-	// A second create with a case/whitespace variant must still trip
-	// the email-unique guard so users cannot end-run case-folding.
+	// Case-variant must still collide on the unique index.
 	_, dupErr := ps.CreatePlayer(t.Context(), "bob", "alice@EXAMPLE.test", "h", auth.RolePlayer)
 	if got, want := dupErr, auth.ErrEmailTaken; !errors.Is(got, want) {
 		t.Errorf("case-variant duplicate err = %v, want %v", got, want)

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -30,6 +30,13 @@
             </div>
 
             <div class="form-field">
+                <label for="email" class="label-eyebrow">Email</label>
+                <input id="email" name="email" type="email" required
+                       autocomplete="email"
+                       value="{{.Email}}" class="form-input">
+            </div>
+
+            <div class="form-field">
                 <label for="password" class="label-eyebrow">Password</label>
                 <input id="password" name="password" type="password" required
                        autocomplete="new-password"

--- a/test/e2e/tests/auth.spec.ts
+++ b/test/e2e/tests/auth.spec.ts
@@ -10,6 +10,7 @@ test('register, log out, log back in, and reach the admin dashboard', async ({ p
 
   await page.goto('/register');
   await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
   await page.locator('input[name=password]').fill(password);
   await page.locator('button[type=submit]').click();
 
@@ -53,6 +54,7 @@ test('deep link while logged out lands at the deep link after login', async ({ p
   // Register fresh and log out so the session is empty for the deep-link click.
   await page.goto('/register');
   await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
   await page.locator('input[name=password]').fill(password);
   await page.locator('button[type=submit]').click();
   await expect(page).toHaveURL(/\/admin\/quizzes$/);

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -175,6 +175,7 @@ test('signed-in player does not see the claim-name CTA on the player client', as
   const username = `e2e-claim-authn-${browserName}-${Date.now()}`;
   await page.goto('/register');
   await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
   await page.locator('input[name=password]').fill('correct-battery-13');
   await page.locator('button[type=submit]').click();
   // Admin lands on /admin/quizzes; subsequent registrants land on /.

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -22,6 +22,7 @@ export const QUIZ_QUESTIONS: readonly QuestionSpec[] = [
 export async function registerAdmin(page: Page, username: string): Promise<void> {
   await page.goto('/register');
   await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
   await page.locator('input[name=password]').fill(PASSWORD);
   await page.locator('button[type=submit]').click();
   await expect(page).toHaveURL(/\/admin\/quizzes$/);

--- a/test/integration/admin_htmx_test.go
+++ b/test/integration/admin_htmx_test.go
@@ -432,6 +432,7 @@ func registerAdminViaHTTP(ctx context.Context, t *testing.T, client *http.Client
 
 	form := url.Values{}
 	form.Add("username", "htmx-admin")
+	form.Add("email", "htmx-admin@example.test")
 	form.Add("password", "htmx-admin-pass-123")
 	form.Add("csrf_token", registerToken)
 

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -90,6 +90,7 @@ func TestAdmin_Integration(t *testing.T) {
 
 	registerForm := url.Values{}
 	registerForm.Add("username", "integration-admin")
+	registerForm.Add("email", "integration-admin@example.test")
 	registerForm.Add("password", "integration-pass-123")
 	registerForm.Add("csrf_token", registerToken)
 

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -114,6 +114,9 @@ func submitAuthForm(
 
 	form := url.Values{}
 	form.Add("username", username)
+	// Always send email so the same helper drives both /login (which
+	// ignores the field) and /register (which requires it since #111).
+	form.Add("email", username+"@example.test")
 	form.Add("password", password)
 	form.Add("csrf_token", token)
 

--- a/test/integration/claim_name_test.go
+++ b/test/integration/claim_name_test.go
@@ -77,6 +77,7 @@ func registerPlayer(
 
 	form := url.Values{}
 	form.Add("username", username)
+	form.Add("email", username+"@example.test")
 	form.Add("password", password)
 	form.Add("csrf_token", token)
 

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -213,6 +213,7 @@ func registerGameplayAdmin(ctx context.Context, t *testing.T, client *http.Clien
 
 	registerForm := url.Values{}
 	registerForm.Add("username", gameplayAdminUsername)
+	registerForm.Add("email", gameplayAdminUsername+"@example.test")
 	registerForm.Add("password", gameplayAdminPassword)
 	registerForm.Add("csrf_token", registerToken)
 

--- a/test/integration/home_test.go
+++ b/test/integration/home_test.go
@@ -54,11 +54,23 @@ func TestHome_Integration(t *testing.T) {
 		t.Fatalf("CreateQuiz quiz2 err = %v, want nil", err)
 	}
 
-	alice, err := stores.Players.CreatePlayer(ctx, "alice-integration", "hash", auth.RolePlayer)
+	alice, err := stores.Players.CreatePlayer(
+		ctx,
+		"alice-integration",
+		"alice-integration"+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	)
 	if err != nil {
 		t.Fatalf("CreatePlayer alice err = %v, want nil", err)
 	}
-	bob, err := stores.Players.CreatePlayer(ctx, "bob-integration", "hash", auth.RolePlayer)
+	bob, err := stores.Players.CreatePlayer(
+		ctx,
+		"bob-integration",
+		"bob-integration"+"@example.test",
+		"hash",
+		auth.RolePlayer,
+	)
 	if err != nil {
 		t.Fatalf("CreatePlayer bob err = %v, want nil", err)
 	}

--- a/test/integration/quiz_ownership_test.go
+++ b/test/integration/quiz_ownership_test.go
@@ -152,6 +152,7 @@ func registerAdminClient(ctx context.Context, t *testing.T, baseURL, username st
 	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
 	form := url.Values{
 		"username":   {username},
+		"email":      {username + "@example.test"},
 		"password":   {"integration-pass-123"},
 		"csrf_token": {token},
 	}


### PR DESCRIPTION
Slice 1 of #111 - registration starts capturing email. No verification token, no gate, no interstitial yet (PR2 and PR3 follow).

## What lands

- **Migration**: adds `players.email_verified_at` DATETIME NULL. The `email_verifications` table moves to PR2.
- **SQL**: `CreatePlayerWithCredentials` + `ClaimPlayer` take an `email` arg now. `ClaimPlayer` also gains an `AND email IS NULL` guard so a session-bearing OAuth-linked row cannot have its verified email overwritten by a /register POST. OAuth-side inserts (`CreatePlayerFromOAuth`, `ClaimPlayerForOAuth`) stamp `email_verified_at = CURRENT_TIMESTAMP` because Google attests the email at link time. New `MarkPlayerEmailVerifiedIfNew` query flips an existing row's `email_verified_at` when the OAuth callback links a Google identity onto a password-registered row (so PR3's gate won't block that user).
- **Store**: `PlayerStore.CreatePlayer` + `ClaimPlayer` accept email, lowercase + trim before insert. New `classifyCredentialConflict` disambiguates SQLITE UNIQUE failures into `ErrUsernameTaken` vs the new `ErrEmailTaken`. `MarkPlayerEmailVerifiedIfNew` wrapper on `OAuthIdentityStore`.
- **Domain**: new `auth.ErrEmailTaken` sentinel; `Player.EmailVerifiedAt *time.Time` field with `IsEmailVerified()` helper; `IsAuthenticated` doc updated to clarify the "authenticated vs verified" split that PR3 will lean on.
- **Handler**: `HandleRegisterSubmit` validates email (loose `looksLikeEmail`: one `@`, host with a dot, host neither starting nor ending with a dot), stores it, surfaces `ErrEmailTaken` as a 409 with `"Email is already registered. Try logging in."`. Form re-renders preserve the submitted email so a failed attempt does not drop the value.
- **Template**: new email input on the register form.
- **Tests**: unit (looksLikeEmail table), in-memory handler tests for duplicate / invalid / case-folded email, real-DB tests for `ErrEmailTaken` + case/whitespace folding, e2e + integration register helpers updated to pass an email.

## Per-#451 decision F documented

- Existing pre-#111 rows (no email) are untouched by this PR. They keep working until PR3 turns the gate on.
- PR2 will add the verify-token table, mint a token on register, send the email, and add the `GET /verify-email?token=...` endpoint.
- PR3 will add the verify-gate to `RequireAdmin` / `RequireAuthenticated` and the post-login interstitial at `/profile/email/add` for the pre-PR1 no-email rows.

## Notes for review

- Three real findings from the review pass landed in this PR before commit: `ClaimPlayer` email-overwrite guard, OAuth-link-by-email stamping `email_verified_at`, and the leading-dot host case in `looksLikeEmail`. Plus updated a stale doc comment + added the real-DB test for `ErrEmailTaken`.