### PR TITLE
Rename the display-name form field so password managers stop treating it as a login username

### DIFF
--- a/internal/admin/playeractions.go
+++ b/internal/admin/playeractions.go
@@ -184,7 +184,7 @@ func HandlePlayerSetUsername(
 			return
 		}
 
-		name := strings.TrimSpace(r.PostFormValue("username"))
+		name := strings.TrimSpace(r.PostFormValue("display_name"))
 
 		_, err := store.RenamePlayer(r.Context(), playerID, name)
 		switch {
@@ -480,7 +480,7 @@ type newPlayerCreateInput struct {
 
 func newPlayerInput(r *http.Request) newPlayerCreateInput {
 	in := newPlayerCreateInput{
-		Username: strings.TrimSpace(r.PostFormValue("username")),
+		Username: strings.TrimSpace(r.PostFormValue("display_name")),
 		Email:    strings.ToLower(strings.TrimSpace(r.PostFormValue("email"))),
 		Password: r.PostFormValue("password"),
 	}

--- a/internal/admin/playeractions_credentials_test.go
+++ b/internal/admin/playeractions_credentials_test.go
@@ -109,7 +109,7 @@ func postUsername(t *testing.T, store *credStubStore, username string) *httptest
 	t.Helper()
 	handler := HandlePlayerSetUsername(slog.New(slog.DiscardHandler), store, newCredFlash(t))
 
-	form := url.Values{"username": {username}}
+	form := url.Values{"display_name": {username}}
 	req := httptest.NewRequestWithContext(
 		t.Context(), http.MethodPost, "/admin/players/7/username",
 		strings.NewReader(form.Encode()),

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -150,7 +150,7 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		rawUsername := r.PostFormValue("username")
+		rawUsername := r.PostFormValue("display_name")
 		rawEmail := r.PostFormValue("email")
 		password := r.PostFormValue("password")
 		passwordConfirm := r.PostFormValue("password_confirm")

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -324,7 +324,7 @@ func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 		t.Errorf("status = %d, want %d", got, want)
 	}
 	body := rec.Body.String()
-	if want := `name="username"`; !strings.Contains(body, want) {
+	if want := `name="display_name"`; !strings.Contains(body, want) {
 		t.Errorf("body = %q, want substring %q", body, want)
 	}
 	// passwordHelp template func renders the form's help text from the
@@ -344,7 +344,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -416,7 +416,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"bob"},
+		"display_name":     {"bob"},
 		"email":            {"bob@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -450,7 +450,7 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 		RegisterDeps{AdminEmails: []string{"alice@example.test", "carol@example.test"}},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"carol"},
+		"display_name":     {"carol"},
 		"email":            {"carol@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -474,7 +474,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {"short"},
 		"password_confirm": {"short"},
@@ -504,7 +504,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 
 	longPassword := strings.Repeat("a", MaxPasswordLength+1)
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {longPassword},
 		"password_confirm": {longPassword},
@@ -532,7 +532,7 @@ func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
 
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -565,7 +565,7 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 		RegisterDeps{Mailer: sender},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"bob"},
+		"display_name":     {"bob"},
 		"email":            {"shared@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -604,7 +604,7 @@ func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 	store := newStubPlayerStore()
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"not-an-email"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -625,7 +625,7 @@ func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -645,7 +645,7 @@ func TestHandleRegisterSubmit_MismatchedPasswords_Rejects(t *testing.T) {
 
 	password := "correctbattery"
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {password},
 		"password_confirm": {"correctbatterydifferent"},
@@ -684,7 +684,7 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	store := newStubPlayerStore()
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"  ALICE@Example.Test "},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -723,7 +723,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -786,7 +786,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
-		"username":         {"alice"}, // already taken by the seeded credentialled row
+		"display_name":     {"alice"}, // already taken by the seeded credentialled row
 		"email":            {"new-alice@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -848,7 +848,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	cookie := rec.Result().Cookies()[0]
 
 	form := url.Values{
-		"username":         {"latecomer"},
+		"display_name":     {"latecomer"},
 		"email":            {"latecomer@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -1306,7 +1306,7 @@ func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
 	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"   "},
+		"display_name":     {"   "},
 		"email":            {"petname@example.test"},
 		"password":         {"correctbattery"},
 		"password_confirm": {"correctbattery"},
@@ -1333,7 +1333,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 
 	password := strings.Repeat("a", MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{
-		"username":         {"alice"},
+		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
 		"password":         {password},
 		"password_confirm": {password},

--- a/internal/auth/invite_handler.go
+++ b/internal/auth/invite_handler.go
@@ -131,7 +131,7 @@ func HandleAcceptInviteSubmit(logger *slog.Logger, csrfMgr *csrf.Manager, deps A
 			return
 		}
 
-		username := r.PostFormValue("username")
+		username := r.PostFormValue("display_name")
 		password := r.PostFormValue("password")
 		confirm := r.PostFormValue("confirm")
 		if msg, ok := validateAcceptInviteInput(username, password, confirm); !ok {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -102,7 +102,7 @@ func HandleProfileUsername(
 			return
 		}
 
-		raw := r.PostFormValue("username")
+		raw := r.PostFormValue("display_name")
 		cleaned := strings.TrimSpace(raw)
 
 		updated, err := players.RenamePlayer(r.Context(), player.ID, cleaned)

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -80,7 +80,7 @@ func postRename(t *testing.T, store auth.PlayerStore, newName string) (string, *
 	csrfMgr := csrf.New([]byte("test-key-32-bytes-test-key-32byt"), false)
 	handler := HandleProfileUsername(logger, csrfMgr, store)
 
-	form := url.Values{"username": {newName}}
+	form := url.Values{"display_name": {newName}}
 	req := httptest.NewRequestWithContext(
 		t.Context(), http.MethodPost, "/profile/username",
 		strings.NewReader(form.Encode()),

--- a/internal/web/tmpl/admin/pages/playerdetail.gohtml
+++ b/internal/web/tmpl/admin/pages/playerdetail.gohtml
@@ -93,8 +93,8 @@
                     </form>
                     <form method="POST" action="/admin/players/{{.Player.ID}}/username" class="flex flex-col gap-2">
                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-                        <label for="username-input" class="text-text-dim text-xs uppercase tracking-[0.14em]">Set display name</label>
-                        <input id="username-input" type="text" name="username" required value="{{.Player.Username}}"
+                        <label for="display-name-input" class="text-text-dim text-xs uppercase tracking-[0.14em]">Name</label>
+                        <input id="display-name-input" type="text" name="display_name" required value="{{.Player.Username}}"
                                class="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text">
                         <button type="submit" class="btn-ghost">Save display name</button>
                     </form>

--- a/internal/web/tmpl/admin/pages/playernew.gohtml
+++ b/internal/web/tmpl/admin/pages/playernew.gohtml
@@ -25,8 +25,8 @@
         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
 
         <label class="flex flex-col gap-1 text-sm">
-            <span class="text-text-dim text-xs uppercase tracking-[0.14em]">Display name (optional)</span>
-            <input type="text" name="username" value="{{.Username}}" autocomplete="off"
+            <span class="text-text-dim text-xs uppercase tracking-[0.14em]">Name (optional)</span>
+            <input type="text" name="display_name" value="{{.Username}}" autocomplete="off"
                    class="rounded-md border border-border bg-surface px-3 py-2 text-text" placeholder="Auto-generated if left blank">
         </label>
 

--- a/internal/web/tmpl/admin/pages/settings.gohtml
+++ b/internal/web/tmpl/admin/pages/settings.gohtml
@@ -79,8 +79,8 @@
         <form method="POST" action="/admin/players" class="flex flex-col gap-4 max-w-md">
             <input type="hidden" name="csrf_token" value="{{csrfToken}}">
             <label class="flex flex-col gap-1 text-sm">
-                <span class="text-text-dim text-xs uppercase tracking-[0.14em]">Display name (optional)</span>
-                <input type="text" name="username" autocomplete="off"
+                <span class="text-text-dim text-xs uppercase tracking-[0.14em]">Name (optional)</span>
+                <input type="text" name="display_name" autocomplete="off"
                        class="rounded-md border border-border bg-surface px-3 py-2 text-text" placeholder="Auto-generated if left blank">
             </label>
             <label class="flex flex-col gap-1 text-sm">

--- a/internal/web/tmpl/auth/pages/accept_invite.gohtml
+++ b/internal/web/tmpl/auth/pages/accept_invite.gohtml
@@ -20,8 +20,8 @@
             <input type="hidden" name="csrf_token" value="{{csrfToken}}">
             <input type="hidden" name="token" value="{{.Token}}">
             <label class="flex flex-col gap-1 text-sm">
-                <span class="text-text-dim">Display name</span>
-                <input type="text" name="username" value="{{.Username}}" autocomplete="username" required class="form-input">
+                <span class="text-text-dim">Name</span>
+                <input type="text" name="display_name" value="{{.Username}}" autocomplete="nickname" required class="form-input">
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Password</span>

--- a/internal/web/tmpl/auth/pages/profile.gohtml
+++ b/internal/web/tmpl/auth/pages/profile.gohtml
@@ -26,9 +26,9 @@
             <input type="hidden" name="csrf_token" value="{{csrfToken}}">
 
             <div class="form-field">
-                <label for="username" class="label-eyebrow">Display name</label>
-                <input id="username" name="username" type="text" required
-                       autocomplete="username"
+                <label for="display_name" class="label-eyebrow">Name</label>
+                <input id="display_name" name="display_name" type="text" required
+                       autocomplete="nickname"
                        value="{{.Username}}" class="form-input">
                 <p class="mt-2 text-xs text-text-mute">
                     This is the name your leaderboard rows are shown under.

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -31,8 +31,8 @@
             </div>
 
             <div class="form-field">
-                <label for="username" class="label-eyebrow">Display name</label>
-                <input id="username" name="username" type="text"
+                <label for="display_name" class="label-eyebrow">Name</label>
+                <input id="display_name" name="display_name" type="text"
                        autocomplete="nickname"
                        value="{{.Username}}" class="form-input">
                 <p class="mt-2 text-xs text-text-mute">Leave blank to use a generated name.</p>

--- a/test/e2e/tests/admin-player-credentials.spec.ts
+++ b/test/e2e/tests/admin-player-credentials.spec.ts
@@ -14,7 +14,7 @@ async function registerPlayer(
     const playerPage = await playerContext.newPage();
     await playerPage.goto('/register');
     await playerPage.locator('input[name=email]').fill(`${username}@example.test`);
-    await playerPage.locator('input[name=username]').fill(username);
+    await playerPage.locator('input[name=display_name]').fill(username);
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();
@@ -49,7 +49,7 @@ test('admin sets a player display name and password from the detail page', async
 
   // Rename via the new display-name form; PRG returns with a flash and
   // the persisted name shows in the page heading.
-  const nameInput = page.getByLabel('Set display name');
+  const nameInput = page.getByLabel('Name', { exact: true });
   await expect(nameInput).toHaveValue(targetUsername);
   await nameInput.fill(renamedUsername);
   await page.getByRole('button', { name: 'Save display name' }).click();

--- a/test/e2e/tests/admin-players.spec.ts
+++ b/test/e2e/tests/admin-players.spec.ts
@@ -27,7 +27,7 @@ test('admin marks an unverified player verified via the detail view', async ({ p
     const targetPage = await targetContext.newPage();
     await targetPage.goto('/register');
     await targetPage.locator('input[name=email]').fill(`${targetUsername}@example.test`);
-    await targetPage.locator('input[name=username]').fill(targetUsername);
+    await targetPage.locator('input[name=display_name]').fill(targetUsername);
     await targetPage.locator('input[name=password]').fill(PASSWORD);
     await targetPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await targetPage.locator('button[type=submit]').click();

--- a/test/e2e/tests/admin-settings.spec.ts
+++ b/test/e2e/tests/admin-settings.spec.ts
@@ -15,7 +15,7 @@ async function registerPlayer(
     const playerPage = await playerContext.newPage();
     await playerPage.goto('/register');
     await playerPage.locator('input[name=email]').fill(`${username}@example.test`);
-    await playerPage.locator('input[name=username]').fill(username);
+    await playerPage.locator('input[name=display_name]').fill(username);
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -42,7 +42,7 @@ export async function registerAdmin(page: Page, username: string): Promise<void>
 export async function registerForPending(page: Page, username: string): Promise<void> {
   await page.goto('/register');
   await page.locator('input[name=email]').fill(`${username}@example.test`);
-  await page.locator('input[name=username]').fill(username);
+  await page.locator('input[name=display_name]').fill(username);
   await page.locator('input[name=password]').fill(PASSWORD);
   await page.locator('input[name=password_confirm]').fill(PASSWORD);
   await page.locator('button[type=submit]').click();

--- a/test/integration/admin_player_mgmt_test.go
+++ b/test/integration/admin_player_mgmt_test.go
@@ -258,9 +258,9 @@ func TestAdminPlayerMgmt_CreatePlayer(t *testing.T) {
 		ctx, t, adminClient, srv.BaseURL,
 		srv.BaseURL+"/admin/players",
 		url.Values{
-			"username": {"create-target"},
-			"email":    {"create-target@example.test"},
-			"password": {"create-target-pass-123"},
+			"display_name": {"create-target"},
+			"email":        {"create-target@example.test"},
+			"password":     {"create-target-pass-123"},
 		},
 	)
 
@@ -471,7 +471,14 @@ func TestAdminPlayerMgmt_SetUsername(t *testing.T) {
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setname-target")
 	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/username"
 
-	res := postAdminAction(ctx, t, adminClient, srv.BaseURL, usernameURL, url.Values{"username": {"renamed-target"}})
+	res := postAdminAction(
+		ctx,
+		t,
+		adminClient,
+		srv.BaseURL,
+		usernameURL,
+		url.Values{"display_name": {"renamed-target"}},
+	)
 	if got, want := res.StatusCode, http.StatusSeeOther; got != want {
 		t.Fatalf("set-username status = %d, want %d", got, want)
 	}

--- a/test/integration/invite_flow_test.go
+++ b/test/integration/invite_flow_test.go
@@ -417,11 +417,11 @@ func postAcceptInvite(
 	t.Helper()
 	csrfToken := fetchCSRFToken(ctx, t, client, baseURL+"/login")
 	form := url.Values{
-		"csrf_token": {csrfToken},
-		"token":      {rawToken},
-		"username":   {username},
-		"password":   {invitePassword},
-		"confirm":    {invitePassword},
+		"csrf_token":   {csrfToken},
+		"token":        {rawToken},
+		"display_name": {username},
+		"password":     {invitePassword},
+		"confirm":      {invitePassword},
 	}
 	req := newFormReq(ctx, t, baseURL+"/accept-invite", form)
 	resp, err := client.Do(req)

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -125,7 +125,7 @@ func postRegister(
 	t.Helper()
 
 	form := url.Values{}
-	form.Add("username", username)
+	form.Add("display_name", username)
 	form.Add("email", username+"@example.test")
 	form.Add("password", password)
 	form.Add("password_confirm", password)

--- a/test/integration/profile_test.go
+++ b/test/integration/profile_test.go
@@ -59,8 +59,8 @@ func TestProfile_Integration(t *testing.T) {
 		if got, want := snap.status, http.StatusOK; got != want {
 			t.Fatalf("status = %d, want %d", got, want)
 		}
-		if !strings.Contains(snap.body, `name="username"`) {
-			t.Error("body missing username input")
+		if !strings.Contains(snap.body, `name="display_name"`) {
+			t.Error("body missing display name input")
 		}
 		// The value attribute must contain the signed-in admin's name
 		// so the input arrives pre-filled.
@@ -153,8 +153,8 @@ func profilePOST(ctx context.Context, t *testing.T, client *http.Client, baseURL
 	// current nonce cookie is fresh.
 	priming := profileGET(ctx, t, client, baseURL)
 	form := url.Values{
-		"csrf_token": {priming.csrf},
-		"username":   {username},
+		"csrf_token":   {priming.csrf},
+		"display_name": {username},
 	}
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPost, baseURL+"/profile/username", strings.NewReader(form.Encode()),

--- a/test/integration/register_enumeration_test.go
+++ b/test/integration/register_enumeration_test.go
@@ -70,7 +70,7 @@ func registerRaw(
 	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
 
 	form := url.Values{}
-	form.Add("username", username)
+	form.Add("display_name", username)
 	form.Add("email", email)
 	form.Add("password", password)
 	form.Add("password_confirm", password)


### PR DESCRIPTION
Closes #580

Login is by email (since #446), so the display-name input was never a login credential - but it was named/id'd `username`, and `accept_invite` even set `autocomplete="username"`, so password managers (Bitwarden) treated it as the login identifier and autofilled it wrongly. This renames the HTML field so they stop.

Per the ticket's decided naming:
- visible label "Name"
- `autocomplete="nickname"` (a chosen handle, not the `name`/full-legal-name token)
- field `id`/`name` `display_name`

Changed across the forms that carry it: register, profile, accept-invite, and the admin player-new / player-detail / settings forms. The five `PostFormValue("username")` reads (register, accept-invite, profile, two admin actions) switch to `display_name` in lockstep, and the unit/integration/e2e tests that post or fill the field are updated to match.

Scope is HTML field + form key only. The `players.username` DB column and Go-internal `Username` naming are unchanged (that's the separate, optional #581). The login form (`name="email"`) is untouched.