### PR TITLE
Let break-glass tools run with only the database configured

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -92,12 +92,12 @@ func ResetPassword(
 		return fmt.Errorf(resetWrap, errResetEmailRequired)
 	}
 
-	cfg, err := config.Parse(getenv)
+	dbc, err := config.ParseDatabase(getenv)
 	if err != nil {
 		return fmt.Errorf("reset password: parse config: %w", err)
 	}
 
-	conn, err := setupDB(ctx, cfg, logger)
+	conn, err := setupDB(ctx, dbc, logger)
 	if err != nil {
 		return err
 	}
@@ -168,12 +168,12 @@ func PromoteAdmin(
 		return fmt.Errorf("promote admin: %w", errPromoteEmailRequired)
 	}
 
-	cfg, err := config.Parse(getenv)
+	dbc, err := config.ParseDatabase(getenv)
 	if err != nil {
 		return fmt.Errorf("promote admin: parse config: %w", err)
 	}
 
-	conn, err := setupDB(ctx, cfg, logger)
+	conn, err := setupDB(ctx, dbc, logger)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func Check(ctx context.Context, getenv func(string) string, stdout io.Writer) er
 	}
 	logConfigSummary(ctx, logger, cfg)
 
-	conn, err := setupDB(ctx, cfg, logger)
+	conn, err := setupDB(ctx, cfg.DatabaseConfig(), logger)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func Run(
 	}
 	logConfigSummary(signalCtx, logger, cfg)
 
-	conn, err := setupDB(signalCtx, cfg, logger)
+	conn, err := setupDB(signalCtx, cfg.DatabaseConfig(), logger)
 	if err != nil {
 		return err
 	}
@@ -584,14 +584,14 @@ func buildMailer(
 	return mailer.NewTester(inner), mailer.NewStatusView(smtpCfg, true, cfg.BaseURL), nil
 }
 
