### PR TITLE
Give the reset-password and verify-email fields a visible border

### DIFF
--- a/internal/web/tmpl/auth/pages/reset_password.gohtml
+++ b/internal/web/tmpl/auth/pages/reset_password.gohtml
@@ -21,11 +21,11 @@
             <input type="hidden" name="token" value="{{.Token}}">
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">New password</span>
-                <input type="password" name="password" autocomplete="new-password" required class="input">
+                <input type="password" name="password" autocomplete="new-password" required class="form-input">
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Confirm new password</span>
-                <input type="password" name="confirm" autocomplete="new-password" required class="input">
+                <input type="password" name="confirm" autocomplete="new-password" required class="form-input">
             </label>
             <button type="submit" class="btn-primary">Update password</button>
         </form>

--- a/internal/web/tmpl/auth/pages/verify_email_request.gohtml
+++ b/internal/web/tmpl/auth/pages/verify_email_request.gohtml
@@ -24,7 +24,7 @@
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Email</span>
                 <input type="email" name="email" value="{{.Email}}" autocomplete="email" required
-                       class="input">
+                       class="form-input">
             </label>
             <button type="submit" class="btn-primary" {{if .SubmitDisabled}}disabled aria-disabled="true"{{end}}>
                 {{if .SubmitDisabled}}Wait {{.SubmitWaitSecs}}s{{else}}Send verification link{{end}}


### PR DESCRIPTION
Closes #561

The "New password" / "Confirm new password" inputs on the reset-password page (and the email field on verify-email-request) used `class="input"` - which is not a defined component class - so they rendered with no border, hard to see on the dark surface. Every other form uses `.form-input` (which carries `border border-border`); this was a leftover from an `input` -> `form-input` rename that missed these three inputs.

Changed the three inputs to `class="form-input"`. No CSS change - `.form-input` already exists and is in the built `app.css` (`make tailwind-check` clean). `make check` green.