### PR TITLE
Give the heavy share e2e tests a longer timeout so firefox CI stops flaking

### DIFF
--- a/test/e2e/tests/share.spec.ts
+++ b/test/e2e/tests/share.spec.ts
@@ -11,6 +11,10 @@ import { registerAdmin, createQuizWithQuestions, startQuizAsAnonymous, answerRem
 // fallback dialog renders.
 
 test('player client start screen has a share button that opens the dialog with invite text', async ({ page, browserName }) => {
+  // registerAdmin (register + verify + login) plus the four-question
+  // quiz authoring runs well past the default 30s budget on a loaded
+  // firefox CI worker (#585); match the playthrough specs' budget.
+  test.setTimeout(90_000);
   const username = `e2e-admin-share-start-${browserName}`;
   const quizTitle = `E2E Share Start Quiz ${browserName}`;
 
@@ -48,6 +52,8 @@ test('player client start screen has a share button that opens the dialog with i
 });
 
 test('player client finish screen has a share button that includes the score', async ({ page, browserName }) => {
+  // Heavy register + quiz authoring + full playthrough; see #585.
+  test.setTimeout(90_000);
   const username = `e2e-admin-share-finish-${browserName}`;
   const quizTitle = `E2E Share Finish Quiz ${browserName}`;
 
@@ -90,6 +96,8 @@ test('player client finish screen has a share button that includes the score', a
 // leaderboard payload instead. This spec exercises the revisit
 // path: play through, navigate away, come back, share.
 test('share-result reads score from the leaderboard so a revisit still brags the real number', async ({ page, browserName }) => {
+  // Heavy register + quiz authoring + full playthrough; see #585.
+  test.setTimeout(90_000);
   const username = `e2e-admin-share-revisit-${browserName}`;
   const quizTitle = `E2E Share Revisit Quiz ${browserName}`;
 
@@ -147,6 +155,8 @@ test('share-result reads score from the leaderboard so a revisit still brags the
 });
 
 test('home page popular-card share button opens the dialog with invitation text', async ({ page, browserName }) => {
+  // Heavy register + quiz authoring + full playthrough; see #585.
+  test.setTimeout(90_000);
   const username = `e2e-admin-share-home-${browserName}`;
   const quizTitle = `E2E Share Home Quiz ${browserName}`;
 


### PR DESCRIPTION
Closes #585

`share.spec.ts:50` (the finish-screen test) timed out on firefox CI on the default 30s budget while the other quiz-playthrough specs all set 60-120s. The #574 hard gate made `registerAdmin` heavier (it now stamps verification and logs in), tipping these already-near-budget tests over on a loaded firefox worker.

Sets `test.setTimeout(90_000)` (matching `player.spec.ts`) on all four share tests, which each run `registerAdmin` + four-question quiz authoring (three also do a full playthrough). Test-harness timing only; no product behavior changes.