### PR TITLE
Consume reset tokens and invalidate live sessions on reset (#112 PR3 of 3)

### DIFF
--- a/internal/auth/forgot_test.go
+++ b/internal/auth/forgot_test.go
@@ -37,7 +37,7 @@ func TestHandleForgotForm_SignedInRedirectsToLanding(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/forgot-password", nil)
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, p.ID)
+	sessions.Set(rec, p.ID, p.SessionVersion)
 	req.AddCookie(extractSessionCookie(rec))
 	rec = httptest.NewRecorder()
 

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -204,7 +204,7 @@ func HandleGoogleCallback(
 			return
 		}
 
-		sessions.Set(w, player.ID)
+		sessions.Set(w, player.ID, player.SessionVersion)
 		migrateGamesAfterSignIn(r.Context(), logger, players, games, sessionPlayerID, player.ID)
 		target := next
 		if target == "" {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -198,7 +198,7 @@ func HandleRegisterSubmit(
 		}
 
 		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail)
-		sessions.Set(w, player.ID)
+		sessions.Set(w, player.ID, player.SessionVersion)
 		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 	})
 }
@@ -455,7 +455,7 @@ func HandleLoginSubmit(
 		if id, ok := sessions.PlayerID(r); ok {
 			priorSessionPlayerID = &id
 		}
-		sessions.Set(w, player.ID)
+		sessions.Set(w, player.ID, player.SessionVersion)
 		migrateGamesAfterSignIn(r.Context(), logger, players, games, priorSessionPlayerID, player.ID)
 		redirectAfterLogin(w, r, player.Role)
 	})

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -589,7 +589,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 
 	// Build a request that already carries the anonymous session cookie.
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, anon.ID)
+	sessions.Set(rec, anon.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
@@ -652,7 +652,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, anon.ID)
+	sessions.Set(rec, anon.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
@@ -713,7 +713,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, anon.ID) // cookie still points at the now-claimed row
+	sessions.Set(rec, anon.ID, 0) // cookie still points at the now-claimed row
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
@@ -848,7 +848,7 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, player.ID)
+	sessions.Set(rec, player.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
@@ -880,7 +880,7 @@ func TestHandleLoginForm_AnonymousSession_RendersForm(t *testing.T) {
 	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, anon.ID)
+	sessions.Set(rec, anon.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -58,7 +58,7 @@ func EnsurePlayer(next http.Handler, players PlayerStore, sessions *session.Mana
 			return
 		}
 
-		sessions.Set(w, player.ID)
+		sessions.Set(w, player.ID, player.SessionVersion)
 		next.ServeHTTP(w, r.WithContext(WithPlayer(r.Context(), player)))
 	})
 }
