### PR TITLE
Seed dev data with an authored multi-round quiz

### DIFF
--- a/cmd/seed-dev/export_test.go
+++ b/cmd/seed-dev/export_test.go
@@ -1,0 +1,20 @@
+package main
+
+// Test-only re-exports so the external main_test package can exercise
+// the fixture->domain mapping without widening the production surface.
+var (
+	ExportQuizFromFixture              = quizFromFixture
+	ErrExportFixtureQuestionsOrRounds  = errFixtureQuestionsOrRounds
+	ErrExportFixtureRoundTitleRequired = errFixtureRoundTitleRequired
+	ErrExportFixtureRoundNoQuestions   = errFixtureRoundNoQuestions
+)
+
+// ExportQuizFixture, ExportRoundFixture, ExportQuestionFixture, and
+// ExportOptionFixture re-export the unexported fixture types so the
+// external test can build inputs for ExportQuizFromFixture.
+type (
+	ExportQuizFixture     = quizFixture
+	ExportRoundFixture    = roundFixture
+	ExportQuestionFixture = questionFixture
+	ExportOptionFixture   = optionFixture
+)

--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -66,10 +66,22 @@ const (
 // JSON can flow through either the live admin endpoint or this
 // tool. Decoupling from quiz.Quiz keeps the wire shape small and
 // LLM-friendly (no IDs, no timestamps).
+//
+// Questions and Rounds are mutually exclusive, matching the admin
+// import payload (#546): a flat quiz supplies Questions (every
+// question lands in the default round), a multi-round quiz supplies
+// Rounds with their own questions.
 type quizFixture struct {
 	Title       string            `json:"title"`
 	Description string            `json:"description"`
-	Questions   []questionFixture `json:"questions"`
+	Questions   []questionFixture `json:"questions,omitempty"`
+	Rounds      []roundFixture    `json:"rounds,omitempty"`
+}
+
+type roundFixture struct {
+	Title     string            `json:"title"`
+	Summary   string            `json:"summary,omitempty"`
+	Questions []questionFixture `json:"questions"`
 }
 
 type questionFixture struct {
@@ -178,7 +190,10 @@ func seedQuizzes(
 ) ([]*quiz.Quiz, error) {
 	out := make([]*quiz.Quiz, 0, len(fixtures))
 	for i := range fixtures {
-		qz := quizFromFixture(&fixtures[i])
+		qz, err := quizFromFixture(&fixtures[i])
+		if err != nil {
+			return out, fmt.Errorf("build quiz %q: %w", fixtures[i].Title, err)
+		}
 		if err := quizzes.CreateQuiz(ctx, qz); err != nil {
 			if errors.Is(err, quiz.ErrSlugTaken) {
 				logger.Info("quiz already exists (skipping)", slog.String("title", qz.Title))
@@ -194,29 +209,107 @@ func seedQuizzes(
 	return out, nil
 }
 
+// errFixtureQuestionsOrRounds is returned when a fixture supplies both a
+// top-level questions array and a rounds array, or neither. The two are
+// mutually exclusive, mirroring the admin import payload (#546). The
+// fixtures are in-repo, so a malformed one is a programming error worth
+// failing the run over rather than tolerating.
+var (
+	errFixtureQuestionsOrRounds = errors.New(
+		"provide either a top-level questions array or a rounds array, not both and not neither",
+	)
+	// errFixtureRoundTitleRequired is returned when a rounds fixture
+	// carries a round with no title, mirroring the admin import (#546).
+	errFixtureRoundTitleRequired = errors.New("round title is required")
+	// errFixtureRoundNoQuestions is returned when a rounds fixture
+	// carries a round with no questions, mirroring the admin import (#546).
+	errFixtureRoundNoQuestions = errors.New("round needs at least one question")
+)
+
 // quizFromFixture converts a fixture into a domain Quiz pinned to the
 // seed admin. Question positions are 1..N in document order; the slug
 // is derived from the title the same way the admin import handler
 // does so an operator who imports the same JSON via /admin/quizzes/
 // import gets the same row shape.
-func quizFromFixture(f *quizFixture) *quiz.Quiz {
+//
+// A rounds fixture maps each round onto qz.Rounds (with a 0-based
+// round Position) and mirrors every question onto qz.Questions with a
+// quiz-wide 1..N position across all rounds - the same flattening the
+// admin import does (#546). The mirror matters here because finishGame
+// iterates qz.Questions to write game_questions; a rounds quiz with no
+// flat mirror would seed plays with zero questions.
+func quizFromFixture(f *quizFixture) (*quiz.Quiz, error) {
+	if (len(f.Questions) == 0) == (len(f.Rounds) == 0) {
+		return nil, errFixtureQuestionsOrRounds
+	}
+
 	qz := &quiz.Quiz{
 		Title:             f.Title,
 		Slug:              slug.Make(f.Title),
 		Description:       f.Description,
 		CreatedByPlayerID: seededAdminID,
 	}
-	qz.Questions = make([]*quiz.Question, 0, len(f.Questions))
-	for i, qf := range f.Questions {
-		qq := &quiz.Question{Text: qf.Text, Position: i + 1}
-		qq.Options = make([]*quiz.Option, 0, len(qf.Options))
-		for _, of := range qf.Options {
-			qq.Options = append(qq.Options, &quiz.Option{Text: of.Text, Correct: of.Correct})
+
+	if len(f.Rounds) > 0 {
+		if err := fillQuizFromRounds(qz, f.Rounds); err != nil {
+			return nil, err
 		}
-		qz.Questions = append(qz.Questions, qq)
+
+		return qz, nil
 	}
 
-	return qz
+	qz.Questions = make([]*quiz.Question, 0, len(f.Questions))
+	for i, qf := range f.Questions {
+		qz.Questions = append(qz.Questions, questionFromFixture(qf, i+1))
+	}
+
+	return qz, nil
+}
+
+// fillQuizFromRounds maps the authored rounds onto qz.Rounds and mirrors
+// every question onto qz.Questions with a quiz-wide 1..N position in
+// document order, so finishGame still finds the full question set when
+// seeding plays (#546). A round must carry a non-empty title and at
+// least one question, mirroring the admin import's per-round checks.
+func fillQuizFromRounds(qz *quiz.Quiz, rounds []roundFixture) error {
+	qz.Rounds = make([]*quiz.Round, 0, len(rounds))
+	pos := 0
+	for i, rf := range rounds {
+		if rf.Title == "" {
+			return fmt.Errorf("round %d: %w", i+1, errFixtureRoundTitleRequired)
+		}
+		if len(rf.Questions) == 0 {
+			return fmt.Errorf("round %q: %w", rf.Title, errFixtureRoundNoQuestions)
+		}
+
+		round := &quiz.Round{
+			Position:  i,
+			Title:     rf.Title,
+			Summary:   rf.Summary,
+			Questions: make([]*quiz.Question, 0, len(rf.Questions)),
+		}
+		for _, qf := range rf.Questions {
+			pos++
+			qq := questionFromFixture(qf, pos)
+			round.Questions = append(round.Questions, qq)
+			qz.Questions = append(qz.Questions, qq)
+		}
+		qz.Rounds = append(qz.Rounds, round)
+	}
+
+	return nil
+}
+
+// questionFromFixture maps one fixture question onto the domain type at
+// the given quiz-wide position.
+func questionFromFixture(qf questionFixture, position int) *quiz.Question {
+	qq := &quiz.Question{Text: qf.Text, Position: position}
+	qq.Options = make([]*quiz.Option, 0, len(qf.Options))
+	for _, of := range qf.Options {
+		qq.Options = append(qq.Options, &quiz.Option{Text: of.Text, Correct: of.Correct})
+	}
+
+	return qq
 }
 
 // seedPlays creates playerCount anonymous players and finishes

--- a/cmd/seed-dev/main_test.go
+++ b/cmd/seed-dev/main_test.go
@@ -1,0 +1,180 @@
+package main_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/starquake/topbanana/cmd/seed-dev"
+)
+
+func TestQuizFromFixtureFlat(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{
+		Title:       "Flat Quiz",
+		Description: "A single-round quiz.",
+		Questions: []ExportQuestionFixture{
+			{Text: "Q1", Options: []ExportOptionFixture{{Text: "A", Correct: true}, {Text: "B"}}},
+			{Text: "Q2", Options: []ExportOptionFixture{{Text: "C"}, {Text: "D", Correct: true}}},
+		},
+	}
+
+	qz, err := ExportQuizFromFixture(&f)
+	if err != nil {
+		t.Fatalf("ExportQuizFromFixture() err = %v, want nil", err)
+	}
+
+	if got, want := len(qz.Rounds), 0; got != want {
+		t.Errorf("len(Rounds) = %d, want %d", got, want)
+	}
+	if got, want := len(qz.Questions), 2; got != want {
+		t.Fatalf("len(Questions) = %d, want %d", got, want)
+	}
+	for i, q := range qz.Questions {
+		if got, want := q.Position, i+1; got != want {
+			t.Errorf("Questions[%d].Position = %d, want %d", i, got, want)
+		}
+	}
+	if got, want := qz.Questions[0].Text, "Q1"; got != want {
+		t.Errorf("Questions[0].Text = %q, want %q", got, want)
+	}
+	if got, want := len(qz.Questions[0].Options), 2; got != want {
+		t.Errorf("len(Questions[0].Options) = %d, want %d", got, want)
+	}
+}
+
+func TestQuizFromFixtureRounds(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{
+		Title:       "Round Quiz",
+		Description: "A multi-round quiz.",
+		Rounds: []ExportRoundFixture{
+			{
+				Title:   "Warm-up",
+				Summary: "An easy start.",
+				Questions: []ExportQuestionFixture{
+					{Text: "R1Q1", Options: []ExportOptionFixture{{Text: "A", Correct: true}, {Text: "B"}}},
+					{Text: "R1Q2", Options: []ExportOptionFixture{{Text: "C", Correct: true}, {Text: "D"}}},
+				},
+			},
+			{
+				Title:   "Final stretch",
+				Summary: "One harder round.",
+				Questions: []ExportQuestionFixture{
+					{Text: "R2Q1", Options: []ExportOptionFixture{{Text: "E", Correct: true}, {Text: "F"}}},
+				},
+			},
+		},
+	}
+
+	qz, err := ExportQuizFromFixture(&f)
+	if err != nil {
+		t.Fatalf("ExportQuizFromFixture() err = %v, want nil", err)
+	}
+
+	if got, want := len(qz.Rounds), 2; got != want {
+		t.Fatalf("len(Rounds) = %d, want %d", got, want)
+	}
+
+	if got, want := qz.Rounds[0].Title, "Warm-up"; got != want {
+		t.Errorf("Rounds[0].Title = %q, want %q", got, want)
+	}
+	if got, want := qz.Rounds[0].Summary, "An easy start."; got != want {
+		t.Errorf("Rounds[0].Summary = %q, want %q", got, want)
+	}
+	if got, want := qz.Rounds[0].Position, 0; got != want {
+		t.Errorf("Rounds[0].Position = %d, want %d", got, want)
+	}
+	if got, want := qz.Rounds[1].Title, "Final stretch"; got != want {
+		t.Errorf("Rounds[1].Title = %q, want %q", got, want)
+	}
+	if got, want := qz.Rounds[1].Position, 1; got != want {
+		t.Errorf("Rounds[1].Position = %d, want %d", got, want)
+	}
+
+	if got, want := len(qz.Rounds[0].Questions), 2; got != want {
+		t.Errorf("len(Rounds[0].Questions) = %d, want %d", got, want)
+	}
+	if got, want := len(qz.Rounds[1].Questions), 1; got != want {
+		t.Errorf("len(Rounds[1].Questions) = %d, want %d", got, want)
+	}
+
+	// finishGame iterates qz.Questions, so the flat mirror must hold every
+	// question with quiz-wide positions 1..N in document order across rounds.
+	if got, want := len(qz.Questions), 3; got != want {
+		t.Fatalf("len(Questions) = %d, want %d", got, want)
+	}
+	wantText := []string{"R1Q1", "R1Q2", "R2Q1"}
+	for i, q := range qz.Questions {
+		if got, want := q.Position, i+1; got != want {
+			t.Errorf("Questions[%d].Position = %d, want %d", i, got, want)
+		}
+		if got, want := q.Text, wantText[i]; got != want {
+			t.Errorf("Questions[%d].Text = %q, want %q", i, got, want)
+		}
+	}
+
+	// The flat mirror and the per-round slices share the same question
+	// pointers, so a position assigned once is visible from both views.
+	if qz.Rounds[0].Questions[0] != qz.Questions[0] {
+		t.Error("Rounds[0].Questions[0] is not the same pointer as Questions[0]")
+	}
+	if qz.Rounds[1].Questions[0] != qz.Questions[2] {
+		t.Error("Rounds[1].Questions[0] is not the same pointer as Questions[2]")
+	}
+}
+
+func TestQuizFromFixtureRoundsAndQuestionsRejected(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{
+		Title:     "Both",
+		Questions: []ExportQuestionFixture{{Text: "Q1"}},
+		Rounds:    []ExportRoundFixture{{Title: "R", Questions: []ExportQuestionFixture{{Text: "R1Q1"}}}},
+	}
+
+	if _, err := ExportQuizFromFixture(&f); !errors.Is(err, ErrExportFixtureQuestionsOrRounds) {
+		t.Errorf("err = %v, want %v", err, ErrExportFixtureQuestionsOrRounds)
+	}
+}
+
+func TestQuizFromFixtureNeitherRejected(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{Title: "Empty"}
+
+	if _, err := ExportQuizFromFixture(&f); !errors.Is(err, ErrExportFixtureQuestionsOrRounds) {
+		t.Errorf("err = %v, want %v", err, ErrExportFixtureQuestionsOrRounds)
+	}
+}
+
+func TestQuizFromFixtureRoundTitleRequired(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{
+		Title: "No Round Title",
+		Rounds: []ExportRoundFixture{
+			{Title: "", Questions: []ExportQuestionFixture{{Text: "R1Q1"}}},
+		},
+	}
+
+	if _, err := ExportQuizFromFixture(&f); !errors.Is(err, ErrExportFixtureRoundTitleRequired) {
+		t.Errorf("err = %v, want %v", err, ErrExportFixtureRoundTitleRequired)
+	}
+}
+
+func TestQuizFromFixtureRoundNoQuestions(t *testing.T) {
+	t.Parallel()
+
+	f := ExportQuizFixture{
+		Title: "Empty Round",
+		Rounds: []ExportRoundFixture{
+			{Title: "Lonely", Questions: nil},
+		},
+	}
+
+	if _, err := ExportQuizFromFixture(&f); !errors.Is(err, ErrExportFixtureRoundNoQuestions) {
+		t.Errorf("err = %v, want %v", err, ErrExportFixtureRoundNoQuestions)
+	}
+}

--- a/dev/fixtures/quizzes.json
+++ b/dev/fixtures/quizzes.json
@@ -1,11 +1,26 @@
 [
   {
     "title": "European Capitals",
-    "description": "Twelve quick-fire questions covering EU capitals.",
-    "questions": [
-      {"text": "Which city sits on the river Vltava?", "options": [{"text": "Bratislava", "correct": false}, {"text": "Budapest", "correct": false}, {"text": "Prague", "correct": true}, {"text": "Warsaw", "correct": false}]},
-      {"text": "What is the capital of Portugal?", "options": [{"text": "Madrid", "correct": false}, {"text": "Lisbon", "correct": true}, {"text": "Porto", "correct": false}, {"text": "Faro", "correct": false}]},
-      {"text": "Which capital lies on the Danube?", "options": [{"text": "Berlin", "correct": false}, {"text": "Vienna", "correct": true}, {"text": "Rome", "correct": false}, {"text": "Helsinki", "correct": false}]}
+    "description": "A tour of EU capitals, split into two rounds.",
+    "rounds": [
+      {
+        "title": "Warm-up",
+        "summary": "Three well-known capitals to ease everyone in before the harder round.",
+        "questions": [
+          {"text": "Which city sits on the river Vltava?", "options": [{"text": "Bratislava", "correct": false}, {"text": "Budapest", "correct": false}, {"text": "Prague", "correct": true}, {"text": "Warsaw", "correct": false}]},
+          {"text": "What is the capital of Portugal?", "options": [{"text": "Madrid", "correct": false}, {"text": "Lisbon", "correct": true}, {"text": "Porto", "correct": false}, {"text": "Faro", "correct": false}]},
+          {"text": "Which capital lies on the Danube?", "options": [{"text": "Berlin", "correct": false}, {"text": "Vienna", "correct": true}, {"text": "Rome", "correct": false}, {"text": "Helsinki", "correct": false}]}
+        ]
+      },
+      {
+        "title": "Northern reaches",
+        "summary": "The Nordic and Baltic capitals, where the trickier guesses tend to live.",
+        "questions": [
+          {"text": "What is the capital of Finland?", "options": [{"text": "Oslo", "correct": false}, {"text": "Stockholm", "correct": false}, {"text": "Helsinki", "correct": true}, {"text": "Tallinn", "correct": false}]},
+          {"text": "Which city is the capital of Estonia?", "options": [{"text": "Riga", "correct": false}, {"text": "Tallinn", "correct": true}, {"text": "Vilnius", "correct": false}, {"text": "Helsinki", "correct": false}]},
+          {"text": "What is the capital of Denmark?", "options": [{"text": "Copenhagen", "correct": true}, {"text": "Bergen", "correct": false}, {"text": "Malmo", "correct": false}, {"text": "Aarhus", "correct": false}]}
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
Closes #549

## Why

The dev seeder built every quiz as a flat `questions[]` list, so each seeded quiz had a single default round with no summary - meaning a fresh `make seed-dev` never exercised the round intro/recap cards (#548), which only appear for rounds with an authored summary. Testing rounds locally required hand-authoring a summary in the admin UI.

## What

- Extended the seeder fixtures to mirror the import `rounds[]` wire shape (#546): a `roundFixture` (title + optional summary + questions) and an optional `rounds[]` on `quizFixture`, mutually exclusive with the top-level `questions[]`.
- `quizFromFixture` now builds `qz.Rounds` for rounds-based fixtures (reusing the store's authored-rounds path from #546), assigning quiz-wide positions 1..N across rounds and mirroring every question onto the flat `qz.Questions` - which `finishGame` iterates to seed plays, so leaderboard seeding still works for round quizzes.
- Converted one fixture ("European Capitals") to a 2-round quiz with titles + summaries; the other 31 stay flat, so a fresh seed exercises both paths.
- Added `cmd/seed-dev` unit tests (none existed) for the rounds mapping and the flat path.

## Verification

- `make check` green.
- Seeder run against a throwaway DB: 32 quizzes seeded, "European Capitals" has 2 authored rounds with summaries (positions 1-3 / 4-6), and its seeded play wrote 6 game_questions (the flat-mirror invariant holds).