### PR TITLE
Log the user in after a password reset

### DIFF
--- a/internal/auth/reset_handler.go
+++ b/internal/auth/reset_handler.go
@@ -72,14 +72,16 @@ func resetTokenLivePreflight(r *http.Request, logger *slog.Logger, tokens ResetT
 // hashes the new password, then calls ConsumeResetToken which atomically
 // marks the token consumed, rotates password_hash, and bumps
 // session_version (so every cookie minted before the reset becomes
-// invalid the moment the transaction commits). The handler does NOT
-// log the user in - it 303s to /login so the new credentials are
-// exercised on the next request.
+// invalid the moment the transaction commits). On success it logs the
+// reset-token holder in with the post-rotation session_version and 303s
+// to their role landing; every OTHER session stays invalidated by the
+// rotation.
 func HandleResetSubmit(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
 	tokens ResetTokenStore,
 	sessions *session.Manager,
+	players PlayerStore,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password.gohtml")
 	invalid := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password_invalid.gohtml")
@@ -112,13 +114,10 @@ func HandleResetSubmit(
 			return
 		}
 
-		_, err = tokens.ConsumeResetToken(r.Context(), HashResetToken(raw), hashed)
+		playerID, err := tokens.ConsumeResetToken(r.Context(), HashResetToken(raw), hashed)
 		switch {
 		case err == nil:
-			// Clear any current session so the user lands on a clean
-			// /login and exercises the new password.
-			sessions.Clear(w)
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			autoLoginAfterReset(w, r, logger, sessions, players, playerID)
 		case errors.Is(err, ErrResetTokenInvalid):
 			invalid.render(w, r, http.StatusGone, resetPageData{Title: "Reset link"})
 		default:
@@ -126,6 +125,36 @@ func HandleResetSubmit(
 			http.Error(w, "internal error", http.StatusInternalServerError)
 		}
 	})
+}
+
+// autoLoginAfterReset signs the reset-token holder in after a
+// successful ConsumeResetToken and 303s to their role landing. It
+// re-fetches the player so the session is minted with the
+// post-rotation session_version - using the pre-rotation value would
+// have the new cookie rejected on the very next request. The password
+// change is already committed at this point, so any failure here
+// (lookup or otherwise) must not surface as an error that hides the
+// successful reset: we log it and fall back to clearing the session
+// and redirecting to /login, where the just-set password works.
+func autoLoginAfterReset(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	sessions *session.Manager,
+	players PlayerStore,
+	playerID int64,
+) {
+	player, err := players.GetPlayerByID(r.Context(), playerID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "reset-password auto-login lookup failed",
+			slog.Int64("player_id", playerID), slog.Any("err", err))
+		sessions.Clear(w)
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+
+		return
+	}
+	sessions.Set(w, player.ID, player.SessionVersion)
+	http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
 }
 
 // validateResetInput pins the same length rule the register form

--- a/internal/auth/reset_handler_test.go
+++ b/internal/auth/reset_handler_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/session"
 )
 
 func TestHandleResetForm_LivePreflightRendersForm(t *testing.T) {
@@ -67,6 +69,176 @@ func TestHandleResetForm_LookupErrorFallsOpen(t *testing.T) {
 		t.Errorf("status = %d, want %d (preflight error must fall open)", got, want)
 	}
 }
