### PR TITLE
Send and consume an email-verify link (#111 PR2 of 3)

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -324,6 +324,10 @@ func Run(
 	}()
 
 	stores := store.New(conn, logger)
+	if sweepErr := stores.VerifyTokens.DeleteExpiredVerifyTokens(signalCtx); sweepErr != nil {
+		logger.WarnContext(signalCtx, "verify-token sweep at startup failed",
+			slog.Any("err", sweepErr))
+	}
 	gameService := game.NewService(stores.Games, stores.Quizzes, logger)
 	if cfg.RevealDelay > 0 {
 		gameService.SetRevealDelay(cfg.RevealDelay)

--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -77,3 +77,15 @@ const GoogleNextCookieName = googleNextCookieName
 
 // LooksLikeEmail exposes looksLikeEmail for the external test package.
 var LooksLikeEmail = looksLikeEmail
+
+// BuildVerifyLink exposes buildVerifyLink so the URL-shape tests can
+// assert the link path + query encoding from the external test package.
+var BuildVerifyLink = buildVerifyLink
+
+// ErrVerifyBaseURLEmpty / ErrVerifyBaseURLInvalid expose the sentinel
+// errors buildVerifyLink returns so the external test package can match
+// on them via [errors.Is].
+var (
+	ErrVerifyBaseURLEmpty   = errVerifyBaseURLEmpty
+	ErrVerifyBaseURLInvalid = errVerifyBaseURLInvalid
+)

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -9,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/starquake/topbanana/internal/absurl"
 	"github.com/starquake/topbanana/internal/csrf"
@@ -103,19 +105,35 @@ func HandleRegisterForm(
 	})
 }
 
+// RegisterDeps is the bundle of optional dependencies the register
+// handler needs to dispatch the email verification link. Bundled into
+// a struct so the handler signature stays under revive's
+// argument-limit cap as the dep set grows (#111). Mailer / Tokens /
+// BaseURL together cover the verify-email side; leave them as their
+// zero values and SendVerifyEmailBestEffort logs a warning instead of
+// sending, which is the right behaviour for unit tests.
+type RegisterDeps struct {
+	AdminUsernames []string
+	GoogleEnabled  bool
+	Mailer         VerifyEmailSender
+	Tokens         VerifyTokenStore
+	BaseURL        string
+}
+
 // HandleRegisterSubmit handles POST /register. When the caller already
 // has an anonymous session row, the handler upgrades that row via
 // ClaimPlayer so the visitor's game history follows them; if the row
 // was concurrently claimed it falls back to CreatePlayer. Usernames in
 // adminUsernames are promoted to admin; the first password-bearing
 // registrant is atomically promoted by the store (see CreatePlayer).
+// On success the handler dispatches a verification email best-effort
+// so an SMTP outage does not block the signup.
 func HandleRegisterSubmit(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
 	players PlayerStore,
 	sessions *session.Manager,
-	adminUsernames []string,
-	googleEnabled bool,
+	deps RegisterDeps,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/register.gohtml")
 
@@ -139,14 +157,14 @@ func HandleRegisterSubmit(
 				Username:   input.CleanedUsername,
 				Email:      input.CleanedEmail,
 				Message:    input.ErrMsg,
-				ShowGoogle: googleEnabled,
+				ShowGoogle: deps.GoogleEnabled,
 			})
 
 			return
 		}
 
 		role := RolePlayer
-		if slices.Contains(adminUsernames, input.CleanedUsername) {
+		if slices.Contains(deps.AdminUsernames, input.CleanedUsername) {
 			role = RoleAdmin
 		}
 
@@ -168,7 +186,7 @@ func HandleRegisterSubmit(
 					Username:   input.CleanedUsername,
 					Email:      input.CleanedEmail,
 					Message:    msg,
-					ShowGoogle: googleEnabled,
+					ShowGoogle: deps.GoogleEnabled,
 				})
 
 				return
@@ -179,9 +197,47 @@ func HandleRegisterSubmit(
 			return
 		}
 
+		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail)
 		sessions.Set(w, player.ID)
 		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 	})
+}
+
+// verifyEmailDispatchTimeout caps the detached SMTP attempt spawned by
+// dispatchVerifyEmail. Set above mailer.SendTimeout so the inner dial
+// gets its own 30 s budget before this outer timeout fires; the extra
+// margin covers GenerateVerifyToken + CreateVerifyToken.
+const verifyEmailDispatchTimeout = 45 * time.Second
+
+// dispatchVerifyEmail fires the verify-email send on a background
+// goroutine so the register response is not held open while SMTP dials.
+// The spawned context is detached from r.Context() so a closed browser
+// tab does not cancel the send. The deps fields are nil/empty in unit
+// tests that do not exercise the mail path; a partial-but-nonzero deps
+// (Mailer/Tokens set, BaseURL missing) is treated as a misconfiguration
+// and warned about so an operator notices.
+func dispatchVerifyEmail(
+	ctx context.Context,
+	logger *slog.Logger,
+	deps RegisterDeps,
+	playerID int64,
+	recipient string,
+) {
+	if deps.Mailer == nil || deps.Tokens == nil {
+		return
+	}
+	if deps.BaseURL == "" {
+		logger.WarnContext(ctx, "verify email dispatch skipped: BASE_URL is empty",
+			slog.Int64("player_id", playerID))
+
+		return
+	}
+	bg, cancel := context.WithTimeout(context.WithoutCancel(ctx), verifyEmailDispatchTimeout)
+	go func() {
+		defer cancel()
+		SendVerifyEmailBestEffort(bg, logger, deps.Tokens, deps.Mailer,
+			deps.BaseURL, recipient, playerID, time.Now().UTC())
+	}()
 }
 
 // registerCollisionMessage maps the register-time conflict sentinels

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -312,7 +312,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -357,7 +357,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
 		"email":    {"bob@example.test"},
@@ -396,8 +396,7 @@ func TestHandleRegisterSubmit_AdminUsernamesEnv_PromotesToAdmin(t *testing.T) {
 		nil,
 		store,
 		session.New([]byte("k"), true),
-		[]string{"alice", "carol"},
-		false,
+		RegisterDeps{AdminUsernames: []string{"alice", "carol"}},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"carol"},
@@ -422,7 +421,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -450,7 +449,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
@@ -478,7 +477,7 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"email":    {"alice@example.test"},
@@ -501,7 +500,7 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"bob"},
 		"email":    {"shared@example.test"},
