### PR TITLE
Move the round summary field above the name field in the round form

### DIFF
--- a/internal/web/tmpl/admin/pages/roundform.gohtml
+++ b/internal/web/tmpl/admin/pages/roundform.gohtml
@@ -39,6 +39,20 @@
         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
         <input type="hidden" name="id" value="{{.Round.ID}}">
 
+        {{$textErr := index .FieldErrors "summary"}}
+        <div class="form-field">
+            <label class="label-eyebrow" for="summary">
+                Round summary
+                <span class="label-hint">Optional. Shown when this round ends, before the next round starts.</span>
+            </label>
+            <textarea id="summary" name="summary" rows="3"
+                      class="form-input min-h-[100px] resize-y{{if $textErr}} form-input-error{{end}}"
+                      {{if $textErr}}aria-invalid="true" aria-describedby="summary-error"{{end}}>{{.Round.Summary}}</textarea>
+            {{if $textErr}}
+                <p id="summary-error" class="form-help-error" role="alert">{{$textErr}}</p>
+            {{end}}
+        </div>
+
         {{$titleErr := index .FieldErrors "title"}}
         <div class="form-field">
             <label class="label-eyebrow" for="title">
@@ -51,20 +65,6 @@
                    {{if $titleErr}}aria-invalid="true" aria-describedby="title-error"{{end}}>
             {{if $titleErr}}
                 <p id="title-error" class="form-help-error" role="alert">{{$titleErr}}</p>
-            {{end}}
-        </div>
-
-        {{$textErr := index .FieldErrors "summary"}}
-        <div class="form-field">
-            <label class="label-eyebrow" for="summary">
-                Round summary
-                <span class="label-hint">Optional. Shown when this round ends, before the next round starts.</span>
-            </label>
-            <textarea id="summary" name="summary" rows="3"
-                      class="form-input min-h-[100px] resize-y{{if $textErr}} form-input-error{{end}}"
-                      {{if $textErr}}aria-invalid="true" aria-describedby="summary-error"{{end}}>{{.Round.Summary}}</textarea>
-            {{if $textErr}}
-                <p id="summary-error" class="form-help-error" role="alert">{{$textErr}}</p>
             {{end}}
         </div>
 


### PR DESCRIPTION
Closes #569

Reorders the admin round form so the **Round summary** field comes first, above **Round name**. Pure template field-reorder - no behavior, validation, or field-name change. `tailwind-check` clean (no class change); the round-form e2e specs (admin.spec round CRUD, round.spec) pass unchanged since they locate fields by name. `make check` green.