### PR TITLE
Fail the build on non-ASCII bytes in Go and SQL sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
     - name: sqlc drift check
       run: make sqlc-check
 
+    # ASCII gate (#483). The required `lint` job's golangci-lint
+    # asciicheck only catches non-ASCII in identifiers; comments and
+    # string literals (where em dashes break sqlc v1.31.1) slip past it.
+    # `make lint-ascii` greps for them and now exits non-zero, so this
+    # step blocks a regression. Lives here rather than the lint workflow
+    # because that job runs the golangci-lint action directly, not `make`.
+    - name: ASCII source check
+      run: make lint-ascii
+
     # `make test-coverage` runs the full suite with -tags=integration,
     # so a separate integration step would just duplicate the work.
     # Dropped here as part of #202.

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ SQLC_BIN     := $(BIN_DIR)/sqlc
 # migration-against-existing-data class of bug — which test-coverage's
 # fresh DB can't catch — fails locally before CI does.
 .PHONY: check
-check: lint sql-lint sqlc-check tailwind-check build test-coverage smoke
+check: lint lint-ascii sql-lint sqlc-check tailwind-check build test-coverage smoke
 
 .PHONY: lint
 lint: $(GOLANGCI_BIN)
@@ -111,9 +111,11 @@ lint-migrations:
 	    echo "lint-migrations: no offending migrations."; \
 	fi
 
-# Advisory: flags non-ASCII bytes in Go/SQL sources (sqlc v1.31.1
-# breaks downstream queries on em-dashed SQL comments). Never fails
-# the build.
+# Fails the build on non-ASCII bytes in Go/SQL sources (sqlc v1.31.1
+# breaks downstream queries on em-dashed SQL comments; CLAUDE.md hard
+# rule). golangci-lint's asciicheck only covers identifiers, so this
+# grep is the gate for comments and string literals. Wired into `check`
+# and the CI build job (#483).
 .PHONY: lint-ascii
 lint-ascii:
 	@hits=$$(LC_ALL=C grep -rnP '[^\x00-\x7f]' \
@@ -123,6 +125,7 @@ lint-ascii:
 	if [ -n "$$hits" ]; then \
 	    echo "lint-ascii: non-ASCII bytes in source (em dashes break sqlc; see CLAUDE.md):"; \
 	    echo "$$hits" | sed 's/^/  /'; \
+	    exit 1; \
 	else \
 	    echo "lint-ascii: no non-ASCII bytes in Go or SQL sources."; \
 	fi


### PR DESCRIPTION
Closes #483

## What

Makes the ASCII rule (CLAUDE.md hard rule — em dashes in SQL comments break sqlc v1.31.1) actually enforced, instead of honour-system:

- `make lint-ascii` now **exits non-zero** when it finds non-ASCII bytes (it previously printed offenders and fell through).
- Wired into the `check` aggregate so local `make check` catches regressions.
- Added an **ASCII source check** step to the required CI `build` job.

## Deviation from the issue's "no workflow change needed"

#483 assumed adding `lint-ascii` to `make check` (or `make lint`) would make the required CI `lint` job fail. It won't: the `lint` job runs the `golangci/golangci-lint-action` directly, not `make lint` — and the `build` job runs individual `make` targets, not `make check`. So nothing in CI would have invoked `lint-ascii`. I added a one-line `make lint-ascii` step to the existing required `build` job instead (mirrors the `tailwind-check` / `sqlc-check` steps already there). Per CLAUDE.md this needs no required-checks-list update since it's a step in an already-required job, not a new job.

## Verification

- Clean tree: `make lint-ascii` -> exit 0.
- Planted an em dash in a `.go` comment: `make lint-ascii` -> non-zero, prints `file:line` of the offender.
- `make check` stays green on current main (zero hits after #479).