@@ -520,7 +519,7 @@ func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"email":    {"not-an-email"},
@@ -539,7 +538,7 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"alice"},
 		"email":    {"  ALICE@Example.Test "},
@@ -573,7 +572,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
 
 	// Build a request that already carries the anonymous session cookie.
 	rec := httptest.NewRecorder()
@@ -637,7 +636,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID)
@@ -698,7 +697,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID) // cookie still points at the now-claimed row
@@ -1086,7 +1085,7 @@ func TestHandleRegisterSubmit_WhitespaceOnlyUsername(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"username": {"   "},
@@ -1110,7 +1109,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), nil, false)
+	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	password := strings.Repeat("a", MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{

--- a/internal/auth/verify.go
+++ b/internal/auth/verify.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// VerifyTokenTTL is the lifetime of a freshly minted verify-email link.
+// Long enough that a recipient who opens the mail next morning still
+// finds it live; short enough that a leaked mailbox stops being a path
+// into the account within a day.
+const VerifyTokenTTL = 24 * time.Hour
+
+// ErrVerifyTokenInvalid is returned by ConsumeVerifyToken when the
+// supplied token does not match a live row. Distinct from
+// ErrVerifyTokenAlreadyUsed so the handler can render an "already
+// verified" page instead of a generic "this link is no longer valid".
+var ErrVerifyTokenInvalid = errors.New("verify token invalid")
+
+// ErrVerifyTokenAlreadyUsed is returned by ConsumeVerifyToken when the
+// supplied token was already consumed. The caller renders an "already
+// verified" landing page rather than treating the duplicate click as
+// an error - the second click is a normal user action (mail client
+// pre-fetched the link, browser reload, etc.).
+var ErrVerifyTokenAlreadyUsed = errors.New("verify token already used")
+
+// errVerifyBaseURLEmpty / errVerifyBaseURLInvalid back the buildVerifyLink
+// validation errors. Sentinel so callers can [errors.Is] them without
+// string-matching the wrap message.
+var (
+	errVerifyBaseURLEmpty   = errors.New("verify token: BASE_URL is empty")
+	errVerifyBaseURLInvalid = errors.New("verify token: BASE_URL is invalid")
+)
+
+// verifyTokenBytes is the random-bytes length of a freshly minted
+// token. 32 bytes (256 bits) is well above the brute-force threshold
+// and base64-encodes to a comfortable URL length.
+const verifyTokenBytes = 32
+
+// VerifyTokenStore persists email-verify tokens. Implemented by
+// store.PlayerStore against the real DB; the interface lives here so
+// the auth package can drive the verify flow without a direct import
+// of the storage layer.
+type VerifyTokenStore interface {
+	// CreateVerifyToken records the sha256 hex of a freshly minted token.
+	// The raw token is never stored - a DB leak should not be replayable.
+	CreateVerifyToken(ctx context.Context, tokenHash string, playerID int64, expiresAt time.Time) error
+	// ConsumeVerifyToken atomically marks the row consumed and stamps
+	// email_verified_at on the player in the same transaction. Returns
+	// the player id on success, ErrVerifyTokenAlreadyUsed when the row
+	// exists but is already consumed, and ErrVerifyTokenInvalid when no
+	// live row matches (never existed, or expired).
+	ConsumeVerifyToken(ctx context.Context, tokenHash string) (int64, error)
+	// DeleteExpiredVerifyTokens removes rows whose expires_at has
+	// passed. Called from the startup sweep so the table cannot grow
+	// without bound on a long-running deploy.
+	DeleteExpiredVerifyTokens(ctx context.Context) error
+}
+
+// VerifyEmailSender is the slice of mailer.Mailer the verify-email
+// flow uses. Narrow interface so tests don't need to spin up a full
+// SMTP server.
+type VerifyEmailSender interface {
+	Send(ctx context.Context, msg mailer.Message) error
+}
+
+// GenerateVerifyToken returns a freshly minted (raw, hash) pair. The
+// raw token is the URL-safe base64 encoding of 32 random bytes from
+// crypto/rand; the hash is its lowercase-hex sha256. Pass the raw
+// token to the email body and the hash to the store.
+func GenerateVerifyToken() (raw, hash string, err error) {
+	buf := make([]byte, verifyTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", "", fmt.Errorf("verify token: read randomness: %w", err)
+	}
+	raw = base64.RawURLEncoding.EncodeToString(buf)
+
+	return raw, HashVerifyToken(raw), nil
+}
+
+// HashVerifyToken returns the lowercase-hex sha256 of a raw token.
+// The encoded form must match what GenerateVerifyToken produced or the
+// store lookup will miss.
+func HashVerifyToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// SendVerifyEmail mints a token, persists the hash, and dispatches
+// the verification email. baseURL is the absolute origin used to build
+// the link (e.g. "https://topbanana.example"); the verify endpoint
+// path is appended here so callers do not have to know it. A mailer
+// failure surfaces verbatim to the caller; the token row is still
+// committed so a future "resend" flow can run independently of SMTP
+// availability.
+func SendVerifyEmail(
+	ctx context.Context,
+	tokens VerifyTokenStore,
+	sender VerifyEmailSender,
+	baseURL, recipient string,
+	playerID int64,
+	now time.Time,
+) error {
+	raw, hash, err := GenerateVerifyToken()
+	if err != nil {
+		return err
+	}
+	link, err := buildVerifyLink(baseURL, raw)
+	if err != nil {
+		return err
+	}
+	expiresAt := now.Add(VerifyTokenTTL)
+	if storeErr := tokens.CreateVerifyToken(ctx, hash, playerID, expiresAt); storeErr != nil {
+		return fmt.Errorf("verify token: store: %w", storeErr)
+	}
+	msg := mailer.Message{
+		To:      recipient,
+		Subject: "Confirm your Top Banana email",
+		Body:    verifyEmailBody(link),
+		Kind:    mailer.KindVerify,
+	}
+	if sendErr := sender.Send(ctx, msg); sendErr != nil {
+		return fmt.Errorf("verify token: send: %w", sendErr)
+	}
+
+	return nil
+}
+
+// SendVerifyEmailBestEffort dispatches the verification email and logs
+// any failure rather than surfacing it. Used by the register handler
+// so an SMTP outage or a mis-typed recipient does not block the
+// signup from completing; the user can retry via the resend flow.
+func SendVerifyEmailBestEffort(
+	ctx context.Context,
+	logger *slog.Logger,
+	tokens VerifyTokenStore,
+	sender VerifyEmailSender,
+	baseURL, recipient string,
+	playerID int64,
+	now time.Time,
+) {
+	if err := SendVerifyEmail(ctx, tokens, sender, baseURL, recipient, playerID, now); err != nil {
+		logger.WarnContext(ctx, "verify email dispatch failed",
+			slog.Int64("player_id", playerID),
+			slog.String("to", recipient),
+			slog.Any("err", err),
+		)
+	}
+}
+
+// buildVerifyLink composes the absolute verify URL. Validates baseURL
+// up front so a misconfigured BASE_URL fails the send loudly instead
+// of silently producing a link the user cannot click.
+func buildVerifyLink(baseURL, rawToken string) (string, error) {
+	if baseURL == "" {
+		return "", errVerifyBaseURLEmpty
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("verify token: parse base url %q: %w", baseURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("%w: %q", errVerifyBaseURLInvalid, baseURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/verify-email"
+	q := u.Query()
+	q.Set("token", rawToken)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// verifyEmailBody is the plain-text body of the verification email.
+// Plain text only - HTML alternative is out of scope for #321/#111;
+// the link is on its own line so any mail client renders it as
+// clickable.
+func verifyEmailBody(link string) string {
+	return "Welcome to Top Banana!\n\n" +
+		"Click the link below to confirm your email address:\n\n" +
+		link + "\n\n" +
+		"This link is valid for 24 hours. If you did not sign up, you can\n" +
+		"ignore this email.\n"
+}

--- a/internal/auth/verify_handler.go
+++ b/internal/auth/verify_handler.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/session"
+)
+
+// verifyEmailPageData is the payload the verify-email page renders.
+// ShowContinue gates the "Continue" CTA: the success and already-used
+// branches show it (pointing at the role landing), the invalid-token
+// branch does not.
+type verifyEmailPageData struct {
+	Title        string
+	Heading      string
+	Message      string
+	ShowContinue bool
+	ContinueHref string
+}
+
+// HandleVerifyEmail returns the handler for GET /verify-email?token=...
+// It atomically consumes the token, stamps email_verified_at on the
+// owning player, and renders a short success / already-verified /
+// invalid page. The handler does NOT require an authenticated session:
+// the link arrives in an inbox the user already controls, and email
+// clients prefetching the link cannot keep the user from completing
+// verification in a fresh browser window.
+func HandleVerifyEmail(
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	tokens VerifyTokenStore,
+	players PlayerStore,
+	sessions *session.Manager,
+) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/verify_email.gohtml")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Strip the raw token from any cross-origin Referer the browser
+		// would otherwise send (Google Fonts on base.gohtml is the
+		// notable case). Modern defaults strip the query already; the
+		// explicit no-referrer header pins the behaviour on older UAs.
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		raw := r.URL.Query().Get("token")
+		if raw == "" {
+			render.render(w, r, http.StatusBadRequest, verifyEmailPageData{
+				Title:   "Verify email",
+				Heading: "Link is missing",
+				Message: "This verification link is missing its token. Use the link from the email exactly as it was sent.",
+			})
+
+			return
+		}
+
+		_, err := tokens.ConsumeVerifyToken(r.Context(), HashVerifyToken(raw))
+		landing := postVerifyLanding(r, players, sessions)
+		switch {
+		case err == nil:
+			render.render(w, r, http.StatusOK, verifyEmailPageData{
+				Title:        "Email verified",
+				Heading:      "Email verified",
+				Message:      "Your email address is confirmed. You can now use everything Top Banana has to offer.",
+				ShowContinue: true,
+				ContinueHref: landing,
+			})
+		case errors.Is(err, ErrVerifyTokenAlreadyUsed):
+			// Read the same as the first-time success: a duplicate
+			// click (mail-client prefetch, browser reload) should not
+			// look like an error.
+			render.render(w, r, http.StatusOK, verifyEmailPageData{
+				Title:        "Email verified",
+				Heading:      "Already verified",
+				Message:      "This email address was already verified. You can carry on.",
+				ShowContinue: true,
+				ContinueHref: landing,
+			})
+		case errors.Is(err, ErrVerifyTokenInvalid):
+			render.render(w, r, http.StatusGone, verifyEmailPageData{
+				Title:   "Verify email",
+				Heading: "Link is no longer valid",
+				Message: "This verification link has expired or was never issued. Sign in to request a fresh one.",
+			})
+		default:
+			logger.ErrorContext(r.Context(), "verify email consume failed", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+	})
+}
+
+// postVerifyLanding picks the Continue link target. Prefers the
+// session player's role landing when the request carries a live
+// session; falls back to the home page when the verifying user is on
+// a different device than the one that signed up.
+func postVerifyLanding(r *http.Request, players PlayerStore, sessions *session.Manager) string {
+	id, ok := sessions.PlayerID(r)
+	if !ok {
+		return playerLandingPath
+	}
+	p, err := players.GetPlayerByID(r.Context(), id)
+	if err != nil {
+		return playerLandingPath
+	}
+
+	return landingPathFor(p.Role)
+}

--- a/internal/auth/verify_handler_test.go
+++ b/internal/auth/verify_handler_test.go
@@ -1,0 +1,96 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/session"
+)
+
+func TestHandleVerifyEmail_MissingToken(t *testing.T) {
+	t.Parallel()
+
+	rec := runVerifyEmail(t, &stubVerifyTokens{}, "")
+	if got, want := rec.Code, http.StatusBadRequest; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestHandleVerifyEmail_Success(t *testing.T) {
+	t.Parallel()
+
+	store := &stubVerifyTokens{consumePlayerID: 99}
+	rec := runVerifyEmail(t, store, "raw-token")
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := store.consumedHash, HashVerifyToken("raw-token"); got != want {
+		t.Errorf("consumedHash = %q, want %q", got, want)
+	}
+}
+
+func TestHandleVerifyEmail_AlreadyUsed(t *testing.T) {
+	t.Parallel()
+
+	rec := runVerifyEmail(t, &stubVerifyTokens{consumeErr: ErrVerifyTokenAlreadyUsed}, "raw-token")
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestHandleVerifyEmail_Invalid(t *testing.T) {
+	t.Parallel()
+
+	rec := runVerifyEmail(t, &stubVerifyTokens{consumeErr: ErrVerifyTokenInvalid}, "raw-token")
+	if got, want := rec.Code, http.StatusGone; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func runVerifyEmail(t *testing.T, tokens *stubVerifyTokens, raw string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	players := newStubPlayerStore()
+	sessions := session.New([]byte("k"), true)
+	handler := HandleVerifyEmail(discardLogger(), nil, tokens, players, sessions)
+
+	target := "/verify-email"
+	if raw != "" {
+		target += "?token=" + raw
+	}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+type stubVerifyTokens struct {
+	consumePlayerID int64
+	consumeErr      error
+	consumedHash    string
+}
+
+func (*stubVerifyTokens) CreateVerifyToken(
+	_ context.Context, _ string, _ int64, _ time.Time,
+) error {
+	return nil
+}
+
+func (s *stubVerifyTokens) ConsumeVerifyToken(_ context.Context, tokenHash string) (int64, error) {
+	s.consumedHash = tokenHash
+	if s.consumeErr != nil {
+		return 0, s.consumeErr
+	}
+
+	return s.consumePlayerID, nil
+}
+
+func (*stubVerifyTokens) DeleteExpiredVerifyTokens(_ context.Context) error {
+	return nil
+}

--- a/internal/auth/verify_test.go
+++ b/internal/auth/verify_test.go
@@ -1,0 +1,228 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/mailer"
+)
+
+func TestGenerateVerifyToken_PairMatches(t *testing.T) {
+	t.Parallel()
+
+	raw, hash, err := GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if got, want := hash, HashVerifyToken(raw); got != want {
+		t.Errorf("HashVerifyToken(raw) = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateVerifyToken_Unique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]struct{}, 32)
+	for range 32 {
+		raw, _, err := GenerateVerifyToken()
+		if err != nil {
+			t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+		}
+		if _, dup := seen[raw]; dup {
+			t.Fatalf("GenerateVerifyToken returned a duplicate token after %d draws", len(seen))
+		}
+		seen[raw] = struct{}{}
+	}
+}
+
+func TestHashVerifyToken_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	const sample = "deadbeef"
+	if got, want := HashVerifyToken(sample), HashVerifyToken(sample); got != want {
+		t.Errorf("HashVerifyToken(%q) = %q, want %q", sample, got, want)
+	}
+	if got, want := HashVerifyToken("a"), HashVerifyToken("b"); got == want {
+		t.Errorf("HashVerifyToken(%q) collides with HashVerifyToken(%q)", "a", "b")
+	}
+}
+
+func TestBuildVerifyLink_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	link, err := BuildVerifyLink("https://topbanana.example", "abc123")
+	if err != nil {
+		t.Fatalf("BuildVerifyLink err = %v, want nil", err)
+	}
+	u, err := url.Parse(link)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) err = %v, want nil", link, err)
+	}
+	if got, want := u.Path, "/verify-email"; got != want {
+		t.Errorf("link.Path = %q, want %q", got, want)
+	}
+	if got, want := u.Query().Get("token"), "abc123"; got != want {
+		t.Errorf("link.Query()[token] = %q, want %q", got, want)
+	}
+}
+
+func TestBuildVerifyLink_TrimsTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	link, err := BuildVerifyLink("https://topbanana.example/", "tok")
+	if err != nil {
+		t.Fatalf("BuildVerifyLink err = %v, want nil", err)
+	}
+	if got, want := link, "https://topbanana.example/verify-email?token=tok"; got != want {
+		t.Errorf("BuildVerifyLink trailing slash = %q, want %q", got, want)
+	}
+}
+
+func TestBuildVerifyLink_BaseURLEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildVerifyLink("", "tok")
+	if got, want := err, ErrVerifyBaseURLEmpty; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestBuildVerifyLink_BaseURLMissingScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildVerifyLink("topbanana.example", "tok")
+	if got, want := err, ErrVerifyBaseURLInvalid; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestSendVerifyEmail_StoresHashSendsMessage(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingVerifyTokenStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendVerifyEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", 42, now)
+	if err != nil {
+		t.Fatalf("SendVerifyEmail err = %v, want nil", err)
+	}
+
+	if got, want := len(tokens.created), 1; got != want {
+		t.Fatalf("tokens.created len = %d, want %d", got, want)
+	}
+	rec := tokens.created[0]
+	if got, want := rec.playerID, int64(42); got != want {
+		t.Errorf("CreateVerifyToken playerID = %d, want %d", got, want)
+	}
+	if got, want := rec.expiresAt, now.Add(VerifyTokenTTL); !got.Equal(want) {
+		t.Errorf("CreateVerifyToken expiresAt = %v, want %v", got, want)
+	}
+	if got, want := len(rec.tokenHash), 64; got != want {
+		t.Errorf("CreateVerifyToken tokenHash len = %d, want %d", got, want)
+	}
+
+	if got, want := len(mailerStub.sent), 1; got != want {
+		t.Fatalf("mailer.sent len = %d, want %d", got, want)
+	}
+	msg := mailerStub.sent[0]
+	if got, want := msg.To, "alice@example.test"; got != want {
+		t.Errorf("msg.To = %q, want %q", got, want)
+	}
+	if got, want := msg.Kind, mailer.KindVerify; got != want {
+		t.Errorf("msg.Kind = %q, want %q", got, want)
+	}
+	if !strings.Contains(msg.Body, "https://topbanana.example/verify-email?token=") {
+		t.Errorf("msg.Body missing verify link, got %q", msg.Body)
+	}
+}
+
+func TestSendVerifyEmail_StoreFailureSkipsSend(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("disk full")
+	tokens := &recordingVerifyTokenStore{createErr: wantErr}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendVerifyEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", 1, now)
+	if got, want := err, wantErr; !errors.Is(got, want) {
+		t.Errorf("err = %v, want wrapping %v", got, want)
+	}
+	if got, want := len(mailerStub.sent), 0; got != want {
+		t.Errorf("mailer.sent len = %d, want %d (store failure must not send)", got, want)
+	}
+}
+
+func TestSendVerifyEmailBestEffort_SwallowsError(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingVerifyTokenStore{createErr: errors.New("disk full")}
+	mailerStub := &recordingSender{}
+	logger := slog.New(slog.DiscardHandler)
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	// Best-effort path must not panic or block when the store fails.
+	SendVerifyEmailBestEffort(t.Context(), logger, tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", 1, now)
+
+	if got, want := len(mailerStub.sent), 0; got != want {
+		t.Errorf("mailer.sent len = %d, want %d", got, want)
+	}
+}
+
+type recordingVerifyTokenStore struct {
+	created   []createVerifyTokenCall
+	createErr error
+}
+
+type createVerifyTokenCall struct {
+	tokenHash string
+	playerID  int64
+	expiresAt time.Time
+}
+
+func (s *recordingVerifyTokenStore) CreateVerifyToken(
+	_ context.Context, tokenHash string, playerID int64, expiresAt time.Time,
+) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, createVerifyTokenCall{
+		tokenHash: tokenHash,
+		playerID:  playerID,
+		expiresAt: expiresAt,
+	})
+
+	return nil
+}
+
+func (*recordingVerifyTokenStore) ConsumeVerifyToken(_ context.Context, _ string) (int64, error) {
+	return 0, errors.ErrUnsupported
+}
+
+func (*recordingVerifyTokenStore) DeleteExpiredVerifyTokens(_ context.Context) error {
+	return nil
+}
+
+type recordingSender struct {
+	sent    []mailer.Message
+	sendErr error
+}
+
+func (s *recordingSender) Send(_ context.Context, msg mailer.Message) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sent = append(s.sent, msg)
+
+	return nil
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -18,6 +18,14 @@ type Break struct {
 	UpdatedAt time.Time
 }
 
+type EmailVerifyToken struct {
+	TokenHash  string
+	PlayerID   int64
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	ConsumedAt sql.NullTime
+}
+
 type Game struct {
 	ID        string
 	QuizID    int64

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -142,6 +142,37 @@ func (q *Queries) ClaimPlayerForOAuth(ctx context.Context, arg ClaimPlayerForOAu
 	return i, err
 }
 
+const consumeEmailVerifyToken = `-- name: ConsumeEmailVerifyToken :one
+UPDATE email_verify_tokens
+SET consumed_at = ?1
+WHERE token_hash = ?2
+  AND consumed_at IS NULL
+  AND expires_at > ?3
+RETURNING player_id
+`
+
+type ConsumeEmailVerifyTokenParams struct {
+	ConsumedAt sql.NullTime
+	TokenHash  string
+	Now        time.Time
+}
+
+// Atomic consume: succeeds only when the row is still unconsumed and not
+// expired. Returns the player_id so the caller can stamp email_verified_at
+// in the same transaction. The caller passes the wall clock as 'now' so
+// both sides of the expires_at comparison use the same RFC3339 encoding
+// the modernc/sqlite driver writes - mixing time.Time with
+// CURRENT_TIMESTAMP produces strings of different lengths and the
+// lexicographic comparison silently lies. sql.ErrNoRows means the token
+// was consumed, expired, or never existed; the caller maps that to a
+// single user-facing "this link is no longer valid" response.
+func (q *Queries) ConsumeEmailVerifyToken(ctx context.Context, arg ConsumeEmailVerifyTokenParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, consumeEmailVerifyToken, arg.ConsumedAt, arg.TokenHash, arg.Now)
+	var player_id int64
+	err := row.Scan(&player_id)
+	return player_id, err
+}
+
 const countAllPlayers = `-- name: CountAllPlayers :one
 SELECT COUNT(*) FROM players
 `
@@ -183,6 +214,25 @@ func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (P
 		&i.EmailVerifiedAt,
 	)
 	return i, err
+}
+
+const createEmailVerifyToken = `-- name: CreateEmailVerifyToken :exec
+INSERT INTO email_verify_tokens (token_hash, player_id, expires_at)
+VALUES (?1, ?2, ?3)
+`
+
+type CreateEmailVerifyTokenParams struct {
+	TokenHash string
+	PlayerID  int64
+	ExpiresAt time.Time
+}
+
+// Stores the sha256 hash of a freshly minted verify-email token. The raw
+// token only exists on the way out the door in the email; a DB leak should
+// not be replayable against GET /verify-email.
+func (q *Queries) CreateEmailVerifyToken(ctx context.Context, arg CreateEmailVerifyTokenParams) error {
+	_, err := q.db.ExecContext(ctx, createEmailVerifyToken, arg.TokenHash, arg.PlayerID, arg.ExpiresAt)
+	return err
 }
 
 const createPlayerFromOAuth = `-- name: CreatePlayerFromOAuth :one
@@ -285,10 +335,6 @@ type CreatePlayerWithCredentialsParams struct {
 // their username at the register form. The column tracks "did the player
 // pick this name themselves" (vs auto-generated petname), so a fresh
 // registrant must be marked as claimed from the moment the row is written.
-//
-// email is required at register time (#111). email_verified_at stays NULL
-// until the player consumes their verify token; the auth gate denies
-// routes for password-bearing rows in that state.
 func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePlayerWithCredentialsParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, createPlayerWithCredentials,
 		arg.Username,
@@ -306,6 +352,42 @@ func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePla
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+	)
+	return i, err
+}
+
+const deleteExpiredEmailVerifyTokens = `-- name: DeleteExpiredEmailVerifyTokens :exec
+DELETE FROM email_verify_tokens
+WHERE expires_at <= ?1
+`
+
+// Housekeeping for the startup sweep. Drops every row whose link has
+// expired so the table does not grow without bound. The caller passes
+// 'now' so the comparison runs in the same encoding the driver writes
+// (see the ConsumeEmailVerifyToken note above).
+func (q *Queries) DeleteExpiredEmailVerifyTokens(ctx context.Context, now time.Time) error {
+	_, err := q.db.ExecContext(ctx, deleteExpiredEmailVerifyTokens, now)
+	return err
+}
+
+const getEmailVerifyToken = `-- name: GetEmailVerifyToken :one
+SELECT token_hash, player_id, created_at, expires_at, consumed_at
+FROM email_verify_tokens
+WHERE token_hash = ?1
+LIMIT 1
+`
+
+// Look up by token hash. Caller checks expires_at vs the wall clock and
+// consumed_at IS NULL before treating it as live.
+func (q *Queries) GetEmailVerifyToken(ctx context.Context, tokenHash string) (EmailVerifyToken, error) {
+	row := q.db.QueryRowContext(ctx, getEmailVerifyToken, tokenHash)
+	var i EmailVerifyToken
+	err := row.Scan(
+		&i.TokenHash,
+		&i.PlayerID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ConsumedAt,
 	)
 	return i, err
 }
@@ -561,13 +643,7 @@ WHERE id = ?1
   AND email_verified_at IS NULL
 `
 
-// Stamps email_verified_at = now() on the row when it is currently
-// NULL. Idempotent: a second call against an already-verified row is
-// a no-op (rows-affected stays 0). Called by the OAuth link-by-email
-// path so a password-registered row that later signs in with the same
-// Google address gets the "verified" flag flipped, otherwise PR3's
-// gate would keep blocking the user even though Google has now
-// attested the address (#111 PR1 review finding).
+// Stamps email_verified_at when currently NULL. Idempotent.
 func (q *Queries) MarkPlayerEmailVerifiedIfNew(ctx context.Context, id int64) (int64, error) {
 	result, err := q.db.ExecContext(ctx, markPlayerEmailVerifiedIfNew, id)
 	if err != nil {

--- a/internal/migrations/20260527120000_add_email_verify_tokens.sql
+++ b/internal/migrations/20260527120000_add_email_verify_tokens.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- email_verify_tokens carries the per-link state for the verify-email flow.
+-- The token itself is never stored: only its sha256 hash, so a DB leak
+-- cannot be replayed against the consume endpoint. ON DELETE CASCADE keeps
+-- the table tidy when a player row is removed. Idempotent consume relies on
+-- consumed_at IS NULL guards in the UPDATE, not a separate state column.
+-- +goose StatementBegin
+CREATE TABLE email_verify_tokens
+(
+    token_hash  TEXT     PRIMARY KEY,
+    player_id   INTEGER  NOT NULL REFERENCES players (id) ON DELETE CASCADE,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at  DATETIME NOT NULL,
+    consumed_at DATETIME
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX email_verify_tokens_player_id_idx ON email_verify_tokens (player_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX email_verify_tokens_player_id_idx;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE email_verify_tokens;
+-- +goose StatementEnd

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -308,3 +308,43 @@ UPDATE players
 SET email_verified_at = CURRENT_TIMESTAMP
 WHERE id = sqlc.arg('id')
   AND email_verified_at IS NULL;
+
+-- name: CreateEmailVerifyToken :exec
+-- Stores the sha256 hash of a freshly minted verify-email token. The raw
+-- token only exists on the way out the door in the email; a DB leak should
+-- not be replayable against GET /verify-email.
+INSERT INTO email_verify_tokens (token_hash, player_id, expires_at)
+VALUES (sqlc.arg('token_hash'), sqlc.arg('player_id'), sqlc.arg('expires_at'));
+
+-- name: GetEmailVerifyToken :one
+-- Look up by token hash. Caller checks expires_at vs the wall clock and
+-- consumed_at IS NULL before treating it as live.
+SELECT *
+FROM email_verify_tokens
+WHERE token_hash = sqlc.arg('token_hash')
+LIMIT 1;
+
+-- name: ConsumeEmailVerifyToken :one
+-- Atomic consume: succeeds only when the row is still unconsumed and not
+-- expired. Returns the player_id so the caller can stamp email_verified_at
+-- in the same transaction. The caller passes the wall clock as 'now' so
+-- both sides of the expires_at comparison use the same RFC3339 encoding
+-- the modernc/sqlite driver writes - mixing time.Time with
+-- CURRENT_TIMESTAMP produces strings of different lengths and the
+-- lexicographic comparison silently lies. sql.ErrNoRows means the token
+-- was consumed, expired, or never existed; the caller maps that to a
+-- single user-facing "this link is no longer valid" response.
+UPDATE email_verify_tokens
+SET consumed_at = sqlc.arg('consumed_at')
+WHERE token_hash = sqlc.arg('token_hash')
+  AND consumed_at IS NULL
+  AND expires_at > sqlc.arg('now')
+RETURNING player_id;
+
+-- name: DeleteExpiredEmailVerifyTokens :exec
+-- Housekeeping for the startup sweep. Drops every row whose link has
+-- expired so the table does not grow without bound. The caller passes
+-- 'now' so the comparison runs in the same encoding the driver writes
+-- (see the ConsumeEmailVerifyToken note above).
+DELETE FROM email_verify_tokens
+WHERE expires_at <= sqlc.arg('now');

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -40,7 +40,7 @@ func addRoutes(
 		flash:  admin.NewEmailFlash([]byte(cfg.SessionKey), cfg.SecureCookies()),
 	}
 
-	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
+	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mailerTester)
 	addAdminRoutes(mux, logger, stores, gameService, sessions, csrfMgr, emailDeps)
 	addProfileRoutes(mux, logger, stores, sessions, csrfMgr)
 	addAPIRoutes(mux, logger, stores, gameService, leaderboardHub, sessions)
@@ -113,6 +113,7 @@ func addAuthRoutes(
 	sessions *session.Manager,
 	csrfMgr *csrf.Manager,
 	cfg *config.Config,
+	mailerTester *mailer.Tester,
 ) {
 	csrfMW := csrfMgr.Middleware
 	googleEnabled := cfg.GoogleLoginEnabled()
@@ -122,7 +123,14 @@ func addAuthRoutes(
 		mux.Handle(
 			"POST /register",
 			csrfMW(auth.HandleRegisterSubmit(
-				logger, csrfMgr, stores.Players, sessions, cfg.AdminUsernames, googleEnabled,
+				logger, csrfMgr, stores.Players, sessions,
+				auth.RegisterDeps{
+					AdminUsernames: cfg.AdminUsernames,
+					GoogleEnabled:  googleEnabled,
+					Mailer:         mailerTester,
+					Tokens:         stores.VerifyTokens,
+					BaseURL:        cfg.BaseURL,
+				},
 			)),
 		)
 	}
@@ -138,6 +146,10 @@ func addAuthRoutes(
 		)),
 	)
 	mux.Handle("POST /logout", csrfMW(auth.HandleLogout(sessions)))
+
+	mux.Handle("GET /verify-email", auth.HandleVerifyEmail(
+		logger, csrfMgr, stores.VerifyTokens, stores.Players, sessions,
+	))
 
 	if googleEnabled {
 		googleAuth := auth.NewGoogleAuthenticator(auth.GoogleConfig{

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -13,6 +13,7 @@ import (
 	sqlite3 "modernc.org/sqlite/lib"
 
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/database"
 	"github.com/starquake/topbanana/internal/db"
 )
 
@@ -299,6 +300,95 @@ func (s *PlayerStore) ClaimPlayerForOAuth(
 func (s *PlayerStore) MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID int64) error {
 	if _, err := s.q.MarkPlayerEmailVerifiedIfNew(ctx, playerID); err != nil {
 		return fmt.Errorf("failed to mark player email verified: %w", err)
+	}
+
+	return nil
+}
+
+// CreateVerifyToken inserts a row in email_verify_tokens with the given
+// hash, player id, and absolute expiry. expiresAt is normalised to UTC
+// so the driver's RFC3339 encoding lines up lexicographically with the
+// UTC clock the consume/sweep paths read - mixing offsets between
+// insert and read silently breaks the string comparison.
+func (s *PlayerStore) CreateVerifyToken(
+	ctx context.Context, tokenHash string, playerID int64, expiresAt time.Time,
+) error {
+	if err := s.q.CreateEmailVerifyToken(ctx, db.CreateEmailVerifyTokenParams{
+		TokenHash: tokenHash,
+		PlayerID:  playerID,
+		ExpiresAt: expiresAt.UTC(),
+	}); err != nil {
+		return fmt.Errorf("failed to create verify token: %w", err)
+	}
+
+	return nil
+}
+
+// ConsumeVerifyToken atomically marks the token row consumed and stamps
+// email_verified_at on the owning player. Returns the player id on
+// success, auth.ErrVerifyTokenAlreadyUsed if the row exists but was
+// already consumed (duplicate click on a stale link), and
+// auth.ErrVerifyTokenInvalid when no row matches (never existed, or
+// expired). Both branches keep the row in place; expired-but-consumed
+// cleanup happens via the sweep query at startup.
+func (s *PlayerStore) ConsumeVerifyToken(ctx context.Context, tokenHash string) (int64, error) {
+	var playerID int64
+	now := time.Now().UTC()
+	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		id, err := q.ConsumeEmailVerifyToken(ctx, db.ConsumeEmailVerifyTokenParams{
+			TokenHash:  tokenHash,
+			Now:        now,
+			ConsumedAt: sql.NullTime{Time: now, Valid: true},
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return classifyVerifyTokenMiss(ctx, q, tokenHash)
+			}
+
+			return fmt.Errorf("failed to consume verify token: %w", err)
+		}
+		if _, err := q.MarkPlayerEmailVerifiedIfNew(ctx, id); err != nil {
+			return fmt.Errorf("failed to stamp email_verified_at: %w", err)
+		}
+		playerID = id
+
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("consume verify token: %w", err)
+	}
+
+	return playerID, nil
+}
+
+// classifyVerifyTokenMiss disambiguates the UPDATE-no-rows case. The
+// row may exist with consumed_at set (legitimate duplicate click) or
+// not exist at all / be expired (invalid). A second SELECT inside the
+// same transaction is cheap and avoids leaking "expired vs consumed
+// vs never-existed" via response codes.
+func classifyVerifyTokenMiss(ctx context.Context, q *db.Queries, tokenHash string) error {
+	row, err := q.GetEmailVerifyToken(ctx, tokenHash)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return auth.ErrVerifyTokenInvalid
+		}
+
+		return fmt.Errorf("failed to look up verify token: %w", err)
+	}
+	if row.ConsumedAt.Valid {
+		return auth.ErrVerifyTokenAlreadyUsed
+	}
+
+	return auth.ErrVerifyTokenInvalid
+}
+
+// DeleteExpiredVerifyTokens drops expired rows from email_verify_tokens.
+// UTC across all sites that read or write expires_at so the driver's
+// RFC3339 encoding stays lexicographically comparable regardless of the
+// host time zone.
+func (s *PlayerStore) DeleteExpiredVerifyTokens(ctx context.Context) error {
+	if err := s.q.DeleteExpiredEmailVerifyTokens(ctx, time.Now().UTC()); err != nil {
+		return fmt.Errorf("failed to delete expired verify tokens: %w", err)
 	}
 
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,6 +26,7 @@ type Stores struct {
 	Players      auth.PlayerStore
 	OAuth        auth.OAuthIdentityStore
 	PlayerLister auth.PlayerLister
+	VerifyTokens auth.VerifyTokenStore
 	Home         home.Store
 }
 
@@ -45,6 +46,7 @@ func New(conn *sql.DB, logger *slog.Logger) *Stores {
 		Players:      players,
 		OAuth:        players,
 		PlayerLister: players,
+		VerifyTokens: players,
 		Home:         NewHomeStore(conn, logger),
 	}
 }

--- a/internal/web/tmpl/auth/pages/verify_email.gohtml
+++ b/internal/web/tmpl/auth/pages/verify_email.gohtml
@@ -1,0 +1,18 @@
+{{define "content"}}
+    <div class="auth-shell text-center">
+        <div class="mb-8 flex flex-col items-center gap-3">
+            <span class="w-9 h-9 inline-flex items-center justify-center text-accent drop-shadow-[0_0_8px_rgba(255,210,63,0.45)]" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-full h-full"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg>
+            </span>
+            <p class="m-0 font-display text-sm font-semibold uppercase tracking-[0.18em]">Top<span class="text-accent font-extrabold">Banana</span>!</p>
+        </div>
+
+        <p class="mb-3 font-display text-text-dim text-xs font-semibold uppercase tracking-[0.2em]">Email verification</p>
+        <h1 class="m-0 font-display font-extrabold leading-none uppercase tracking-tight text-[clamp(1.85rem,5.5vw,2.25rem)]">{{.Heading}}</h1>
+        <p class="mt-3 mb-6 text-text-dim text-[0.95rem]">{{.Message}}</p>
+
+        {{if .ShowContinue}}
+            <a href="{{.ContinueHref}}" class="btn-primary inline-flex">Continue</a>
+        {{end}}
+    </div>
+{{end}}

--- a/test/integration/verify_email_test.go
+++ b/test/integration/verify_email_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/mailer"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// TestVerifyEmail_RoundtripHappyPath covers the end-to-end happy path:
+// generate + persist a token via the store, hit GET /verify-email with
+// the raw token, observe the 200 + flashes-no-banner response, and
+// confirm the player's email_verified_at column got stamped.
+//
+// The HTTP register path is exercised in admin/auth tests already - this
+// test goes through the store directly so it can recover the raw token
+// the email link carries, which the hash-only DB column cannot reveal.
+func TestVerifyEmail_RoundtripHappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // test cleanup, error path is uninteresting.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "verify-happy", "verify-happy@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	if got := player.EmailVerifiedAt; got != nil {
+		t.Errorf("EmailVerifiedAt = %v, want nil before verify", got)
+	}
+
+	raw, hash, err := auth.GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if cerr := stores.VerifyTokens.CreateVerifyToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateVerifyToken err = %v, want nil", cerr)
+	}
+
+	resp := getVerifyEmail(ctx, t, srv.BaseURL, raw)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got := refreshed.EmailVerifiedAt; got == nil {
+		t.Error("EmailVerifiedAt = nil after verify, want stamped")
+	}
+}
+
+// TestVerifyEmail_DuplicateClickReadsAsAlreadyUsed pins the duplicate-click
+// branch: a second click on a freshly used link must render the
+// already-verified page, not an "invalid link" error, so a mail-client
+// prefetch followed by a user click does not look like a failure.
+func TestVerifyEmail_DuplicateClickReadsAsAlreadyUsed(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // test cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "verify-dupe", "verify-dupe@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if cerr := stores.VerifyTokens.CreateVerifyToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateVerifyToken err = %v, want nil", cerr)
+	}
+
+	first := getVerifyEmail(ctx, t, srv.BaseURL, raw)
+	first.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := first.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("first status = %d, want %d", got, want)
+	}
+
+	second := getVerifyEmail(ctx, t, srv.BaseURL, raw)
+	defer second.Body.Close() //nolint:errcheck // cleanup.
+	body, err := io.ReadAll(second.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+	if got, want := second.StatusCode, http.StatusOK; got != want {
+		t.Errorf("second status = %d, want %d", got, want)
+	}
+	if got, want := string(body), "Already verified"; !strings.Contains(got, want) {
+		t.Errorf("second body should contain %q", want)
+	}
+}
+
+// TestVerifyEmail_InvalidToken hits the no-row branch: an unknown token
+// hash returns 410 Gone with the "Link is no longer valid" page so the
+// caller can tell apart "this email is verified" from "your link is
+// junk" via the status code.
+func TestVerifyEmail_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+
+	resp := getVerifyEmail(ctx, t, srv.BaseURL, "not-a-real-token")
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusGone; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+// TestVerifyEmail_ExpiredToken hits the expired branch: a row whose
+// expires_at is in the past must read as "Link is no longer valid"
+// rather than letting the user complete verification on a stale link.
+func TestVerifyEmail_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // test cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "verify-expired", "verify-expired@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if cerr := stores.VerifyTokens.CreateVerifyToken(ctx, hash, player.ID, time.Now().Add(-time.Hour)); cerr != nil {
+		t.Fatalf("CreateVerifyToken err = %v, want nil", cerr)
+	}
+
+	resp := getVerifyEmail(ctx, t, srv.BaseURL, raw)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusGone; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got := refreshed.EmailVerifiedAt; got != nil {
+		t.Errorf("EmailVerifiedAt = %v, want nil after expired-token consume", got)
+	}
+}
+
+// TestSendVerifyEmail_RoundtripStoresAndSends covers SendVerifyEmail
+// against the real store + the diagnostics Tester wrapper. The
+// recorded send log must show one entry for the verify-email kind so
+// future "Recent send log" coverage on the admin page sees the row.
+func TestSendVerifyEmail_RoundtripStoresAndSends(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // test cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "verify-send", "verify-send@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+
+	tester := mailer.NewTester(mailer.NewNoop())
+	err = auth.SendVerifyEmail(
+		ctx, stores.VerifyTokens, tester,
+		"https://topbanana.example", player.Email, player.ID, time.Now(),
+	)
+	if got, want := err, mailer.ErrNotConfigured; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v (no-op mailer wraps to ErrNotConfigured)", got, want)
+	}
+	if got, want := tester.Count(), 1; got != want {
+		t.Errorf("tester.Count() = %d, want %d", got, want)
+	}
+}
+
+// openStores returns a fresh *sql.DB + store.Stores pointing at the
+// test server's DB. Used by the verify-email tests that need direct
+// store access to create + inspect the token + player rows.
+func openStores(t *testing.T, dbURI string) (*sql.DB, *store.Stores) {
+	t.Helper()
+	dbConn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+
+	return dbConn, store.New(dbConn, slog.Default())
+}
+
+// getVerifyEmail issues a single GET /verify-email?token=<raw> with a
+// fresh client (no cookies, no redirect following) so test cases stay
+// independent.
+func getVerifyEmail(ctx context.Context, t *testing.T, baseURL, raw string) *http.Response {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New err = %v, want nil", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	target := baseURL + "/verify-email?" + url.Values{"token": {raw}}.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+
+	return resp
+}


