### PR TITLE
Add pre-game profile and browse-quizzes links for players

### DIFF
--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -73,6 +73,26 @@
                 </a>
             </h1>
 
+            <!-- Signed-in account control (#520). The SPA shell
+                 carries no CSRF token, so logout can't live here; instead
+                 we link to /profile (a GET page that already has logout +
+                 account management). Visible only for authenticated
+                 players AND only outside active gameplay — mirrors the
+                 brand's `!(gameId && !finished)` gate so the question
+                 keeps the full canvas during a live game (#253), while
+                 the start screen and finished leaderboard expose the
+                 account link. Complements the anonymous-only claim CTA
+                 below; the two never show together (this gates on
+                 isAuthenticated(), the CTA on its negation). The link
+                 text deliberately differs from the claim CTA's "sign in"
+                 so claim.spec.ts's unique sign-in assertion still holds. -->
+            <template x-if="isAuthenticated() && !(gameId && !finished)">
+                <p class="mb-6 text-sm text-text-dim text-right">
+                    Signed in as
+                    <a href="/profile" class="text-text hover:text-accent underline-offset-2 hover:underline" data-testid="account-profile-link" x-text="player ? player.username : ''"></a>
+                </p>
+            </template>
+
             <!-- Single claim-name CTA, lifted out of the start-screen
                  and finished-leaderboard views so the leaderboard
                  always sits in the same position on the page —
@@ -191,6 +211,23 @@
                         <span>Share</span>
                     </button>
                 </div>
+
+                {{/* Catalog escape hatch on a deep link. The
+                     non-deep-link block above already offers "Browse all
+                     quizzes" as its primary affordance, but a /play/{slug}
+                     visitor only sees the quiz title + Start cluster, with
+                     no way to reach /quizzes short of going home first.
+                     Surface a secondary text link here, source-ordered
+                     AFTER the Start/Share cluster so keyboard Tab still
+                     lands on Start Game first. Gated to the deep-link
+                     start screen (not the already-played revisit, which
+                     drops the Start button entirely). */}}
+                <template x-if="deepLinkedQuiz && !finished">
+                    <p class="mt-4 text-sm text-text-dim">
+                        or
+                        <a href="/quizzes" class="text-text hover:text-accent underline-offset-2 hover:underline" data-testid="browse-quizzes-link">browse all quizzes</a>
+                    </p>
+                </template>
 
             </div>
 

--- a/internal/web/tmpl/home/layouts/base.gohtml
+++ b/internal/web/tmpl/home/layouts/base.gohtml
@@ -60,7 +60,7 @@
     <span>Top Banana!</span>
     <div class="flex items-center gap-4">
         {{if .Viewer}}
-            <span>Signed in as <span class="text-text-dim">{{.Viewer.Username}}</span></span>
+            <a href="/profile" class="hover:text-text-dim underline-offset-2 hover:underline">Signed in as <span class="text-text-dim">{{.Viewer.Username}}</span></a>
             <form action="/logout" method="POST" class="m-0 p-0 inline">
                 <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <button type="submit" class="m-0 p-0 bg-transparent border-0 cursor-pointer text-text-mute hover:text-text-dim underline-offset-2 hover:underline">Log out</button>

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -46,6 +46,7 @@ const adminUsernames = [
   'e2e-mgmt-admin-chromium', 'e2e-mgmt-admin-firefox',                        // admin-players.spec.ts player management (#450)
   'e2e-admin-nav-chromium', 'e2e-admin-nav-firefox',                          // admin-nav.spec.ts reachability (#517)
   'e2e-admin-nav-active-chromium', 'e2e-admin-nav-active-firefox',            // admin-nav.spec.ts active-section (#517)
+  'e2e-admin-pregame-nav-chromium', 'e2e-admin-pregame-nav-firefox',          // pregame-nav.spec.ts deep-link browse link
 ];
 const ADMIN_EMAILS = adminUsernames.map(u => `${u}@example.test`).join(',');
 

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -43,7 +43,7 @@ export async function registerAdmin(page: Page, username: string): Promise<void>
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
 }
 
-function markEmailVerified(username: string): void {
+export function markEmailVerified(username: string): void {
   const dataDir = process.env.TOPBANANA_E2E_DATA_DIR;
   if (!dataDir) {
     throw new Error('TOPBANANA_E2E_DATA_DIR is not set; helpers cannot stamp email_verified_at');

--- a/test/e2e/tests/pregame-nav.spec.ts
+++ b/test/e2e/tests/pregame-nav.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from './fixtures';
+import { registerAdmin, createQuizWithQuestions, markEmailVerified } from './helpers';
+
+// Pre-game navigation on the player SPA: a signed-in player can reach
+// /profile via the account link, and a deep-linked /play/{slug} start
+// screen exposes a link to the /quizzes catalog.
+
+// Test 1 — a signed-in player sees the account link and it routes to
+// /profile. Registers a plain player rather than relying on
+// registerAdmin so the test is robust to ordering (the "first registrant
+// becomes admin" slot may already be taken by another spec in the same
+// worker), mirroring claim.spec.ts's authenticated-player test.
+test('signed-in player can reach /profile via the account link on the play SPA', async ({ page, browserName }) => {
+  const username = `e2e-pregame-authn-${browserName}-${Date.now()}`;
+  await page.goto('/register');
+  await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
+  await page.locator('input[name=password]').fill('correct-battery-13');
+  await page.locator('input[name=password_confirm]').fill('correct-battery-13');
+  await page.locator('button[type=submit]').click();
+  // The post-register redirect target varies with this worker DB's state
+  // (admin bootstrap -> /admin/quizzes, verify gate -> /verify-email/pending,
+  // otherwise /), so just wait for the registration to land somewhere off
+  // /register. /profile sits behind the verify-email gate, so stamp
+  // email_verified_at directly (the same trick registerAdmin uses) so the
+  // account link lands on the profile page rather than the pending screen.
+  await expect(page).not.toHaveURL(/\/register$/);
+  markEmailVerified(username);
+
+  await page.goto('/client/');
+
+  // The account link shows the player's username and links to /profile.
+  // It is gated on isAuthenticated() so an anonymous visitor never sees
+  // it; the claim CTA covers that case instead.
+  const accountLink = page.getByTestId('account-profile-link');
+  await expect(accountLink).toBeVisible();
+  await expect(accountLink).toHaveText(username);
+
+  // The claim CTA must stay hidden for this signed-in player — the two
+  // affordances are mutually exclusive.
+  await expect(page.locator('.claim-cta')).not.toBeVisible();
+
+  // Plain navigation, not an Alpine event, so wait on the URL change.
+  await Promise.all([
+    page.waitForURL(/\/profile$/),
+    accountLink.click(),
+  ]);
+});
+
+// Test 2 — an anonymous deep-linked /play/{slug} start screen exposes a
+// link to the /quizzes catalog. The non-deep-link /client/ entry already
+// surfaces "Browse all quizzes" as its primary affordance; this pins the
+// secondary escape hatch that lets a deep-link visitor reach the catalog
+// without going home first.
+test('deep-linked play start screen exposes a link to the quizzes catalog', async ({ page, browserName }) => {
+  test.setTimeout(60_000);
+
+  const adminUser = `e2e-admin-pregame-nav-${browserName}`;
+  const quizTitle = `E2E Pregame Nav ${browserName}`;
+
+  await registerAdmin(page, adminUser);
+  await createQuizWithQuestions(page, quizTitle);
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Land on the deep link via the public list, the same path a shared
+  // quiz link takes a visitor down.
+  await page.goto('/quizzes');
+  await page.getByRole('link', { name: quizTitle }).click();
+  await expect(page).toHaveURL(/\/play\/[^/]+-\d+$/);
+
+  // The deep-link start screen shows the quiz title + Start cluster. The
+  // browse link sits below as a secondary affordance.
+  await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();
+  const browseLink = page.getByTestId('browse-quizzes-link');
+  await expect(browseLink).toBeVisible();
+
+  await Promise.all([
+    page.waitForURL(/\/quizzes$/),
+    browseLink.click(),
+  ]);
+});


### PR DESCRIPTION
Closes #520

## What

Fixes pre-game navigation gaps on the player surfaces (focused, frontend-only — within the existing Tailwind + Alpine system):

- **Play SPA — signed-in account control.** Authenticated players now see "Signed in as <username>" linking to `/profile`, gated to the start/finished screens (hidden during a live question, mirroring the brand's `!(gameId && !finished)` gate). Previously signed-in players had no account affordance on the SPA at all. No logout form here (the shell has no CSRF token) — `/profile` already carries logout + account management.
- **Play SPA — catalog escape hatch on deep links.** A `/play/{slug}` start screen now shows a secondary "browse all quizzes" link, source-ordered after the Start/Share cluster so keyboard Tab still hits Start Game first.
- **Home + `/quizzes` — `/profile` reachable.** The footer "Signed in as <username>" is now a link to `/profile` (Log out button unchanged), so profile is reachable everywhere pre-game.

## Tests

- New `test/e2e/tests/pregame-nav.spec.ts`: signed-in player reaches `/profile` from the SPA; deep-linked start screen exposes a `/quizzes` link.
- `markEmailVerified` exported from `helpers.ts` (the new spec stamps verification since `/profile` is behind the verified-email gate); `playwright.config.ts` admin allowlist updated.
- `make check` green; `make test-e2e` 64 passed (chromium + firefox), including re-runs of `claim`/`home`/`player` — the unique "sign in" link assertion in `claim.spec.ts` still holds (the new account link uses distinct text + `/profile`).

## Decisions — confirm or redirect

1. **SPA account link**: placed directly under the brand, right-aligned discreet text ("Signed in as <name>"), distinct from the claim CTA's "sign in" so the e2e stays green. Link only — no logout on the SPA (CSRF). OK, or do you want logout there too (would need a CSRF token plumbed into the shell)?
2. **Deep-link browse link**: low-key text link after the Start cluster, not a button, to stay secondary. Acceptable?
3. **Footer "Signed in as" -> /profile**: turned the username into the profile link. Fine, or prefer a separate "Profile" link alongside it?

## Out of scope (noted in #520)

- Logout inside the SPA (needs CSRF in the shell).
- Role-gating the footer "Manage quizzes" -> /admin link (needs `Viewer.IsAdmin`).
- Any broader gameplay/visual rethink — this is pre-game links + navigation only.