-func setupDB(signalCtx context.Context, cfg *config.Config, logger *slog.Logger) (*sql.DB, error) {
+func setupDB(signalCtx context.Context, dbc config.DatabaseConfig, logger *slog.Logger) (*sql.DB, error) {
 	conn, err := database.Open(
 		signalCtx,
-		cfg.DBDriver,
-		cfg.DBURI,
-		cfg.DBMaxOpenConns,
-		cfg.DBMaxIdleConns,
-		cfg.DBConnMaxLifetime,
+		dbc.Driver,
+		dbc.URI,
+		dbc.MaxOpenConns,
+		dbc.MaxIdleConns,
+		dbc.ConnMaxLifetime,
 	)
 	if err != nil {
 		logger.ErrorContext(signalCtx, "error opening database connection", slog.Any("err", err))

--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -141,6 +141,78 @@ func envFor(dbURI string) func(string) string {
 	}
 }
 
+// minimalEnvFor returns a getenv-style closure that exposes ONLY DB_URI -
+// no APP_ENV, no SESSION_KEY, no SMTP/OAuth. This is the locked-out
+// recovery scenario the break-glass tools must run in: config.Parse would
+// reject it (production-secure defaults require SESSION_KEY when APP_ENV is
+// unset), but config.ParseDatabase resolves just the DB so the tools work.
+func minimalEnvFor(dbURI string) func(string) string {
+	return func(key string) string {
+		if key == "DB_URI" {
+			return dbURI
+		}
+
+		return ""
+	}
+}
+
+// TestPromoteAdmin_MinimalEnv_NoSessionKey pins the break-glass contract:
+// PromoteAdmin succeeds with only DB_URI set (no APP_ENV, no SESSION_KEY),
+// which config.Parse would reject. The role change must actually land.
+func TestPromoteAdmin_MinimalEnv_NoSessionKey(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		username = "alice"
+		email    = "alice@example.test"
+	)
+	seedPlayer(t, dbURI, username)
+	demoteToHost(t, dbURI, username)
+
+	var stdout, stderr bytes.Buffer
+	if err := PromoteAdmin(t.Context(), minimalEnvFor(dbURI), &stdout, &stderr, email); err != nil {
+		t.Fatalf("PromoteAdmin err = %v, want nil with only DB_URI set", err)
+	}
+
+	p := fetchSeededPlayer(t, dbURI)
+	if got, want := p.Role, auth.RoleAdmin; got != want {
+		t.Errorf("Role after PromoteAdmin = %q, want %q", got, want)
+	}
+}
+
+// TestResetPassword_MinimalEnv_NoSessionKey is the ResetPassword half of
+// the break-glass contract: a password reset succeeds with only DB_URI set.
+func TestResetPassword_MinimalEnv_NoSessionKey(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		username    = "alice"
+		email       = "alice@example.test"
+		newPassword = "new-correct-battery"
+	)
+	originalHash := seedPlayer(t, dbURI, username)
+
+	stdin := strings.NewReader(newPassword + "\n" + newPassword + "\n")
+	var stdout, stderr bytes.Buffer
+	if err := ResetPassword(t.Context(), minimalEnvFor(dbURI), stdin, &stdout, &stderr, email); err != nil {
+		t.Fatalf("ResetPassword err = %v, want nil with only DB_URI set", err)
+	}
+
+	p := fetchSeededPlayer(t, dbURI)
+	if got, want := p.PasswordHash, originalHash; got == want {
+		t.Errorf("PasswordHash after ResetPassword = %q, want a value different from %q", got, want)
+	}
+	if err := auth.CheckPassword(p.PasswordHash, newPassword); err != nil {
+		t.Errorf("CheckPassword(newPassword) err = %v, want nil", err)
+	}
+}
+
 func TestResetPassword_HappyPath_RotatesHash(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,93 @@ type Config struct {
 	TrustedProxyCIDRs []*net.IPNet
 }
 
+// DatabaseConfig holds only the database settings setupDB needs. The
+// break-glass CLI tools (reset-password, promote-admin) resolve just
+// these via [ParseDatabase] so they run in a half-configured or
+// locked-out environment without the full-server validation (SESSION_KEY,
+// SMTP, OAuth, ...) standing in the way.
+type DatabaseConfig struct {
+	Driver          string
+	URI             string
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+}
+
+// DatabaseConfig returns the database-only view of the full config so
+// server-boot callers and the break-glass tools share one path into
+// setupDB.
+func (c *Config) DatabaseConfig() DatabaseConfig {
+	return DatabaseConfig{
+		Driver:          c.DBDriver,
+		URI:             c.DBURI,
+		MaxOpenConns:    c.DBMaxOpenConns,
+		MaxIdleConns:    c.DBMaxIdleConns,
+		ConnMaxLifetime: c.DBConnMaxLifetime,
+	}
+}
+
+// ParseDatabase resolves only the database settings, applying the same
+// rules as [Parse] (DB_URI from env falling back to DBURIDefault outside
+// production, ErrDBURINotSetInProduction when unset in production, driver
+// and pool defaults plus their env overrides) without requiring
+// SESSION_KEY or any other server field. This keeps the break-glass CLI
+// tools runnable when the rest of the config is missing or broken.
+func ParseDatabase(getenv func(string) string) (DatabaseConfig, error) {
+	appEnvironment := getenv("APP_ENV")
+
+	dbc := DatabaseConfig{
+		Driver:          DBDriverDefault,
+		URI:             DBURIDefault,
+		MaxOpenConns:    DBMaxOpenConnsDefault,
+		MaxIdleConns:    DBMaxIdleConnsDefault,
+		ConnMaxLifetime: DBConnMaxLifetimeDefault,
+	}
+	if err := resolveDatabaseConfig(getenv, appEnvironment, &dbc); err != nil {
+		return DatabaseConfig{}, err
+	}
+
+	return dbc, nil
+}
+
+// resolveDatabaseConfig applies the DB_URI fallback / production guard and
+// the pool-setting env overrides onto dbc. Shared by [Parse] and
+// [ParseDatabase] so the two cannot drift.
+func resolveDatabaseConfig(getenv func(string) string, appEnvironment string, dbc *DatabaseConfig) error {
+	if val := getenv("DB_URI"); val != "" {
+		dbc.URI = val
+	}
+	if appEnvironment == AppEnvironmentProduction && getenv("DB_URI") == "" {
+		return ErrDBURINotSetInProduction
+	}
+
+	if val := getenv("DB_MAX_OPEN_CONNS"); val != "" {
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid DB_MAX_OPEN_CONNS: %q, err: %w", val, err)
+		}
+		dbc.MaxOpenConns = n
+	}
+
+	if val := getenv("DB_MAX_IDLE_CONNS"); val != "" {
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid DB_MAX_IDLE_CONNS: %q, err: %w", val, err)
+		}
+		dbc.MaxIdleConns = n
+	}
+
+	if val := getenv("DB_CONN_MAX_LIFETIME"); val != "" {
+		d, err := time.ParseDuration(val)
+		if err != nil {
+			return fmt.Errorf("invalid DB_CONN_MAX_LIFETIME: %q, err: %w", val, err)
+		}
+		dbc.ConnMaxLifetime = d
+	}
+
+	return nil
+}
+
 // SMTPConfigured reports whether enough SMTP env vars are populated
 // for the real mailer to dial out. Used by [cmd/server/app.app] to
 // pick between the go-mail-backed mailer and the no-op stub. Mirrors
