### PR TITLE
Use sqlc diff for the sqlc freshness check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,15 +68,22 @@ sqlc-generate: $(SQLC_BIN)
 # ship (it did once - the deleted ListAllPlayers/CountAllPlayers funcs
 # lingered in internal/db/players.sql.go). Mirrors the tailwind-check
 # gap-filler for the CSS layer.
+#
+# `sqlc diff` compares freshly-generated output against the files on disk
+# and exits non-zero when they differ - in-memory, without writing or
+# consulting git. The previous `generate` + `git diff` approach conflated
+# "stale" with "regenerated but not yet committed", so every feature
+# branch that touched internal/queries/ failed this check locally until
+# the result was committed (a false failure on #546/#548). Comparing the
+# generated output to the working tree fixes that while staying correct
+# on CI, where the files are already committed.
 .PHONY: sqlc-check
 sqlc-check: $(SQLC_BIN)
-	@$(SQLC_BIN) generate
-	@if ! git diff --quiet -- internal/db; then \
-	    echo "ERROR: internal/db is out of date - run \`make sqlc-generate\` and commit the result."; \
-	    git diff -- internal/db; \
+	@$(SQLC_BIN) diff || { \
+	    echo "ERROR: internal/db is out of date - run \`make sqlc-generate\` to regenerate it."; \
 	    exit 1; \
-	fi; \
-	echo "internal/db is up to date."
+	}
+	@echo "internal/db is up to date."
 
 # Advisory grep for cross-file rationale in comments (#177). Server-side
 # comments that explain what the frontend does with a value rot silently


### PR DESCRIPTION
Closes #550

## Problem

`make sqlc-check` ran `sqlc generate` then failed on any `git diff` in `internal/db`. That conflated two states:
1. **Stale** generated code (queries changed, not regenerated) - the real failure to catch.
2. **Correctly regenerated but not yet committed** - normal on a feature branch that touches `internal/queries/`.

Case 2 made `make check` fail locally on every queries-touching branch until `internal/db` was committed - a confusing false failure hit on #546 and #548. CI passed only because there the files are already committed.

## Fix

Use `sqlc diff`, which compares freshly-generated output against the files on disk and exits non-zero when they differ - in memory, without writing and without consulting git. So it passes whenever the working-tree files match the queries (committed or not) and fails when they're stale. CI behaviour is unchanged (committed + in-sync still passes; a query edited without regenerating still fails).

## Verification

- In-sync tree: `make sqlc-check` -> "internal/db is up to date." (rc 0).
- Stale (`sqlc diff` sees a difference): prints the diff + a "run make sqlc-generate" hint and exits non-zero.
- `make check` green.

The false-failure is fixed by construction: there is no longer any git check, so correctly-regenerated-but-uncommitted files take the same exit-0 path as in-sync.