### PR TITLE
Tick the auth cooldown buttons down and re-enable them without a reload

### DIFF
--- a/internal/web/static/js/cooldown.js
+++ b/internal/web/static/js/cooldown.js
@@ -1,0 +1,52 @@
+// cooldown.js ticks the rate-limit "Wait Ns" submit buttons on the auth
+// pages (forgot-password, verify-email request, verify-email pending)
+// down to zero and re-enables them, so a visitor who waits out the
+// lockout can submit again without reloading the page.
+//
+// The server renders the initial disabled state and the wait count
+// (e.g. `Wait 60s`, `disabled`) at page load; that server-rendered
+// markup stays the source of truth on first paint and works unchanged
+// if this module never runs. All this module does is let the UI catch
+// up to the cooldown the server already enforces: server-side
+// enforcement remains authoritative, so a submit fired right at expiry
+// that the server still considers too early simply re-renders the
+// cooldown page again, which is fine.
+//
+// Generic across all three pages: each button carries the remaining
+// seconds in data-cooldown and its active label in data-cooldown-label,
+// so the page templates differ only in those attribute values. The
+// module is scanned by Tailwind via the @source "../js" directive, but
+// it emits no class names of its own.
+
+function startCooldown(button) {
+    let remaining = Number.parseInt(button.dataset.cooldown ?? '', 10);
+    // No countdown to run: not in cooldown (0 / empty) or a malformed
+    // value. Leave whatever the server rendered untouched.
+    if (!Number.isFinite(remaining) || remaining <= 0) return;
+
+    const activeLabel = button.dataset.cooldownLabel ?? '';
+
+    const tick = () => {
+        remaining -= 1;
+        if (remaining > 0) {
+            button.textContent = `Wait ${remaining}s`;
+
+            return;
+        }
+        clearInterval(timer);
+        button.textContent = activeLabel;
+        button.removeAttribute('disabled');
+        button.removeAttribute('aria-disabled');
+    };
+
+    const timer = setInterval(tick, 1000);
+}
+
+if (typeof document !== 'undefined') {
+    const run = () => document.querySelectorAll('[data-cooldown]').forEach(startCooldown);
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', run);
+    } else {
+        run();
+    }
+}

--- a/internal/web/tmpl/auth/layouts/base.gohtml
+++ b/internal/web/tmpl/auth/layouts/base.gohtml
@@ -34,6 +34,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap">
     <link rel="stylesheet" href="/assets/css/app.css">
+    {{/* cooldown.js ticks the rate-limit "Wait Ns" submit buttons down
+         and re-enables them at zero. It self-noops on auth pages with no
+         [data-cooldown] element, so loading it on every auth page is
+         fine. */}}
+    <script type="module" src="/assets/js/cooldown.js" defer></script>
     <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/sw.js');</script>
 </head>
 <body class="bg-bg text-text font-sans antialiased min-h-screen leading-relaxed">

--- a/internal/web/tmpl/auth/pages/forgot_password.gohtml
+++ b/internal/web/tmpl/auth/pages/forgot_password.gohtml
@@ -26,7 +26,7 @@
                 <input id="identifier" type="email" name="identifier" value="{{.Identifier}}" autocomplete="email" required
                        class="form-input">
             </div>
-            <button type="submit" class="btn-primary" {{if .SubmitDisabled}}disabled aria-disabled="true"{{end}}>
+            <button type="submit" class="btn-primary" data-cooldown="{{.SubmitWaitSecs}}" data-cooldown-label="Send reset link" {{if .SubmitDisabled}}disabled aria-disabled="true"{{end}}>
                 {{if .SubmitDisabled}}Wait {{.SubmitWaitSecs}}s{{else}}Send reset link{{end}}
             </button>
         </form>

--- a/internal/web/tmpl/auth/pages/verify_email_pending.gohtml
+++ b/internal/web/tmpl/auth/pages/verify_email_pending.gohtml
@@ -22,7 +22,7 @@
 
         <form action="/verify-email/resend" method="POST" class="mb-6">
             <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-            <button type="submit" class="btn-primary" {{if .ResendDisabled}}disabled aria-disabled="true"{{end}}>
+            <button type="submit" class="btn-primary" data-cooldown="{{.ResendWaitSeconds}}" data-cooldown-label="Resend verification email" {{if .ResendDisabled}}disabled aria-disabled="true"{{end}}>
                 {{if .ResendDisabled}}Wait {{.ResendWaitSeconds}}s{{else}}Resend verification email{{end}}
             </button>
         </form>