@@ -278,9 +365,6 @@ func Parse(getenv func(string) string) (*Config, error) {
 	if val := getenv("PORT"); val != "" {
 		c.Port = val
 	}
-	if val := getenv("DB_URI"); val != "" {
-		c.DBURI = val
-	}
 	if c.AppEnvironment == "development" {
 		if val := getenv("CLIENT_DIR"); val != "" {
 			c.ClientDir = val
@@ -290,13 +374,12 @@ func Parse(getenv func(string) string) (*Config, error) {
 		}
 	}
 
-	if err := parseTypedEnvVars(getenv, &c); err != nil {
+	if err := c.applyDatabaseConfig(getenv); err != nil {
 		return nil, err
 	}
 
-	// Mandatory fields
-	if c.AppEnvironment == AppEnvironmentProduction && getenv("DB_URI") == "" {
-		return nil, ErrDBURINotSetInProduction
+	if err := parseTypedEnvVars(getenv, &c); err != nil {
+		return nil, err
 	}
 
 	key, err := resolveSessionKey(getenv("SESSION_KEY"), c.AppEnvironment)
@@ -336,32 +419,10 @@ func (c *Config) GoogleLoginEnabled() bool {
 }
 
 // parseTypedEnvVars reads strict-typed env vars (ints, durations, bools) into c. It returns a
-// wrapped error if any value fails to parse.
+// wrapped error if any value fails to parse. The DB pool settings are
+// resolved separately via [resolveDatabaseConfig] so the break-glass tools
+// can reuse them without the rest of the server config.
 func parseTypedEnvVars(getenv func(string) string, c *Config) error {
-	if val := getenv("DB_MAX_OPEN_CONNS"); val != "" {
-		n, err := strconv.Atoi(val)
-		if err != nil {
-			return fmt.Errorf("invalid DB_MAX_OPEN_CONNS: %q, err: %w", val, err)
-		}
-		c.DBMaxOpenConns = n
-	}
-
-	if val := getenv("DB_MAX_IDLE_CONNS"); val != "" {
-		n, err := strconv.Atoi(val)
-		if err != nil {
-			return fmt.Errorf("invalid DB_MAX_IDLE_CONNS: %q, err: %w", val, err)
-		}
-		c.DBMaxIdleConns = n
-	}
-
-	if val := getenv("DB_CONN_MAX_LIFETIME"); val != "" {
-		d, err := time.ParseDuration(val)
-		if err != nil {
-			return fmt.Errorf("invalid DB_CONN_MAX_LIFETIME: %q, err: %w", val, err)
-		}
-		c.DBConnMaxLifetime = d
-	}
-
 	if val := getenv("REGISTRATION_ENABLED"); val != "" {
 		b, err := strconv.ParseBool(val)
 		if err != nil {
@@ -517,4 +578,22 @@ func resolveSessionKey(envValue, appEnvironment string) (string, error) {
 // IsProduction returns true if the application is running in production.
 func (c *Config) IsProduction() bool {
 	return c.AppEnvironment == AppEnvironmentProduction
+}
+
+// applyDatabaseConfig resolves the database settings into c via the
+// shared resolveDatabaseConfig helper and writes them back onto the
+// DB* fields. Pulled out of Parse so Parse stays within the
+// function-length limit; ParseDatabase uses the same helper.
+func (c *Config) applyDatabaseConfig(getenv func(string) string) error {
+	dbc := c.DatabaseConfig()
+	if err := resolveDatabaseConfig(getenv, c.AppEnvironment, &dbc); err != nil {
+		return err
+	}
+	c.DBDriver = dbc.Driver
+	c.DBURI = dbc.URI
+	c.DBMaxOpenConns = dbc.MaxOpenConns
+	c.DBMaxIdleConns = dbc.MaxIdleConns
+	c.DBConnMaxLifetime = dbc.ConnMaxLifetime
+
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -623,6 +623,173 @@ func TestParse_GoogleOAuth(t *testing.T) {
 	})
 }
 
+func TestParseDatabase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DB_URI unset outside production falls back to default", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(string) string { return "" }
+		dbc, err := ParseDatabase(getenv)
+		if err != nil {
+			t.Fatalf("ParseDatabase err = %v, want nil", err)
+		}
+		if got, want := dbc.URI, DBURIDefault; got != want {
+			t.Errorf("URI = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("DB_URI unset in production returns ErrDBURINotSetInProduction", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(key string) string {
+			if key == "APP_ENV" {
+				return "production"
+			}
+
+			return ""
+		}
+		_, err := ParseDatabase(getenv)
+		if got, want := err, ErrDBURINotSetInProduction; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("explicit DB_URI is honored", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(key string) string {
+			if key == "DB_URI" {
+				return "file:override.sqlite"
+			}
+
+			return ""
+		}
+		dbc, err := ParseDatabase(getenv)
+		if err != nil {
+			t.Fatalf("ParseDatabase err = %v, want nil", err)
+		}
+		if got, want := dbc.URI, "file:override.sqlite"; got != want {
+			t.Errorf("URI = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("driver and pool defaults", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(string) string { return "" }
+		dbc, err := ParseDatabase(getenv)
+		if err != nil {
+			t.Fatalf("ParseDatabase err = %v, want nil", err)
+		}
+		if got, want := dbc.Driver, DBDriverDefault; got != want {
+			t.Errorf("Driver = %q, want %q", got, want)
+		}
+		if got, want := dbc.MaxOpenConns, DBMaxOpenConnsDefault; got != want {
+			t.Errorf("MaxOpenConns = %d, want %d", got, want)
+		}
+		if got, want := dbc.MaxIdleConns, DBMaxIdleConnsDefault; got != want {
+			t.Errorf("MaxIdleConns = %d, want %d", got, want)
+		}
+		if got, want := dbc.ConnMaxLifetime, DBConnMaxLifetimeDefault; got != want {
+			t.Errorf("ConnMaxLifetime = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("pool env overrides are honored", func(t *testing.T) {
+		t.Parallel()
+
+		envs := map[string]string{
+			"DB_MAX_OPEN_CONNS":    "100",
+			"DB_MAX_IDLE_CONNS":    "200",
+			"DB_CONN_MAX_LIFETIME": "10m",
+		}
+		getenv := func(key string) string { return envs[key] }
+		dbc, err := ParseDatabase(getenv)
+		if err != nil {
+			t.Fatalf("ParseDatabase err = %v, want nil", err)
+		}
+		if got, want := dbc.MaxOpenConns, 100; got != want {
+			t.Errorf("MaxOpenConns = %d, want %d", got, want)
+		}
+		if got, want := dbc.MaxIdleConns, 200; got != want {
+			t.Errorf("MaxIdleConns = %d, want %d", got, want)
+		}
+		if got, want := dbc.ConnMaxLifetime, 10*time.Minute; got != want {
+			t.Errorf("ConnMaxLifetime = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("invalid pool override returns error", func(t *testing.T) {
+		t.Parallel()
+
+		getenv := func(key string) string {
+			if key == "DB_MAX_OPEN_CONNS" {
+				return "lots"
+			}
+
+			return ""
+		}
+		_, err := ParseDatabase(getenv)
+		if err == nil {
+			t.Fatal("ParseDatabase err = nil, want non-nil")
+		}
+		if got, want := err.Error(), "invalid DB_MAX_OPEN_CONNS"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+
+	t.Run("does not require SESSION_KEY outside development", func(t *testing.T) {
+		t.Parallel()
+
+		// The whole point: a half-configured / locked-out environment
+		// (production-like APP_ENV, no SESSION_KEY) must still resolve the
+		// DB so the break-glass tools can run. Parse would reject this with
+		// ErrSessionKeyRequired; ParseDatabase must not.
+		envs := map[string]string{
+			"APP_ENV": "production",
+			"DB_URI":  "file:test.sqlite",
+		}
+		getenv := func(key string) string { return envs[key] }
+		dbc, err := ParseDatabase(getenv)
+		if err != nil {
+			t.Fatalf("ParseDatabase err = %v, want nil (no SESSION_KEY needed)", err)
+		}
+		if got, want := dbc.URI, "file:test.sqlite"; got != want {
+			t.Errorf("URI = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestConfig_DatabaseConfig pins that the full-server config and the
+// break-glass tools resolve the same DB values: Parse's result projected
+// through DatabaseConfig() must match ParseDatabase on the same env.
+func TestConfig_DatabaseConfig(t *testing.T) {
+	t.Parallel()
+
+	envs := map[string]string{
+		"APP_ENV":              "test",
+		"DB_URI":               "file:shared.sqlite",
+		"DB_MAX_OPEN_CONNS":    "42",
+		"DB_MAX_IDLE_CONNS":    "7",
+		"DB_CONN_MAX_LIFETIME": "90s",
+		"SESSION_KEY":          "test-session-key",
+	}
+	getenv := func(key string) string { return envs[key] }
+
+	c, err := Parse(getenv)
+	if err != nil {
+		t.Fatalf("Parse err = %v, want nil", err)
+	}
+	dbc, err := ParseDatabase(getenv)
+	if err != nil {
+		t.Fatalf("ParseDatabase err = %v, want nil", err)
+	}
+	if got, want := c.DatabaseConfig(), dbc; got != want {
+		t.Errorf("c.DatabaseConfig() = %+v, want %+v (Parse and ParseDatabase must agree)", got, want)
+	}
+}
+
 func TestConfig_GoogleLoginEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #553

## Problem

`-promote-admin` and `-reset-password` (`cmd/server/app`) called `config.Parse`, which validates the whole server config - so they required `SESSION_KEY` (unless APP_ENV=development) and the rest, even though they only need the database. A recovery tool you reach for when things are broken shouldn't demand a fully-valid production config.

## Fix

- New `config.DatabaseConfig` (Driver, URI, pool settings) + `config.ParseDatabase(getenv)` that resolves ONLY the DB settings - DB_URI from env / `DBURIDefault` outside production / `ErrDBURINotSetInProduction` when unset in production, plus driver and pool defaults and their env overrides - without requiring SESSION_KEY or anything else.
- `setupDB` now takes `config.DatabaseConfig`. Server-boot paths pass `cfg.DatabaseConfig()`; the two break-glass tools call `config.ParseDatabase` and drop their `config.Parse`.
- All DB resolution (URI fallback, production guard, pool env overrides) lives in one shared `resolveDatabaseConfig` helper used by both `Parse` and `ParseDatabase`, so they can't drift. `Parse`'s DB behaviour is unchanged.

## Verification

- `make check` green; config tests cover `ParseDatabase` (dev fallback, prod-required error, explicit value, defaults) and that it succeeds with no SESSION_KEY; app tests run `PromoteAdmin`/`ResetPassword` with a minimal env (only DB_URI).
- Manual: `env -u APP_ENV -u SESSION_KEY DB_URI=file:...  go run ./cmd/server/ -promote-admin x@example.test` migrates the DB and fails on *email not found* (not a config error) - previously it errored on `SESSION_KEY must be set` before touching the DB.