### PR TITLE
Add an Invites link to the admin navbar

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -142,6 +142,8 @@ func navSection(path string) string {
 		return "quizzes"
 	case strings.HasPrefix(path, "/admin/players"):
 		return "players"
+	case strings.HasPrefix(path, "/admin/invites"):
+		return "invites"
 	case strings.HasPrefix(path, "/admin/email"):
 		return "email"
 	case strings.HasPrefix(path, "/admin/settings"):

--- a/internal/admin/navsection_test.go
+++ b/internal/admin/navsection_test.go
@@ -22,6 +22,8 @@ func TestNavSection(t *testing.T) {
 		{name: "quiz import", path: "/admin/quizzes/import", want: "quizzes"},
 		{name: "players list", path: "/admin/players", want: "players"},
 		{name: "player detail", path: "/admin/players/7", want: "players"},
+		{name: "invites list", path: "/admin/invites", want: "invites"},
+		{name: "invites new", path: "/admin/invites/new", want: "invites"},
 		{name: "email", path: "/admin/email", want: "email"},
 		{name: "email test", path: "/admin/email/test", want: "email"},
 		{name: "settings", path: "/admin/settings", want: "settings"},

--- a/internal/web/tmpl/admin/layouts/navbar.gohtml
+++ b/internal/web/tmpl/admin/layouts/navbar.gohtml
@@ -21,6 +21,8 @@
                     {{if isAdmin}}
                     <a href="/admin/players" {{if eq $s "players"}}aria-current="page"{{end}}
                        class="px-3 py-2 rounded-sm transition-colors {{if eq $s "players"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Players</a>
+                    <a href="/admin/invites" {{if eq $s "invites"}}aria-current="page"{{end}}
+                       class="px-3 py-2 rounded-sm transition-colors {{if eq $s "invites"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Invites</a>
                     <a href="/admin/email" {{if eq $s "email"}}aria-current="page"{{end}}
                        class="px-3 py-2 rounded-sm transition-colors {{if eq $s "email"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Email</a>
                     <a href="/admin/settings" {{if eq $s "settings"}}aria-current="page"{{end}}
@@ -50,6 +52,8 @@
             {{if isAdmin}}
             <a href="/admin/players" {{if eq $s "players"}}aria-current="page"{{end}}
                class="px-3 py-2 rounded-sm transition-colors {{if eq $s "players"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Players</a>
+            <a href="/admin/invites" {{if eq $s "invites"}}aria-current="page"{{end}}
+               class="px-3 py-2 rounded-sm transition-colors {{if eq $s "invites"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Invites</a>
             <a href="/admin/email" {{if eq $s "email"}}aria-current="page"{{end}}
                class="px-3 py-2 rounded-sm transition-colors {{if eq $s "email"}}text-text border-b-2 border-accent{{else}}text-text-dim hover:text-text{{end}}">Email</a>
             <a href="/admin/settings" {{if eq $s "settings"}}aria-current="page"{{end}}

--- a/test/e2e/tests/admin-nav.spec.ts
+++ b/test/e2e/tests/admin-nav.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from './fixtures';
 import { registerAdmin } from './helpers';
 
-// #517 — persistent admin top nav. The three real sections (Quizzes,
-// Players, Email) must be reachable from any admin page via the navbar.
-// Email was previously orphaned (linked only by typing the URL), so the
-// nav link is the load-bearing addition this spec guards.
-test('admin top nav reaches all three sections', async ({ page, browserName }) => {
+// #517 / #582 — persistent admin top nav. The real sections (Quizzes,
+// Players, Invites, Email) must be reachable from any admin page via the
+// navbar. Email was orphaned before #517 and Invites before #582 (each
+// linked only by typing the URL or the dashboard card), so the nav links
+// are the load-bearing additions this spec guards.
+test('admin top nav reaches all sections', async ({ page, browserName }) => {
   const username = `e2e-admin-nav-${browserName}`;
 
   await registerAdmin(page, username);
@@ -19,6 +20,11 @@ test('admin top nav reaches all three sections', async ({ page, browserName }) =
 
   await nav.getByRole('link', { name: 'Players' }).first().click();
   await expect(page).toHaveURL(/\/admin\/players$/);
+
+  // Invites was orphaned before #582 — assert the nav links it and it loads.
+  await nav.getByRole('link', { name: 'Invites' }).first().click();
+  await expect(page).toHaveURL(/\/admin\/invites$/);
+  await expect(page.getByRole('heading', { name: 'Invites', level: 1 })).toBeVisible();
 
   // Email was orphaned before #517 — assert the nav links it and it loads.
   await nav.getByRole('link', { name: 'Email' }).first().click();
@@ -37,4 +43,9 @@ test('admin nav marks the active section', async ({ page, browserName }) => {
   await page.goto('/admin/players');
   await expect(nav.getByRole('link', { name: 'Players' }).first()).toHaveAttribute('aria-current', 'page');
   await expect(nav.getByRole('link', { name: 'Quizzes' }).first()).not.toHaveAttribute('aria-current', 'page');
+
+  // Invites highlights its own section too (#582).
+  await page.goto('/admin/invites');
+  await expect(nav.getByRole('link', { name: 'Invites' }).first()).toHaveAttribute('aria-current', 'page');
+  await expect(nav.getByRole('link', { name: 'Players' }).first()).not.toHaveAttribute('aria-current', 'page');
 });


### PR DESCRIPTION
Closes #582

Invite management (/admin/invites) was only reachable from the "Invite player" card on the /admin dashboard - the persistent admin navbar listed Quizzes, Players, Email, and Settings but not Invites, so once you left the dashboard there was no link to it.

- Adds an "Invites" link (to /admin/invites) to both the desktop and mobile navbar rows, inside the existing `{{if isAdmin}}` block, between Players and Email (matching the dashboard card order).
- Maps `/admin/invites` to the `invites` nav section in `navSection`, so the link gets the `aria-current="page"` active-state highlight on the invites page (the invites page already renders through the standard per-request renderer that wires `navSection`).
- Unit test: `navSection` now covers `/admin/invites` and `/admin/invites/new`.
- E2e (`admin-nav.spec.ts`): the nav reaches the Invites section and loads the page, and the Invites link highlights when active.