### PR TITLE
Stop the registration form revealing whether an email already has an account

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/starquake/topbanana/internal/absurl"
 	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/envtag"
+	"github.com/starquake/topbanana/internal/mailer"
 	"github.com/starquake/topbanana/internal/session"
 	"github.com/starquake/topbanana/internal/web/tmpl"
 )
@@ -180,38 +181,76 @@ func HandleRegisterSubmit(
 			return
 		}
 
+		renderers := registerRenderers{form: render, pending: pending, sessions: sessions}
+
 		player, err := claimOrCreatePlayer(
 			r, players, sessions, input.CleanedUsername, input.CleanedEmail, hashed, role,
 		)
 		if err != nil {
-			if msg, ok := registerCollisionMessage(err); ok {
-				render.render(w, r, http.StatusConflict, formData{
-					Title:      "Register",
-					Username:   input.CleanedUsername,
-					Email:      input.CleanedEmail,
-					Message:    msg,
-					ShowGoogle: deps.GoogleEnabled,
-				})
-
-				return
-			}
-			logger.ErrorContext(r.Context(), "error creating player", slog.Any("err", err))
-			http.Error(w, "internal error", http.StatusInternalServerError)
+			handleRegisterError(w, r, logger, renderers, deps, input, err)
 
 			return
 		}
 
 		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail)
-		// Hard email-verification gate (#574): no session until the
-		// address is proven. Clear unconditionally so the anonymous
-		// upgrade path (ClaimPlayer) does not leave the pre-existing
-		// anonymous cookie live and sign the unverified account in.
-		sessions.Clear(w)
-		pending.render(w, r, http.StatusOK, registerPendingData{
-			Title: "Verify your email",
-			Email: input.CleanedEmail,
-		})
+		renderers.renderPending(w, r, input.CleanedEmail)
 	})
+}
+
+// registerRenderers bundles the two register-flow renderers and the
+// session manager so the error/pending helpers stay under revive's
+// argument-count cap.
+type registerRenderers struct {
+	form     *templateRenderer
+	pending  *templateRenderer
+	sessions *session.Manager
+}
+
+// renderPending clears any prior session and renders the confirmation
+// page. The hard email-verification gate (#574) means no session is set
+// until the address is proven; clearing unconditionally signs out the
+// anonymous-upgrade path (ClaimPlayer) so a pre-existing anonymous cookie
+// cannot leave the unverified account signed in.
+func (rr registerRenderers) renderPending(w http.ResponseWriter, r *http.Request, email string) {
+	rr.sessions.Clear(w)
+	rr.pending.render(w, r, http.StatusOK, registerPendingData{
+		Title: "Verify your email",
+		Email: email,
+	})
+}
+
+// handleRegisterError writes the response for a failed
+// claimOrCreatePlayer. ErrEmailTaken is account-existence-opaque: a
+// distinct 409 would turn the form into an enumeration oracle, so it
+// responds exactly as the fresh-signup branch does and notifies the real
+// owner out of band instead (#573). ErrUsernameTaken re-renders the form
+// with a 409 - a display name is a public handle, not an enumeration
+// secret. Anything else is a 500.
+func handleRegisterError(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	renderers registerRenderers,
+	deps RegisterDeps,
+	input registerInput,
+	err error,
+) {
+	switch {
+	case errors.Is(err, ErrEmailTaken):
+		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail)
+		renderers.renderPending(w, r, input.CleanedEmail)
+	case errors.Is(err, ErrUsernameTaken):
+		renderers.form.render(w, r, http.StatusConflict, formData{
+			Title:      "Register",
+			Username:   input.CleanedUsername,
+			Email:      input.CleanedEmail,
+			Message:    "That display name is already taken.",
+			ShowGoogle: deps.GoogleEnabled,
+		})
+	default:
+		logger.ErrorContext(r.Context(), "error creating player", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
 }
 
 // registerPendingData backs the post-register confirmation page shown
@@ -260,18 +299,39 @@ func dispatchVerifyEmail(
 	}()
 }
 
