### PR TITLE
Allow unused nolint directives in the lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,6 +139,12 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+      # golangci-lint's incremental cache can intermittently miss the issue a
+      # nolint suppresses (e.g. the revive flag-parameter nolint in
+      # internal/mailer/status.go), making nolintlint flag a still-needed
+      # directive as "unused" and failing CI nondeterministically. Tolerate it.
+      # Upstream bug: https://github.com/golangci/golangci-lint/issues/3228
+      allow-unused: true
     godox:
       keywords:
 #        - TODO     # will be enabled in the future


### PR DESCRIPTION
## Why

The `lint` (golangci-lint) check on `main` failed on the #544 merge run:

```
internal/mailer/status.go:26:1: directive `//nolint:revive // configured is a flag-shaped param matching cfg.SMTPConfigured().` is unused for linter "revive" (nolintlint)
```

That nolint directive is genuinely needed: removing it locally makes revive fire `flag-parameter: parameter 'configured' seems to be a control flag` on `NewStatusView`. The "unused" report is a false positive from golangci-lint's incremental cache intermittently missing the revive issue the directive suppresses (the CI run restored a cache; a clean local run reports 0 issues). Neither #541 nor #544 touched `status.go` or the lint config, so this surfaced nondeterministically rather than from a code change.

## What

Set `nolintlint.allow-unused: true` so a still-needed directive that is intermittently seen as unused no longer fails CI. `require-explanation` and `require-specific` stay on, so directives still have to be justified and scoped.