### PR TITLE
Require email verification before a new account is signed in

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -138,6 +138,7 @@ func HandleRegisterSubmit(
 	deps RegisterDeps,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/register.gohtml")
+	pending := newTemplateRenderer(logger, csrfMgr, "auth/pages/register_pending.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxFormBodySize)
@@ -201,9 +202,25 @@ func HandleRegisterSubmit(
 		}
 
 		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail)
-		sessions.Set(w, player.ID, player.SessionVersion)
-		http.Redirect(w, r, landingPathFor(player.Role), http.StatusSeeOther)
+		// Hard email-verification gate (#574): no session until the
+		// address is proven. Clear unconditionally so the anonymous
+		// upgrade path (ClaimPlayer) does not leave the pre-existing
+		// anonymous cookie live and sign the unverified account in.
+		sessions.Clear(w)
+		pending.render(w, r, http.StatusOK, registerPendingData{
+			Title: "Verify your email",
+			Email: input.CleanedEmail,
+		})
 	})
+}
+
+// registerPendingData backs the post-register confirmation page shown
+// after a successful signup. The visitor has no session at this point
+// (the hard gate clears it), so the template is the no-session resend
+// variant pointing at /verify-email/request.
+type registerPendingData struct {
+	Title string
+	Email string
 }
 
 // verifyEmailDispatchTimeout caps the detached SMTP attempt spawned by

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -350,12 +350,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
-	if got, want := rec.Header().Get("Location"), "/admin/quizzes"; got != want {
-		t.Errorf("Location = %q, want %q", got, want)
-	}
+	assertRegisterPending(t, rec, "alice@example.test")
 
 	p, err := store.GetPlayerByUsername(t.Context(), "alice")
 	if err != nil {
@@ -364,17 +359,49 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	if got, want := p.Role, RoleAdmin; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
 	}
+}
 
-	// Cookie was set
-	cookies := rec.Result().Cookies()
-	found := false
-	for _, c := range cookies {
-		if c.Name == session.CookieName {
-			found = true
+// assertRegisterPending pins the post-#574 hard-gate contract: a
+// successful registration renders the confirmation page with 200,
+// names the recipient address in the body, and does NOT leave a live
+// session cookie. sessions.Clear emits a deletion cookie (empty value,
+// negative MaxAge), which is expected; a non-empty session value is the
+// failure we guard against.
+func assertRegisterPending(t *testing.T, rec *httptest.ResponseRecorder, email string) {
+	t.Helper()
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if got, want := body, "Verify your email"; !strings.Contains(got, want) {
+		t.Errorf("body missing confirmation headline %q; body=%.300q", want, got)
+	}
+	if got, want := body, email; !strings.Contains(got, want) {
+		t.Errorf("body missing recipient address %q; body=%.300q", want, got)
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == session.CookieName && c.Value != "" {
+			t.Errorf("live session cookie set on register: %+v", c)
 		}
 	}
-	if !found {
-		t.Error("session cookie was not set")
+}
+
+// assertSessionCleared pins the anonymous-upgrade arm of the hard gate
+// (#574): registering while holding an anonymous session cookie must
+// emit a deletion cookie (empty value, negative MaxAge) so the
+// pre-existing anonymous session is signed out rather than left live.
+func assertSessionCleared(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	cleared := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == session.CookieName && c.Value == "" && c.MaxAge < 0 {
+			cleared = true
+
+			break
+		}
+	}
+	if !cleared {
+		t.Errorf("expected session cookie to be cleared; cookies = %v", rec.Result().Cookies())
 	}
 }
 
@@ -395,14 +422,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
-	// #288: a non-admin must NOT land on /admin/quizzes, which would
-	// bounce them through RequireAdmin to the Access Denied page.
-	if got, want := rec.Header().Get("Location"), "/"; got != want {
-		t.Errorf("Location = %q, want %q", got, want)
-	}
+	assertRegisterPending(t, rec, "bob@example.test")
 
 	p, err := store.GetPlayerByUsername(t.Context(), "bob")
 	if err != nil {
@@ -436,9 +456,7 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d", got, want)
-	}
+	assertRegisterPending(t, rec, "carol@example.test")
 
 	p, err := store.GetPlayerByUsername(t.Context(), "carol")
 	if err != nil {
@@ -585,9 +603,7 @@ func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "alice@example.test")
 	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}
@@ -646,9 +662,7 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "alice@example.test")
 	p, err := store.GetPlayerByUsername(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
@@ -694,9 +708,8 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "alice@example.test")
+	assertSessionCleared(t, rec)
 
 	// The same row was upgraded - no new row should appear, and the
 	// anonymous username should be gone.
@@ -820,9 +833,8 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "latecomer@example.test")
+	assertSessionCleared(t, rec)
 	// A fresh row was created instead of clobbering the already-claimed one.
 	latecomer, err := store.GetPlayerByUsername(t.Context(), "latecomer")
 	if err != nil {
@@ -1272,9 +1284,7 @@ func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "petname@example.test")
 	// The whitespace-only username path falls into GeneratePetname, so
 	// no row should be created under the empty key. The row exists under
 	// the petname; we look it up by email instead.
@@ -1301,9 +1311,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 		"password_confirm": {password},
 	})
 
-	if got, want := rec.Code, http.StatusSeeOther; got != want {
-		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
-	}
+	assertRegisterPending(t, rec, "alice@example.test")
 	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}

--- a/internal/web/tmpl/auth/pages/register_pending.gohtml
+++ b/internal/web/tmpl/auth/pages/register_pending.gohtml
@@ -1,0 +1,24 @@
+{{define "content"}}
+    <div class="auth-shell text-center">
+        <div class="mb-8 flex flex-col items-center gap-3">
+            <span class="w-9 h-9 inline-flex items-center justify-center text-accent drop-shadow-[0_0_8px_rgba(255,210,63,0.45)]" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-full h-full"><path d="M4 13c3.5-2 8-2 10 2a5.5 5.5 0 0 1 8 5"/><path d="M5.15 17.89c5.52-1.52 8.65-6.89 7-12C11.55 4 11.5 2 13 2c3.22 0 5 5.5 5 8 0 6.5-4.2 12-10.49 12C5.11 22 2 22 2 20c0-1.5 1.14-1.55 3.15-2.11Z"/></svg>
+            </span>
+            <p class="m-0 font-display text-sm font-semibold uppercase tracking-[0.18em]">Top<span class="text-accent font-extrabold">Banana</span>!</p>
+        </div>
+
+        <p class="mb-3 font-display text-text-dim text-xs font-semibold uppercase tracking-[0.2em]">One more step</p>
+        <h1 class="m-0 font-display font-extrabold leading-none uppercase tracking-tight text-[clamp(1.85rem,5.5vw,2.25rem)]">Verify your email</h1>
+        <p class="mt-3 mb-6 text-text-dim text-[0.95rem]">
+            We sent a confirmation link to <strong class="text-text font-semibold">{{.Email}}</strong>. Click it to finish setting up your account.
+        </p>
+
+        <p class="mb-6 text-sm text-text-dim">
+            <a href="/login" class="underline">Already verified? Sign in</a>
+        </p>
+
+        <p class="mb-6 text-sm text-text-dim">
+            <a href="/verify-email/request" class="underline">Didn't get the link?</a>
+        </p>
+    </div>
+{{end}}