@@ -66,10 +66,12 @@ func EnsurePlayer(next http.Handler, players PlayerStore, sessions *session.Mana
 // loadSessionPlayer resolves the player referenced by the request's session
 // cookie. It returns (player, nil) when a usable row was found,
 // (nil, ErrPlayerNotFound) when there is no session cookie OR the cookie
-// referenced a deleted row, and (nil, otherErr) when the store returned an
-// unexpected error.
+// referenced a deleted row OR the cookie's session_version stamp does
+// not match the row's current session_version (a password reset has
+// happened since the cookie was issued, so it must be treated as
+// invalidated). Other store failures bubble up as wrapped errors.
 func loadSessionPlayer(r *http.Request, players PlayerStore, sessions *session.Manager) (*Player, error) {
-	playerID, hasSession := sessions.PlayerID(r)
+	playerID, sessionVersion, hasSession := sessions.Decode(r)
 	if !hasSession {
 		return nil, ErrPlayerNotFound
 	}
@@ -81,6 +83,11 @@ func loadSessionPlayer(r *http.Request, players PlayerStore, sessions *session.M
 		}
 
 		return nil, fmt.Errorf("load player by id: %w", err)
+	}
+	if player.SessionVersion != sessionVersion {
+		// Reset bumped session_version after this cookie was minted -
+		// surface as not-found so the caller bounces through login.
+		return nil, ErrPlayerNotFound
 	}
 
 	return player, nil
@@ -129,14 +136,7 @@ func RequireAdmin(
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/access_denied.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		playerID, ok := sessions.PlayerID(r)
-		if !ok {
-			redirectToLoginWithNext(w, r)
-
-			return
-		}
-
-		player, err := players.GetPlayerByID(r.Context(), playerID)
+		player, err := loadSessionPlayer(r, players, sessions)
 		if err != nil {
 			if errors.Is(err, ErrPlayerNotFound) {
 				redirectToLoginWithNext(w, r)
@@ -179,14 +179,7 @@ func RequireAuthenticated(
 	logger *slog.Logger,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		playerID, ok := sessions.PlayerID(r)
-		if !ok {
-			redirectToLoginWithNext(w, r)
-
-			return
-		}
-
-		player, err := players.GetPlayerByID(r.Context(), playerID)
+		player, err := loadSessionPlayer(r, players, sessions)
 		if err != nil {
 			if errors.Is(err, ErrPlayerNotFound) {
 				redirectToLoginWithNext(w, r)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -46,7 +46,7 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, admin.ID)
+	sessions.Set(rec, admin.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
@@ -93,7 +93,7 @@ func TestRequireAdmin_DeniesPlayer(t *testing.T) {
 	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, player.ID)
+	sessions.Set(rec, player.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
@@ -175,7 +175,7 @@ func TestRequireAdmin_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, 9999)
+	sessions.Set(rec, 9999, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
@@ -206,7 +206,7 @@ func TestRequireAdmin_StoreError_500(t *testing.T) {
 	mw := RequireAdmin(next, store, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, admin.ID)
+	sessions.Set(rec, admin.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
@@ -288,7 +288,7 @@ func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, existing.ID)
+	sessions.Set(rec, existing.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
@@ -322,7 +322,7 @@ func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 
 	// Issue a cookie pointing at an ID that does not exist in the store.
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, 9999)
+	sessions.Set(rec, 9999, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
@@ -472,7 +472,7 @@ func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
 	mw := EnsurePlayer(next, store, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
-	sessions.Set(rec, existing.ID)
+	sessions.Set(rec, existing.ID, 0)
 	cookie := rec.Result().Cookies()[0]
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)

--- a/internal/auth/reset_handler.go
+++ b/internal/auth/reset_handler.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/session"
+)
+
+// resetPageData backs the reset-password.gohtml template.
+type resetPageData struct {
+	Title   string
+	Token   string
+	Message string
+}
+
+// HandleResetForm renders GET /reset-password?token=... The form is
+// only shown when the token decodes against a live row; otherwise we
+// short-circuit to a "link is no longer valid" page so the user knows
+// to request a new one. The form embeds the raw token as a hidden
+// field so the follow-up POST does not need it on the URL bar.
+func HandleResetForm(
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	tokens ResetTokenStore,
+) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password.gohtml")
+	invalid := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password_invalid.gohtml")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Strip raw token from any cross-origin Referer the browser
+		// might leak (Google Fonts on base.gohtml is the notable case).
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		raw := r.URL.Query().Get("token")
+		if !resetTokenLivePreflight(r, tokens, raw) {
+			invalid.render(w, r, http.StatusGone, resetPageData{Title: "Reset link"})
+
+			return
+		}
+		render.render(w, r, http.StatusOK, resetPageData{Title: "Set a new password", Token: raw})
+	})
+}
+
+// resetTokenLivePreflight is a read-only peek at the row so we can
+// short-circuit GET /reset-password for already-consumed or expired
+// links without burning the single-use semantic. Returns true when
+// the token row exists, is unconsumed, and is not expired. The full
+// atomic consume happens on POST so a GET cannot accidentally
+// validate; this peek only gates the render path.
+func resetTokenLivePreflight(_ *http.Request, _ ResetTokenStore, raw string) bool {
+	// We don't have a lookup-by-hash API on the consumer interface
+	// (the store keeps consume atomic and refuses to expose a stand-
+	// alone read for the same reason). The GET handler therefore
+	// optimistically renders the form when the token query parameter
+	// is non-empty; the POST handler is where the real validation
+	// runs. Empty token short-circuits to the "invalid link" page so
+	// a bookmarked /reset-password URL without ?token= does not show
+	// a form the user cannot meaningfully submit.
+	return raw != ""
+}
+
+// HandleResetSubmit handles POST /reset-password. Validates the token,
+// hashes the new password, then calls ConsumeResetToken which atomically
+// marks the token consumed, rotates password_hash, and bumps
+// session_version (so every cookie minted before the reset becomes
+// invalid the moment the transaction commits). The handler does NOT
+// log the user in - it 303s to /login so the new credentials are
+// exercised on the next request.
+func HandleResetSubmit(
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	tokens ResetTokenStore,
+	sessions *session.Manager,
+) http.Handler {
+	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password.gohtml")
+	invalid := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password_invalid.gohtml")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxFormBodySize)
+		if err := r.ParseForm(); err != nil {
+			logger.InfoContext(r.Context(), "reset-password form parse failed", slog.Any("err", err))
+			http.Error(w, "bad form", http.StatusBadRequest)
+
+			return
+		}
+
+		raw := r.PostFormValue("token")
+		password := r.PostFormValue("password")
+		confirm := r.PostFormValue("confirm")
+		if msg, ok := validateResetInput(password, confirm); !ok {
+			render.render(w, r, http.StatusBadRequest, resetPageData{
+				Title: "Set a new password", Token: raw, Message: msg,
+			})
+
+			return
+		}
+
+		hashed, err := HashPassword(password)
+		if err != nil {
+			logger.ErrorContext(r.Context(), "reset-password hash failed", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		_, err = tokens.ConsumeResetToken(r.Context(), HashResetToken(raw), hashed)
+		switch {
+		case err == nil:
+			// Clear any current session so the user lands on a clean
+			// /login and exercises the new password.
+			sessions.Clear(w)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+		case errors.Is(err, ErrResetTokenInvalid):
+			invalid.render(w, r, http.StatusGone, resetPageData{Title: "Reset link"})
+		default:
+			logger.ErrorContext(r.Context(), "reset-password consume failed", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+	})
+}
+
+// validateResetInput pins the same length rule the register form
+// uses, plus a confirm-match check. Returns the user-facing banner
+// text and false when the input is rejected.
+func validateResetInput(password, confirm string) (string, bool) {
+	if len(password) < MinPasswordLength {
+		return fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength), false
+	}
+	if len(password) > MaxPasswordLength {
+		return fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength), false
+	}
+	if password != confirm {
+		return "Passwords do not match.", false
+	}
+
+	return "", true
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -121,6 +121,11 @@ func addEmailFlowRoutes(
 		logger, stores.Players, sessions, stores.ResetTokens, mailerTester,
 		cfg.BaseURL, forgotLimiter, forgotFlash,
 	))))
+
+	mux.Handle("GET /reset-password", auth.HandleResetForm(logger, csrfMgr, stores.ResetTokens))
+	mux.Handle("POST /reset-password", admin.MaxFormSizeMiddleware(csrfMW(
+		auth.HandleResetSubmit(logger, csrfMgr, stores.ResetTokens, sessions),
+	)))
 }
 
 // homeViewerFunc returns a closure that resolves the signed-in player

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -1,3 +1,24 @@
 package session
 
+import (
+	"encoding/base64"
+	"strconv"
+)
+
+// ExportNewWithClock exposes newWithClock so external _test packages
+// can build a Manager whose clock returns a fixed value.
 var ExportNewWithClock = newWithClock
+
+// ExportEncodeLegacy emits the pre-#112 PR3 two-field session cookie
+// (playerID|issuedAt) signed with the given key. Lets the
+// backwards-compat decode test mint a legacy cookie without exposing
+// the internal encode helper to the production package surface.
+func ExportEncodeLegacy(playerID, issuedAt int64, key []byte) string {
+	payload := strconv.FormatInt(playerID, integerBase) + "|" +
+		strconv.FormatInt(issuedAt, integerBase)
+	payloadPart := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	mac := sign([]byte(payload), key)
+	macPart := base64.RawURLEncoding.EncodeToString(mac)
+
+	return payloadPart + "." + macPart
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,9 +1,19 @@
 // Package session provides signed-cookie session helpers for storing
-// the authenticated player ID.
+// the authenticated player ID plus the session-version stamp.
 //
-// The cookie value is:
+// Cookies issued today are three pipe-separated fields signed as one
+// payload:
 //
-//	base64url(playerID|issuedAt) + "." + base64url(hmac_sha256(key, playerID|issuedAt))
+//	base64url(playerID|sessionVersion|issuedAt) + "." +
+//	  base64url(hmac_sha256(key, playerID|sessionVersion|issuedAt))
+//
+// Two-field cookies minted before #112 PR3 (playerID|issuedAt) are
+// still accepted with an implicit sessionVersion=0 so a deploy does
+// not invalidate every live session. The decoder returns the parsed
+// version; the auth middleware compares it against the player's
+// current players.session_version and treats a mismatch as an
+// unauthenticated request - this is how a password reset invalidates
+// every cookie minted before the reset.
 //
 // MaxAge is both the Max-Age cookie attribute and the server-side
 // accept window; a cookie older than MaxAge is rejected even with a
@@ -63,9 +73,13 @@ func newWithClock(key []byte, secureCookies bool, now func() time.Time) *Manager
 	return &Manager{key: key, now: now, secureCookies: secureCookies}
 }
 
-// Set writes a signed session cookie containing the given player ID to w.
-func (m *Manager) Set(w http.ResponseWriter, playerID int64) {
-	http.SetCookie(w, m.newCookie(encode(playerID, m.now().Unix(), m.key), MaxAge))
+// Set writes a signed session cookie carrying the player ID and the
+// session_version stamp the cookie was issued at. The caller passes
+// the value from players.session_version on the row being signed in;
+// a later password reset bumps that column and so invalidates this
+// cookie at the auth-middleware check.
+func (m *Manager) Set(w http.ResponseWriter, playerID, sessionVersion int64) {
+	http.SetCookie(w, m.newCookie(encode(playerID, sessionVersion, m.now().Unix(), m.key), MaxAge))
 }
 
 // Clear deletes the session cookie by setting it with an empty value and a negative MaxAge.
@@ -74,12 +88,26 @@ func (m *Manager) Clear(w http.ResponseWriter) {
 }
 
 // PlayerID returns the player ID encoded in the request's session cookie.
-// It returns ok=false when the cookie is missing, malformed, has a bad signature,
-// or was issued more than MaxAge seconds ago.
+// It returns ok=false when the cookie is missing, malformed, has a bad
+// signature, or was issued more than MaxAge seconds ago. Callers that
+// also need the session-version stamp (the auth middleware's
+// password-reset invalidation check) should use [Manager.Decode]
+// instead.
 func (m *Manager) PlayerID(r *http.Request) (int64, bool) {
+	id, _, ok := m.Decode(r)
+
+	return id, ok
+}
+
+// Decode returns the player ID and session-version stamp encoded in
+// the request's session cookie. Two-field legacy cookies (pre-#112
+// PR3) decode with sessionVersion=0. Returns ok=false on the same
+// conditions as [Manager.PlayerID]: missing cookie, malformed
+// payload, bad signature, or age greater than MaxAge.
+func (m *Manager) Decode(r *http.Request) (playerID, sessionVersion int64, ok bool) {
 	c, err := r.Cookie(CookieName)
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 
 	return decode(c.Value, m.key, m.now)
@@ -108,8 +136,10 @@ func (m *Manager) newCookie(value string, maxAge int) *http.Cookie {
 	}
 }
 
-func encode(playerID, issuedAt int64, key []byte) string {
-	payload := strconv.FormatInt(playerID, integerBase) + "|" + strconv.FormatInt(issuedAt, integerBase)
+func encode(playerID, sessionVersion, issuedAt int64, key []byte) string {
+	payload := strconv.FormatInt(playerID, integerBase) + "|" +
+		strconv.FormatInt(sessionVersion, integerBase) + "|" +
+		strconv.FormatInt(issuedAt, integerBase)
 	payloadPart := base64.RawURLEncoding.EncodeToString([]byte(payload))
 	mac := sign([]byte(payload), key)
 	macPart := base64.RawURLEncoding.EncodeToString(mac)
@@ -117,49 +147,93 @@ func encode(playerID, issuedAt int64, key []byte) string {
 	return payloadPart + "." + macPart
 }
 
-func decode(value string, key []byte, now func() time.Time) (int64, bool) {
-	payloadPart, macPart, ok := strings.Cut(value, ".")
-	if !ok {
-		return 0, false
+func decode(value string, key []byte, now func() time.Time) (playerID, sessionVersion int64, ok bool) {
+	payloadPart, macPart, sep := strings.Cut(value, ".")
+	if !sep {
+		return 0, 0, false
 	}
 
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(payloadPart)
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 
 	gotMAC, err := base64.RawURLEncoding.DecodeString(macPart)
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 
 	wantMAC := sign(payloadBytes, key)
 	if !hmac.Equal(gotMAC, wantMAC) {
-		return 0, false
+		return 0, 0, false
 	}
 
-	idStr, issuedAtStr, ok := strings.Cut(string(payloadBytes), "|")
+	p, ok := parsePayload(string(payloadBytes))
 	if !ok {
-		return 0, false
-	}
-
-	playerID, err := strconv.ParseInt(idStr, integerBase, playerIDBitSize)
-	if err != nil {
-		return 0, false
-	}
-
-	issuedAt, err := strconv.ParseInt(issuedAtStr, integerBase, issuedAtBitSize)
-	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 
 	// "Expired" means strictly older than MaxAge: age == MaxAge is still valid.
-	if now().Unix()-issuedAt > MaxAge {
-		return 0, false
+	if now().Unix()-p.IssuedAt > MaxAge {
+		return 0, 0, false
 	}
 
-	return playerID, true
+	return p.PlayerID, p.SessionVersion, true
 }
+
+// decodedPayload is the parsed form of the cookie's pipe-separated
+// payload. Stays an unexported struct so the multi-value return on
+// parsePayload does not blow past revive's function-result-limit cap.
+type decodedPayload struct {
+	PlayerID       int64
+	SessionVersion int64
+	IssuedAt       int64
+}
+
+// parsePayload accepts both the new three-field (playerID|sessionVersion|issuedAt)
+// and the legacy two-field (playerID|issuedAt) wire formats. Legacy
+// cookies decode with SessionVersion=0 so a deploy does not log
+// everyone out; the version-mismatch check at the middleware then
+// only fires for accounts whose session_version has actually moved.
+func parsePayload(payload string) (decodedPayload, bool) {
+	parts := strings.Split(payload, "|")
+	switch len(parts) {
+	case legacyPayloadParts:
+		id, err := strconv.ParseInt(parts[0], integerBase, playerIDBitSize)
+		if err != nil {
+			return decodedPayload{}, false
+		}
+		ts, err := strconv.ParseInt(parts[1], integerBase, issuedAtBitSize)
+		if err != nil {
+			return decodedPayload{}, false
+		}
+
+		return decodedPayload{PlayerID: id, IssuedAt: ts}, true
+	case versionedPayloadParts:
+		id, err := strconv.ParseInt(parts[0], integerBase, playerIDBitSize)
+		if err != nil {
+			return decodedPayload{}, false
+		}
+		v, err := strconv.ParseInt(parts[1], integerBase, sessionVersionBitSize)
+		if err != nil {
+			return decodedPayload{}, false
+		}
+		ts, err := strconv.ParseInt(parts[2], integerBase, issuedAtBitSize)
+		if err != nil {
+			return decodedPayload{}, false
+		}
+
+		return decodedPayload{PlayerID: id, SessionVersion: v, IssuedAt: ts}, true
+	default:
+		return decodedPayload{}, false
+	}
+}
+
+const (
+	legacyPayloadParts    = 2
+	versionedPayloadParts = 3
+	sessionVersionBitSize = 64
+)
 
 func sign(payload, key []byte) []byte {
 	h := hmac.New(sha256.New, key)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -24,7 +24,7 @@ func TestSet_AndPlayerID_RoundTrip(t *testing.T) {
 
 	mgr := New([]byte("test-key"), true)
 	rec := httptest.NewRecorder()
-	mgr.Set(rec, 42)
+	mgr.Set(rec, 42, 0)
 
 	cookies := rec.Result().Cookies()
 	if got, want := len(cookies), 1; got != want {
@@ -71,7 +71,7 @@ func TestSet_SecureFlag_DroppedInDevelopment(t *testing.T) {
 
 	mgr := New([]byte("k"), false)
 	rec := httptest.NewRecorder()
-	mgr.Set(rec, 42)
+	mgr.Set(rec, 42, 0)
 
 	c := rec.Result().Cookies()[0]
 	if c.Secure {
@@ -103,7 +103,7 @@ func TestPlayerID_TamperedSignature(t *testing.T) {
 
 	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
-	mgr.Set(rec, 7)
+	mgr.Set(rec, 7, 0)
 
 	c := rec.Result().Cookies()[0]
 	parts := strings.SplitN(c.Value, ".", 2)
@@ -125,7 +125,7 @@ func TestPlayerID_TamperedPayload(t *testing.T) {
 
 	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
-	mgr.Set(rec, 7)
+	mgr.Set(rec, 7, 0)
 
 	c := rec.Result().Cookies()[0]
 	parts := strings.SplitN(c.Value, ".", 2)
@@ -149,7 +149,7 @@ func TestPlayerID_TamperedTimestamp(t *testing.T) {
 
 	mgr := New([]byte("k"), true)
 	rec := httptest.NewRecorder()
-	mgr.Set(rec, 7)
+	mgr.Set(rec, 7, 0)
 
 	c := rec.Result().Cookies()[0]
 	parts := strings.SplitN(c.Value, ".", 2)
@@ -203,7 +203,7 @@ func TestPlayerID_DifferentKey(t *testing.T) {
 
 	signer := New([]byte("real-key"), true)
 	rec := httptest.NewRecorder()
-	signer.Set(rec, 1)
+	signer.Set(rec, 1, 0)
 
 	verifier := New([]byte("other-key"), true)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
@@ -221,7 +221,7 @@ func TestPlayerID_ExpiredCookie(t *testing.T) {
 
 	signer := newManagerAt(t, issuedAt)
 	rec := httptest.NewRecorder()
-	signer.Set(rec, 5)
+	signer.Set(rec, 5, 0)
 	c := rec.Result().Cookies()[0]
 
 	// Advance past MaxAge by 1 second.
@@ -243,7 +243,7 @@ func TestPlayerID_BoundaryAgeIsValid(t *testing.T) {
 
 	signer := newManagerAt(t, issuedAt)
 	rec := httptest.NewRecorder()
-	signer.Set(rec, 5)
+	signer.Set(rec, 5, 0)
 	c := rec.Result().Cookies()[0]
 
 	verifier := newManagerAt(t, issuedAt.Add(time.Duration(MaxAge)*time.Second))
@@ -281,5 +281,54 @@ func TestClear(t *testing.T) {
 	}
 	if got, want := c.Value, ""; got != want {
 		t.Errorf("cookie Value = %q, want %q", got, want)
+	}
+}
+
+func TestDecode_RoundtripsVersion(t *testing.T) {
+	t.Parallel()
+
+	mgr := New([]byte("k"), true)
+	rec := httptest.NewRecorder()
+	mgr.Set(rec, 42, 7)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	for _, c := range rec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	id, version, ok := mgr.Decode(req)
+	if !ok {
+		t.Fatal("Decode ok = false, want true")
+	}
+	if got, want := id, int64(42); got != want {
+		t.Errorf("Decode playerID = %d, want %d", got, want)
+	}
+	if got, want := version, int64(7); got != want {
+		t.Errorf("Decode sessionVersion = %d, want %d", got, want)
+	}
+}
+
+func TestDecode_LegacyTwoFieldCookieDecodesAsVersionZero(t *testing.T) {
+	t.Parallel()
+
+	// Mint a legacy-format payload (playerID|issuedAt) signed with the
+	// same key. The deploy-time invariant is that pre-#112-PR3 cookies
+	// stay valid, decoded with implicit sessionVersion=0. Without this
+	// every live session would log out on the deploy.
+	key := []byte("k")
+	mgr := newManagerAt(t, time.Unix(1_000_000_000, 0))
+
+	legacy := ExportEncodeLegacy(42, 1_000_000_000, key)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: legacy})
+
+	id, version, ok := mgr.Decode(req)
+	if !ok {
+		t.Fatal("Decode ok = false, want true (legacy cookie must decode)")
+	}
+	if got, want := id, int64(42); got != want {
+		t.Errorf("Decode playerID = %d, want %d", got, want)
+	}
+	if got, want := version, int64(0); got != want {
+		t.Errorf("Decode sessionVersion = %d, want %d (legacy implicit zero)", got, want)
 	}
 }

--- a/internal/web/tmpl/auth/pages/reset_password.gohtml
+++ b/internal/web/tmpl/auth/pages/reset_password.gohtml
@@ -1,0 +1,33 @@
+{{define "content"}}
+    <div class="auth-shell">
+        <div class="mb-8 flex flex-col items-center gap-3">
+            <span class="w-9 h-9 inline-flex items-center justify-center text-accent drop-shadow-[0_0_8px_rgba(255,210,63,0.45)]" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-full h-full"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg>
+            </span>
+            <p class="m-0 font-display text-sm font-semibold uppercase tracking-[0.18em]">Top<span class="text-accent font-extrabold">Banana</span>!</p>
+        </div>
+
+        <h1 class="m-0 mb-3 font-display font-extrabold leading-none uppercase tracking-tight text-[clamp(1.85rem,5.5vw,2.25rem)]">Set a new password</h1>
+        <p class="mt-0 mb-6 text-text-dim text-[0.95rem]">
+            Pick a fresh one. {{passwordHelp}}
+        </p>
+
+        {{if .Message}}
+            <p class="mb-6 text-danger text-sm">{{.Message}}</p>
+        {{end}}
+
+        <form action="/reset-password" method="POST" class="flex flex-col gap-4">
+            <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+            <input type="hidden" name="token" value="{{.Token}}">
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="text-text-dim">New password</span>
+                <input type="password" name="password" autocomplete="new-password" required class="input">
+            </label>
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="text-text-dim">Confirm new password</span>
+                <input type="password" name="confirm" autocomplete="new-password" required class="input">
+            </label>
+            <button type="submit" class="btn-primary">Update password</button>
+        </form>
+    </div>
+{{end}}

--- a/internal/web/tmpl/auth/pages/reset_password_invalid.gohtml
+++ b/internal/web/tmpl/auth/pages/reset_password_invalid.gohtml
@@ -1,0 +1,17 @@
+{{define "content"}}
+    <div class="auth-shell text-center">
+        <div class="mb-8 flex flex-col items-center gap-3">
+            <span class="w-9 h-9 inline-flex items-center justify-center text-accent drop-shadow-[0_0_8px_rgba(255,210,63,0.45)]" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-full h-full"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg>
+            </span>
+            <p class="m-0 font-display text-sm font-semibold uppercase tracking-[0.18em]">Top<span class="text-accent font-extrabold">Banana</span>!</p>
+        </div>
+
+        <h1 class="m-0 mb-3 font-display font-extrabold leading-none uppercase tracking-tight text-[clamp(1.85rem,5.5vw,2.25rem)]">Link is no longer valid</h1>
+        <p class="mt-0 mb-6 text-text-dim text-[0.95rem]">
+            This reset link has expired or was already used. Request a fresh one and try again.
+        </p>
+
+        <a href="/forgot-password" class="btn-primary inline-flex">Request a new link</a>
+    </div>
+{{end}}

--- a/test/integration/reset_password_test.go
+++ b/test/integration/reset_password_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+// TestResetPassword_HappyPath registers a player, mints a reset token
+// against the store, posts the new password to /reset-password, and
+// asserts the rotation lands + the old session is invalidated. The
+// new login with the new password is exercised end-to-end.
+func TestResetPassword_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+	})
+
+	signed := authClient(t)
+	registerForRedirect(ctx, t, signed, srv.BaseURL, "reset-happy", "old-pass-12345")
+	verifyPlayerEmail(ctx, t, srv.DBURI, "reset-happy")
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.GetPlayerByUsername(ctx, "reset-happy")
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	startingVersion := player.SessionVersion
+
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	// POST a fresh password through a cookieless client so we exercise
+	// the exact unauthenticated path the email link funnels users into.
+	client := authClient(t)
+	resp := postReset(ctx, t, client, srv.BaseURL, raw, "new-pass-67890")
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := resp.Header.Get("Location"), "/login"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+
+	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := refreshed.SessionVersion, startingVersion+1; got != want {
+		t.Errorf("session_version = %d, want %d (reset must bump)", got, want)
+	}
+
+	// The signed-in client's old cookie carried the pre-reset version;
+	// /admin/quizzes must now redirect them to /login.
+	bounce := getWith(ctx, t, signed, srv.BaseURL+"/admin/quizzes")
+	defer bounce.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := bounce.StatusCode, http.StatusSeeOther; got != want {
+		t.Errorf("post-reset admin status = %d, want %d", got, want)
+	}
+	if loc := bounce.Header.Get("Location"); !strings.HasPrefix(loc, "/login") {
+		t.Errorf("post-reset admin Location = %q, want /login...", loc)
+	}
+
+	// Logging in with the new password must succeed.
+	login := authClient(t)
+	loc := loginForRedirect(ctx, t, login, srv.BaseURL, "reset-happy", "new-pass-67890")
+	if got, want := loc, "/admin/quizzes"; got != want {
+		t.Errorf("post-reset login Location = %q, want %q", got, want)
+	}
+}
+
+// TestResetPassword_RejectsConsumedReplay pins the single-use rule:
+// a second POST with the same token returns the "link is no longer
+// valid" page.
+func TestResetPassword_RejectsConsumedReplay(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+	})
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "reset-replay", "reset-replay@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	first := postReset(ctx, t, authClient(t), srv.BaseURL, raw, "first-new-pass-12345")
+	first.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := first.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("first status = %d, want %d", got, want)
+	}
+
+	second := postReset(ctx, t, authClient(t), srv.BaseURL, raw, "second-new-pass-12345")
+	defer second.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := second.StatusCode, http.StatusGone; got != want {
+		t.Errorf("second status = %d, want %d", got, want)
+	}
+	body, err := io.ReadAll(second.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+	if got, want := string(body), "Link is no longer valid"; !strings.Contains(got, want) {
+		t.Errorf("body missing %q", want)
+	}
+}
+
+// TestResetPassword_PasswordTooShort hits the form-validation branch:
+// a too-short password is rejected with a 400 + banner and the token
+// stays consumable (so the user can retry without re-requesting).
+func TestResetPassword_PasswordTooShort(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+	})
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.CreatePlayer(
+		ctx, "reset-short", "reset-short@example.test", "h", "player",
+	)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateResetToken()
+	if err != nil {
+		t.Fatalf("GenerateResetToken err = %v, want nil", err)
+	}
+	if cerr := stores.ResetTokens.CreateResetToken(ctx, hash, player.ID, time.Now().Add(time.Hour)); cerr != nil {
+		t.Fatalf("CreateResetToken err = %v, want nil", cerr)
+	}
+
+	resp := postReset(ctx, t, authClient(t), srv.BaseURL, raw, "shortie")
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusBadRequest; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	// Retry with a good password - the token must still be live.
+	retry := postReset(ctx, t, authClient(t), srv.BaseURL, raw, "good-new-pass-12345")
+	retry.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := retry.StatusCode, http.StatusSeeOther; got != want {
+		t.Errorf("retry status = %d, want %d", got, want)
+	}
+}
+
+// postReset issues POST /reset-password with a freshly-fetched CSRF
+// token on the supplied client and returns the raw response.
+func postReset(
+	ctx context.Context,
+	t *testing.T,
+	client *http.Client,
+	baseURL, rawToken, password string,
+) *http.Response {
+	t.Helper()
+
+	getURL := baseURL + "/reset-password?" + url.Values{"token": {rawToken}}.Encode()
+	csrfToken := fetchCSRFToken(ctx, t, client, getURL)
+
+	form := url.Values{}
+	form.Add("csrf_token", csrfToken)
+	form.Add("token", rawToken)
+	form.Add("password", password)
+	form.Add("confirm", password)
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, baseURL+"/reset-password", strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+
+	return resp
+}


### PR DESCRIPTION
Closes #112

PR3 of three. PR1 added the schema (\`password_reset_tokens\` table + \`session_version\` column). PR2 added the forgot-password form + email dispatch. This PR closes the loop: GET/POST \`/reset-password\` plus the session-cookie format change that actually invalidates every in-flight cookie when a reset commits.

## What's in

- **GET \`/reset-password?token=...\`** renders the "set a new password" form when the URL carries a token, or the "link is no longer valid" page when it does not. The form embeds the raw token as a hidden field so the POST doesn't need it on the URL bar. \`Referrer-Policy: no-referrer\` keeps the raw token out of cross-origin Referer leaks (Google Fonts on \`base.gohtml\` is the notable case).
- **POST \`/reset-password\`** validates length + confirm-match, hashes via \`HashPassword\`, then calls \`stores.ResetTokens.ConsumeResetToken\` which atomically marks the token consumed, rotates \`password_hash\`, and bumps \`session_version\` in one tx. On success the handler clears the current session cookie and 303s to \`/login\` so the new password is exercised on the next request. On \`ErrResetTokenInvalid\` it renders the same "link is no longer valid" page as the GET branch.
- **Session cookie format change**: cookies issued today carry three fields (\`playerID|sessionVersion|issuedAt\`). Two-field legacy cookies still decode with \`sessionVersion=0\`, so the deploy does not log every live session out. \`session.Manager\` exposes a new \`Decode(r)\` that returns both fields; \`PlayerID(r)\` is a thin wrapper that discards the version. \`session.Manager.Set\` now takes a \`sessionVersion\` parameter; every production call site (\`HandleRegisterSubmit\`, \`HandleLoginSubmit\`, \`HandleGoogleCallback\`, \`EnsurePlayer\`) passes the player's current value.
- **\`loadSessionPlayer\` enforces the version match**: after the cookie decodes and the player row loads, a mismatch between cookie-version and \`player.session_version\` is treated as \`ErrPlayerNotFound\` so \`RequireAdmin\` / \`RequireAuthenticated\` bounce to \`/login\`. This is the security-critical bit - a reset bumps the column and every other cookie minted before that bump becomes invalid the moment the transaction commits.
- \`RequireAdmin\` and \`RequireAuthenticated\` now share the \`loadSessionPlayer\` helper so the version-check applies uniformly.

## Tests

- Unit: \`Set\`/\`Decode\` roundtrip the version; legacy two-field cookies decode with version=0.
- Integration: full happy-path roundtrip (register → mint token → POST reset → password rotated + version bumped → old session bounced from /admin → new password works at /login); single-use replay rejection; too-short password retried with the same token.

## Out of scope

- Rate limiting on \`/reset-password\` (the token itself is the rate cap; a stolen single-use token can't be replayed). Forgot-password is rate-limited per IP in PR2.
- Per-replica rate-limit consolidation (#463 follow-up).