### PR TITLE
Add password-reset token table and session_version column (#112 PR1 of 3)

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -328,6 +328,10 @@ func Run(
 		logger.WarnContext(signalCtx, "verify-token sweep at startup failed",
 			slog.Any("err", sweepErr))
 	}
+	if sweepErr := stores.ResetTokens.DeleteExpiredResetTokens(signalCtx); sweepErr != nil {
+		logger.WarnContext(signalCtx, "reset-token sweep at startup failed",
+			slog.Any("err", sweepErr))
+	}
 	gameService := game.NewService(stores.Games, stores.Quizzes, logger)
 	if cfg.RevealDelay > 0 {
 		gameService.SetRevealDelay(cfg.RevealDelay)

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -49,6 +49,10 @@ type Player struct {
 	Role            string
 	CreatedAt       time.Time
 	UsernameClaimed bool
+	// SessionVersion is bumped on password reset so every in-flight
+	// cookie (which carries the version it was issued at) becomes
+	// invalid the moment the reset commits (#112).
+	SessionVersion int64
 }
 
 // IsEmailVerified reports whether the player's email has been verified.

--- a/internal/auth/reset.go
+++ b/internal/auth/reset.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// ResetTokenTTL is the lifetime of a forgot-password link. Shorter than
+// the verify TTL: a reset token grants password rotation, so the
+// blast-radius of a leaked link is higher and the convenience of a
+// long-lived link is lower (users typically click within minutes).
+const ResetTokenTTL = 30 * time.Minute
+
+// ErrResetTokenInvalid is returned by ConsumeResetToken when the
+// supplied token does not match a live row (never existed, expired,
+// or already consumed). Reset tokens are single-use by design, so
+// there is no "already consumed" distinction surfaced to the caller -
+// the safer UX is to render a single "this link is no longer valid"
+// page and let the user request a new one.
+var ErrResetTokenInvalid = errors.New("reset token invalid")
+
+// ResetTokenStore persists password-reset tokens. Implemented by
+// store.PlayerStore against the real DB; the interface lives here so
+// the auth package can drive the forgot-password flow without a direct
+// import of the storage layer.
+type ResetTokenStore interface {
+	// CreateResetToken records the sha256 hex of a freshly minted
+	// token. The raw token is never stored - a DB leak should not be
+	// replayable.
+	CreateResetToken(ctx context.Context, tokenHash string, playerID int64, expiresAt time.Time) error
+	// ConsumeResetToken atomically marks the row consumed, rotates the
+	// player's password_hash, and bumps session_version in the same
+	// transaction. Returns the player id on success and
+	// ErrResetTokenInvalid when no live row matches. The session_version
+	// bump invalidates every other in-flight cookie the moment the
+	// transaction commits (#112).
+	ConsumeResetToken(ctx context.Context, tokenHash, newPasswordHash string) (int64, error)
+	// DeleteExpiredResetTokens removes rows whose expires_at has
+	// passed. Called from the startup sweep so the table cannot grow
+	// without bound on a long-running deploy.
+	DeleteExpiredResetTokens(ctx context.Context) error
+}
+
+// GenerateResetToken returns a freshly minted (raw, hash) pair. Same
+// shape as GenerateVerifyToken so the email-link UX is uniform: 32
+// random bytes, URL-safe base64, sha256-hex hash for storage.
+func GenerateResetToken() (raw, hash string, err error) {
+	return GenerateVerifyToken()
+}
+
+// HashResetToken returns the lowercase-hex sha256 of a raw reset
+// token. Alias for HashVerifyToken so callers reading the reset code
+// path do not have to cross into the verify package.
+func HashResetToken(raw string) string {
+	return HashVerifyToken(raw)
+}
+
+// SendResetEmail mints a token, persists the hash, and dispatches the
+// forgot-password email. Mirrors SendVerifyEmail in shape but uses the
+// reset link path and the shorter TTL so the two flows cannot be
+// confused at the call sites. A mailer failure surfaces verbatim to
+// the caller so the forgot-password handler can flash a meaningful
+// (but still account-existence-opaque) message.
+func SendResetEmail(
+	ctx context.Context,
+	tokens ResetTokenStore,
+	sender VerifyEmailSender,
+	baseURL, recipient string,
+	playerID int64,
+	now time.Time,
+) error {
+	raw, hash, err := GenerateResetToken()
+	if err != nil {
+		return err
+	}
+	link, err := buildResetLink(baseURL, raw)
+	if err != nil {
+		return err
+	}
+	expiresAt := now.Add(ResetTokenTTL)
+	if storeErr := tokens.CreateResetToken(ctx, hash, playerID, expiresAt); storeErr != nil {
+		return fmt.Errorf("reset token: store: %w", storeErr)
+	}
+	msg := mailer.Message{
+		To:      recipient,
+		Subject: "Reset your Top Banana password",
+		Body:    resetEmailBody(link),
+		Kind:    mailer.KindReset,
+	}
+	if sendErr := sender.Send(ctx, msg); sendErr != nil {
+		return fmt.Errorf("reset token: send: %w", sendErr)
+	}
+
+	return nil
+}
+
+// buildResetLink composes the absolute reset URL. Same validation as
+// buildVerifyLink: fail loudly when BASE_URL is missing or
+// shape-malformed so a misconfigured deploy does not silently produce
+// a link the user cannot click.
+func buildResetLink(baseURL, rawToken string) (string, error) {
+	if baseURL == "" {
+		return "", errVerifyBaseURLEmpty
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("reset token: parse base url %q: %w", baseURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("%w: %q", errVerifyBaseURLInvalid, baseURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/reset-password"
+	q := u.Query()
+	q.Set("token", rawToken)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// resetEmailBody is the plain-text body of the reset email. Mirrors
+// the verify body shape so the two channels read consistently.
+func resetEmailBody(link string) string {
+	return "We received a request to reset your Top Banana password.\n\n" +
+		"Click the link below to choose a new one:\n\n" +
+		link + "\n\n" +
+		"This link is valid for 30 minutes. If you did not request a reset,\n" +
+		"you can ignore this email.\n"
+}

--- a/internal/auth/reset_test.go
+++ b/internal/auth/reset_test.go
@@ -1,0 +1,154 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/mailer"
+)
+
+func TestGenerateResetToken_PairMatches(t *testing.T) {
+	t.Parallel()
+
+	raw, hash, err := GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if got, want := hash, HashResetToken(raw); got != want {
+		t.Errorf("HashResetToken(raw) = %q, want %q", got, want)
+	}
+}
+
+func TestSendResetEmail_StoresAndSends(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingResetTokenStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendResetEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", 42, now)
+	if err != nil {
+		t.Fatalf("SendResetEmail err = %v, want nil", err)
+	}
+
+	if got, want := len(tokens.created), 1; got != want {
+		t.Fatalf("tokens.created len = %d, want %d", got, want)
+	}
+	rec := tokens.created[0]
+	if got, want := rec.playerID, int64(42); got != want {
+		t.Errorf("CreateResetToken playerID = %d, want %d", got, want)
+	}
+	if got, want := rec.expiresAt, now.Add(ResetTokenTTL); !got.Equal(want) {
+		t.Errorf("CreateResetToken expiresAt = %v, want %v", got, want)
+	}
+	if got, want := len(rec.tokenHash), 64; got != want {
+		t.Errorf("CreateResetToken tokenHash len = %d, want %d", got, want)
+	}
+
+	if got, want := len(mailerStub.sent), 1; got != want {
+		t.Fatalf("mailer.sent len = %d, want %d", got, want)
+	}
+	msg := mailerStub.sent[0]
+	if got, want := msg.To, "alice@example.test"; got != want {
+		t.Errorf("msg.To = %q, want %q", got, want)
+	}
+	if got, want := msg.Kind, mailer.KindReset; got != want {
+		t.Errorf("msg.Kind = %q, want %q", got, want)
+	}
+	if !strings.Contains(msg.Body, "https://topbanana.example/reset-password?token=") {
+		t.Errorf("msg.Body missing reset link, got %q", msg.Body)
+	}
+}
+
+func TestSendResetEmail_StoreFailureSkipsSend(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("disk full")
+	tokens := &recordingResetTokenStore{createErr: wantErr}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendResetEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", 1, now)
+	if got, want := err, wantErr; !errors.Is(got, want) {
+		t.Errorf("err = %v, want wrapping %v", got, want)
+	}
+	if got, want := len(mailerStub.sent), 0; got != want {
+		t.Errorf("mailer.sent len = %d, want %d (store failure must not send)", got, want)
+	}
+}
+
+func TestBuildResetLink_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// BuildResetLink is exercised indirectly through SendResetEmail's
+	// body assertion, but we want a direct path-shape test too.
+	tokens := &recordingResetTokenStore{}
+	mailerStub := &recordingSender{}
+	if err := SendResetEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "x@example.test", 1, time.Now()); err != nil {
+		t.Fatalf("SendResetEmail err = %v, want nil", err)
+	}
+	body := mailerStub.sent[0].Body
+	// Parse the embedded link to confirm the shape: scheme + host +
+	// /reset-password path + token query.
+	start := strings.Index(body, "https://")
+	if start < 0 {
+		t.Fatalf("body has no https:// link, got %q", body)
+	}
+	end := strings.Index(body[start:], "\n")
+	if end < 0 {
+		t.Fatalf("body link not terminated by newline, got %q", body)
+	}
+	link := body[start : start+end]
+	u, err := url.Parse(link)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) err = %v, want nil", link, err)
+	}
+	if got, want := u.Path, "/reset-password"; got != want {
+		t.Errorf("link.Path = %q, want %q", got, want)
+	}
+	if got := u.Query().Get("token"); got == "" {
+		t.Error("link query missing token")
+	}
+}
+
+type recordingResetTokenStore struct {
+	created   []createResetTokenCall
+	createErr error
+}
+
+type createResetTokenCall struct {
+	tokenHash string
+	playerID  int64
+	expiresAt time.Time
+}
+
+func (s *recordingResetTokenStore) CreateResetToken(
+	_ context.Context, tokenHash string, playerID int64, expiresAt time.Time,
+) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, createResetTokenCall{
+		tokenHash: tokenHash,
+		playerID:  playerID,
+		expiresAt: expiresAt,
+	})
+
+	return nil
+}
+
+func (*recordingResetTokenStore) ConsumeResetToken(_ context.Context, _, _ string) (int64, error) {
+	return 0, errors.ErrUnsupported
+}
+
+func (*recordingResetTokenStore) DeleteExpiredResetTokens(_ context.Context) error {
+	return nil
+}

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -317,7 +317,7 @@ func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlaye
 }
 
 const getPlayer = `-- name: GetPlayer :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 FROM players
 WHERE id = ?
 `