### PR DESCRIPTION
PR2 of three for #111. PR1 (#458) captured the email at register; this PR mints + sends the verification link and consumes it.

## What's in

- `email_verify_tokens` table keyed by sha256 of the raw token; the token itself never lives in the DB.
- `auth.GenerateVerifyToken` / `HashVerifyToken` / `SendVerifyEmail` / `SendVerifyEmailBestEffort` in `internal/auth/verify.go`.
- `GET /verify-email?token=...` consumes atomically and stamps `email_verified_at` in one transaction (`store.PlayerStore.ConsumeVerifyToken`). 200 on success / already-used, 410 on invalid or expired.
- Register handler now bundles its deps into `RegisterDeps`; on success it kicks off `SendVerifyEmail` on a background goroutine with a detached context so SMTP cannot block the redirect.
- Startup sweep wires `DeleteExpiredVerifyTokens` so the table cannot grow without bound.
- `Referrer-Policy: no-referrer` on the verify response so the raw token cannot leak via cross-origin asset fetches.
- Unit tests for token gen/hash/link, send happy path + store-failure swallow.
- Handler tests for missing/success/already-used/invalid branches.
- Integration tests for the store roundtrip, duplicate-click, invalid + expired tokens, and the SMTP-noop send roundtrip.

## What's deferred to PR3 (#69)

- The interstitial / route gate that bounces unverified signed-in players.
- The "resend verify email" flow.

Closes #111 will move to PR3.