-// registerCollisionMessage maps the register-time conflict sentinels
-// onto the user-facing banner. ok=false when err is something else
-// and the caller should treat it as a 500.
-func registerCollisionMessage(err error) (string, bool) {
-	switch {
-	case errors.Is(err, ErrUsernameTaken):
-		return "That display name is already taken.", true
-	case errors.Is(err, ErrEmailTaken):
-		return "Email is already registered. Try logging in.", true
+// dispatchRegisterExisting notifies the owner of an already-registered
+// address that someone attempted to register with it. The collided
+// address IS the existing owner's verified address, so sending to
+// recipient reaches the real owner; the unauthenticated submitter
+// learns nothing. Runs on a detached goroutine with a bounded timeout,
+// mirroring dispatchVerifyEmail, so the email-collision response
+// returns on the same timing path as the success response. A nil
+// Mailer (unit tests) skips the send; a send failure is logged at Warn
+// and never surfaced.
+func dispatchRegisterExisting(
+	ctx context.Context,
+	logger *slog.Logger,
+	deps RegisterDeps,
+	recipient string,
+) {
+	if deps.Mailer == nil {
+		return
 	}
-
-	return "", false
+	bg, cancel := context.WithTimeout(context.WithoutCancel(ctx), verifyEmailDispatchTimeout)
+	go func() {
+		defer cancel()
+		msg := mailer.Message{
+			To:      recipient,
+			Subject: "Someone tried to register with your Top Banana! email",
+			Body: "Someone tried to create a Top Banana! account with this email address.\n\n" +
+				"An account already exists for this address. If it was you, sign in or reset your password instead.\n\n" +
+				"If it was not you, no action is needed.\n",
+			Kind: mailer.KindRegisterExisting,
+		}
+		if err := deps.Mailer.Send(bg, msg); err != nil {
+			logger.WarnContext(bg, "register-existing notice failed", slog.Any("err", err))
+		}
+	}()
 }
 
 // claimOrCreatePlayer upgrades an anonymous session row via ClaimPlayer

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -546,6 +546,11 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 	}
 }
 
+// TestHandleRegisterSubmit_DuplicateEmail pins the account-enumeration
+// opacity contract (#573): registering with an already-registered email
+// must return the same pending page (200, same body, no live session) as
+// a fresh signup, and dispatch an out-of-band notice to the real owner
+// rather than surface a distinct "already registered" response.
 func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	t.Parallel()
 