@@ -334,6 +334,7 @@ func (q *Queries) GetPlayer(ctx context.Context, id int64) (Player, error) {
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -71,6 +71,14 @@ type Option struct {
 	IsCorrect  bool
 }
 
+type PasswordResetToken struct {
+	TokenHash  string
+	PlayerID   int64
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	ConsumedAt sql.NullTime
+}
+
 type Player struct {
 	ID              int64
 	Username        string
@@ -80,6 +88,7 @@ type Player struct {
 	CreatedAt       time.Time
 	UsernameClaimed int64
 	EmailVerifiedAt sql.NullTime
+	SessionVersion  int64
 }
 
 type PlayerIdentity struct {

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -30,7 +30,7 @@ SET username = ?1,
 WHERE players.id = ?5
   AND players.password_hash IS NULL
   AND players.email IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type ClaimPlayerParams struct {
@@ -79,6 +79,7 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -98,7 +99,7 @@ SET email = ?1,
 WHERE players.id = ?2
   AND players.password_hash IS NULL
   AND players.email IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type ClaimPlayerForOAuthParams struct {
@@ -138,6 +139,7 @@ func (q *Queries) ClaimPlayerForOAuth(ctx context.Context, arg ClaimPlayerForOAu
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -173,6 +175,35 @@ func (q *Queries) ConsumeEmailVerifyToken(ctx context.Context, arg ConsumeEmailV
 	return player_id, err
 }
 
+const consumePasswordResetToken = `-- name: ConsumePasswordResetToken :one
+UPDATE password_reset_tokens
+SET consumed_at = ?1
+WHERE token_hash = ?2
+  AND consumed_at IS NULL
+  AND expires_at > ?3
+RETURNING player_id
+`
+
+type ConsumePasswordResetTokenParams struct {
+	ConsumedAt sql.NullTime
+	TokenHash  string
+	Now        time.Time
+}
+
+// Atomic consume: succeeds only when the row is still unconsumed and
+// not expired. Returns the player_id so the caller can stamp the new
+// password_hash + bump session_version in the same transaction. The
+// caller passes 'now' on both sides so the comparison runs in the
+// driver's RFC3339 encoding (same gotcha email_verify_tokens dodged).
+// sql.ErrNoRows means consumed, expired, or never existed; the caller
+// maps that to a single user-facing "link is no longer valid" response.
+func (q *Queries) ConsumePasswordResetToken(ctx context.Context, arg ConsumePasswordResetTokenParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, consumePasswordResetToken, arg.ConsumedAt, arg.TokenHash, arg.Now)
+	var player_id int64
+	err := row.Scan(&player_id)
+	return player_id, err
+}
+
 const countAllPlayers = `-- name: CountAllPlayers :one
 SELECT COUNT(*) FROM players
 `
@@ -188,7 +219,7 @@ func (q *Queries) CountAllPlayers(ctx context.Context) (int64, error) {
 const createAnonymousPlayer = `-- name: CreateAnonymousPlayer :one
 INSERT INTO players (username, role)
 VALUES (?1, 'player')
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 // Used by the EnsurePlayer middleware to back a fresh visitor with a real
@@ -212,6 +243,7 @@ func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (P
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -235,6 +267,25 @@ func (q *Queries) CreateEmailVerifyToken(ctx context.Context, arg CreateEmailVer
 	return err
 }
 
+const createPasswordResetToken = `-- name: CreatePasswordResetToken :exec
+INSERT INTO password_reset_tokens (token_hash, player_id, expires_at)
+VALUES (?1, ?2, ?3)
+`
+
+type CreatePasswordResetTokenParams struct {
+	TokenHash string
+	PlayerID  int64
+	ExpiresAt time.Time
+}
+
+// Stores the sha256 hash of a freshly minted reset-password token. The
+// raw token only exists on the way out the door in the email; a DB leak
+// should not be replayable against POST /reset-password.
+func (q *Queries) CreatePasswordResetToken(ctx context.Context, arg CreatePasswordResetTokenParams) error {
+	_, err := q.db.ExecContext(ctx, createPasswordResetToken, arg.TokenHash, arg.PlayerID, arg.ExpiresAt)
+	return err
+}
+
 const createPlayerFromOAuth = `-- name: CreatePlayerFromOAuth :one
 INSERT INTO players (username, email, email_verified_at, role, username_claimed)
 VALUES (
@@ -251,7 +302,7 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type CreatePlayerFromOAuthParams struct {
@@ -286,6 +337,7 @@ func (q *Queries) CreatePlayerFromOAuth(ctx context.Context, arg CreatePlayerFro
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -307,7 +359,7 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type CreatePlayerWithCredentialsParams struct {
@@ -352,6 +404,7 @@ func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePla
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -367,6 +420,19 @@ WHERE expires_at <= ?1
 // (see the ConsumeEmailVerifyToken note above).
 func (q *Queries) DeleteExpiredEmailVerifyTokens(ctx context.Context, now time.Time) error {
 	_, err := q.db.ExecContext(ctx, deleteExpiredEmailVerifyTokens, now)
+	return err
+}
+
+const deleteExpiredPasswordResetTokens = `-- name: DeleteExpiredPasswordResetTokens :exec
+DELETE FROM password_reset_tokens
+WHERE expires_at <= ?1
+`
+
+// Housekeeping for the startup sweep. UTC across the wire so the
+// comparison stays lexicographically sane regardless of the host
+// timezone.
+func (q *Queries) DeleteExpiredPasswordResetTokens(ctx context.Context, now time.Time) error {
+	_, err := q.db.ExecContext(ctx, deleteExpiredPasswordResetTokens, now)
 	return err
 }
 
@@ -392,8 +458,30 @@ func (q *Queries) GetEmailVerifyToken(ctx context.Context, tokenHash string) (Em
 	return i, err
 }
 
+const getPasswordResetToken = `-- name: GetPasswordResetToken :one
+SELECT token_hash, player_id, created_at, expires_at, consumed_at
+FROM password_reset_tokens
+WHERE token_hash = ?1
+LIMIT 1
+`
+
+// Look up a reset row by hash. Returned regardless of consumed_at /
+// expires_at - the caller decides whether to treat it as live.
+func (q *Queries) GetPasswordResetToken(ctx context.Context, tokenHash string) (PasswordResetToken, error) {
+	row := q.db.QueryRowContext(ctx, getPasswordResetToken, tokenHash)
+	var i PasswordResetToken
+	err := row.Scan(
+		&i.TokenHash,
+		&i.PlayerID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ConsumedAt,
+	)
+	return i, err
+}
+
 const getPlayerByEmail = `-- name: GetPlayerByEmail :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 FROM players
 WHERE email = ?
 LIMIT 1
@@ -415,12 +503,13 @@ func (q *Queries) GetPlayerByEmail(ctx context.Context, email sql.NullString) (P
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
 
 const getPlayerByProviderSubject = `-- name: GetPlayerByProviderSubject :one
-SELECT p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at
+SELECT p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at, p.session_version
 FROM players p
 JOIN player_identities pi ON pi.player_id = p.id
 WHERE pi.provider = ? AND pi.subject = ?
@@ -448,12 +537,13 @@ func (q *Queries) GetPlayerByProviderSubject(ctx context.Context, arg GetPlayerB
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
 
 const getPlayerByUsername = `-- name: GetPlayerByUsername :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 FROM players
 WHERE username = ?
 LIMIT 1
@@ -471,6 +561,7 @@ func (q *Queries) GetPlayerByUsername(ctx context.Context, username string) (Pla
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -498,7 +589,7 @@ func (q *Queries) LinkProviderIdentity(ctx context.Context, arg LinkProviderIden
 
 const listAllPlayers = `-- name: ListAllPlayers :many
 SELECT
-    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at,
+    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at, p.session_version,
     EXISTS (SELECT 1 FROM player_identities pi WHERE pi.player_id = p.id) AS has_oauth,
     CAST(COALESCE((SELECT pi.provider FROM player_identities pi WHERE pi.player_id = p.id ORDER BY pi.provider LIMIT 1), '') AS TEXT) AS oauth_provider
 FROM players p
@@ -520,6 +611,7 @@ type ListAllPlayersRow struct {
 	CreatedAt       time.Time
 	UsernameClaimed int64
 	EmailVerifiedAt sql.NullTime
+	SessionVersion  int64
 	HasOauth        bool
 	OauthProvider   string
 }
@@ -554,6 +646,7 @@ func (q *Queries) ListAllPlayers(ctx context.Context, arg ListAllPlayersParams) 
 			&i.CreatedAt,
 			&i.UsernameClaimed,
 			&i.EmailVerifiedAt,
+			&i.SessionVersion,
 			&i.HasOauth,
 			&i.OauthProvider,
 		); err != nil {
@@ -657,7 +750,7 @@ UPDATE players
 SET username = ?1,
     username_claimed = 1
 WHERE id = ?2
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type RenamePlayerParams struct {
@@ -689,8 +782,35 @@ func (q *Queries) RenamePlayer(ctx context.Context, arg RenamePlayerParams) (Pla
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
+}
+
+const resetPlayerPassword = `-- name: ResetPlayerPassword :execrows
+UPDATE players
+SET password_hash = ?1,
+    session_version = session_version + 1
+WHERE id = ?2
+`
+
+type ResetPlayerPasswordParams struct {
+	PasswordHash sql.NullString
+	ID           int64
+}
+
+// Atomically rotates password_hash and bumps session_version on the
+// given row. The session_version increment is the security-critical
+// part: every in-flight cookie carries the version it was issued at,
+// so a bump invalidates every other session the moment this commits.
+// Returns the number of affected rows; the caller checks for >0 to
+// distinguish a successful reset from a player_id pointing nowhere.
+func (q *Queries) ResetPlayerPassword(ctx context.Context, arg ResetPlayerPasswordParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, resetPlayerPassword, arg.PasswordHash, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const setPlayerPasswordHash = `-- name: SetPlayerPasswordHash :execrows
@@ -730,7 +850,7 @@ UPDATE players
 SET username = ?1,
     username_claimed = 1
 WHERE id = ?2 AND password_hash IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at
+RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version
 `
 
 type UpdatePlayerUsernameParams struct {
@@ -762,6 +882,7 @@ func (q *Queries) UpdatePlayerUsername(ctx context.Context, arg UpdatePlayerUser
 		&i.CreatedAt,
 		&i.UsernameClaimed,
 		&i.EmailVerifiedAt,
+		&i.SessionVersion,
 	)
 	return i, err
 }

--- a/internal/migrations/20260527160000_add_password_reset_tokens.sql
+++ b/internal/migrations/20260527160000_add_password_reset_tokens.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- password_reset_tokens carries the per-link state for the forgot-password
+-- flow (#112). Mirrors email_verify_tokens but stays a separate table so
+-- the two flows can diverge on TTL and consume semantics: verify links are
+-- 24h and idempotent; reset links are 30min and single-use, atomic with
+-- the password rotation. The token itself is never stored - only its
+-- sha256 hash, so a DB leak cannot be replayed against the consume
+-- endpoint. ON DELETE CASCADE keeps the table tidy when a player row is
+-- removed.
+-- +goose StatementBegin
+CREATE TABLE password_reset_tokens
+(
+    token_hash  TEXT     PRIMARY KEY,
+    player_id   INTEGER  NOT NULL REFERENCES players (id) ON DELETE CASCADE,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at  DATETIME NOT NULL,
+    consumed_at DATETIME
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX password_reset_tokens_player_id_idx ON password_reset_tokens (player_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX password_reset_tokens_player_id_idx;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE password_reset_tokens;
+-- +goose StatementEnd

--- a/internal/migrations/20260527170000_add_session_version.sql
+++ b/internal/migrations/20260527170000_add_session_version.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- session_version backs the post-reset session-invalidation rule
+-- (#112): the password reset handler bumps this counter and the
+-- session cookie carries the value it was issued with, so every
+-- in-flight cookie minted before the reset becomes invalid the moment
+-- the counter changes. NOT NULL DEFAULT 0 so existing rows have a
+-- well-defined starting value; pre-deploy session cookies decode with
+-- an implicit version=0 (per the session module's backwards-compatible
+-- parser) so they continue to validate until the first reset.
+-- +goose StatementBegin
+ALTER TABLE players ADD COLUMN session_version INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE players DROP COLUMN session_version;
+-- +goose StatementEnd

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -348,3 +348,52 @@ RETURNING player_id;
 -- (see the ConsumeEmailVerifyToken note above).
 DELETE FROM email_verify_tokens
 WHERE expires_at <= sqlc.arg('now');
+
+-- name: CreatePasswordResetToken :exec
+-- Stores the sha256 hash of a freshly minted reset-password token. The
+-- raw token only exists on the way out the door in the email; a DB leak
+-- should not be replayable against POST /reset-password.
+INSERT INTO password_reset_tokens (token_hash, player_id, expires_at)
+VALUES (sqlc.arg('token_hash'), sqlc.arg('player_id'), sqlc.arg('expires_at'));
+
+-- name: GetPasswordResetToken :one
+-- Look up a reset row by hash. Returned regardless of consumed_at /
+-- expires_at - the caller decides whether to treat it as live.
+SELECT *
+FROM password_reset_tokens
+WHERE token_hash = sqlc.arg('token_hash')
+LIMIT 1;
+
+-- name: ConsumePasswordResetToken :one
+-- Atomic consume: succeeds only when the row is still unconsumed and
+-- not expired. Returns the player_id so the caller can stamp the new
+-- password_hash + bump session_version in the same transaction. The
+-- caller passes 'now' on both sides so the comparison runs in the
+-- driver's RFC3339 encoding (same gotcha email_verify_tokens dodged).
+-- sql.ErrNoRows means consumed, expired, or never existed; the caller
+-- maps that to a single user-facing "link is no longer valid" response.
+UPDATE password_reset_tokens
+SET consumed_at = sqlc.arg('consumed_at')
+WHERE token_hash = sqlc.arg('token_hash')
+  AND consumed_at IS NULL
+  AND expires_at > sqlc.arg('now')
+RETURNING player_id;
+
+-- name: DeleteExpiredPasswordResetTokens :exec
+-- Housekeeping for the startup sweep. UTC across the wire so the
+-- comparison stays lexicographically sane regardless of the host
+-- timezone.
+DELETE FROM password_reset_tokens
+WHERE expires_at <= sqlc.arg('now');
+
+-- name: ResetPlayerPassword :execrows
+-- Atomically rotates password_hash and bumps session_version on the
+-- given row. The session_version increment is the security-critical
+-- part: every in-flight cookie carries the version it was issued at,
+-- so a bump invalidates every other session the moment this commits.
+-- Returns the number of affected rows; the caller checks for >0 to
+-- distinguish a successful reset from a player_id pointing nowhere.
+UPDATE players
+SET password_hash = sqlc.arg('password_hash'),
+    session_version = session_version + 1
+WHERE id = sqlc.arg('id');

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -394,6 +394,81 @@ func (s *PlayerStore) DeleteExpiredVerifyTokens(ctx context.Context) error {
 	return nil
 }
 
+// CreateResetToken inserts a row in password_reset_tokens with the
+// given hash, player id, and absolute expiry. expiresAt is normalised
+// to UTC so the driver's RFC3339 encoding lines up lexicographically
+// with the UTC clock the consume/sweep paths read - mixing offsets
+// between insert and read silently breaks the string comparison.
+func (s *PlayerStore) CreateResetToken(
+	ctx context.Context, tokenHash string, playerID int64, expiresAt time.Time,
+) error {
+	if err := s.q.CreatePasswordResetToken(ctx, db.CreatePasswordResetTokenParams{
+		TokenHash: tokenHash,
+		PlayerID:  playerID,
+		ExpiresAt: expiresAt.UTC(),
+	}); err != nil {
+		return fmt.Errorf("failed to create reset token: %w", err)
+	}
+
+	return nil
+}
+
+// ConsumeResetToken atomically marks the reset row consumed, rotates
+// password_hash, and bumps session_version - all in one transaction
+// so a crash mid-flow cannot leave a player with a consumed token but
+// an old password, nor a new password with old sessions still live.
+// Returns the player id on success, auth.ErrResetTokenInvalid when no
+// live row matches (never existed, expired, or already consumed).
+func (s *PlayerStore) ConsumeResetToken(
+	ctx context.Context, tokenHash, newPasswordHash string,
+) (int64, error) {
+	var playerID int64
+	now := time.Now().UTC()
+	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		id, err := q.ConsumePasswordResetToken(ctx, db.ConsumePasswordResetTokenParams{
+			TokenHash:  tokenHash,
+			Now:        now,
+			ConsumedAt: sql.NullTime{Time: now, Valid: true},
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return auth.ErrResetTokenInvalid
+			}
+
+			return fmt.Errorf("failed to consume reset token: %w", err)
+		}
+		rows, err := q.ResetPlayerPassword(ctx, db.ResetPlayerPasswordParams{
+			ID:           id,
+			PasswordHash: sql.NullString{String: newPasswordHash, Valid: true},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to rotate password: %w", err)
+		}
+		if rows == 0 {
+			return auth.ErrResetTokenInvalid
+		}
+		playerID = id
+
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("consume reset token: %w", err)
+	}
+
+	return playerID, nil
+}
+
+// DeleteExpiredResetTokens drops expired rows from password_reset_tokens.
+// UTC mirrors the email-verify sweep so the lexicographic comparison
+// stays consistent across the host timezone.
+func (s *PlayerStore) DeleteExpiredResetTokens(ctx context.Context) error {
+	if err := s.q.DeleteExpiredPasswordResetTokens(ctx, time.Now().UTC()); err != nil {
+		return fmt.Errorf("failed to delete expired reset tokens: %w", err)
+	}
+
+	return nil
+}
+
 // LinkProviderIdentity inserts a player_identities row tying the given
 // player to the (provider, subject) pair. Returns
 // auth.ErrIdentityAlreadyLinked when the UNIQUE (provider, subject)
@@ -601,6 +676,7 @@ func playerFromRow(row db.Player) *auth.Player {
 		Role:            row.Role,
 		CreatedAt:       row.CreatedAt,
 		UsernameClaimed: row.UsernameClaimed != 0,
+		SessionVersion:  row.SessionVersion,
 	}
 	if row.Email.Valid {
 		p.Email = row.Email.String

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,6 +27,7 @@ type Stores struct {
 	OAuth        auth.OAuthIdentityStore
 	PlayerLister auth.PlayerLister
 	VerifyTokens auth.VerifyTokenStore
+	ResetTokens  auth.ResetTokenStore
 	Home         home.Store
 }
 
@@ -47,6 +48,7 @@ func New(conn *sql.DB, logger *slog.Logger) *Stores {
 		OAuth:        players,
 		PlayerLister: players,
 		VerifyTokens: players,
+		ResetTokens:  players,
 		Home:         NewHomeStore(conn, logger),
 	}
 }

--- a/test/integration/reset_token_store_test.go
+++ b/test/integration/reset_token_store_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+// TestResetTokenStore_RoundtripHappyPath covers the store-level
+// roundtrip for the #112 reset-token table: mint a token, persist its
+// hash, then consume it. The consume call rotates password_hash AND
+// bumps session_version atomically; both effects are observed via a
+// follow-up GetPlayerByID.
+func TestResetTokenStore_RoundtripHappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "reset-happy", "reset-happy@example.test", "old-hash", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	startingVersion := player.SessionVersion
+
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	gotID, err := stores.ResetTokens.ConsumeResetToken(ctx, auth.HashResetToken(raw), "new-hash")
+	if err != nil {
+		t.Fatalf("ConsumeResetToken err = %v, want nil", err)
+	}
+	if got, want := gotID, player.ID; got != want {
+		t.Errorf("ConsumeResetToken playerID = %d, want %d", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := refreshed.PasswordHash, "new-hash"; got != want {
+		t.Errorf("password_hash = %q, want %q", got, want)
+	}
+	if got, want := refreshed.SessionVersion, startingVersion+1; got != want {
+		t.Errorf("session_version = %d, want %d (bump on reset)", got, want)
+	}
+}
+
+// TestResetTokenStore_ReplayRejectsConsumedToken pins single-use: a
+// second consume against the same hash returns ErrResetTokenInvalid
+// and leaves the player row untouched.
+func TestResetTokenStore_ReplayRejectsConsumedToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "reset-replay", "reset-replay@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	if _, cerr := stores.ResetTokens.ConsumeResetToken(ctx, auth.HashResetToken(raw), "first"); cerr != nil {
+		t.Fatalf("first consume err = %v, want nil", cerr)
+	}
+	_, cerr := stores.ResetTokens.ConsumeResetToken(ctx, auth.HashResetToken(raw), "second")
+	if got, want := cerr, auth.ErrResetTokenInvalid; !errors.Is(got, want) {
+		t.Errorf("second consume err = %v, want %v", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := refreshed.PasswordHash, "first"; got != want {
+		t.Errorf("password_hash = %q, want %q (replay must not overwrite)", got, want)
+	}
+}
+
+// TestResetTokenStore_ExpiredTokenRejected pins the expires_at check:
+// a token whose expires_at is in the past consumes as invalid and
+// leaves password_hash + session_version untouched.
+func TestResetTokenStore_ExpiredTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "reset-expired", "reset-expired@example.test", "old", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	startingVersion := player.SessionVersion
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(-time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	_, cerr := stores.ResetTokens.ConsumeResetToken(ctx, auth.HashResetToken(raw), "new")
+	if got, want := cerr, auth.ErrResetTokenInvalid; !errors.Is(got, want) {
+		t.Errorf("expired consume err = %v, want %v", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := refreshed.PasswordHash, "old"; got != want {
+		t.Errorf("password_hash = %q, want %q (expired must not overwrite)", got, want)
+	}
+	if got, want := refreshed.SessionVersion, startingVersion; got != want {
+		t.Errorf("session_version = %d, want %d (expired must not bump)", got, want)
+	}
+}
+
+// TestResetTokenStore_InvalidHashRejected covers the no-row branch.
+func TestResetTokenStore_InvalidHashRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	_, cerr := stores.ResetTokens.ConsumeResetToken(ctx, "no-such-hash", "new")
+	if got, want := cerr, auth.ErrResetTokenInvalid; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
PR1 of three for #112. Schema + plumbing only - no observable behaviour change. PR2 will add the forgot-password endpoint, PR3 the reset-password endpoint plus the session-version cookie format that actually invalidates live sessions on reset.

## What's in

- New \`password_reset_tokens\` table (token_hash, player_id, created_at, expires_at, consumed_at). Same shape as \`email_verify_tokens\` but kept separate so the two flows can diverge on TTL (24 h vs 30 min) and consume semantics (idempotent vs single-use).
- New \`session_version INTEGER NOT NULL DEFAULT 0\` column on \`players\`. PR3 wires this into the session cookie so password reset bumps it and every other in-flight cookie becomes invalid.
- Backfill of the seed admin migration already-merged: nothing new for that here.
- \`auth.GenerateResetToken\` / \`HashResetToken\` (renames of the verify equivalents so reset call sites read in their own domain), \`SendResetEmail\`, \`ResetTokenStore\` interface, \`ErrResetTokenInvalid\` sentinel.
- \`store.PlayerStore\` gains \`CreateResetToken\`, \`ConsumeResetToken\` (atomic: consume + rotate password_hash + bump session_version in one tx), \`DeleteExpiredResetTokens\`.
- Startup sweep wires \`DeleteExpiredResetTokens\` alongside the verify-token sweep so the table cannot grow without bound.
- \`auth.Player\` gains \`SessionVersion int64\`; \`playerFromRow\` populates it.
- Unit tests for token gen + send (happy path, store-failure swallow). Integration tests for store roundtrip: happy path, replay rejection, expired-token rejection, unknown-hash rejection.
- Reuses the SMTP transport already shipped via #321 - no new mailer wiring.

## Out of scope (PR2 / PR3)

- GET/POST \`/forgot-password\` form + dispatch (PR2).
- GET/POST \`/reset-password\` form + consume (PR3).
- Session cookie format change to carry \`session_version\` (PR3) - until PR3 lands the column is read-only.
- Rate limiting on \`/forgot-password\` (PR2; reuse the verify-resend limiter pattern).