--- a/test/e2e/tests/admin-player-credentials.spec.ts
+++ b/test/e2e/tests/admin-player-credentials.spec.ts
@@ -18,7 +18,10 @@ async function registerPlayer(
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();
-    await expect(playerPage).toHaveURL('/');
+    // Hard gate (#574): register creates the row then renders the
+    // confirmation page at /register with no session. The row exists
+    // (unverified), which is all the admin action needs.
+    await expect(playerPage).toHaveURL(/\/register$/);
     await playerPage.close();
   } finally {
     await playerContext.close();

--- a/test/e2e/tests/admin-players.spec.ts
+++ b/test/e2e/tests/admin-players.spec.ts
@@ -31,9 +31,11 @@ test('admin marks an unverified player verified via the detail view', async ({ p
     await targetPage.locator('input[name=password]').fill(PASSWORD);
     await targetPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await targetPage.locator('button[type=submit]').click();
-    // The second registration lands on / (player role) without ever
-    // verifying the address.
-    await expect(targetPage).toHaveURL('/');
+    // Hard gate (#574): register creates the row then renders the
+    // confirmation page at /register with no session. The row exists
+    // and is unverified - exactly the state this test needs so it shows
+    // up under the Unverified tab.
+    await expect(targetPage).toHaveURL(/\/register$/);
     await targetPage.close();
   } finally {
     await targetContext.close();

--- a/test/e2e/tests/admin-settings.spec.ts
+++ b/test/e2e/tests/admin-settings.spec.ts
@@ -19,7 +19,10 @@ async function registerPlayer(
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();
-    await expect(playerPage).toHaveURL('/');
+    // Hard gate (#574): register creates the row then renders the
+    // confirmation page at /register with no session. The row exists
+    // (unverified), which is all the admin action needs.
+    await expect(playerPage).toHaveURL(/\/register$/);
     await playerPage.close();
   } finally {
     await playerContext.close();

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { registerAdmin, createQuizWithQuestions, playThroughQuiz } from './helpers';
+import { registerAdmin, registerForPending, login, markEmailVerified, createQuizWithQuestions, playThroughQuiz } from './helpers';
 
 // Petname format: Title-cased Adjective-Adjective-Noun, e.g. "Steamy-Farty-Bear".
 // EnsurePlayer middleware generates one of these for every fresh anonymous
@@ -173,15 +173,12 @@ test('Change your name modal pre-fills the input with the current display name',
 // claimed the "first registrant becomes admin" slot.
 test('signed-in player does not see the claim-name CTA on the player client', async ({ page, browserName }) => {
   const username = `e2e-claim-authn-${browserName}-${Date.now()}`;
-  await page.goto('/register');
-  await page.locator('input[name=username]').fill(username);
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
-  await page.locator('input[name=password]').fill('correct-battery-13');
-  await page.locator('input[name=password_confirm]').fill('correct-battery-13');
-  await page.locator('button[type=submit]').click();
-  // Admin lands on /admin/quizzes; subsequent registrants land on /.
-  // Either signals a successful registration + session cookie set.
-  await expect(page).toHaveURL(/(\/admin\/quizzes|\/)$/);
+  // The hard gate (#574) means register no longer signs the player in.
+  // Verify the row directly, then log in so the client sees an
+  // authenticated player.
+  await registerForPending(page, username);
+  markEmailVerified(username);
+  await login(page, username);
 
   await page.goto('/client/');
 

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -23,24 +23,42 @@ export const QUIZ_QUESTIONS: readonly QuestionSpec[] = [
 ];
 
 export async function registerAdmin(page: Page, username: string): Promise<void> {
+  await registerForPending(page, username);
+  // The hard email-verification gate (#574) means register no longer
+  // hands out a session: SMTP isn't wired in e2e so we cannot complete
+  // the user-facing verify flow, so stamp email_verified_at directly
+  // (same trick home.spec.ts uses to wipe games), then log in to obtain
+  // a session and land on the admin dashboard.
+  markEmailVerified(username);
+  await login(page, username);
+  await expect(page).toHaveURL(/\/admin\/quizzes$/);
+}
+
+// registerForPending fills and submits the register form, then asserts
+// the post-#574 hard-gate outcome: register renders the "verify your
+// email" confirmation at /register with no session (no redirect). The
+// row now exists but the visitor is not signed in. Email is the
+// credential after #446; username is the optional display name.
+export async function registerForPending(page: Page, username: string): Promise<void> {
   await page.goto('/register');
-  // Email is the credential after #446; username is the optional
-  // display name. Filling both keeps tests deterministic about which
-  // row is created.
   await page.locator('input[name=email]').fill(`${username}@example.test`);
   await page.locator('input[name=username]').fill(username);
   await page.locator('input[name=password]').fill(PASSWORD);
   await page.locator('input[name=password_confirm]').fill(PASSWORD);
   await page.locator('button[type=submit]').click();
-  // Post-register the gate (#111 PR3) bounces unverified admins to
-  // /verify-email/pending. SMTP isn't wired in e2e so we cannot
-  // complete the user-facing verify flow; shell out to sqlite3 to
-  // stamp email_verified_at directly (same trick home.spec.ts uses
-  // to wipe games), then drive the browser to the admin dashboard.
-  await expect(page).toHaveURL(/\/verify-email\/pending$/);
-  markEmailVerified(username);
-  await page.goto('/admin/quizzes');
-  await expect(page).toHaveURL(/\/admin\/quizzes$/);
+  await expect(page).toHaveURL(/\/register$/);
+  await expect(page.getByRole('heading', { name: 'Verify your email' })).toBeVisible();
+}
+
+// login submits the login form for the named account. The caller asserts
+// the post-login landing URL (it varies by role). LOGIN_COOLDOWN is set
+// to 0s in playwright.config.ts, so back-to-back logins in a worker do
+// not trip the per-IP rate limiter.
+export async function login(page: Page, username: string): Promise<void> {
+  await page.goto('/login');
+  await page.locator('input[name=email]').fill(`${username}@example.test`);
+  await page.locator('input[name=password]').fill(PASSWORD);
+  await page.locator('button[type=submit]').click();
 }
 
 export function markEmailVerified(username: string): void {

--- a/test/e2e/tests/pregame-nav.spec.ts
+++ b/test/e2e/tests/pregame-nav.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { registerAdmin, createQuizWithQuestions, markEmailVerified } from './helpers';
+import { registerAdmin, registerForPending, login, createQuizWithQuestions, markEmailVerified } from './helpers';
 
 // Pre-game navigation on the player SPA: a signed-in player can reach
 // /profile via the account link, and a deep-linked /play/{slug} start
@@ -12,20 +12,12 @@ import { registerAdmin, createQuizWithQuestions, markEmailVerified } from './hel
 // worker), mirroring claim.spec.ts's authenticated-player test.
 test('signed-in player can reach /profile via the account link on the play SPA', async ({ page, browserName }) => {
   const username = `e2e-pregame-authn-${browserName}-${Date.now()}`;
-  await page.goto('/register');
-  await page.locator('input[name=username]').fill(username);
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
-  await page.locator('input[name=password]').fill('correct-battery-13');
-  await page.locator('input[name=password_confirm]').fill('correct-battery-13');
-  await page.locator('button[type=submit]').click();
-  // The post-register redirect target varies with this worker DB's state
-  // (admin bootstrap -> /admin/quizzes, verify gate -> /verify-email/pending,
-  // otherwise /), so just wait for the registration to land somewhere off
-  // /register. /profile sits behind the verify-email gate, so stamp
-  // email_verified_at directly (the same trick registerAdmin uses) so the
-  // account link lands on the profile page rather than the pending screen.
-  await expect(page).not.toHaveURL(/\/register$/);
+  // The hard gate (#574) means register no longer signs the player in.
+  // Verify the row directly, then log in so the SPA sees an
+  // authenticated, verified player.
+  await registerForPending(page, username);
   markEmailVerified(username);
+  await login(page, username);
 
   await page.goto('/client/');
 

--- a/test/e2e/tests/profile.spec.ts
+++ b/test/e2e/tests/profile.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { PASSWORD, markEmailVerified } from './helpers';
+import { registerForPending, login, markEmailVerified } from './helpers';
 
 // Registers a plain player (not via registerAdmin, which assumes the
 // ADMIN_EMAILS promotion slot) and clears the verified-email gate so
@@ -7,19 +7,13 @@ import { PASSWORD, markEmailVerified } from './helpers';
 test('profile page links to change-email and change-password', async ({ page, browserName }) => {
   const username = `e2e-profile-${browserName}-${Date.now()}`;
 
-  await page.goto('/register');
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
-  await page.locator('input[name=username]').fill(username);
-  await page.locator('input[name=password]').fill(PASSWORD);
-  await page.locator('input[name=password_confirm]').fill(PASSWORD);
-  await page.locator('button[type=submit]').click();
-
-  // Registration sets the session and redirects off /register (a plain
-  // player lands on /, an admin on /verify-email/pending). Either way the
-  // row now exists, so wait for the redirect, then clear the verified-email
-  // gate that /profile enforces.
-  await expect(page).not.toHaveURL(/\/register$/);
+  // The hard gate (#574) means register no longer signs the player in:
+  // it renders the confirmation page with no session. Verify the row
+  // directly, then log in to clear the verified-email gate /profile
+  // enforces and obtain a session.
+  await registerForPending(page, username);
   markEmailVerified(username);
+  await login(page, username);
 
   await page.goto('/profile');
 

--- a/test/integration/admin_htmx_test.go
+++ b/test/integration/admin_htmx_test.go
@@ -63,8 +63,7 @@ func TestAdminHTMX_QuestionReorder(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	adminPlayer, err := stores.Players.GetPlayerByUsername(ctx, "htmx-admin")
 	if err != nil {
@@ -247,8 +246,7 @@ func TestAdminHTMX_RoundMove(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	adminPlayer, err := stores.Players.GetPlayerByUsername(ctx, "htmx-admin")
 	if err != nil {
@@ -404,43 +402,6 @@ func postHXRoundMove(
 	}
 
 	return string(body)
-}
-
-// registerAdminViaHTTP posts /register through the supplied client so
-// the response sets the session cookie on its jar. The first registered
-// user becomes the admin per the existing auth flow. Tests that hit
-// /admin/* afterwards should also call verifyPlayerEmail to satisfy
-// the #111 PR3 verified-email gate.
-func registerAdminViaHTTP(ctx context.Context, t *testing.T, client *http.Client, baseURL string) {
-	t.Helper()
-
-	registerToken := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-
-	form := url.Values{}
-	form.Add("username", "htmx-admin")
-	form.Add("email", "htmx-admin@example.test")
-	form.Add("password", "htmx-admin-pass-123")
-	form.Add("password_confirm", "htmx-admin-pass-123")
-	form.Add("csrf_token", registerToken)
-
-	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, baseURL+"/register", strings.NewReader(form.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("NewRequest err = %v, want nil", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("register client.Do err = %v, want nil", err)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("register Body.Close err = %v, want nil", cerr)
-	}
-	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register status = %d, want %d", got, want)
-	}
 }
 
 // verifyPlayerEmail stamps email_verified_at on the named player so

--- a/test/integration/admin_import_test.go
+++ b/test/integration/admin_import_test.go
@@ -34,8 +34,7 @@ func TestAdminImport_Integration(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	// Fetching the import form should both seed the CSRF nonce on the jar
 	// AND render the example JSON block — without the example the page is

--- a/test/integration/admin_player_mgmt_test.go
+++ b/test/integration/admin_player_mgmt_test.go
@@ -26,21 +26,9 @@ func TestAdminPlayerMgmt_FilterTabsAndCounts(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"mgmt-admin", "mgmt-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "mgmt-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "mgmt-admin", "mgmt-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"mgmt-unverified", "mgmt-unverified-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "mgmt-unverified", "mgmt-unverified-pass-123")
 
 	body := getOK(ctx, t, adminClient, srv.BaseURL+"/admin/players")
 	if got, want := body, "Unverified"; !strings.Contains(got, want) {
@@ -76,21 +64,9 @@ func TestAdminPlayerMgmt_DetailViewRenders(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"detail-admin", "detail-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "detail-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "detail-admin", "detail-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"detail-target", "detail-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "detail-target", "detail-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "detail-target")
 
@@ -117,21 +93,9 @@ func TestAdminPlayerMgmt_MarkVerifiedFlipsRow(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"verify-admin", "verify-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "verify-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "verify-admin", "verify-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"verify-target", "verify-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "verify-target", "verify-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "verify-target")
 	verifyURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/verify"
@@ -163,13 +127,7 @@ func TestAdminPlayerMgmt_WrongStateRejected(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"reject-admin", "reject-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "reject-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "reject-admin", "reject-admin-pass-123")
 
 	// Try to mark the admin (already verified) verified again - should
 	// be rejected because the row is not in the unverified bucket.
@@ -205,21 +163,9 @@ func TestAdminPlayerMgmt_SetEmailValidates(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"setemail-admin", "setemail-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "setemail-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "setemail-admin", "setemail-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"setemail-target", "setemail-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "setemail-target", "setemail-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setemail-target")
 	emailURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/email"
@@ -259,21 +205,9 @@ func TestAdminPlayerMgmt_SetEmailClearsVerification(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"reverify-admin", "reverify-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "reverify-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "reverify-admin", "reverify-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"reverify-target", "reverify-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "reverify-target", "reverify-target-pass-123")
 	// Verify the target so it starts in the verified bucket.
 	verifyPlayerEmail(ctx, t, srv.DBURI, "reverify-target")
 
@@ -318,13 +252,7 @@ func TestAdminPlayerMgmt_CreatePlayer(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"create-admin", "create-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "create-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "create-admin", "create-admin-pass-123")
 
 	postAdminAction(
 		ctx, t, adminClient, srv.BaseURL,
@@ -373,22 +301,18 @@ func TestAdminPlayerMgmt_CreateRequiresAdmin(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"create-admin-boss", "create-admin-boss-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "create-admin-boss")
+	registerVerifyAndMint(
+		ctx,
+		t,
+		adminClient,
+		srv.BaseURL,
+		srv.DBURI,
+		"create-admin-boss",
+		"create-admin-boss-pass-123",
+	)
 
 	hostClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, hostClient, srv.BaseURL,
-		"create-host", "create-host-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "create-host")
+	registerVerifyAndMint(ctx, t, hostClient, srv.BaseURL, srv.DBURI, "create-host", "create-host-pass-123")
 	makeHost(ctx, t, srv.DBURI, "create-host")
 
 	req, err := http.NewRequestWithContext(
@@ -429,13 +353,7 @@ func TestAdminPlayerMgmt_RequiresCSRF(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"csrf-admin", "csrf-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "csrf-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "csrf-admin", "csrf-admin-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "csrf-admin")
 	verifyURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/verify"
@@ -471,22 +389,10 @@ func TestAdminPlayerMgmt_NonAdminBlocked(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"nonadmin-admin", "nonadmin-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "nonadmin-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "nonadmin-admin", "nonadmin-admin-pass-123")
 
 	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"nonadmin-target", "nonadmin-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "nonadmin-target")
+	registerVerifyAndMint(ctx, t, playerClient, srv.BaseURL, srv.DBURI, "nonadmin-target", "nonadmin-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "nonadmin-target")
 	req, err := http.NewRequestWithContext(
@@ -526,21 +432,9 @@ func TestAdminPlayerMgmt_SetRolePromotesToAdmin(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"role-admin", "role-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "role-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "role-admin", "role-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"role-target", "role-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "role-target", "role-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "role-target")
 	roleURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/role"
@@ -570,21 +464,9 @@ func TestAdminPlayerMgmt_SetUsername(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"setname-admin", "setname-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "setname-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "setname-admin", "setname-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"setname-target", "setname-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "setname-target", "setname-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setname-target")
 	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/username"
@@ -618,21 +500,9 @@ func TestAdminPlayerMgmt_SetPassword(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"setpass-admin", "setpass-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "setpass-admin")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "setpass-admin", "setpass-admin-pass-123")
 
-	playerClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"setpass-target", "setpass-target-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
+	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "setpass-target", "setpass-target-pass-123")
 	verifyPlayerEmail(ctx, t, srv.DBURI, "setpass-target")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setpass-target")
@@ -677,22 +547,10 @@ func TestAdminPlayerMgmt_SetCredentialsRequireAdmin(t *testing.T) {
 	})
 
 	adminClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"creds-admin-boss", "creds-admin-boss-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "creds-admin-boss")
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "creds-admin-boss", "creds-admin-boss-pass-123")
 
 	hostClient := newAdminMgmtClient(t)
-	if got := registerForRedirect(
-		ctx, t, hostClient, srv.BaseURL,
-		"creds-host", "creds-host-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not land on /: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "creds-host")
+	registerVerifyAndMint(ctx, t, hostClient, srv.BaseURL, srv.DBURI, "creds-host", "creds-host-pass-123")
 	makeHost(ctx, t, srv.DBURI, "creds-host")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "creds-admin-boss")

--- a/test/integration/admin_players_test.go
+++ b/test/integration/admin_players_test.go
@@ -55,20 +55,8 @@ func TestAdminPlayersList_RendersForAdmin(t *testing.T) {
 	// plain password player — we need both labels in the rendered table
 	// to pin the AccountType derivation end-to-end.
 	adminClient := authClient(t)
-	if got := registerForRedirect(
-		ctx, t, adminClient, srv.BaseURL,
-		"players-admin", "players-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("first registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "players-admin")
-	playerClient := authClient(t)
-	if got := registerForRedirect(
-		ctx, t, playerClient, srv.BaseURL,
-		"players-player", "players-player-pass-123",
-	); got != "/" {
-		t.Fatalf("second registration did not stay player: Location = %q", got)
-	}
+	registerVerifyAndMint(ctx, t, adminClient, srv.BaseURL, srv.DBURI, "players-admin", "players-admin-pass-123")
+	registerForPending(ctx, t, authClient(t), srv.BaseURL, "players-player", "players-player-pass-123")
 
 	body := getOK(ctx, t, adminClient, srv.BaseURL+"/admin/players")
 
@@ -96,17 +84,7 @@ func TestAdminPlayersList_PaginationParam(t *testing.T) {
 	})
 
 	client := authClient(t)
-	if got := registerForRedirect(
-		ctx,
-		t,
-		client,
-		srv.BaseURL,
-		"page-admin",
-		"page-admin-pass-123",
-	); got != "/admin/quizzes" {
-		t.Fatalf("registration did not promote to admin: Location = %q", got)
-	}
-	verifyPlayerEmail(ctx, t, srv.DBURI, "page-admin")
+	registerVerifyAndMint(ctx, t, client, srv.BaseURL, srv.DBURI, "page-admin", "page-admin-pass-123")
 
 	// A wildly out-of-range page parameter must clamp to the last
 	// page (here, the only page) rather than 404 or 500. We assert

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -83,40 +83,11 @@ func TestAdmin_Integration(t *testing.T) {
 		},
 	}
 
-	// Register the first user (becomes admin) so subsequent /admin/* requests succeed.
-	// Fetching the GET form first sets the CSRF nonce cookie on the jar and
-	// returns the hidden token, both of which the POST then carries.
-	registerToken := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-
-	registerForm := url.Values{}
-	registerForm.Add("username", "integration-admin")
-	registerForm.Add("email", "integration-admin@example.test")
-	registerForm.Add("password", "integration-pass-123")
-	registerForm.Add("password_confirm", "integration-pass-123")
-	registerForm.Add("csrf_token", registerToken)
-
-	registerReq, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		baseURL+"/register",
-		strings.NewReader(registerForm.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("failed to create register request: %v", err)
-	}
-	registerReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	registerResp, err := client.Do(registerReq)
-	if err != nil {
-		t.Fatalf("failed to register: %v", err)
-	}
-	if got, want := registerResp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register status = %d, want %d", got, want)
-	}
-	if cerr := registerResp.Body.Close(); cerr != nil {
-		t.Errorf("failed to close register body: %v", cerr)
-	}
-
-	verifyPlayerEmail(ctx, t, srv.DBURI, "integration-admin")
+	// Register the first user (becomes admin), verify their email, and
+	// sign them in so subsequent /admin/* requests succeed. The #574 hard
+	// gate means register no longer hands out a session, so the sign-in
+	// is an explicit verify + login step.
+	registerVerifyAndSignIn(ctx, t, client, baseURL, srv.DBURI, "integration-admin", "integration-pass-123")
 
 	// Visit the quiz-create form GET so we can pull a fresh CSRF token tied
 	// to the now-authenticated session jar.

--- a/test/integration/anon_migration_test.go
+++ b/test/integration/anon_migration_test.go
@@ -43,12 +43,11 @@ func TestAnonMigration_Integration(t *testing.T) {
 		t.Fatalf("CreateQuiz err = %v, want nil", err)
 	}
 
-	// Register the destination account directly so the anonymous
-	// visitor can sign INTO it later. Need a separate client so its
-	// cookie jar doesn't carry the destination's session into the
-	// anonymous-play step below.
-	destClient := authClient(t)
-	registerForRedirect(ctx, t, destClient, baseURL, "migration-dest", "correct-battery-13")
+	// Register the destination account so the anonymous visitor can sign
+	// INTO it later. Use a throwaway client: the #574 hard gate means
+	// register hands out no session, and the migration is driven by the
+	// anonymous client logging in below, not by this jar.
+	registerForPending(ctx, t, authClient(t), baseURL, "migration-dest", "correct-battery-13")
 	destPlayer, err := stores.Players.GetPlayerByUsername(ctx, "migration-dest")
 	if err != nil {
 		t.Fatalf("lookup destination player err = %v, want nil", err)
@@ -122,7 +121,7 @@ func lookupAnonPlayer(ctx context.Context, t *testing.T, players auth.PlayerStor
 // sees a prior anonymous session and triggers the migration. The
 // username argument is converted to "<username>@example.test" - the
 // integration suite's convention for the email auto-assigned during
-// registerForRedirect, and the post-#446 login credential.
+// registration, and the post-#446 login credential.
 func loginAnonAsDest(ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string) {
 	t.Helper()
 

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -4,14 +4,17 @@ package integration_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/session"
 )
 
 // TestAuthRedirect_PerRole pins the #288 fix end-to-end: register and
@@ -35,20 +38,17 @@ func TestAuthRedirect_PerRole(t *testing.T) {
 	})
 	baseURL := srv.BaseURL
 
-	t.Run("admin register lands on /admin/quizzes", func(t *testing.T) {
+	// Register no longer redirects (#574 hard gate): it renders the
+	// "verify your email" confirmation page with 200 and no session.
+	// The login subtests below pin the per-role redirect instead.
+	t.Run("admin register renders pending page", func(t *testing.T) {
 		client := authClient(t)
-		location := registerForRedirect(ctx, t, client, baseURL, "redirect-admin", "redirect-admin-pass-123")
-		if got, want := location, "/admin/quizzes"; got != want {
-			t.Errorf("admin register Location = %q, want %q", got, want)
-		}
+		registerForPending(ctx, t, client, baseURL, "redirect-admin", "redirect-admin-pass-123")
 	})
 
-	t.Run("player register lands on /", func(t *testing.T) {
+	t.Run("player register renders pending page", func(t *testing.T) {
 		client := authClient(t)
-		location := registerForRedirect(ctx, t, client, baseURL, "redirect-player", "redirect-player-pass-123")
-		if got, want := location, "/"; got != want {
-			t.Errorf("player register Location = %q, want %q", got, want)
-		}
+		registerForPending(ctx, t, client, baseURL, "redirect-player", "redirect-player-pass-123")
 	})
 
 	// Stamp email_verified_at on both registered rows so the post-#492
@@ -80,6 +80,41 @@ func TestAuthRedirect_PerRole(t *testing.T) {
 	})
 }
 
+// testSessionKey is the fixed signing key startServer sets as the
+// default SESSION_KEY (see testmain_test.go) so tests can mint a
+// matching session cookie with mintSessionCookie. The hard
+// email-verification gate (#574) means register and login no longer
+// hand out a session for an unverified account, so the verify-gate
+// tests forge the signed-in-but-unverified state directly instead.
+const testSessionKey = "integration-test-session-key-0123456789abcdef"
+
+// mintSessionCookie signs a session cookie for the named player using
+// testSessionKey and installs it on client's jar, putting the client in
+// the signed-in state without going through login. startServer signs
+// cookies with testSessionKey by default, so the minted cookie verifies
+// unless the test overrode SESSION_KEY.
+func mintSessionCookie(ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username string) {
+	t.Helper()
+
+	dbConn, stores := openStores(t, dbURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	if err != nil {
+		t.Fatalf("mintSessionCookie GetPlayerByUsername err = %v, want nil", err)
+	}
+
+	rec := httptest.NewRecorder()
+	session.New([]byte(testSessionKey), false).Set(rec, player.ID, player.SessionVersion)
+	cookie := rec.Result().Cookies()[0]
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("url.Parse err = %v, want nil", err)
+	}
+	client.Jar.SetCookies(parsed, []*http.Cookie{cookie})
+}
+
 // authClient builds a fresh http.Client with a cookie jar and the
 // don't-follow-redirects policy every auth test in this package uses.
 func authClient(t *testing.T) *http.Client {
@@ -97,14 +132,93 @@ func authClient(t *testing.T) *http.Client {
 	}
 }
 
-// registerForRedirect POSTs /register and returns the Location header
-// from the 303 response so the caller can assert on it directly.
-func registerForRedirect(
+// registerForPending POSTs /register and asserts the post-#574
+// hard-gate contract: 200, the "Verify your email" confirmation body
+// naming the recipient, and no live session cookie on the jar. Returns
+// nothing - the registered row exists in the DB but the visitor is not
+// signed in until they verify and log in (see registerVerifyAndSignIn).
+func registerForPending(
 	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string,
-) string {
+) {
 	t.Helper()
 
-	return submitAuthForm(ctx, t, client, baseURL, "/register", username, password)
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
+	resp := postRegister(ctx, t, client, baseURL, token, username, password)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("register status = %d, want %d", got, want)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+	if got, want := string(body), "Verify your email"; !strings.Contains(got, want) {
+		t.Errorf("register body missing confirmation headline %q; body=%.300q", want, got)
+	}
+	if got, want := string(body), username+"@example.test"; !strings.Contains(got, want) {
+		t.Errorf("register body missing recipient address %q; body=%.300q", want, got)
+	}
+	assertNoLiveSession(t, resp)
+}
+
+// assertNoLiveSession fails when resp carries a session cookie with a
+// non-empty value. A deletion cookie (empty value, negative MaxAge)
+// emitted by sessions.Clear is fine - that is the hard gate signing the
+// anonymous-upgrade path out.
+func assertNoLiveSession(t *testing.T, resp *http.Response) {
+	t.Helper()
+	for _, c := range resp.Cookies() {
+		if c.Name == session.CookieName && c.Value != "" {
+			t.Errorf("live session cookie set on register: %+v", c)
+		}
+	}
+}
+
+// registerVerifyAndSignIn registers username through /register, stamps
+// email_verified_at directly in the DB (bypassing the email channel),
+// then logs in so client's cookie jar carries a live session. This is
+// the post-#574 replacement for the old "register => signed in"
+// behaviour that many tests relied on: the hard gate means a session is
+// only obtained after verification + login.
+func registerVerifyAndSignIn(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+) {
+	t.Helper()
+
+	registerForPending(ctx, t, client, baseURL, username, password)
+	verifyPlayerEmail(ctx, t, dbURI, username)
+	loginForRedirect(ctx, t, client, baseURL, username, password)
+}
+
+// registerVerifyAndMint registers username, stamps email_verified_at in
+// the DB, and mints a session cookie onto client's jar without going
+// through /login. Use this instead of registerVerifyAndSignIn when a
+// single test signs in several accounts against one server: minting
+// sidesteps the per-IP login cooldown (#494) that back-to-back logins
+// would trip. Relies on startServer's default SESSION_KEY.
+func registerVerifyAndMint(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+) {
+	t.Helper()
+
+	registerForPending(ctx, t, client, baseURL, username, password)
+	verifyPlayerEmail(ctx, t, dbURI, username)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
+}
+
+// registerAndMint registers username and mints a session cookie onto
+// client's jar WITHOUT stamping email_verified_at, leaving the player
+// signed in but unverified. Use it when a test needs a signed-in row
+// that must stay in the unverified bucket. Relies on startServer's
+// default SESSION_KEY.
+func registerAndMint(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+) {
+	t.Helper()
+
+	registerForPending(ctx, t, client, baseURL, username, password)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
 }
 
 // loginForRedirect POSTs /login and returns the Location header from
@@ -117,14 +231,11 @@ func loginForRedirect(
 	return submitAuthForm(ctx, t, client, baseURL, "/login", username, password)
 }
 
-// submitAuthForm shares the GET-CSRF + POST-form dance between the
-// register and login probes. Asserts the response is 303 (anything
-// else means the auth flow itself failed, not the redirect rule).
-//
-// Username + password_confirm are always populated so the same helper
-// drives both /login (which ignores those fields after #446 - the
-// credential is email) and /register (which uses username as an
-// optional display name and requires the confirm to match).
+// submitAuthForm runs the GET-CSRF + POST-form dance for the /login
+// redirect probe and asserts the response is 303 (anything else means
+// the auth flow itself failed, not the redirect rule). The email
+// credential is derived from username so a row registered as
+// username@example.test logs in cleanly.
 func submitAuthForm(
 	ctx context.Context, t *testing.T, client *http.Client, baseURL, path, username, password string,
 ) string {
@@ -133,10 +244,8 @@ func submitAuthForm(
 	token := fetchCSRFToken(ctx, t, client, baseURL+path)
 
 	form := url.Values{}
-	form.Add("username", username)
 	form.Add("email", username+"@example.test")
 	form.Add("password", password)
-	form.Add("password_confirm", password)
 	form.Add("csrf_token", token)
 
 	req, err := http.NewRequestWithContext(

--- a/test/integration/claim_name_test.go
+++ b/test/integration/claim_name_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
-	"net/url"
 	"strings"
 	"testing"
 )
@@ -39,10 +38,11 @@ func TestClaimName_NonAnonymousReturnsAlreadyClaimed(t *testing.T) {
 		},
 	}
 
-	// Register a password-bearing player. The /register handler sets
-	// password_hash + username_claimed=1, so this row is the
-	// "non-anonymous" case the PATCH must reject.
-	registerPlayer(ctx, t, client, baseURL, "claim-resident", "claim-resident-pass-123")
+	// Register a password-bearing player and sign them in. The /register
+	// handler sets password_hash + username_claimed=1, so this row is
+	// the "non-anonymous" case the PATCH must reject. The hard gate
+	// (#574) means a session only arrives after verify + login.
+	registerVerifyAndSignIn(ctx, t, client, baseURL, srv.DBURI, "claim-resident", "claim-resident-pass-123")
 
 	body, status := patchPlayerUsernameWithBody(ctx, t, client, baseURL, "different-name")
 	if got, want := status, http.StatusConflict; got != want {
@@ -61,44 +61,6 @@ func TestClaimName_NonAnonymousReturnsAlreadyClaimed(t *testing.T) {
 	}
 	if payload.Message == "" {
 		t.Error("body.message is empty, want a non-empty human-readable string")
-	}
-}
-
-// registerPlayer posts /register through the supplied client so the
-// resulting session cookie lands on its jar. Mirrors the existing
-// registerAdminViaHTTP helper but with caller-supplied credentials so
-// the test can pick an account that won't collide with sibling tests.
-func registerPlayer(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string,
-) {
-	t.Helper()
-
-	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-
-	form := url.Values{}
-	form.Add("username", username)
-	form.Add("email", username+"@example.test")
-	form.Add("password", password)
-	form.Add("password_confirm", password)
-	form.Add("csrf_token", token)
-
-	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, baseURL+"/register", strings.NewReader(form.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("NewRequest err = %v, want nil", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("client.Do err = %v, want nil", err)
-	}
-	if cerr := resp.Body.Close(); cerr != nil {
-		t.Errorf("Body.Close err = %v, want nil", cerr)
-	}
-	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register status = %d, want %d", got, want)
 	}
 }
 

--- a/test/integration/email_admin_test.go
+++ b/test/integration/email_admin_test.go
@@ -64,8 +64,7 @@ func TestEmailAdmin_UnconfiguredShowsDisabled(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.BaseURL+"/admin/email", nil)
 	if err != nil {
@@ -121,8 +120,7 @@ func TestEmailAdmin_RendersBaseURLWhenSet(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.BaseURL+"/admin/email", nil)
 	if err != nil {
@@ -172,8 +170,7 @@ func TestEmailAdmin_RendersBaseURLDisabledWhenEmpty(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.BaseURL+"/admin/email", nil)
 	if err != nil {
@@ -231,8 +228,7 @@ func TestEmailAdmin_TestSendOnUnconfiguredRedirectsWithFlash(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, postClient, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, postClient, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	csrfToken := fetchCSRFToken(ctx, t, postClient, srv.BaseURL+"/admin/email")
 
@@ -336,8 +332,7 @@ func TestEmailAdmin_GetOnTestRouteRedirects(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.BaseURL+"/admin/email/test", nil)
 	if err != nil {
@@ -384,8 +379,7 @@ func TestEmailAdmin_RateLimitsRepeatedSends(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-	verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 	postOnce := func() *http.Response {
 		t.Helper()

--- a/test/integration/favicon_test.go
+++ b/test/integration/favicon_test.go
@@ -77,18 +77,17 @@ func TestFavicon_Integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cookiejar.New err = %v, want nil", err)
 		}
-		// CheckRedirect: ErrUseLastResponse so registerAdminViaHTTP sees the
-		// 303 it expects (the default client would follow it). Once the
-		// session cookie is set, GET /admin still returns 200 directly so
-		// the redirect override doesn't affect the favicon check below.
+		// CheckRedirect: ErrUseLastResponse so registerVerifyAndSignIn sees
+		// the login 303 it expects (the default client would follow it).
+		// Once the session cookie is set, GET /admin still returns 200
+		// directly so the override doesn't affect the favicon check below.
 		client := &http.Client{
 			Jar: jar,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		}
-		registerAdminViaHTTP(ctx, t, client, srv.BaseURL)
-		verifyPlayerEmail(ctx, t, srv.DBURI, "htmx-admin")
+		registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 		assertFaviconLink(ctx, t, client, srv.BaseURL+"/admin")
 	})
 }

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -206,39 +206,15 @@ func loginAdminAndResetPlayer(
 	}
 }
 
-// registerGameplayAdmin posts /register through the supplied client so
-// the response sets the session cookie on its jar. The first
-// password-bearing registrant is promoted to admin.
+// registerGameplayAdmin posts /register through the supplied client to
+// create the first password-bearing registrant (promoted to admin). The
+// #574 hard gate means register no longer hands out a session; the
+// caller verifies the email via the store and logs in separately
+// (loginAdminAndResetPlayer) when it needs an authenticated jar.
 func registerGameplayAdmin(ctx context.Context, t *testing.T, client *http.Client, baseURL string) {
 	t.Helper()
 
-	registerToken := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-
-	registerForm := url.Values{}
-	registerForm.Add("username", gameplayAdminUsername)
-	registerForm.Add("email", gameplayAdminUsername+"@example.test")
-	registerForm.Add("password", gameplayAdminPassword)
-	registerForm.Add("password_confirm", gameplayAdminPassword)
-	registerForm.Add("csrf_token", registerToken)
-
-	registerReq, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, baseURL+"/register",
-		strings.NewReader(registerForm.Encode()),
-	)
-	if err != nil {
-		t.Fatalf("failed to build register request: %v", err)
-	}
-	registerReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	registerResp, err := client.Do(registerReq)
-	if err != nil {
-		t.Fatalf("failed to register: %v", err)
-	}
-	if got, want := registerResp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register status = %d, want %d", got, want)
-	}
-	if cerr := registerResp.Body.Close(); cerr != nil {
-		t.Errorf("register body close err = %v", cerr)
-	}
+	registerForPending(ctx, t, client, baseURL, gameplayAdminUsername, gameplayAdminPassword)
 }
 
 // integrationSetup bundles the artefacts a gameplay-style integration test

--- a/test/integration/home_test.go
+++ b/test/integration/home_test.go
@@ -245,14 +245,14 @@ func TestHome_Integration_FooterAffordance(t *testing.T) {
 		"REGISTRATION_ENABLED": "true",
 	})
 
-	// Register a password account so the home-page session resolves to
-	// an authenticated player. authClient + the existing register-form
-	// helpers come from auth_redirect_test.go in the same package.
+	// Register a password account and sign it in so the home-page session
+	// resolves to an authenticated player. The #574 hard gate means
+	// register no longer hands out a session, so the cookie is minted
+	// directly (no email verification needed - the home page does not
+	// gate on it). Helpers come from auth_redirect_test.go in the same
+	// package.
 	regClient := authClient(t)
-	location := registerForRedirect(ctx, t, regClient, srv.BaseURL, "homefooter-admin", "correct-battery-13")
-	if got, want := location, "/admin/quizzes"; got != want {
-		t.Fatalf("register Location = %q, want %q (first user becomes admin)", got, want)
-	}
+	registerAndMint(ctx, t, regClient, srv.BaseURL, srv.DBURI, "homefooter-admin", "correct-battery-13")
 
 	t.Run("anonymous request renders the Log in link", func(t *testing.T) {
 		snap := fetchWithClient(ctx, t, authClient(t), srv.BaseURL+"/")

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -51,7 +51,7 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	regCSRF := fetchCSRFToken(ctx, t, regClient, srv.BaseURL+"/register")
 	registerResp := postRegister(ctx, t, regClient, srv.BaseURL, regCSRF, username, password)
 	registerResp.Body.Close() //nolint:errcheck // cleanup.
-	if got, want := registerResp.StatusCode, http.StatusSeeOther; got != want {
+	if got, want := registerResp.StatusCode, http.StatusOK; got != want {
 		t.Fatalf("register status = %d, want %d", got, want)
 	}
 
@@ -116,9 +116,9 @@ func waitForVerifyTokenCount(ctx context.Context, t *testing.T, dbConn *sql.DB, 
 }
 
 // postRegister POSTs /register with the given credentials + pre-fetched
-// CSRF token. Mirrors submitAuthForm in auth_redirect_test.go but lives
-// here so the unverified-login test can opt out of the 303-only
-// assertion that helper bakes in.
+// CSRF token and returns the raw response so callers assert on status,
+// body, and cookies themselves. After #574 a successful register
+// renders the confirmation page with 200 and no session cookie.
 func postRegister(
 	ctx context.Context, t *testing.T, client *http.Client, baseURL, csrfToken, username, password string,
 ) *http.Response {

--- a/test/integration/og_test.go
+++ b/test/integration/og_test.go
@@ -60,11 +60,11 @@ func TestOGMetadata_Integration(t *testing.T) {
 
 	t.Run("admin quizzes page exposes sitewide OG defaults", func(t *testing.T) {
 		t.Parallel()
-		// /admin/quizzes is owner-gated, so a fresh registration is the
+		// /admin/quizzes is owner-gated, so registering + signing in is the
 		// cheapest way to land an authenticated client on the page. The
 		// first password-bearing registrant is promoted to admin.
-		// registerAdminViaHTTP expects to see the 303 directly, so
-		// suppress the default redirect policy on the throwaway client.
+		// registerVerifyAndSignIn sees the login 303 directly, so suppress
+		// the default redirect policy on the throwaway client.
 		jar, jerr := cookiejar.New(nil)
 		if jerr != nil {
 			t.Fatalf("cookiejar.New err = %v, want nil", jerr)
@@ -73,8 +73,7 @@ func TestOGMetadata_Integration(t *testing.T) {
 			Jar:           jar,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 		}
-		registerAdminViaHTTP(ctx, t, client, baseURL)
-		verifyPlayerEmail(ctx, t, setup.DBURI, "htmx-admin")
+		registerVerifyAndSignIn(ctx, t, client, baseURL, setup.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
 		resp := httpGet(ctx, t, client, baseURL+"/admin/quizzes")
 		defer closeBody(t, resp.Body)

--- a/test/integration/profile_email_test.go
+++ b/test/integration/profile_email_test.go
@@ -29,8 +29,7 @@ func TestProfileEmail_HappyPathSwapsAndStaysSignedIn(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-change-happy", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-change-happy")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-change-happy", "correct-battery-13")
 
 	const newAddr = "fresh-inbox@example.test"
 
@@ -106,8 +105,7 @@ func TestProfileEmail_MalformedRejected(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-malformed", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-malformed")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-malformed", "correct-battery-13")
 
 	flash := profileEmailPOST(ctx, t, client, srv.BaseURL, "not-an-email")
 	if got, want := flash.status, http.StatusSeeOther; got != want {
@@ -129,8 +127,7 @@ func TestProfileEmail_NoOpRejected(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-noop", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-noop")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-noop", "correct-battery-13")
 
 	flash := profileEmailPOST(ctx, t, client, srv.BaseURL, "email-noop@example.test")
 	if got, want := flash.status, http.StatusSeeOther; got != want {
@@ -151,17 +148,21 @@ func TestProfileEmail_NoOpRejected(t *testing.T) {
 func TestProfileEmail_CollisionOpaque(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+	// Two sign-ins from the same localhost peer share the per-IP login
+	// limiter bucket; disable the cooldown so the second login is not
+	// 429'd by the 3s default (#494).
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"LOGIN_COOLDOWN":       "0",
+	})
 
 	// Register the rival who owns the target address.
 	rival := authClient(t)
-	registerForRedirect(ctx, t, rival, srv.BaseURL, "email-rival", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-rival")
+	registerVerifyAndSignIn(ctx, t, rival, srv.BaseURL, srv.DBURI, "email-rival", "correct-battery-13")
 
 	// Register the player attempting the change.
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-collide", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-collide")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-collide", "correct-battery-13")
 
 	flash := profileEmailPOST(ctx, t, client, srv.BaseURL, "email-rival@example.test")
 	if got, want := flash.status, http.StatusSeeOther; got != want {
@@ -243,8 +244,7 @@ func TestProfileEmail_OldSessionInvalidatedAfterSwap(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	primary := authClient(t)
-	registerForRedirect(ctx, t, primary, srv.BaseURL, "email-rotate", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-rotate")
+	registerVerifyAndSignIn(ctx, t, primary, srv.BaseURL, srv.DBURI, "email-rotate", "correct-battery-13")
 
 	// Mint a second client carrying the same session cookie at the
 	// pre-swap session_version. Easiest way: log in a fresh client
@@ -290,8 +290,7 @@ func TestProfileEmail_WrongPasswordRejected(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-wrongpw", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-wrongpw")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-wrongpw", "correct-battery-13")
 
 	flash := profileEmailPOSTWithPassword(ctx, t, client, srv.BaseURL, "fresh@example.test", "not-the-password")
 	if got, want := flash.status, http.StatusSeeOther; got != want {
@@ -312,8 +311,7 @@ func TestProfileEmail_EmptyPasswordRejected(t *testing.T) {
 	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "email-emptypw", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "email-emptypw")
+	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "email-emptypw", "correct-battery-13")
 
 	flash := profileEmailPOSTWithPassword(ctx, t, client, srv.BaseURL, "fresh@example.test", "")
 	if got, want := flash.status, http.StatusSeeOther; got != want {

--- a/test/integration/profile_password_test.go
+++ b/test/integration/profile_password_test.go
@@ -33,8 +33,7 @@ func TestProfilePassword_Integration(t *testing.T) {
 	updatedPassword := "fresh-passphrase-99"
 
 	authn := authClient(t)
-	registerForRedirect(ctx, t, authn, srv.BaseURL, username, originalPassword)
-	verifyPlayerEmail(ctx, t, srv.DBURI, username)
+	registerVerifyAndMint(ctx, t, authn, srv.BaseURL, srv.DBURI, username, originalPassword)
 
 	t.Run("anonymous visitor redirected to login", func(t *testing.T) {
 		client := authClient(t)

--- a/test/integration/profile_test.go
+++ b/test/integration/profile_test.go
@@ -52,8 +52,7 @@ func TestProfile_Integration(t *testing.T) {
 	// Register an admin so the rest of the subtests have an
 	// authenticated session to drive against.
 	authn := authClient(t)
-	registerForRedirect(ctx, t, authn, srv.BaseURL, "profile-admin", "correct-battery-13")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "profile-admin")
+	registerVerifyAndMint(ctx, t, authn, srv.BaseURL, srv.DBURI, "profile-admin", "correct-battery-13")
 
 	t.Run("GET /profile renders form with the current username", func(t *testing.T) {
 		snap := profileGET(ctx, t, authn, srv.BaseURL)
@@ -82,8 +81,7 @@ func TestProfile_Integration(t *testing.T) {
 
 	t.Run("POST /profile/username with a taken value returns 409", func(t *testing.T) {
 		// Register a second player so the admin can collide with them.
-		other := authClient(t)
-		registerForRedirect(ctx, t, other, srv.BaseURL, "rival-name", "correct-battery-13")
+		registerForPending(ctx, t, authClient(t), srv.BaseURL, "rival-name", "correct-battery-13")
 
 		snap := profilePOST(ctx, t, authn, srv.BaseURL, "rival-name")
 		if got, want := snap.status, http.StatusConflict; got != want {

--- a/test/integration/quiz_ownership_test.go
+++ b/test/integration/quiz_ownership_test.go
@@ -134,12 +134,13 @@ func TestQuizOwnership_Integration(t *testing.T) {
 
 // registerAdminClient builds a cookie-jar HTTP client, registers the
 // supplied username through the public /register form (which promotes
-// to admin via ADMIN_EMAILS), and returns the client carrying the
-// resulting session cookie. dbURI is the test server's DB URI; the
-// helper stamps email_verified_at on the new row so follow-up admin
-// requests pass the #111 PR3 verified-email gate. Mirrors the helper
-// pattern in TestAdmin_Integration but pulled out so the cross-admin
-// test can spin up two distinct sessions cheaply.
+// to admin via ADMIN_EMAILS), stamps email_verified_at, and mints a
+// session cookie onto the jar so follow-up admin requests pass both the
+// auth middleware and the #111 PR3 verified-email gate. After the #574
+// hard gate, register no longer hands out a session, so the cookie is
+// minted directly (startServer signs with the default testSessionKey).
+// Minting also sidesteps the per-IP login cooldown that several
+// back-to-back logins would trip.
 func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, username string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
@@ -153,25 +154,9 @@ func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, user
 		},
 	}
 
-	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-	form := url.Values{
-		"username":         {username},
-		"email":            {username + "@example.test"},
-		"password":         {"integration-pass-123"},
-		"password_confirm": {"integration-pass-123"},
-		"csrf_token":       {token},
-	}
-	req := newFormReq(ctx, t, baseURL+"/register", form)
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("register %q err = %v, want nil", username, err)
-	}
-	defer closeBody(t, resp.Body)
-	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register %q status = %d, want %d", username, got, want)
-	}
-
+	registerForPending(ctx, t, client, baseURL, username, "integration-pass-123")
 	verifyPlayerEmail(ctx, t, dbURI, username)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
 
 	return client
 }

--- a/test/integration/quiz_visibility_test.go
+++ b/test/integration/quiz_visibility_test.go
@@ -150,9 +150,9 @@ func TestQuizVisibility_Integration(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	registerPlayer(ctx, t, authClient, baseURL, "visibility-resident", "visibility-pass-123")
+	registerVerifyAndSignIn(ctx, t, authClient, baseURL, setup.DBURI, "visibility-resident", "visibility-pass-123")
 	// Drop the redirect interceptor so subsequent GETs follow 303
-	// redirects normally (the registration handler 303s on success).
+	// redirects normally (the login handler 303s on success).
 	authClient.CheckRedirect = nil
 
 	t.Run("logged-in player can fetch private quiz directly", func(t *testing.T) {

--- a/test/integration/register_verify_gate_test.go
+++ b/test/integration/register_verify_gate_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/session"
+)
+
+// TestRegister_HardGate_NoSessionUntilVerified pins #574 end-to-end: a
+// successful registration renders the confirmation page with 200 and no
+// live session cookie, commits a verify-token row, and leaves the
+// account unable to reach an authenticated route until the email is
+// verified and the account logs in.
+func TestRegister_HardGate_NoSessionUntilVerified(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		// BASE_URL must resolve or SendVerifyEmail short-circuits before
+		// the token row commits, breaking the token-count assertion.
+		"BASE_URL": "https://topbanana.example",
+	})
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	const (
+		username = "hardgate"
+		password = "hard-gate-pass-123"
+	)
+
+	client := authClient(t)
+	csrf := fetchCSRFToken(ctx, t, client, srv.BaseURL+"/register")
+	resp := postRegister(ctx, t, client, srv.BaseURL, csrf, username, password)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck // cleanup.
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+
+	// 1. Register renders the confirmation page (200, not 303).
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("register status = %d, want %d (body=%.300q)", got, want, body)
+	}
+	if got, want := string(body), "Verify your email"; !strings.Contains(got, want) {
+		t.Errorf("register body missing confirmation headline %q; body=%.300q", want, got)
+	}
+
+	// 2. No live session cookie was issued.
+	for _, c := range resp.Cookies() {
+		if c.Name == session.CookieName && c.Value != "" {
+			t.Errorf("live session cookie set on register: %+v", c)
+		}
+	}
+
+	// 3. A verify-token row was committed for the new account.
+	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	if err != nil {
+		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+	}
+	if player.EmailVerifiedAt != nil {
+		t.Fatalf("EmailVerifiedAt = %v, want nil right after register", player.EmailVerifiedAt)
+	}
+	waitForVerifyTokenRow(ctx, t, dbConn, player.ID)
+
+	// 4. The registering client cannot reach an authenticated route: its
+	// jar carries no session (register cleared it), so /profile bounces
+	// to /login.
+	gated := getWith(ctx, t, client, srv.BaseURL+"/profile")
+	gated.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := gated.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("pre-verify /profile status = %d, want %d", got, want)
+	}
+	if got := gated.Header.Get("Location"); !strings.HasPrefix(got, "/login") {
+		t.Errorf("pre-verify /profile Location = %q, want /login...", got)
+	}
+
+	// 5. Verify the email, log in, and confirm the account now reaches the
+	// authenticated route.
+	verifyPlayerEmail(ctx, t, srv.DBURI, username)
+	loginClient := authClient(t)
+	loc := loginForRedirect(ctx, t, loginClient, srv.BaseURL, username, password)
+	if got, want := loc, "/admin/quizzes"; got != want {
+		t.Errorf("post-verify login Location = %q, want %q (first registrant is admin)", got, want)
+	}
+
+	after := getWith(ctx, t, loginClient, srv.BaseURL+"/profile")
+	defer after.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := after.StatusCode, http.StatusOK; got != want {
+		t.Errorf("post-verify /profile status = %d, want %d", got, want)
+	}
+}

--- a/test/integration/reset_password_test.go
+++ b/test/integration/reset_password_test.go
@@ -28,10 +28,11 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	})
 
 	// First password-bearing registrant is promoted to admin, so the
-	// reset-token holder's role landing is /admin/quizzes.
+	// reset-token holder's role landing is /admin/quizzes. The signed
+	// client holds a live session at the pre-reset version so the test
+	// can prove the reset's session_version bump bounces it.
 	signed := authClient(t)
-	registerForRedirect(ctx, t, signed, srv.BaseURL, "reset-happy", "old-pass-12345")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "reset-happy")
+	registerVerifyAndMint(ctx, t, signed, srv.BaseURL, srv.DBURI, "reset-happy", "old-pass-12345")
 
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.

--- a/test/integration/testmain_test.go
+++ b/test/integration/testmain_test.go
@@ -67,6 +67,12 @@ func startServer(t *testing.T, extraEnv map[string]string) (context.Context, tes
 			"HOST":    "localhost",
 			"PORT":    "0",
 			"DB_URI":  dbURI,
+			// Fixed signing key so tests can mint a matching session cookie
+			// via mintSessionCookie (auth_redirect_test.go). The #574 hard
+			// gate stopped register from handing out a session, so tests
+			// that need a signed-in-but-unverified client forge the cookie
+			// directly. Overridable via extraEnv.
+			"SESSION_KEY": testSessionKey,
 		}
 		maps.Copy(env, extraEnv)
 

--- a/test/integration/verify_email_test.go
+++ b/test/integration/verify_email_test.go
@@ -189,10 +189,11 @@ func TestVerifyEmail_MismatchedSessionClears(t *testing.T) {
 		"REGISTRATION_ENABLED": "true",
 	})
 
-	// Register user A and hold their session cookie.
+	// Register user A, verify, and sign them in so clientA holds a live
+	// session cookie. The #574 hard gate means register alone no longer
+	// produces one.
 	clientA := authClient(t)
-	registerForRedirect(ctx, t, clientA, srv.BaseURL, "verify-session-a", "session-a-pass-123")
-	verifyPlayerEmail(ctx, t, srv.DBURI, "verify-session-a")
+	registerVerifyAndSignIn(ctx, t, clientA, srv.BaseURL, srv.DBURI, "verify-session-a", "session-a-pass-123")
 
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.

--- a/test/integration/verify_email_visibility_test.go
+++ b/test/integration/verify_email_visibility_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/cookiejar"
-	"net/url"
 	"testing"
 )
 
@@ -38,7 +37,7 @@ func TestVerifyEmail_SeparateConnectionStampVisibleToNextRequest(t *testing.T) {
 	// UNVERIFIED on purpose: we want RequireVerifiedEmail to bounce them
 	// until the separate-connection stamp lands.
 	const username = "verify-race"
-	client := registerClientUnverified(ctx, t, baseURL, username)
+	client := registerClientUnverified(ctx, t, baseURL, srv.DBURI, username)
 
 	gated := baseURL + "/admin/quizzes"
 
@@ -79,11 +78,13 @@ func assertBouncedToPending(ctx context.Context, t *testing.T, client *http.Clie
 	}
 }
 
-// registerClientUnverified mirrors registerAdminClient but stops after
-// the register POST, leaving email_verified_at NULL so the caller can
-// drive RequireVerifiedEmail in its unverified state. Returns the
-// cookie-jar client carrying the new session.
-func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, username string) *http.Client {
+// registerClientUnverified registers username through /register and
+// mints a session cookie onto its jar WITHOUT stamping
+// email_verified_at, leaving the player in the signed-in-but-unverified
+// state the caller needs to drive RequireVerifiedEmail. The #574 hard
+// gate means register no longer hands out a session, so the cookie is
+// minted directly (startServer signs with the default testSessionKey).
+func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, dbURI, username string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -96,23 +97,8 @@ func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, userna
 		},
 	}
 
-	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-	form := url.Values{
-		"username":         {username},
-		"email":            {username + "@example.test"},
-		"password":         {"integration-pass-123"},
-		"password_confirm": {"integration-pass-123"},
-		"csrf_token":       {token},
-	}
-	req := newFormReq(ctx, t, baseURL+"/register", form)
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("register %q err = %v, want nil", username, err)
-	}
-	defer closeBody(t, resp.Body)
-	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("register %q status = %d, want %d", username, got, want)
-	}
+	registerForPending(ctx, t, client, baseURL, username, "integration-pass-123")
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
 
 	return client
 }

--- a/test/integration/verify_gate_test.go
+++ b/test/integration/verify_gate_test.go
@@ -28,10 +28,8 @@ func TestVerifyGate_UnverifiedAdminBouncesToPending(t *testing.T) {
 	})
 
 	client := authClient(t)
-	loc := registerForRedirect(ctx, t, client, srv.BaseURL, "gate-admin", "gate-admin-pass-123")
-	if got, want := loc, "/admin/quizzes"; got != want {
-		t.Fatalf("register Location = %q, want %q", got, want)
-	}
+	registerForPending(ctx, t, client, srv.BaseURL, "gate-admin", "gate-admin-pass-123")
+	mintSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, "gate-admin")
 
 	resp := getWith(ctx, t, client, srv.BaseURL+"/admin/quizzes")
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
@@ -54,7 +52,8 @@ func TestVerifyGate_PendingPageShowsRecipientEmail(t *testing.T) {
 	})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "gate-pending", "gate-pending-pass-123")
+	registerForPending(ctx, t, client, srv.BaseURL, "gate-pending", "gate-pending-pass-123")
+	mintSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, "gate-pending")
 
 	resp := getWith(ctx, t, client, srv.BaseURL+"/verify-email/pending")
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
@@ -106,7 +105,8 @@ func TestVerifyGate_AfterVerifyAdminReachesDashboard(t *testing.T) {
 	})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "gate-after", "gate-after-pass-123")
+	registerForPending(ctx, t, client, srv.BaseURL, "gate-after", "gate-after-pass-123")
+	mintSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, "gate-after")
 
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
@@ -147,7 +147,8 @@ func TestVerifyGate_ResendRateLimited(t *testing.T) {
 	})
 
 	client := authClient(t)
-	registerForRedirect(ctx, t, client, srv.BaseURL, "gate-resend", "gate-resend-pass-123")
+	registerForPending(ctx, t, client, srv.BaseURL, "gate-resend", "gate-resend-pass-123")
+	mintSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, "gate-resend")
 	csrfToken := fetchCSRFToken(ctx, t, client, srv.BaseURL+"/verify-email/pending")
 
 	first := postResend(ctx, t, client, srv.BaseURL, csrfToken)


### PR DESCRIPTION
Closes #574

Registration no longer signs the new account in. The handler dispatches the verification email, clears any session cookie (signing out the anonymous-upgrade path too), and renders a neutral "Verify your email" confirmation page with HTTP 200. The account becomes usable only after the verification link is followed and the user logs in, matching the unverified-login block the login path already enforces (#492).

Decisions: hard gate (no session until verified); the ClaimPlayer anonymous-upgrade path is signed out as well, so no unverified account is ever signed in.

- `internal/auth/handler.go`: replace `sessions.Set` + redirect with `sessions.Clear` + render the new confirmation page.
- `internal/web/tmpl/auth/pages/register_pending.gohtml`: new no-session confirmation page (links to /login and the no-session /verify-email/request resend).
- Unit tests assert 200 + confirmation body + no live session cookie (deletion cookie expected on the anonymous-upgrade arm).
- New integration test `register_verify_gate_test.go` pins the end-to-end gate: register -> 200, no session, token row exists, /profile denied until verified, reachable after verify + login.
- Integration and e2e suites updated: helpers that relied on register-auto-signin now verify-then-login (or mint a session cookie to avoid the per-IP login cooldown).

Out of scope: the registration account-enumeration leak (#573), tracked separately.