+
+func TestHandleResetSubmit_AutoLoginToRoleLanding(t *testing.T) {
+	t.Parallel()
+
+	players := newStubPlayerStore()
+	admin, err := players.CreatePlayer(t.Context(), "reset-admin", "reset-admin@example.test", "old-hash", RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	admin.SessionVersion = 7
+
+	tokens := &consumeResetStore{playerID: admin.ID}
+	sessions := session.New([]byte("test-session-key"), false)
+	rec := runResetSubmit(t, tokens, sessions, players)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Header().Get("Location"), "/admin/quizzes"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+
+	id, version, ok := decodeSessionCookie(t, sessions, rec)
+	if !ok {
+		t.Fatal("reset response did not set a valid session cookie")
+	}
+	if got, want := id, admin.ID; got != want {
+		t.Errorf("session player id = %d, want %d", got, want)
+	}
+	// The cookie must carry the post-rotation version (read back from
+	// the store), not a stale one, or the next request would reject it.
+	if got, want := version, admin.SessionVersion; got != want {
+		t.Errorf("session version = %d, want %d (post-rotation value)", got, want)
+	}
+}
+
+func TestHandleResetSubmit_PlayerLandsOnHome(t *testing.T) {
+	t.Parallel()
+
+	players := newStubPlayerStore()
+	p, err := players.CreatePlayer(t.Context(), "reset-player", "reset-player@example.test", "old-hash", RolePlayer)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	// The first password-bearing registrant is auto-promoted to admin;
+	// force the role back to player so this test exercises the home landing.
+	p.Role = RolePlayer
+
+	tokens := &consumeResetStore{playerID: p.ID}
+	sessions := session.New([]byte("test-session-key"), false)
+	rec := runResetSubmit(t, tokens, sessions, players)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Header().Get("Location"), "/"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+	if _, _, ok := decodeSessionCookie(t, sessions, rec); !ok {
+		t.Error("reset response did not set a valid session cookie")
+	}
+}
+
+// TestHandleResetSubmit_LookupFailureFallsBackToLogin pins the
+// graceful-degradation path: the password change already committed, so
+// a failed auto-login lookup must clear the session and 303 to /login
+// rather than 500 in a way that hides the successful reset.
+func TestHandleResetSubmit_LookupFailureFallsBackToLogin(t *testing.T) {
+	t.Parallel()
+
+	players := newStubPlayerStore()
+	players.failGet = true
+
+	tokens := &consumeResetStore{playerID: 99}
+	sessions := session.New([]byte("test-session-key"), false)
+	rec := runResetSubmit(t, tokens, sessions, players)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Header().Get("Location"), "/login"; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+	// Fallback clears the session: the cookie is set with an empty value.
+	if _, _, ok := decodeSessionCookie(t, sessions, rec); ok {
+		t.Error("fallback must not leave a live session cookie")
+	}
+}
+
+func TestHandleResetSubmit_InvalidTokenRendersGone(t *testing.T) {
+	t.Parallel()
+
+	tokens := &consumeResetStore{consumeErr: ErrResetTokenInvalid}
+	sessions := session.New([]byte("test-session-key"), false)
+	rec := runResetSubmit(t, tokens, sessions, newStubPlayerStore())
+
+	if got, want := rec.Code, http.StatusGone; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func runResetSubmit(
+	t *testing.T,
+	tokens ResetTokenStore,
+	sessions *session.Manager,
+	players PlayerStore,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := HandleResetSubmit(discardLogger(), nil, tokens, sessions, players)
+	form := url.Values{}
+	form.Set("token", "raw-token")
+	form.Set("password", "new-pass-12345")
+	form.Set("confirm", "new-pass-12345")
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/reset-password", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// decodeSessionCookie replays the Set-Cookie from rec onto a fresh
+// request and asks the manager to decode it, so the test verifies the
+// cookie the handler minted is actually valid (not just present).
+func decodeSessionCookie(
+	t *testing.T, sessions *session.Manager, rec *httptest.ResponseRecorder,
+) (playerID, sessionVersion int64, ok bool) {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	for _, c := range rec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	return sessions.Decode(req)
+}
+
+// consumeResetStore is a ResetTokenStore whose ConsumeResetToken
+// returns a fixed player id (or a fixed error). The lookup/create/
+// delete surface is uninteresting for the POST path and returns
+// errors.ErrUnsupported.
+type consumeResetStore struct {
+	playerID   int64
+	consumeErr error
+}
+
+func (s *consumeResetStore) ConsumeResetToken(_ context.Context, _, _ string) (int64, error) {
+	if s.consumeErr != nil {
+		return 0, s.consumeErr
+	}
+
+	return s.playerID, nil
+}
+
+func (*consumeResetStore) LookupResetToken(_ context.Context, _ string) (int64, bool, error) {
+	return 0, false, errors.ErrUnsupported
+}
+
+func (*consumeResetStore) CreateResetToken(_ context.Context, _ string, _ int64, _ time.Time) error {
+	return errors.ErrUnsupported
+}
+
+func (*consumeResetStore) DeleteExpiredResetTokens(_ context.Context) error {
+	return nil
+}
+
+var _ ResetTokenStore = (*consumeResetStore)(nil)
 
 func runResetForm(t *testing.T, tokens ResetTokenStore, raw string) *httptest.ResponseRecorder {
 	t.Helper()

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -158,7 +158,7 @@ func addEmailFlowRoutes(
 
 	mux.Handle("GET /reset-password", auth.HandleResetForm(logger, csrfMgr, stores.ResetTokens))
 	mux.Handle("POST /reset-password", admin.MaxFormSizeMiddleware(csrfMW(
-		auth.HandleResetSubmit(logger, csrfMgr, stores.ResetTokens, sessions),
+		auth.HandleResetSubmit(logger, csrfMgr, stores.ResetTokens, sessions, stores.Players),
 	)))
 }
 

--- a/test/integration/reset_password_test.go
+++ b/test/integration/reset_password_test.go
@@ -12,11 +12,13 @@ import (
 	"time"
 
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/session"
 )
 
 // TestResetPassword_HappyPath registers a player, mints a reset token
 // against the store, posts the new password to /reset-password, and
-// asserts the rotation lands + the old session is invalidated. The
+// asserts the rotation lands, the reset-token holder is auto-logged-in
+// onto their role landing, and every OTHER session is invalidated. The
 // new login with the new password is exercised end-to-end.
 func TestResetPassword_HappyPath(t *testing.T) {
 	t.Parallel()
@@ -25,6 +27,8 @@ func TestResetPassword_HappyPath(t *testing.T) {
 		"REGISTRATION_ENABLED": "true",
 	})
 
+	// First password-bearing registrant is promoted to admin, so the
+	// reset-token holder's role landing is /admin/quizzes.
 	signed := authClient(t)
 	registerForRedirect(ctx, t, signed, srv.BaseURL, "reset-happy", "old-pass-12345")
 	verifyPlayerEmail(ctx, t, srv.DBURI, "reset-happy")
@@ -54,8 +58,12 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
 		t.Fatalf("status = %d, want %d", got, want)
 	}
-	if got, want := resp.Header.Get("Location"), "/login"; got != want {
+	// Auto-login lands the holder on their role page, not /login.
+	if got, want := resp.Header.Get("Location"), "/admin/quizzes"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
+	}
+	if !hasSessionCookie(resp) {
+		t.Errorf("reset response did not set a %q cookie; auto-login must mint a session", session.CookieName)
 	}
 
 	refreshed, err := stores.Players.GetPlayerByID(ctx, player.ID)
@@ -64,6 +72,14 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	}
 	if got, want := refreshed.SessionVersion, startingVersion+1; got != want {
 		t.Errorf("session_version = %d, want %d (reset must bump)", got, want)
+	}
+
+	// The auto-login cookie carries the post-rotation version, so the
+	// holder can reach a gated page without bouncing to /login.
+	gated := getWith(ctx, t, client, srv.BaseURL+"/admin/quizzes")
+	defer gated.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := gated.StatusCode, http.StatusOK; got != want {
+		t.Errorf("post-reset gated status = %d, want %d (auto-login must reach the landing)", got, want)
 	}
 
 	// The signed-in client's old cookie carried the pre-reset version;
@@ -83,6 +99,19 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	if got, want := loc, "/admin/quizzes"; got != want {
 		t.Errorf("post-reset login Location = %q, want %q", got, want)
 	}
+}
+
+// hasSessionCookie reports whether resp sets a non-empty session
+// cookie. A cleared session writes the same cookie name with an empty
+// value + MaxAge<0, so an empty value does not count as a live session.
+func hasSessionCookie(resp *http.Response) bool {
+	for _, c := range resp.Cookies() {
+		if c.Name == session.CookieName && c.Value != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // TestResetPassword_RejectsConsumedReplay pins the single-use rule:


### PR DESCRIPTION
Closes #563

## Change

After a successful token-based password reset, the user is now logged in and sent to their role landing (`/admin/quizzes` for admins, `/` otherwise) instead of being cleared and redirected to `/login` to sign in again.

`HandleResetSubmit` gains a `players PlayerStore` dep. On success it re-fetches the player (`GetPlayerByID`) to read the POST-rotation `session_version`, mints a session with it (`sessions.Set`), and 303s to `landingPathFor(role)`. `ConsumeResetToken` still rotates `session_version`, so every OTHER session stays invalidated - only the reset-token holder (who controls the email and just set the password) gets the new cookie.

## Graceful degradation

The password change is already committed when `ConsumeResetToken` succeeds. If the auto-login lookup fails, the handler logs it and falls back to `sessions.Clear` + redirect `/login` (the just-set password still works) rather than 500-ing and hiding the successful reset. The invalid-token (410) and generic-error (500) branches are unchanged.

## Tests

- Integration `TestResetPassword_HappyPath`: now asserts the 303 lands on the role page, a session cookie is set, a follow-up request to a gated endpoint succeeds (200, auto-login works), and a pre-reset session is still bounced (old sessions invalidated).
- Unit tests for the submit path: admin lands on `/admin/quizzes`, player on `/`, session minted with the post-rotation version, and the graceful `/login` fallback when the lookup fails.

`make check` + `make test-integration` green.