### PR TITLE
Use immediate SQLite transactions to avoid write-conflict errors

### DIFF
--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -32,7 +32,7 @@ import (
 // defaultDBURI mirrors config.DBURIDefault. Duplicated here so the
 // seeder can run without depending on the full config package's
 // production-vs-dev gates.
-const defaultDBURI = "file:topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)"
+const defaultDBURI = "file:topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate"
 
 // seededAdminID matches the ID set by migration
 // 20260111110308_add_admin_player.sql. The seeder attributes every

--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -6,7 +6,7 @@ services:
       - APP_ENV=production
       - HOST=0.0.0.0
       - PORT=8080
-      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
+      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
       # REGISTRATION_ENABLED is now env-driven so the operator can
       # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
       # without a redeploy. Defaults true when unset so a fresh stack

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -6,7 +6,7 @@ services:
       - APP_ENV=staging
       - HOST=0.0.0.0
       - PORT=8080
-      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
+      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
       # REGISTRATION_ENABLED is now env-driven so the operator can
       # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
       # without a redeploy. Defaults true when unset so a fresh stack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - APP_ENV=development
       - HOST=0.0.0.0
       - PORT=8080
-      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)
+      - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
       - REGISTRATION_ENABLED=true
       - ADMIN_EMAILS=admin@example.test
       # Uncomment to wire the app to the mailpit sibling service for

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ const (
 	// DBDriverDefault is the default database driver. Currently, only sqlite is supported.
 	DBDriverDefault = "sqlite"
 	// DBURIDefault is the default database URI. Default is topbanana.sqlite in the current directory.
-	DBURIDefault = "file:topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)"
+	DBURIDefault = "file:topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate"
 	// DBMaxOpenConnsDefault is the default maximum number of open database connections.
 	DBMaxOpenConnsDefault = 10
 	// DBMaxIdleConnsDefault is the default maximum number of idle database connections.

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -39,7 +39,7 @@ func SetupTestDB(t *testing.T) (string, func()) {
 	}
 
 	dsn := fmt.Sprintf(
-		"file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)",
+		"file:%s?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate",
 		tmpDBPath,
 	)
 
@@ -66,7 +66,7 @@ func OpenUnmigrated(t *testing.T) *sql.DB {
 
 	db, err := sql.Open(
 		"sqlite",
-		":memory:?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)",
+		":memory:?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate",
 	)
 	if err != nil {
 		t.Fatalf("error opening SQLite database: %v", err)

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -112,7 +112,7 @@ const workerServer = (workerIndex: number) => {
       APP_ENV: 'development',
       HOST: '127.0.0.1',
       PORT: String(port),
-      DB_URI: `file:${dbPath}?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)`,
+      DB_URI: `file:${dbPath}?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate`,
       SESSION_KEY: 'e2e-test-session-key-do-not-use-in-prod-1234567890abcdef',
       REGISTRATION_ENABLED: 'true',
       // Shrink the per-question reveal beat (#247, default 3s) so the


### PR DESCRIPTION
Closes #551

## Root cause (not a test-sync issue)

#551 was filed as a flaky e2e/integration test. Reproduced and traced to a real **server concurrency bug**: under concurrent writes, a read-then-write transaction fails with SQLite **error 517 (`SQLITE_BUSY_SNAPSHOT`)** - a WAL write-conflict that `busy_timeout` does NOT retry (retrying a stale snapshot can't help). The handler then returns **500**.

Reproduced deterministically: `go test -race -count=40 -run TestRoles_HostGating` failed with `error deleting quiz ... database is locked (517)` -> `POST /admin/quizzes/{id}/delete status=500`. The flaky test was just the visible symptom; the same 500 can hit production when two users write concurrently.

## Fix

Add `_txlock=immediate` to every SQLite DSN. With modernc.org/sqlite this makes each transaction `BEGIN IMMEDIATE`, taking the write lock up front so concurrent writers serialize via `busy_timeout` instead of failing instantly with a snapshot conflict. Standard Go+SQLite fix; strictly safer (no new failure mode, slightly more writer serialization).

Applied to all 7 DSN construction sites so behaviour is consistent everywhere:
- `internal/config/config.go` (`DBURIDefault`, dev) and `cmd/seed-dev/main.go`
- `internal/dbtest/dbtest.go` (file + `:memory:` test DSNs)
- `test/e2e/playwright.config.ts`
- `docker-compose.yml`, `deployments/demo/docker-compose.{staging,production}.yml` (this is where prod/staging `DB_URI` lives - so production is fixed by this PR, no GitHub-var change needed)

## Verification

- `go test -race -count=60 -run TestRoles_HostGating`: 0 failures, 0 "database is locked" (baseline 40x reliably failed).
- `make check` (includes the `-race`+coverage integration run that surfaced the flake): green.

## Note

The same pragma string is now duplicated across 7 files (Go consts, TS, YAML) and drifted before. Can't fully centralise across languages, but the Go sites (`config.DBURIDefault` vs `seed-dev.defaultDBURI`) could share one const - left as a follow-up to keep this PR focused.