@@ -554,7 +559,11 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	sender := &recordingSender{}
+	handler := HandleRegisterSubmit(
+		discardLogger(), nil, store, session.New([]byte("k"), true),
+		RegisterDeps{Mailer: sender},
+	)
 	rec := postForm(t, handler, "/register", url.Values{
 		"username":         {"bob"},
 		"email":            {"shared@example.test"},
@@ -562,11 +571,30 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 		"password_confirm": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusConflict; got != want {
-		t.Errorf("status = %d, want %d", got, want)
+	assertRegisterPending(t, rec, "shared@example.test")
+	if got := rec.Body.String(); strings.Contains(got, "already registered") {
+		t.Errorf("body leaked account existence; body=%.300q", got)
 	}
-	if got, want := rec.Body.String(), "already registered"; !strings.Contains(got, want) {
-		t.Errorf("body did not mention duplicate email, got %q", got)
+
+	// The owner-notification send fires on a detached goroutine; give it
+	// up to a second to land. The mailer is the in-process recordingSender
+	// so the wait is just goroutine scheduling, not network.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(sender.Sent()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	sent := sender.Sent()
+	if got, want := len(sent), 1; got != want {
+		t.Fatalf("sender.Sent() len = %d, want %d", got, want)
+	}
+	if got, want := sent[0].Kind, mailer.KindRegisterExisting; got != want {
+		t.Errorf("sent[0].Kind = %q, want %q", got, want)
+	}
+	if got, want := sent[0].To, "shared@example.test"; got != want {
+		t.Errorf("sent[0].To = %q, want %q", got, want)
 	}
 }
 

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -26,6 +26,7 @@ const (
 	KindInvite            Kind = "invite"
 	KindTest              Kind = "test"
 	KindEmailChangeNotice Kind = "email_change_notice"
+	KindRegisterExisting  Kind = "register_existing"
 )
 
 // ErrNotConfigured is the sentinel returned by the no-op mailer's Send

--- a/test/integration/register_enumeration_test.go
+++ b/test/integration/register_enumeration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRegister_EmailCollisionOpaque pins the account-enumeration opacity
+// contract (#573): POST /register with an already-registered email must
+// return a response identical (status + body) to a fresh-email signup,
+// so the form cannot be used to learn which addresses have accounts.
+func TestRegister_EmailCollisionOpaque(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	// Register the owner so owner@example.test is taken.
+	owner := authClient(t)
+	registerForPending(ctx, t, owner, srv.BaseURL, "enum-owner", "correct-battery-13")
+
+	// Fresh email: the baseline the collision must match.
+	freshStatus, freshBody := registerRaw(
+		ctx, t, authClient(t), srv.BaseURL, "enum-newcomer", "enum-newcomer@example.test", "correct-battery-13",
+	)
+
+	// Already-registered email under a different display name.
+	collideStatus, collideBody := registerRaw(
+		ctx, t, authClient(t), srv.BaseURL, "enum-prober", "enum-owner@example.test", "correct-battery-13",
+	)
+
+	if got, want := collideStatus, freshStatus; got != want {
+		t.Errorf("collision status = %d, want %d (fresh)", got, want)
+	}
+	if got, want := collideStatus, http.StatusOK; got != want {
+		t.Errorf("collision status = %d, want %d", got, want)
+	}
+
+	// The bodies echo the typed email, so normalise that difference out
+	// before comparing - everything else must be byte-identical.
+	freshNorm := strings.ReplaceAll(freshBody, "enum-newcomer@example.test", "EMAIL")
+	collideNorm := strings.ReplaceAll(collideBody, "enum-owner@example.test", "EMAIL")
+	if freshNorm != collideNorm {
+		t.Errorf("collision body differs from fresh body after email normalisation:\nfresh=%.400q\ncollide=%.400q",
+			freshNorm, collideNorm)
+	}
+
+	// The byte-identical comparison above is the definitive opacity
+	// proof; this guards the specific pre-#573 leak phrasing in case the
+	// fresh and collision bodies ever drift together in a way the
+	// normalised compare misses.
+	if strings.Contains(collideBody, "already registered") {
+		t.Errorf("collision body leaked account existence; body=%.400q", collideBody)
+	}
+}
+
+// registerRaw POSTs /register with an explicit email (decoupled from the
+// username, unlike postRegister) and returns the status and body. Used by
+// the opacity test which needs two distinct usernames sharing one email.
+func registerRaw(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, email, password string,
+) (int, string) {
+	t.Helper()
+
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
+
+	form := url.Values{}
+	form.Add("username", username)
+	form.Add("email", email)
+	form.Add("password", password)
+	form.Add("password_confirm", password)
+	form.Add("csrf_token", token)
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, baseURL+"/register", strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+
+	return resp.StatusCode, string(body)
+}


### PR DESCRIPTION
Closes #573

Submitting the register form with an already-registered email used to return a distinct 409 with "Email is already registered. Try logging in.", letting anyone probe which addresses have accounts. The response is now identical to a fresh signup, and the real account owner is notified out of band instead.

- `ErrEmailTaken` now renders the same "Verify your email" pending page (200, byte-identical body, same cleared session cookie) the fresh-signup branch renders, and fires a best-effort notice to the existing owner ("someone tried to register with your email; sign in or reset your password").
- `ErrUsernameTaken` keeps its 409 form error - a display name is a public handle, not an enumeration secret, and a prober leaves it blank or random anyway.
- Timing stays equalized: both branches run bcrypt synchronously before the collision check and dispatch their email on a detached, non-blocking goroutine.
- New `mailer.KindRegisterExisting` tag for the owner notice.

Opacity is complete across status, body, and the Set-Cookie (both branches clear the session), so the cookie can't re-open the oracle.

Builds on the #574 hard gate. Forgot-password and verify-email-request were already opaque (generic success) and are untouched.

Tests: unit `TestHandleRegisterSubmit_DuplicateEmail` rewritten to assert the opaque pending response + one out-of-band notice to the owner; integration `TestRegister_EmailCollisionOpaque` asserts the fresh-email and already-registered responses are byte-identical (after normalizing the echoed address).