--- a/internal/web/tmpl/auth/pages/verify_email_request.gohtml
+++ b/internal/web/tmpl/auth/pages/verify_email_request.gohtml
@@ -26,7 +26,7 @@
                 <input type="email" name="email" value="{{.Email}}" autocomplete="email" required
                        class="form-input">
             </label>
-            <button type="submit" class="btn-primary" {{if .SubmitDisabled}}disabled aria-disabled="true"{{end}}>
+            <button type="submit" class="btn-primary" data-cooldown="{{.SubmitWaitSecs}}" data-cooldown-label="Send verification link" {{if .SubmitDisabled}}disabled aria-disabled="true"{{end}}>
                 {{if .SubmitDisabled}}Wait {{.SubmitWaitSecs}}s{{else}}Send verification link{{end}}
             </button>
         </form>

--- a/test/e2e/tests/cooldown.spec.ts
+++ b/test/e2e/tests/cooldown.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from './fixtures';
+
+// The forgot-password POST handler enforces a 60s per-IP cooldown. Two
+// submits inside that window make the second one trip the limiter: the
+// PRG redirect re-renders the page with the submit button disabled and
+// labelled "Wait 60s". cooldown.js should then tick that label down and
+// re-enable the button at zero, with no page reload.
+test('forgot-password cooldown button counts down and re-enables', async ({ page }) => {
+  // Install the clock before any navigation so the page's setInterval
+  // is driven by Playwright's virtual clock from first paint -- the
+  // countdown then advances only when we fast-forward, never on the
+  // wall clock.
+  await page.clock.install();
+
+  await page.goto('/forgot-password');
+
+  const submit = page.getByRole('button', { name: 'Send reset link' });
+  await expect(submit).toBeEnabled();
+
+  // First submit succeeds and arms the limiter; the PRG redirect lands
+  // back on /forgot-password with the opaque success notice.
+  await page.locator('input[name=identifier]').fill('nobody@example.test');
+  await submit.click();
+  await expect(page).toHaveURL(/\/forgot-password$/);
+
+  // Second submit inside the 60s window trips the limiter. The redirect
+  // re-renders the page with the button disabled and showing "Wait 60s".
+  await page.locator('input[name=identifier]').fill('nobody@example.test');
+  await page.getByRole('button', { name: /^Wait \d+s$|^Send reset link$/ }).click();
+
+  const cooldownButton = page.getByRole('button', { name: /^Wait \d+s$/ });
+  await expect(cooldownButton).toBeDisabled();
+  await expect(cooldownButton).toHaveText('Wait 60s');
+
+  // Advance past the full 60s cooldown without real waiting. runFor
+  // (not fastForward) fires every intermediate 1s tick of cooldown.js's
+  // setInterval -- fastForward jumps the clock and would fire a repeating
+  // timer only once.
+  await page.clock.runFor(61_000);
+
+  // The button re-enables and the active label returns, with no reload.
+  const reEnabled = page.getByRole('button', { name: 'Send reset link' });
+  await expect(reEnabled).toBeEnabled();
+  await expect(reEnabled).not.toHaveAttribute('aria-disabled', /.*/);
+});


### PR DESCRIPTION
Closes #576

The rate-limit "Wait Ns" submit buttons on the auth pages had their disabled state and countdown rendered once, server-side, at page load. With no client timer, waiting the cooldown out did nothing - the label stayed frozen and the button never re-enabled, so the visitor had to reload. A small client-side countdown now ticks the label down and re-enables the button at zero.

- New `internal/web/static/js/cooldown.js`: a framework-free ES module (mirrors `share.js`) that auto-wires `[data-cooldown]` buttons at DOMContentLoaded, ticks "Wait Ns" down, and at zero restores the active label and removes `disabled`/`aria-disabled`. It no-ops when not in cooldown, so the server-rendered markup stays the source of truth on first paint and works unchanged without JS. Server-side enforcement remains authoritative.
- Loaded via the auth base layout (self-noops on pages without a cooldown button).
- Applied to the three pages that share the pattern: forgot-password, verify-email request, verify-email pending. (login and reset-password have plain buttons, no cooldown - left untouched, correcting the ticket's guess.)
- e2e `cooldown.spec.ts` drives Playwright's virtual clock to trip the 60s forgot-password limiter, then asserts the button counts down and re-enables with no reload.

No Alpine: it is vendored only under the client tree (`/client/`), while these pages are served at `/assets/`, so a vanilla module is the right-sized fix.