### PR TITLE
Rename the players username column to display_name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ WHY comments are encouraged when the rationale isn't obvious from the code. But 
 
 Treat cross-file rationale by category:
 
-1. **Server explains what the frontend will do with this** — high rot risk. **Rewrite as self-contained why**. Explain the local rationale only: "this column tracks whether the player explicitly chose their username; defaults false so callers can tell auto-generated names apart from claimed ones." Lose the "the frontend gates X on this" framing.
+1. **Server explains what the frontend will do with this** — high rot risk. **Rewrite as self-contained why**. Explain the local rationale only: "this column tracks whether the player explicitly chose their display name; defaults false so callers can tell auto-generated names apart from claimed ones." Lose the "the frontend gates X on this" framing.
 
 2. **Test comment above an assertion that pins the invariant** — fine. The test fails loudly if the invariant breaks, so the comment can't drift far. Keep the cross-file wording if it adds context.
 

--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -334,8 +334,8 @@ func seedPlays(
 
 	players := make([]*auth.Player, 0, playerCount)
 	for i := range playerCount {
-		username := fmt.Sprintf("seed-player-%d-%d", time.Now().UnixNano(), i)
-		p, err := stores.Players.CreateAnonymousPlayer(ctx, username)
+		displayName := fmt.Sprintf("seed-player-%d-%d", time.Now().UnixNano(), i)
+		p, err := stores.Players.CreateAnonymousPlayer(ctx, displayName)
 		if err != nil {
 			return 0, fmt.Errorf("create anonymous player: %w", err)
 		}

--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -356,7 +356,7 @@ func seedPlays(
 			if err := finishGame(ctx, stores.Games, p.ID, qz); err != nil {
 				logger.Warn(
 					"finish game",
-					slog.String("player", p.Username),
+					slog.String("player", p.DisplayName),
 					slog.String("quiz", qz.Title),
 					slog.Any("err", err),
 				)

--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -69,9 +69,9 @@ func TestCheck_BadDBURI_ReturnsError(t *testing.T) {
 const seedOldPassword = "old-correct-battery"
 
 // seedPlayer opens the dev DB at dbURI and inserts a player with the given
-// username and the shared [seedOldPassword]. Returns the original hash so
+// displayName and the shared [seedOldPassword]. Returns the original hash so
 // tests can assert it actually changed after ResetPassword.
-func seedPlayer(t *testing.T, dbURI, username string) string {
+func seedPlayer(t *testing.T, dbURI, displayName string) string {
 	t.Helper()
 
 	hashed, err := auth.HashPassword(seedOldPassword)
@@ -95,8 +95,8 @@ func seedPlayer(t *testing.T, dbURI, username string) string {
 	players := store.NewPlayerStore(conn, slog.Default())
 	if _, err := players.CreatePlayer(
 		t.Context(),
-		username,
-		username+"@example.test",
+		displayName,
+		displayName+"@example.test",
 		hashed,
 		auth.RolePlayer,
 	); err != nil {
@@ -108,7 +108,7 @@ func seedPlayer(t *testing.T, dbURI, username string) string {
 
 // fetchSeededPlayer re-opens dbURI and returns the seeded "alice" row. Used
 // by "no-write" assertions to confirm the on-disk hash was not overwritten
-// when a failure path triggered before the UPDATE. The username is fixed
+// when a failure path triggered before the UPDATE. The displayName is fixed
 // because every call site asserts against the same seeded user; passing it
 // in just made unparam noisy.
 func fetchSeededPlayer(t *testing.T, dbURI string) *auth.Player {
@@ -166,11 +166,11 @@ func TestPromoteAdmin_MinimalEnv_NoSessionKey(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	const (
-		username = "alice"
-		email    = "alice@example.test"
+		displayName = "alice"
+		email       = "alice@example.test"
 	)
-	seedPlayer(t, dbURI, username)
-	demoteToHost(t, dbURI, username)
+	seedPlayer(t, dbURI, displayName)
+	demoteToHost(t, dbURI, displayName)
 
 	var stdout, stderr bytes.Buffer
 	if err := PromoteAdmin(t.Context(), minimalEnvFor(dbURI), &stdout, &stderr, email); err != nil {
@@ -192,11 +192,11 @@ func TestResetPassword_MinimalEnv_NoSessionKey(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	const (
-		username    = "alice"
+		displayName = "alice"
 		email       = "alice@example.test"
 		newPassword = "new-correct-battery"
 	)
-	originalHash := seedPlayer(t, dbURI, username)
+	originalHash := seedPlayer(t, dbURI, displayName)
 
 	stdin := strings.NewReader(newPassword + "\n" + newPassword + "\n")
 	var stdout, stderr bytes.Buffer
@@ -220,11 +220,11 @@ func TestResetPassword_HappyPath_RotatesHash(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	const (
-		username    = "alice"
+		displayName = "alice"
 		email       = "alice@example.test"
 		newPassword = "new-correct-battery"
 	)
-	originalHash := seedPlayer(t, dbURI, username)
+	originalHash := seedPlayer(t, dbURI, displayName)
 
 	stdin := strings.NewReader(newPassword + "\n" + newPassword + "\n")
 	var stdout, stderr bytes.Buffer
@@ -296,16 +296,16 @@ func TestPromoteAdmin_HappyPath_SetsAdminRole(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	const (
-		username = "alice"
-		email    = "alice@example.test"
+		displayName = "alice"
+		email       = "alice@example.test"
 	)
 	// Seed two players: the first credentialled registrant becomes Admin
 	// automatically, so the SECOND ("bob", a Player) is the meaningful
-	// promote target. We still promote alice's row by username via the
+	// promote target. We still promote alice's row by displayName via the
 	// fixed-"alice" fetch helper; demote it to Host first so the promote is
 	// a real transition rather than a no-op.
-	seedPlayer(t, dbURI, username)
-	demoteToHost(t, dbURI, username)
+	seedPlayer(t, dbURI, displayName)
+	demoteToHost(t, dbURI, displayName)
 
 	var stdout, stderr bytes.Buffer
 	if err := PromoteAdmin(t.Context(), envFor(dbURI), &stdout, &stderr, email); err != nil {
@@ -350,7 +350,7 @@ func TestPromoteAdmin_BlankEmail_ReturnsError(t *testing.T) {
 // demoteToHost flips the seeded player's role to Host so a subsequent
 // PromoteAdmin is a real transition rather than a no-op against the
 // first-registrant Admin promotion.
-func demoteToHost(t *testing.T, dbURI, username string) {
+func demoteToHost(t *testing.T, dbURI, displayName string) {
 	t.Helper()
 
 	conn, err := sql.Open("sqlite", dbURI)
@@ -363,7 +363,7 @@ func demoteToHost(t *testing.T, dbURI, username string) {
 		}
 	})
 	if _, err := conn.ExecContext(
-		t.Context(), "UPDATE players SET role = ? WHERE display_name = ?", auth.RoleHost, username,
+		t.Context(), "UPDATE players SET role = ? WHERE display_name = ?", auth.RoleHost, displayName,
 	); err != nil {
 		t.Fatalf("demote update err = %v, want nil", err)
 	}

--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -124,9 +124,9 @@ func fetchSeededPlayer(t *testing.T, dbURI string) *auth.Player {
 		}
 	})
 	players := store.NewPlayerStore(conn, slog.Default())
-	p, err := players.GetPlayerByUsername(t.Context(), "alice")
+	p, err := players.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	return p
@@ -363,7 +363,7 @@ func demoteToHost(t *testing.T, dbURI, username string) {
 		}
 	})
 	if _, err := conn.ExecContext(
-		t.Context(), "UPDATE players SET role = ? WHERE username = ?", auth.RoleHost, username,
+		t.Context(), "UPDATE players SET role = ? WHERE display_name = ?", auth.RoleHost, username,
 	); err != nil {
 		t.Fatalf("demote update err = %v, want nil", err)
 	}

--- a/docs/Vision.md
+++ b/docs/Vision.md
@@ -33,7 +33,7 @@ Phase 1 has landed and a chunk of Phase 1.5 too. The doc below describes the run
 
 ### Schema (post-migration `20260520180000`)
 
-- `players (id, username UNIQUE, email UNIQUE, password_hash, role, username_claimed, created_at)` — `email` and `password_hash` are nullable so anonymous play works without inventing either. `username_claimed` flips to 1 when the player explicitly picks a name (register flow or PATCH `/api/players/me`).
+- `players (id, display_name UNIQUE, email UNIQUE, password_hash, role, display_name_claimed, created_at)` — `email` and `password_hash` are nullable so anonymous play works without inventing either. `display_name_claimed` flips to 1 when the player explicitly picks a name (register flow or PATCH `/api/players/me`).
 - `quizzes (id, title, slug UNIQUE, description, created_at, updated_at)`.
 - `questions (id, quiz_id, text, position, image_url)`. Per-question time limit (`time_limit_seconds`) is still hardcoded at 10s in the service (open ticket #99).
 - `options (id, question_id, text, is_correct)`.
@@ -63,7 +63,7 @@ Multi-stage Dockerfile → distroless. `docker-compose.yml` mounts a volume for 
 - **Reveal countdown + correctness reveal.** Each question opens with a 3-second cyan reveal beat before the answer timer starts; after a wrong pick the correct option lights up.
 - **Fullscreen gameplay.** The player client takes the whole viewport during a round; the brand mark hides until the leaderboard view.
 - **Admin JSON import.** A dedicated `/admin/quizzes/import` form accepts a quiz definition in a single JSON document, designed to be filled out by an LLM.
-- **Public home page.** `GET /` ranks popular quizzes by play count over the last 30 days, lists the most active players (claimed usernames only), and exposes a footer link into `/admin`.
+- **Public home page.** `GET /` ranks popular quizzes by play count over the last 30 days, lists the most active players (claimed display names only), and exposes a footer link into `/admin`.
 - **Share affordance.** A reusable `share.js` module powers Share buttons on the public home cards and on the player client (start + finish screens). Uses `navigator.share` when available; otherwise opens a dialog with WhatsApp / Telegram / Reddit / X / Copy.
 
 ### Known gaps and open tickets
@@ -108,7 +108,7 @@ The decisions below are mostly locked in. Status notes mark which ones are imple
 
 ### 1. Player identity — `players` is the universal actor — **IMPLEMENTED**
 
-`players.email` is nullable, `password_hash` and `role` columns are present, `username_claimed` distinguishes auto-petname rows from explicitly-claimed names. Anonymous play creates a `players` row tied to a session cookie. Registering as an anonymous visitor upgrades the existing row in place via `ClaimPlayer`. First-sign-in-wins for conflicting credentials.
+`players.email` is nullable, `password_hash` and `role` columns are present, `display_name_claimed` distinguishes auto-petname rows from explicitly-claimed names. Anonymous play creates a `players` row tied to a session cookie. Registering as an anonymous visitor upgrades the existing row in place via `ClaimPlayer`. First-sign-in-wins for conflicting credentials.
 
 ### 2. Sessions — signed cookie, no DB table — **IMPLEMENTED**
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -113,7 +113,7 @@ func (tr *TemplateRenderer) prepare(w http.ResponseWriter, r *http.Request) (*te
 	username := ""
 	isAdmin := false
 	if p, ok := auth.PlayerFromContext(r.Context()); ok {
-		username = p.Username
+		username = p.DisplayName
 		isAdmin = p.IsAdmin()
 	}
 
@@ -160,17 +160,17 @@ func navSection(path string) string {
 // - handlers populate it via [attachCanEdit] before rendering, and a
 // rule change lives entirely in Go.
 type QuizData struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	UpdatedAt         time.Time
-	QuestionCount     int
-	CreatedByPlayerID int64
-	CreatedByUsername string
-	CanEdit           bool
-	TimeLimitSeconds  int
-	Visibility        string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	UpdatedAt            time.Time
+	QuestionCount        int
+	CreatedByPlayerID    int64
+	CreatedByDisplayName string
+	CanEdit              bool
+	TimeLimitSeconds     int
+	Visibility           string
 	// VisibilityOptions feeds the admin form's selector - pulled
 	// straight from the domain constants so a future level addition
 	// only touches one place.
@@ -264,18 +264,18 @@ func quizDataFromQuiz(qz *quiz.Quiz) *QuizData {
 	}
 
 	return &QuizData{
-		ID:                qz.ID,
-		Title:             qz.Title,
-		Slug:              qz.Slug,
-		Description:       qz.Description,
-		UpdatedAt:         qz.UpdatedAt,
-		QuestionCount:     len(qz.Questions),
-		CreatedByPlayerID: qz.CreatedByPlayerID,
-		CreatedByUsername: qz.CreatedByUsername,
-		TimeLimitSeconds:  qz.TimeLimitSeconds,
-		Visibility:        visibility,
-		VisibilityOptions: quiz.VisibilityValues(),
-		Questions:         questionDataFromQuestions(qz.Questions),
+		ID:                   qz.ID,
+		Title:                qz.Title,
+		Slug:                 qz.Slug,
+		Description:          qz.Description,
+		UpdatedAt:            qz.UpdatedAt,
+		QuestionCount:        len(qz.Questions),
+		CreatedByPlayerID:    qz.CreatedByPlayerID,
+		CreatedByDisplayName: qz.CreatedByDisplayName,
+		TimeLimitSeconds:     qz.TimeLimitSeconds,
+		Visibility:           visibility,
+		VisibilityOptions:    quiz.VisibilityValues(),
+		Questions:            questionDataFromQuestions(qz.Questions),
 	}
 }
 
@@ -485,7 +485,7 @@ func requireQuizOwner(
 		return qz, true
 	}
 
-	owner := qz.CreatedByUsername
+	owner := qz.CreatedByDisplayName
 	if owner == "" {
 		owner = "another admin"
 	}
@@ -847,9 +847,9 @@ func HandleQuizList(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.S
 // in-progress and pre-answer participants (#244/#335) so the admin's
 // Reset button is only offered for games the host can safely wipe.
 type PlayerScoreData struct {
-	PlayerID int64
-	Username string
-	Score    int
+	PlayerID    int64
+	DisplayName string
+	Score       int
 }
 
 // HandleQuizView returns the quiz view page. It also fetches the per-quiz
@@ -1083,9 +1083,9 @@ func loadCompletedPlayers(
 			continue
 		}
 		players = append(players, PlayerScoreData{
-			PlayerID: e.PlayerID,
-			Username: e.Username,
-			Score:    e.Score,
+			PlayerID:    e.PlayerID,
+			DisplayName: e.DisplayName,
+			Score:       e.Score,
 		})
 	}
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -110,10 +110,10 @@ func (tr *TemplateRenderer) prepare(w http.ResponseWriter, r *http.Request) (*te
 		return nil, false
 	}
 
-	username := ""
+	displayName := ""
 	isAdmin := false
 	if p, ok := auth.PlayerFromContext(r.Context()); ok {
-		username = p.DisplayName
+		displayName = p.DisplayName
 		isAdmin = p.IsAdmin()
 	}
 
@@ -125,7 +125,7 @@ func (tr *TemplateRenderer) prepare(w http.ResponseWriter, r *http.Request) (*te
 	section := navSection(r.URL.Path)
 
 	return t.Funcs(template.FuncMap{
-		"currentUser": func() string { return username },
+		"currentUser": func() string { return displayName },
 		"csrfToken":   func() string { return csrfToken },
 		"ogImage":     func() string { return absurl.BaseURL(r) + "/assets/og-image.png" },
 		"navSection":  func() string { return section },

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -605,7 +605,7 @@ func TestHandleQuizList_RendersNavbarLogout(t *testing.T) {
 
 	body := rr.Body.String()
 	if got, want := body, "alice"; !strings.Contains(got, want) {
-		t.Errorf("body should contain signed-in username %q, got %q", want, got)
+		t.Errorf("body should contain signed-in displayName %q, got %q", want, got)
 	}
 	if got, want := body, `action="/logout"`; !strings.Contains(got, want) {
 		t.Errorf("body should contain logout form action %q, got %q", want, got)

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -35,7 +35,7 @@ const testAdminID int64 = 1
 // substitute for tests that previously skipped the auth middleware -
 // the owner gate added in #281 needs the player to know who's asking.
 func withTestAdmin(r *http.Request) *http.Request {
-	signedIn := &auth.Player{ID: testAdminID, Username: "admin", Role: auth.RoleAdmin}
+	signedIn := &auth.Player{ID: testAdminID, DisplayName: "admin", Role: auth.RoleAdmin}
 
 	return r.WithContext(auth.WithPlayer(r.Context(), signedIn))
 }
@@ -116,7 +116,7 @@ func (s stubGameStore) ListParticipantsForQuizLeaderboard(
 		}
 		seen[a.PlayerID] = len(out)
 		out = append(out, &game.LeaderboardParticipant{
-			PlayerID: a.PlayerID, Username: a.Username, IsCompleted: a.IsCompleted,
+			PlayerID: a.PlayerID, DisplayName: a.DisplayName, IsCompleted: a.IsCompleted,
 		})
 	}
 
@@ -593,7 +593,7 @@ func TestHandleQuizList_RendersNavbarLogout(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	// Unit tests don't go through RequireAdmin, so attach the player directly.
-	signedIn := &auth.Player{ID: 1, Username: "alice", Role: auth.RoleAdmin}
+	signedIn := &auth.Player{ID: 1, DisplayName: "alice", Role: auth.RoleAdmin}
 	req = req.WithContext(auth.WithPlayer(req.Context(), signedIn))
 
 	rr := httptest.NewRecorder()
@@ -3254,12 +3254,12 @@ func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
 			listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*game.LeaderboardAnswer, error) {
 				return []*game.LeaderboardAnswer{
 					{
-						PlayerID: 1, Username: "alice",
+						PlayerID: 1, DisplayName: "alice",
 						QuestionStartedAt: now, QuestionExpiredAt: now.Add(10 * time.Second),
 						AnsweredAt: now, Correct: true, IsCompleted: true,
 					},
 					{
-						PlayerID: 2, Username: "bob",
+						PlayerID: 2, DisplayName: "bob",
 						QuestionStartedAt: now, QuestionExpiredAt: now.Add(10 * time.Second),
 						AnsweredAt: now, Correct: true, IsCompleted: true,
 					},

--- a/internal/admin/email_test.go
+++ b/internal/admin/email_test.go
@@ -413,7 +413,7 @@ func TestHandleEmailTest_DetachesRequestContext(t *testing.T) {
 
 	form := "to=ops@example.test"
 	ctx, cancel := context.WithCancel(t.Context())
-	ctx = auth.WithPlayer(ctx, &auth.Player{ID: 1, Username: "admin", Email: "admin@example.test"})
+	ctx = auth.WithPlayer(ctx, &auth.Player{ID: 1, DisplayName: "admin", Email: "admin@example.test"})
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/admin/email/test", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:5555"
@@ -490,7 +490,7 @@ var testFlashKey = []byte("test-flash-key-32-bytes-test-key")
 func renderGET(t *testing.T, status mailer.StatusView, recorder *stubRecorder) string {
 	t.Helper()
 
-	ctx := auth.WithPlayer(t.Context(), &auth.Player{ID: 1, Username: "admin", Email: "admin@example.test"})
+	ctx := auth.WithPlayer(t.Context(), &auth.Player{ID: 1, DisplayName: "admin", Email: "admin@example.test"})
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/admin/email", nil)
 	rr := httptest.NewRecorder()
 
@@ -521,7 +521,7 @@ func postEmailTest(
 	t.Helper()
 
 	form := "to=" + recipient
-	ctx := auth.WithPlayer(t.Context(), &auth.Player{ID: 1, Username: "admin", Email: "admin@example.test"})
+	ctx := auth.WithPlayer(t.Context(), &auth.Player{ID: 1, DisplayName: "admin", Email: "admin@example.test"})
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/admin/email/test", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.RemoteAddr = "1.2.3.4:5555"

--- a/internal/admin/email_test.go
+++ b/internal/admin/email_test.go
@@ -249,7 +249,7 @@ func TestHandleEmailGet_RendersStatusAndLog(t *testing.T) {
 func TestHandleEmailGet_NeverExposesCredentials(t *testing.T) {
 	t.Parallel()
 
-	// StatusView intentionally lacks Username / Password fields, but
+	// StatusView intentionally lacks DisplayName / Password fields, but
 	// pin the rendered body just in case a future change widens the
 	// struct: a credential must never reach the template.
 	status := mailer.StatusView{

--- a/internal/admin/invites.go
+++ b/internal/admin/invites.go
@@ -102,7 +102,7 @@ func loadInvitesPage(
 		rows = append(rows, inviteRow{
 			ID:        p.ID,
 			Email:     p.Email,
-			InvitedBy: p.InviterUsername,
+			InvitedBy: p.InviterDisplayName,
 			CreatedAt: p.CreatedAt,
 			ExpiresAt: p.ExpiresAt,
 		})

--- a/internal/admin/playeractions.go
+++ b/internal/admin/playeractions.go
@@ -382,10 +382,10 @@ func roleChangeNotice(role string) string {
 
 // playerCreatePageData backs the playernew.gohtml template.
 type playerCreatePageData struct {
-	Title    string
-	Username string
-	Email    string
-	Error    string
+	Title       string
+	DisplayName string
+	Email       string
+	Error       string
 }
 
 // HandlePlayerCreateForm renders GET /admin/players/new.
@@ -431,8 +431,8 @@ func HandlePlayerCreateSubmit(
 		input := newPlayerInput(r)
 		if input.errMsg != "" {
 			render.Render(w, r, http.StatusBadRequest, playerCreatePageData{
-				Title:    "Admin Dashboard - New Player",
-				Username: input.Username, Email: input.Email,
+				Title:       "Admin Dashboard - New Player",
+				DisplayName: input.DisplayName, Email: input.Email,
 				Error: input.errMsg,
 			})
 
@@ -443,15 +443,15 @@ func HandlePlayerCreateSubmit(
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error hashing password for admin-create", slog.Any("err", err))
 			render.Render(w, r, http.StatusInternalServerError, playerCreatePageData{
-				Title:    "Admin Dashboard - New Player",
-				Username: input.Username, Email: input.Email,
+				Title:       "Admin Dashboard - New Player",
+				DisplayName: input.DisplayName, Email: input.Email,
 				Error: "Could not create player. Try again.",
 			})
 
 			return
 		}
 
-		player, err := store.CreatePlayerByAdmin(r.Context(), input.Username, input.Email, hash)
+		player, err := store.CreatePlayerByAdmin(r.Context(), input.DisplayName, input.Email, hash)
 		if err != nil {
 			renderCreatePlayerError(w, r, render, input, err)
 
@@ -462,7 +462,7 @@ func HandlePlayerCreateSubmit(
 			map[string]string{"new_email": input.Email})
 		flash.SetNotice(w, fmt.Sprintf(
 			"Player %q created with email %s. Hand the password over out-of-band; it is not stored here.",
-			player.Username, input.Email,
+			player.DisplayName, input.Email,
 		))
 		redirectToPlayerDetail(w, r, player.ID)
 	})
@@ -472,20 +472,20 @@ func HandlePlayerCreateSubmit(
 // admin-create-player flow. errMsg carries the first validation
 // failure; the handler re-renders the form with that banner.
 type newPlayerCreateInput struct {
-	Username string
-	Email    string
-	Password string
-	errMsg   string
+	DisplayName string
+	Email       string
+	Password    string
+	errMsg      string
 }
 
 func newPlayerInput(r *http.Request) newPlayerCreateInput {
 	in := newPlayerCreateInput{
-		Username: strings.TrimSpace(r.PostFormValue("display_name")),
-		Email:    strings.ToLower(strings.TrimSpace(r.PostFormValue("email"))),
-		Password: r.PostFormValue("password"),
+		DisplayName: strings.TrimSpace(r.PostFormValue("display_name")),
+		Email:       strings.ToLower(strings.TrimSpace(r.PostFormValue("email"))),
+		Password:    r.PostFormValue("password"),
 	}
-	if in.Username == "" {
-		in.Username = auth.GeneratePetname()
+	if in.DisplayName == "" {
+		in.DisplayName = auth.GeneratePetname()
 	}
 	if !auth.LooksLikeEmail(in.Email) {
 		in.errMsg = "Enter a valid email address."
@@ -524,8 +524,8 @@ func renderCreatePlayerError(
 		// Fall through to the generic 500 message; err is logged by the caller.
 	}
 	render.Render(w, r, status, playerCreatePageData{
-		Title:    "Admin Dashboard - New Player",
-		Username: in.Username, Email: in.Email,
+		Title:       "Admin Dashboard - New Player",
+		DisplayName: in.DisplayName, Email: in.Email,
 		Error: msg,
 	})
 }

--- a/internal/admin/playeractions.go
+++ b/internal/admin/playeractions.go
@@ -165,11 +165,11 @@ func HandlePlayerSetEmail(
 	})
 }
 
-// HandlePlayerSetUsername handles POST /admin/players/{playerID}/username.
+// HandlePlayerSetDisplayName handles POST /admin/players/{playerID}/display-name.
 // Admin only (gated by RequireAdmin at the route). Renames the target row to
 // the supplied display name; the store enforces the empty / taken sentinels so
 // the handler only maps them to flashes.
-func HandlePlayerSetUsername(
+func HandlePlayerSetDisplayName(
 	logger *slog.Logger,
 	store auth.AdminPlayerStore,
 	flash *auth.SignedFlash,
@@ -190,16 +190,16 @@ func HandlePlayerSetUsername(
 		switch {
 		case err == nil:
 			writeAudit(r.Context(), logger, store, actor.ID, playerID,
-				auth.AdminActionUsernameSet, map[string]string{"new_username": name})
+				auth.AdminActionDisplayNameSet, map[string]string{"new_displayName": name})
 			flash.SetNotice(w, "Display name updated.")
-		case errors.Is(err, auth.ErrUsernameEmpty):
+		case errors.Is(err, auth.ErrDisplayNameEmpty):
 			flash.SetError(w, "Enter a display name.", 0)
-		case errors.Is(err, auth.ErrUsernameTaken):
+		case errors.Is(err, auth.ErrDisplayNameTaken):
 			flash.SetError(w, "That display name is already taken.", 0)
 		case errors.Is(err, auth.ErrPlayerNotFound):
 			flash.SetError(w, "Player not found.", 0)
 		default:
-			logger.ErrorContext(r.Context(), "error setting player username", slog.Any("err", err))
+			logger.ErrorContext(r.Context(), "error setting player displayName", slog.Any("err", err))
 			flash.SetError(w, "Could not update display name. Try again.", 0)
 		}
 		redirectToPlayerDetail(w, r, playerID)
@@ -514,7 +514,7 @@ func renderCreatePlayerError(
 	status := http.StatusInternalServerError
 	msg := "Could not create player. Try again."
 	switch {
-	case errors.Is(err, auth.ErrUsernameTaken):
+	case errors.Is(err, auth.ErrDisplayNameTaken):
 		status = http.StatusConflict
 		msg = "That display name is already taken."
 	case errors.Is(err, auth.ErrEmailTaken):

--- a/internal/admin/playeractions_credentials_test.go
+++ b/internal/admin/playeractions_credentials_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // credStubStore implements auth.AdminPlayerStore for the
-// HandlePlayerSetUsername / HandlePlayerSetPassword tests. Only the methods
+// HandlePlayerSetDisplayName / HandlePlayerSetPassword tests. Only the methods
 // those handlers touch record anything; the rest return a sentinel so an
 // accidental call is loud.
 type credStubStore struct {
@@ -33,14 +33,14 @@ type credStubStore struct {
 	auditCalled  bool
 }
 
-func (s *credStubStore) RenamePlayer(_ context.Context, _ int64, username string) (*auth.Player, error) {
+func (s *credStubStore) RenamePlayer(_ context.Context, _ int64, displayName string) (*auth.Player, error) {
 	s.renameCalled = true
-	s.renameName = username
+	s.renameName = displayName
 	if s.renameErr != nil {
 		return nil, s.renameErr
 	}
 
-	return &auth.Player{ID: 7, DisplayName: username}, nil
+	return &auth.Player{ID: 7, DisplayName: displayName}, nil
 }
 
 func (s *credStubStore) ChangePlayerPassword(_ context.Context, _ int64, passwordHash string) error {
@@ -104,14 +104,14 @@ func newCredFlash(t *testing.T) *auth.SignedFlash {
 	return auth.NewSignedFlash([]byte("test-key-test-key-test-key-32byt"), false, "flash", "/admin")
 }
 
-// postUsername drives HandlePlayerSetUsername with the given form value.
-func postUsername(t *testing.T, store *credStubStore, username string) *httptest.ResponseRecorder {
+// postDisplayName drives HandlePlayerSetDisplayName with the given form value.
+func postDisplayName(t *testing.T, store *credStubStore, displayName string) *httptest.ResponseRecorder {
 	t.Helper()
-	handler := HandlePlayerSetUsername(slog.New(slog.DiscardHandler), store, newCredFlash(t))
+	handler := HandlePlayerSetDisplayName(slog.New(slog.DiscardHandler), store, newCredFlash(t))
 
-	form := url.Values{"display_name": {username}}
+	form := url.Values{"display_name": {displayName}}
 	req := httptest.NewRequestWithContext(
-		t.Context(), http.MethodPost, "/admin/players/7/username",
+		t.Context(), http.MethodPost, "/admin/players/7/display-name",
 		strings.NewReader(form.Encode()),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -144,12 +144,12 @@ func postPassword(t *testing.T, store *credStubStore, password string) *httptest
 	return rec
 }
 
-func TestHandlePlayerSetUsername_SuccessRenamesAndAudits(t *testing.T) {
+func TestHandlePlayerSetDisplayName_SuccessRenamesAndAudits(t *testing.T) {
 	t.Parallel()
 
 	store := &credStubStore{}
 
-	rec := postUsername(t, store, "  New Name  ")
+	rec := postDisplayName(t, store, "  New Name  ")
 
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)
@@ -160,20 +160,20 @@ func TestHandlePlayerSetUsername_SuccessRenamesAndAudits(t *testing.T) {
 	if got, want := store.renameName, "New Name"; got != want {
 		t.Errorf("rename name = %q, want %q", got, want)
 	}
-	if got, want := store.auditAction, auth.AdminActionUsernameSet; got != want {
+	if got, want := store.auditAction, auth.AdminActionDisplayNameSet; got != want {
 		t.Errorf("audit action = %q, want %q", got, want)
 	}
-	if got, want := store.auditPayload, `"new_username":"New Name"`; !strings.Contains(got, want) {
+	if got, want := store.auditPayload, `"new_displayName":"New Name"`; !strings.Contains(got, want) {
 		t.Errorf("audit payload = %q, should contain %q", got, want)
 	}
 }
 
-func TestHandlePlayerSetUsername_TakenFlashesNoAudit(t *testing.T) {
+func TestHandlePlayerSetDisplayName_TakenFlashesNoAudit(t *testing.T) {
 	t.Parallel()
 
-	store := &credStubStore{renameErr: auth.ErrUsernameTaken}
+	store := &credStubStore{renameErr: auth.ErrDisplayNameTaken}
 
-	rec := postUsername(t, store, "taken")
+	rec := postDisplayName(t, store, "taken")
 
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)
@@ -183,12 +183,12 @@ func TestHandlePlayerSetUsername_TakenFlashesNoAudit(t *testing.T) {
 	}
 }
 
-func TestHandlePlayerSetUsername_EmptyFlashesNoAudit(t *testing.T) {
+func TestHandlePlayerSetDisplayName_EmptyFlashesNoAudit(t *testing.T) {
 	t.Parallel()
 
-	store := &credStubStore{renameErr: auth.ErrUsernameEmpty}
+	store := &credStubStore{renameErr: auth.ErrDisplayNameEmpty}
 
-	rec := postUsername(t, store, "   ")
+	rec := postDisplayName(t, store, "   ")
 
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)

--- a/internal/admin/playeractions_credentials_test.go
+++ b/internal/admin/playeractions_credentials_test.go
@@ -40,7 +40,7 @@ func (s *credStubStore) RenamePlayer(_ context.Context, _ int64, username string
 		return nil, s.renameErr
 	}
 
-	return &auth.Player{ID: 7, Username: username}, nil
+	return &auth.Player{ID: 7, DisplayName: username}, nil
 }
 
 func (s *credStubStore) ChangePlayerPassword(_ context.Context, _ int64, passwordHash string) error {

--- a/internal/admin/playerdetail.go
+++ b/internal/admin/playerdetail.go
@@ -232,7 +232,7 @@ func adminActionLabel(action string) string {
 		return "Marked verified"
 	case auth.AdminActionEmailSet:
 		return "Email set"
-	case auth.AdminActionUsernameSet:
+	case auth.AdminActionDisplayNameSet:
 		return "Display name set"
 	case auth.AdminActionPasswordSet:
 		return "Password set"
@@ -271,8 +271,8 @@ func decodeAuditDetail(action, payload string) string {
 	switch action {
 	case auth.AdminActionEmailSet, auth.AdminActionCreated:
 		return fields["new_email"]
-	case auth.AdminActionUsernameSet:
-		return fields["new_username"]
+	case auth.AdminActionDisplayNameSet:
+		return fields["new_displayName"]
 	case auth.AdminActionRoleChanged,
 		auth.AdminActionPromoteSuper, auth.AdminActionDemoteSuper,
 		auth.AdminActionPromoteAdmin, auth.AdminActionDemoteAdmin:

--- a/internal/admin/playerdetail.go
+++ b/internal/admin/playerdetail.go
@@ -56,7 +56,7 @@ type playerDetailData struct {
 
 type playerDetailRow struct {
 	ID                int64
-	Username          string
+	DisplayName       string
 	Email             string
 	Role              string
 	OnboardingState   string
@@ -78,13 +78,13 @@ type playerDetailGame struct {
 }
 
 type playerDetailAudit struct {
-	ID            int64
-	ActorPlayerID int64
-	ActorUsername string
-	Action        string
-	ActionLabel   string
-	Detail        string
-	CreatedAt     time.Time
+	ID               int64
+	ActorPlayerID    int64
+	ActorDisplayName string
+	Action           string
+	ActionLabel      string
+	Detail           string
+	CreatedAt        time.Time
 }
 
 // HandlePlayerDetail renders GET /admin/players/{playerID}. Reads from
@@ -174,7 +174,7 @@ func buildPlayerDetailData(
 ) playerDetailData {
 	row := playerDetailRow{
 		ID:              detail.ID,
-		Username:        detail.Username,
+		DisplayName:     detail.DisplayName,
 		Email:           detail.Email,
 		Role:            detail.Role,
 		OnboardingState: detail.OnboardingState,
@@ -202,13 +202,13 @@ func buildPlayerDetailData(
 	auditRows := make([]playerDetailAudit, 0, len(audit))
 	for _, a := range audit {
 		auditRows = append(auditRows, playerDetailAudit{
-			ID:            a.ID,
-			ActorPlayerID: a.ActorPlayerID,
-			ActorUsername: a.ActorUsername,
-			Action:        a.Action,
-			ActionLabel:   adminActionLabel(a.Action),
-			Detail:        decodeAuditDetail(a.Action, a.Payload),
-			CreatedAt:     a.CreatedAt,
+			ID:               a.ID,
+			ActorPlayerID:    a.ActorPlayerID,
+			ActorDisplayName: a.ActorDisplayName,
+			Action:           a.Action,
+			ActionLabel:      adminActionLabel(a.Action),
+			Detail:           decodeAuditDetail(a.Action, a.Payload),
+			CreatedAt:        a.CreatedAt,
 		})
 	}
 

--- a/internal/admin/players.go
+++ b/internal/admin/players.go
@@ -24,7 +24,7 @@ const playersPerPage = 100
 // stays declarative.
 type playerRow struct {
 	ID              int64
-	Username        string
+	DisplayName     string
 	Email           string
 	AccountType     string
 	OnboardingState string
@@ -189,7 +189,7 @@ func buildPlayerRows(
 	for _, p := range rows {
 		pr := &playerRow{
 			ID:              p.ID,
-			Username:        p.Username,
+			DisplayName:     p.DisplayName,
 			Email:           p.Email,
 			AccountType:     accountTypeLabel(p),
 			OnboardingState: p.OnboardingState,

--- a/internal/admin/players_test.go
+++ b/internal/admin/players_test.go
@@ -176,20 +176,20 @@ func TestHandlePlayersList_RendersRows(t *testing.T) {
 	finishedAt := time.Date(2026, 5, 20, 18, 30, 0, 0, time.UTC)
 	rows := []*auth.PlayerListRow{
 		{
-			ID: 1, Username: "admin", Email: "a@example.com", Role: auth.RoleAdmin,
+			ID: 1, DisplayName: "admin", Email: "a@example.com", Role: auth.RoleAdmin,
 			HasPassword: true, CreatedAt: createdAt, OnboardingState: auth.OnboardingStateVerified,
 		},
 		{
-			ID: 2, Username: "alice", Email: "alice@example.com", Role: auth.RolePlayer,
+			ID: 2, DisplayName: "alice", Email: "alice@example.com", Role: auth.RolePlayer,
 			HasOAuth: true, OAuthProvider: "google", CreatedAt: createdAt,
 			OnboardingState: auth.OnboardingStateOAuth,
 		},
 		{
-			ID: 3, Username: "bob", Email: "bob@example.com", Role: auth.RolePlayer,
+			ID: 3, DisplayName: "bob", Email: "bob@example.com", Role: auth.RolePlayer,
 			HasPassword: true, CreatedAt: createdAt, OnboardingState: auth.OnboardingStateUnverified,
 		},
 		{
-			ID: 4, Username: "anon-xyz", Role: auth.RolePlayer, CreatedAt: createdAt,
+			ID: 4, DisplayName: "anon-xyz", Role: auth.RolePlayer, CreatedAt: createdAt,
 			OnboardingState: auth.OnboardingStateAnonymous,
 		},
 	}

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -13,10 +13,10 @@ import (
 // Mirrors auth.AdminEntry. PromotedAt is nil for rows whose role predates the
 // role_changed_at column; the template renders an em dash in that case.
 type adminRow struct {
-	ID         int64
-	Username   string
-	Email      string
-	PromotedAt *time.Time
+	ID          int64
+	DisplayName string
+	Email       string
+	PromotedAt  *time.Time
 }
 
 // settingsPageData backs settings.gohtml. Admins carries the current top-tier
@@ -54,10 +54,10 @@ func HandleSettings(
 		rows := make([]adminRow, 0, len(entries))
 		for _, e := range entries {
 			rows = append(rows, adminRow{
-				ID:         e.ID,
-				Username:   e.Username,
-				Email:      e.Email,
-				PromotedAt: e.RoleChangedAt,
+				ID:          e.ID,
+				DisplayName: e.DisplayName,
+				Email:       e.Email,
+				PromotedAt:  e.RoleChangedAt,
 			})
 		}
 

--- a/internal/auth/context_test.go
+++ b/internal/auth/context_test.go
@@ -10,7 +10,7 @@ import (
 func TestPlayerFromContext_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	want := &Player{ID: 7, Username: "alice", Role: RoleAdmin}
+	want := &Player{ID: 7, DisplayName: "alice", Role: RoleAdmin}
 	ctx := WithPlayer(t.Context(), want)
 
 	got, ok := PlayerFromContext(ctx)

--- a/internal/auth/forgot.go
+++ b/internal/auth/forgot.go
@@ -165,7 +165,7 @@ func dispatchForgotIfMatch(
 func resolveForgotIdentifier(
 	ctx context.Context, players PlayerStore, identifier string,
 ) (*Player, bool) {
-	if p, err := players.GetPlayerByUsername(ctx, identifier); err == nil {
+	if p, err := players.GetPlayerByDisplayName(ctx, identifier); err == nil {
 		return p, true
 	} else if !errors.Is(err, ErrPlayerNotFound) {
 		return nil, false

--- a/internal/auth/forgot.go
+++ b/internal/auth/forgot.go
@@ -44,7 +44,7 @@ type forgotPageData struct {
 }
 
 // HandleForgotForm renders GET /forgot-password. The form asks for a
-// username or email and posts to the same path. An already-signed-in
+// displayName or email and posts to the same path. An already-signed-in
 // visitor is redirected to their role landing so the password-reset
 // flow is reserved for users who cannot log in.
 func HandleForgotForm(
@@ -123,7 +123,7 @@ func HandleForgotSubmit(
 	})
 }
 
-// dispatchForgotIfMatch looks the identifier up by username then
+// dispatchForgotIfMatch looks the identifier up by displayName then
 // email, and (when found and the player has an email on file)
 // detaches a goroutine that mints+sends a reset link. Lookup misses
 // and OAuth-only rows are silently ignored so the timing of the
@@ -157,7 +157,7 @@ func dispatchForgotIfMatch(
 }
 
 // resolveForgotIdentifier returns the player matching identifier
-// (treated as a username first, then as an email) or (nil, false) if
+// (treated as a displayName first, then as an email) or (nil, false) if
 // neither lookup hits. Errors other than "not found" are swallowed at
 // info level - the account-existence-opaque contract means we cannot
 // surface a transient DB hiccup to the user, and the rate limiter

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -536,10 +536,10 @@ func createGooglePlayer(
 	const maxPetnameAttempts = 5
 	var lastErr error
 	for range maxPetnameAttempts {
-		username := GeneratePetname()
-		player, err := identities.CreatePlayerFromOAuth(ctx, username, email)
+		displayName := GeneratePetname()
+		player, err := identities.CreatePlayerFromOAuth(ctx, displayName, email)
 		if err != nil {
-			if errors.Is(err, ErrUsernameTaken) {
+			if errors.Is(err, ErrDisplayNameTaken) {
 				lastErr = err
 
 				continue

--- a/internal/auth/google_test.go
+++ b/internal/auth/google_test.go
@@ -71,7 +71,7 @@ func (s *stubOAuthStore) GetPlayerByEmail(_ context.Context, email string) (*Pla
 	return p, nil
 }
 
-func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, email string) (*Player, error) {
+func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, displayName, email string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -81,15 +81,15 @@ func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, emai
 	if s.createColl > 0 {
 		s.createColl--
 
-		return nil, ErrUsernameTaken
+		return nil, ErrDisplayNameTaken
 	}
 	if _, exists := s.byEmail[email]; exists && email != "" {
-		return nil, ErrUsernameTaken
+		return nil, ErrDisplayNameTaken
 	}
 
 	p := &Player{
 		ID:          s.nextID,
-		DisplayName: username,
+		DisplayName: displayName,
 		Email:       email,
 		Role:        RolePlayer,
 	}
@@ -161,13 +161,13 @@ func (s *stubOAuthStore) MarkPlayerEmailVerifiedIfNew(_ context.Context, playerI
 // seedAnonymous inserts a fully anonymous players row (no password,
 // no email) so the session-claim test has a target the
 // ClaimPlayerForOAuth guard accepts.
-func (s *stubOAuthStore) seedAnonymous(username string) *Player {
+func (s *stubOAuthStore) seedAnonymous(displayName string) *Player {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	p := &Player{
 		ID:          s.nextID,
-		DisplayName: username,
+		DisplayName: displayName,
 		Role:        RolePlayer,
 	}
 	s.nextID++
@@ -180,13 +180,13 @@ func (s *stubOAuthStore) seedAnonymous(username string) *Player {
 // existing target without going through CreatePlayerFromOAuth. Always
 // inserts as a plain "player" - the OAuth race-recovery tests don't
 // exercise admin-promotion paths, so the role is fixed.
-func (s *stubOAuthStore) seed(email, username string) *Player {
+func (s *stubOAuthStore) seed(email, displayName string) *Player {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	p := &Player{
 		ID:          s.nextID,
-		DisplayName: username,
+		DisplayName: displayName,
 		Email:       email,
 		Role:        RolePlayer,
 	}
@@ -359,7 +359,7 @@ func TestLinkOrCreateGooglePlayer_RetriesPetnameCollision(t *testing.T) {
 
 // TestLinkOrCreateGooglePlayer_ExhaustsRetries ensures the loop does
 // not spin forever when collisions keep firing; the caller sees a
-// wrapped ErrUsernameTaken instead.
+// wrapped ErrDisplayNameTaken instead.
 func TestLinkOrCreateGooglePlayer_ExhaustsRetries(t *testing.T) {
 	t.Parallel()
 
@@ -372,7 +372,7 @@ func TestLinkOrCreateGooglePlayer_ExhaustsRetries(t *testing.T) {
 	if err == nil {
 		t.Fatal("ExportLinkOrCreateGooglePlayer err = nil, want non-nil after exhausting retries")
 	}
-	if got, want := err, ErrUsernameTaken; !errors.Is(got, want) {
+	if got, want := err, ErrDisplayNameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want it to wrap %v", got, want)
 	}
 }
@@ -381,7 +381,7 @@ func TestLinkOrCreateGooglePlayer_ExhaustsRetries(t *testing.T) {
 // session-claim path: when the request already has a session pointing
 // at a fully anonymous players row, the OAuth callback upgrades that
 // row in place instead of creating a new one. The visitor keeps their
-// player_id (and any custom username) on first Google sign-in.
+// player_id (and any custom displayName) on first Google sign-in.
 func TestLinkOrCreateGooglePlayer_ClaimsAnonymousSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/google_test.go
+++ b/internal/auth/google_test.go
@@ -88,10 +88,10 @@ func (s *stubOAuthStore) CreatePlayerFromOAuth(_ context.Context, username, emai
 	}
 
 	p := &Player{
-		ID:       s.nextID,
-		Username: username,
-		Email:    email,
-		Role:     RolePlayer,
+		ID:          s.nextID,
+		DisplayName: username,
+		Email:       email,
+		Role:        RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -166,9 +166,9 @@ func (s *stubOAuthStore) seedAnonymous(username string) *Player {
 	defer s.mu.Unlock()
 
 	p := &Player{
-		ID:       s.nextID,
-		Username: username,
-		Role:     RolePlayer,
+		ID:          s.nextID,
+		DisplayName: username,
+		Role:        RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -185,10 +185,10 @@ func (s *stubOAuthStore) seed(email, username string) *Player {
 	defer s.mu.Unlock()
 
 	p := &Player{
-		ID:       s.nextID,
-		Username: username,
-		Email:    email,
-		Role:     RolePlayer,
+		ID:          s.nextID,
+		DisplayName: username,
+		Email:       email,
+		Role:        RolePlayer,
 	}
 	s.nextID++
 	s.players[p.ID] = p
@@ -319,8 +319,8 @@ func TestLinkOrCreateGooglePlayer_LinkExistingEmail(t *testing.T) {
 	if got, want := player.ID, existing.ID; got != want {
 		t.Errorf("player.ID = %d, want %d (linked, not created)", got, want)
 	}
-	if got, want := player.Username, "alice"; got != want {
-		t.Errorf("player.Username = %q, want %q", got, want)
+	if got, want := player.DisplayName, "alice"; got != want {
+		t.Errorf("player.DisplayName = %q, want %q", got, want)
 	}
 
 	// Lookup by subject now resolves to the same row.
@@ -397,8 +397,8 @@ func TestLinkOrCreateGooglePlayer_ClaimsAnonymousSession(t *testing.T) {
 	if got, want := player.ID, anon.ID; got != want {
 		t.Errorf("player.ID = %d, want %d (anonymous row reused, not replaced)", got, want)
 	}
-	if got, want := player.Username, "happy-banana"; got != want {
-		t.Errorf("player.Username = %q, want %q (preserved across claim)", got, want)
+	if got, want := player.DisplayName, "happy-banana"; got != want {
+		t.Errorf("player.DisplayName = %q, want %q (preserved across claim)", got, want)
 	}
 	if got, want := player.Email, "claim@example.test"; got != want {
 		t.Errorf("player.Email = %q, want %q (set on claim)", got, want)

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -63,8 +63,8 @@ const maxFormBodySize = 64 * 1024
 
 // formData is the data passed to the register and login templates.
 type formData struct {
-	Title    string
-	Username string
+	Title       string
+	DisplayName string
 	// Email is the trimmed+lowercased value; preserved across form
 	// re-renders so a failed validation doesn't drop it.
 	Email   string
@@ -150,19 +150,19 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		rawUsername := r.PostFormValue("display_name")
+		rawDisplayName := r.PostFormValue("display_name")
 		rawEmail := r.PostFormValue("email")
 		password := r.PostFormValue("password")
 		passwordConfirm := r.PostFormValue("password_confirm")
 
-		input := validateRegisterInput(rawUsername, rawEmail, password, passwordConfirm)
+		input := validateRegisterInput(rawDisplayName, rawEmail, password, passwordConfirm)
 		if !input.OK {
 			render.render(w, r, http.StatusBadRequest, formData{
-				Title:      "Register",
-				Username:   input.CleanedUsername,
-				Email:      input.CleanedEmail,
-				Message:    input.ErrMsg,
-				ShowGoogle: deps.GoogleEnabled,
+				Title:       "Register",
+				DisplayName: input.CleanedDisplayName,
+				Email:       input.CleanedEmail,
+				Message:     input.ErrMsg,
+				ShowGoogle:  deps.GoogleEnabled,
 			})
 
 			return
@@ -184,7 +184,7 @@ func HandleRegisterSubmit(
 		renderers := registerRenderers{form: render, pending: pending, sessions: sessions}
 
 		player, err := claimOrCreatePlayer(
-			r, players, sessions, input.CleanedUsername, input.CleanedEmail, hashed, role,
+			r, players, sessions, input.CleanedDisplayName, input.CleanedEmail, hashed, role,
 		)
 		if err != nil {
 			handleRegisterError(w, r, logger, renderers, deps, input, err)
@@ -241,11 +241,11 @@ func handleRegisterError(
 		renderers.renderPending(w, r, input.CleanedEmail)
 	case errors.Is(err, ErrUsernameTaken):
 		renderers.form.render(w, r, http.StatusConflict, formData{
-			Title:      "Register",
-			Username:   input.CleanedUsername,
-			Email:      input.CleanedEmail,
-			Message:    "That display name is already taken.",
-			ShowGoogle: deps.GoogleEnabled,
+			Title:       "Register",
+			DisplayName: input.CleanedDisplayName,
+			Email:       input.CleanedEmail,
+			Message:     "That display name is already taken.",
+			ShowGoogle:  deps.GoogleEnabled,
 		})
 	default:
 		logger.ErrorContext(r.Context(), "error creating player", slog.Any("err", err))
@@ -740,11 +740,11 @@ func HandleLogout(sessions *session.Manager) http.Handler {
 
 // registerInput is the result of validateRegisterInput.
 type registerInput struct {
-	// CleanedUsername is the username, whitespace-trimmed. Falls back to
+	// CleanedDisplayName is the username, whitespace-trimmed. Falls back to
 	// a [GeneratePetname] result when the input trims to "" so the post-
 	// #446 register flow accepts a blank display name and still produces
 	// a non-empty username for the schema's NOT NULL guard.
-	CleanedUsername string
+	CleanedDisplayName string
 	// CleanedEmail is the email, whitespace-trimmed and lowercased so
 	// case variants cannot create duplicate accounts.
 	CleanedEmail string
@@ -759,20 +759,20 @@ type registerInput struct {
 // [GeneratePetname] so register-with-just-email works after #446 made
 // the display name optional; email is the credential identifier.
 func validateRegisterInput(username, email, password, passwordConfirm string) registerInput {
-	cleanedUsername := strings.TrimSpace(username)
-	if cleanedUsername == "" {
-		cleanedUsername = GeneratePetname()
+	cleanedDisplayName := strings.TrimSpace(username)
+	if cleanedDisplayName == "" {
+		cleanedDisplayName = GeneratePetname()
 	}
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	if !LooksLikeEmail(cleanedEmail) {
 		return registerInput{
-			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
+			CleanedDisplayName: cleanedDisplayName, CleanedEmail: cleanedEmail,
 			ErrMsg: "Enter a valid email address.", OK: false,
 		}
 	}
 	if len(password) < MinPasswordLength {
 		return registerInput{
-			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
+			CleanedDisplayName: cleanedDisplayName, CleanedEmail: cleanedEmail,
 			ErrMsg: fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength),
 			OK:     false,
 		}
@@ -782,19 +782,19 @@ func validateRegisterInput(username, email, password, passwordConfirm string) re
 		// turns a wrapped 500 into a normal form-validation error with a
 		// user-friendly message.
 		return registerInput{
-			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
+			CleanedDisplayName: cleanedDisplayName, CleanedEmail: cleanedEmail,
 			ErrMsg: fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength),
 			OK:     false,
 		}
 	}
 	if password != passwordConfirm {
 		return registerInput{
-			CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail,
+			CleanedDisplayName: cleanedDisplayName, CleanedEmail: cleanedEmail,
 			ErrMsg: "Passwords do not match.", OK: false,
 		}
 	}
 
-	return registerInput{CleanedUsername: cleanedUsername, CleanedEmail: cleanedEmail, OK: true}
+	return registerInput{CleanedDisplayName: cleanedDisplayName, CleanedEmail: cleanedEmail, OK: true}
 }
 
 // LooksLikeEmail is the shared shape check used by the register flow,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -223,7 +223,7 @@ func (rr registerRenderers) renderPending(w http.ResponseWriter, r *http.Request
 // claimOrCreatePlayer. ErrEmailTaken is account-existence-opaque: a
 // distinct 409 would turn the form into an enumeration oracle, so it
 // responds exactly as the fresh-signup branch does and notifies the real
-// owner out of band instead (#573). ErrUsernameTaken re-renders the form
+// owner out of band instead (#573). ErrDisplayNameTaken re-renders the form
 // with a 409 - a display name is a public handle, not an enumeration
 // secret. Anything else is a 500.
 func handleRegisterError(
@@ -239,7 +239,7 @@ func handleRegisterError(
 	case errors.Is(err, ErrEmailTaken):
 		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail)
 		renderers.renderPending(w, r, input.CleanedEmail)
-	case errors.Is(err, ErrUsernameTaken):
+	case errors.Is(err, ErrDisplayNameTaken):
 		renderers.form.render(w, r, http.StatusConflict, formData{
 			Title:       "Register",
 			DisplayName: input.CleanedDisplayName,
@@ -342,17 +342,17 @@ func claimOrCreatePlayer(
 	r *http.Request,
 	players PlayerStore,
 	sessions *session.Manager,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	playerID, ok := sessions.PlayerID(r)
 	if !ok {
-		return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
+		return createPlayerWrapped(r, players, displayName, email, passwordHash, requestedRole)
 	}
 
 	existing, err := players.GetPlayerByID(r.Context(), playerID)
 	if err != nil {
 		if errors.Is(err, ErrPlayerNotFound) {
-			return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
+			return createPlayerWrapped(r, players, displayName, email, passwordHash, requestedRole)
 		}
 
 		return nil, fmt.Errorf("get player by id for claim: %w", err)
@@ -361,13 +361,13 @@ func claimOrCreatePlayer(
 		// Session already belongs to a credentialled account. Treat this as a
 		// fresh registration so the new account is created independently;
 		// the existing session is replaced when the caller resets the cookie.
-		return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
+		return createPlayerWrapped(r, players, displayName, email, passwordHash, requestedRole)
 	}
 
-	claimed, err := players.ClaimPlayer(r.Context(), playerID, username, email, passwordHash, requestedRole)
+	claimed, err := players.ClaimPlayer(r.Context(), playerID, displayName, email, passwordHash, requestedRole)
 	if err != nil {
 		if errors.Is(err, ErrPlayerAlreadyClaimed) || errors.Is(err, ErrPlayerNotFound) {
-			return createPlayerWrapped(r, players, username, email, passwordHash, requestedRole)
+			return createPlayerWrapped(r, players, displayName, email, passwordHash, requestedRole)
 		}
 
 		return nil, fmt.Errorf("claim player: %w", err)
@@ -381,9 +381,9 @@ func claimOrCreatePlayer(
 func createPlayerWrapped(
 	r *http.Request,
 	players PlayerStore,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*Player, error) {
-	p, err := players.CreatePlayer(r.Context(), username, email, passwordHash, requestedRole)
+	p, err := players.CreatePlayer(r.Context(), displayName, email, passwordHash, requestedRole)
 	if err != nil {
 		return nil, fmt.Errorf("create player: %w", err)
 	}
@@ -740,10 +740,10 @@ func HandleLogout(sessions *session.Manager) http.Handler {
 
 // registerInput is the result of validateRegisterInput.
 type registerInput struct {
-	// CleanedDisplayName is the username, whitespace-trimmed. Falls back to
+	// CleanedDisplayName is the displayName, whitespace-trimmed. Falls back to
 	// a [GeneratePetname] result when the input trims to "" so the post-
 	// #446 register flow accepts a blank display name and still produces
-	// a non-empty username for the schema's NOT NULL guard.
+	// a non-empty displayName for the schema's NOT NULL guard.
 	CleanedDisplayName string
 	// CleanedEmail is the email, whitespace-trimmed and lowercased so
 	// case variants cannot create duplicate accounts.
@@ -754,12 +754,12 @@ type registerInput struct {
 	OK bool
 }
 
-// validateRegisterInput trims the username and email, lowercases the
-// email, and validates the inputs. A blank username falls back to
+// validateRegisterInput trims the displayName and email, lowercases the
+// email, and validates the inputs. A blank displayName falls back to
 // [GeneratePetname] so register-with-just-email works after #446 made
 // the display name optional; email is the credential identifier.
-func validateRegisterInput(username, email, password, passwordConfirm string) registerInput {
-	cleanedDisplayName := strings.TrimSpace(username)
+func validateRegisterInput(displayName, email, password, passwordConfirm string) registerInput {
+	cleanedDisplayName := strings.TrimSpace(displayName)
 	if cleanedDisplayName == "" {
 		cleanedDisplayName = GeneratePetname()
 	}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -49,7 +49,7 @@ func newStubPlayerStore() *stubPlayerStore {
 	}
 }
 
-func (s *stubPlayerStore) GetPlayerByUsername(_ context.Context, username string) (*Player, error) {
+func (s *stubPlayerStore) GetPlayerByDisplayName(_ context.Context, username string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -115,7 +115,7 @@ func (s *stubPlayerStore) CreatePlayer(
 
 	p := &Player{
 		ID:           s.nextID,
-		Username:     username,
+		DisplayName:  username,
 		Email:        email,
 		PasswordHash: passwordHash,
 		Role:         role,
@@ -150,9 +150,9 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 	}
 
 	p := &Player{
-		ID:       s.nextID,
-		Username: username,
-		Role:     RolePlayer,
+		ID:          s.nextID,
+		DisplayName: username,
+		Role:        RolePlayer,
 	}
 	s.nextID++
 	s.byID[p.ID] = p
@@ -190,9 +190,9 @@ func (s *stubPlayerStore) ClaimPlayer(
 		}
 	}
 
-	delete(s.byName, existing.Username)
+	delete(s.byName, existing.DisplayName)
 	existing.Email = email
-	existing.Username = username
+	existing.DisplayName = username
 	existing.PasswordHash = passwordHash
 	existing.Role = s.resolveRoleLocked(requestedRole)
 	s.byName[username] = existing
@@ -200,7 +200,7 @@ func (s *stubPlayerStore) ClaimPlayer(
 	return existing, nil
 }
 
-func (s *stubPlayerStore) UpdatePlayerUsername(
+func (s *stubPlayerStore) UpdatePlayerDisplayName(
 	_ context.Context, playerID int64, username string,
 ) (*Player, error) {
 	s.mu.Lock()
@@ -217,8 +217,8 @@ func (s *stubPlayerStore) UpdatePlayerUsername(
 		return nil, ErrUsernameTaken
 	}
 
-	delete(s.byName, existing.Username)
-	existing.Username = username
+	delete(s.byName, existing.DisplayName)
+	existing.DisplayName = username
 	s.byName[username] = existing
 
 	return existing, nil
@@ -241,8 +241,8 @@ func (s *stubPlayerStore) RenamePlayer(
 		return nil, ErrUsernameTaken
 	}
 
-	delete(s.byName, existing.Username)
-	existing.Username = username
+	delete(s.byName, existing.DisplayName)
+	existing.DisplayName = username
 	s.byName[username] = existing
 
 	return existing, nil
@@ -352,9 +352,9 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 
 	assertRegisterPending(t, rec, "alice@example.test")
 
-	p, err := store.GetPlayerByUsername(t.Context(), "alice")
+	p, err := store.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := p.Role, RoleAdmin; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
@@ -424,9 +424,9 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 
 	assertRegisterPending(t, rec, "bob@example.test")
 
-	p, err := store.GetPlayerByUsername(t.Context(), "bob")
+	p, err := store.GetPlayerByDisplayName(t.Context(), "bob")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := p.Role, RolePlayer; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
@@ -458,9 +458,9 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 
 	assertRegisterPending(t, rec, "carol@example.test")
 
-	p, err := store.GetPlayerByUsername(t.Context(), "carol")
+	p, err := store.GetPlayerByDisplayName(t.Context(), "carol")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := p.Role, RoleAdmin; got != want {
 		t.Errorf("Role = %q, want %q", got, want)
@@ -487,8 +487,8 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
-		t.Errorf("player should not have been created, GetPlayerByUsername err = %v", err)
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+		t.Errorf("player should not have been created, GetPlayerByDisplayName err = %v", err)
 	}
 }
 
@@ -517,8 +517,8 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
-		t.Errorf("player should not have been created, GetPlayerByUsername err = %v", err)
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+		t.Errorf("player should not have been created, GetPlayerByDisplayName err = %v", err)
 	}
 }
 
@@ -632,7 +632,7 @@ func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); err != nil {
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}
 }
@@ -673,7 +673,7 @@ func TestHandleRegisterSubmit_MismatchedPasswords_Rejects(t *testing.T) {
 	if strings.Contains(body, "correctbatterydifferent") {
 		t.Errorf("body must not leak the submitted password_confirm, got %q", body)
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, err = %v", err)
 	}
 }
@@ -691,9 +691,9 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	p, err := store.GetPlayerByUsername(t.Context(), "alice")
+	p, err := store.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := p.Email, "alice@example.test"; got != want {
 		t.Errorf("stored email = %q, want %q", got, want)
@@ -741,9 +741,9 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 
 	// The same row was upgraded - no new row should appear, and the
 	// anonymous username should be gone.
-	upgraded, err := store.GetPlayerByUsername(t.Context(), "alice")
+	upgraded, err := store.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := upgraded.ID, anon.ID; got != want {
 		t.Errorf("upgraded.ID = %d, want %d (player ID should be preserved)", got, want)
@@ -751,7 +751,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	if upgraded.PasswordHash == "" {
 		t.Error("upgraded.PasswordHash is empty, want bcrypt hash from claim")
 	}
-	if _, err := store.GetPlayerByUsername(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("anonymous row still resolvable by old username; err = %v, want ErrPlayerNotFound", err)
 	}
 }
@@ -807,7 +807,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByID err = %v, want nil", err)
 	}
-	if got, want := stillAnon.Username, "anon-claimer"; got != want {
+	if got, want := stillAnon.DisplayName, "anon-claimer"; got != want {
 		t.Errorf("anonymous row Username = %q, want %q (should be unchanged)", got, want)
 	}
 	if !stillAnon.IsAnonymous() {
@@ -864,9 +864,9 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	assertRegisterPending(t, rec, "latecomer@example.test")
 	assertSessionCleared(t, rec)
 	// A fresh row was created instead of clobbering the already-claimed one.
-	latecomer, err := store.GetPlayerByUsername(t.Context(), "latecomer")
+	latecomer, err := store.GetPlayerByDisplayName(t.Context(), "latecomer")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, dontWant := latecomer.ID, anon.ID; got == dontWant {
 		t.Errorf("latecomer reused the racer's anonymous ID %d, want a fresh row", got)
@@ -1320,7 +1320,7 @@ func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByEmail err = %v, want nil", err)
 	}
-	if p.Username == "" {
+	if p.DisplayName == "" {
 		t.Error("created Username is empty, want a non-empty petname")
 	}
 }
@@ -1340,7 +1340,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	if _, err := store.GetPlayerByUsername(t.Context(), "alice"); err != nil {
+	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -26,7 +26,7 @@ type stubPlayerStore struct {
 	nextID  int64
 	failGet bool
 	// forceAnonCollisions, when > 0, makes the next N CreateAnonymousPlayer
-	// calls return ErrUsernameTaken without inserting. Each call decrements
+	// calls return ErrDisplayNameTaken without inserting. Each call decrements
 	// the counter, so once it reaches zero the stub returns to its normal
 	// insert-or-conflict behaviour. Used by the petname retry-loop tests
 	// to drive the middleware down the collision path a deterministic
@@ -49,11 +49,11 @@ func newStubPlayerStore() *stubPlayerStore {
 	}
 }
 
-func (s *stubPlayerStore) GetPlayerByDisplayName(_ context.Context, username string) (*Player, error) {
+func (s *stubPlayerStore) GetPlayerByDisplayName(_ context.Context, displayName string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	p, ok := s.byName[username]
+	p, ok := s.byName[displayName]
 	if !ok {
 		return nil, ErrPlayerNotFound
 	}
@@ -95,13 +95,13 @@ func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*Player, e
 // rule is observed atomically.
 func (s *stubPlayerStore) CreatePlayer(
 	_ context.Context,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.byName[username]; exists {
-		return nil, ErrUsernameTaken
+	if _, exists := s.byName[displayName]; exists {
+		return nil, ErrDisplayNameTaken
 	}
 	if email != "" {
 		for _, p := range s.byID {
@@ -115,21 +115,21 @@ func (s *stubPlayerStore) CreatePlayer(
 
 	p := &Player{
 		ID:           s.nextID,
-		DisplayName:  username,
+		DisplayName:  displayName,
 		Email:        email,
 		PasswordHash: passwordHash,
 		Role:         role,
 	}
 	s.nextID++
 	s.byID[p.ID] = p
-	s.byName[username] = p
+	s.byName[displayName] = p
 
 	return p, nil
 }
 
 // CreateAnonymousPlayer mirrors store.CreateAnonymousPlayer: insert a row
-// with the given username, no password_hash, role = "player".
-func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username string) (*Player, error) {
+// with the given displayName, no password_hash, role = "player".
+func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, displayName string) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -142,32 +142,32 @@ func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, username stri
 	if s.forceAnonCollisions > 0 {
 		s.forceAnonCollisions--
 
-		return nil, ErrUsernameTaken
+		return nil, ErrDisplayNameTaken
 	}
 
-	if _, exists := s.byName[username]; exists {
-		return nil, ErrUsernameTaken
+	if _, exists := s.byName[displayName]; exists {
+		return nil, ErrDisplayNameTaken
 	}
 
 	p := &Player{
 		ID:          s.nextID,
-		DisplayName: username,
+		DisplayName: displayName,
 		Role:        RolePlayer,
 	}
 	s.nextID++
 	s.byID[p.ID] = p
-	s.byName[username] = p
+	s.byName[displayName] = p
 
 	return p, nil
 }
 
 // ClaimPlayer mirrors store.ClaimPlayer: upgrades an anonymous row in place
 // or fails with ErrPlayerAlreadyClaimed / ErrPlayerNotFound /
-// ErrUsernameTaken.
+// ErrDisplayNameTaken.
 func (s *stubPlayerStore) ClaimPlayer(
 	_ context.Context,
 	playerID int64,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -179,8 +179,8 @@ func (s *stubPlayerStore) ClaimPlayer(
 	if existing.PasswordHash != "" {
 		return nil, ErrPlayerAlreadyClaimed
 	}
-	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, ErrUsernameTaken
+	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
+		return nil, ErrDisplayNameTaken
 	}
 	if email != "" {
 		for _, p := range s.byID {
@@ -192,16 +192,16 @@ func (s *stubPlayerStore) ClaimPlayer(
 
 	delete(s.byName, existing.DisplayName)
 	existing.Email = email
-	existing.DisplayName = username
+	existing.DisplayName = displayName
 	existing.PasswordHash = passwordHash
 	existing.Role = s.resolveRoleLocked(requestedRole)
-	s.byName[username] = existing
+	s.byName[displayName] = existing
 
 	return existing, nil
 }
 
 func (s *stubPlayerStore) UpdatePlayerDisplayName(
-	_ context.Context, playerID int64, username string,
+	_ context.Context, playerID int64, displayName string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -213,46 +213,46 @@ func (s *stubPlayerStore) UpdatePlayerDisplayName(
 	if existing.PasswordHash != "" {
 		return nil, ErrPlayerNotAnonymous
 	}
-	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, ErrUsernameTaken
+	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
+		return nil, ErrDisplayNameTaken
 	}
 
 	delete(s.byName, existing.DisplayName)
-	existing.DisplayName = username
-	s.byName[username] = existing
+	existing.DisplayName = displayName
+	s.byName[displayName] = existing
 
 	return existing, nil
 }
 
 func (s *stubPlayerStore) RenamePlayer(
-	_ context.Context, playerID int64, username string,
+	_ context.Context, playerID int64, displayName string,
 ) (*Player, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if strings.TrimSpace(username) == "" {
-		return nil, ErrUsernameEmpty
+	if strings.TrimSpace(displayName) == "" {
+		return nil, ErrDisplayNameEmpty
 	}
 	existing, ok := s.byID[playerID]
 	if !ok {
 		return nil, ErrPlayerNotFound
 	}
-	if other, exists := s.byName[username]; exists && other.ID != playerID {
-		return nil, ErrUsernameTaken
+	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
+		return nil, ErrDisplayNameTaken
 	}
 
 	delete(s.byName, existing.DisplayName)
-	existing.DisplayName = username
-	s.byName[username] = existing
+	existing.DisplayName = displayName
+	s.byName[displayName] = existing
 
 	return existing, nil
 }
 
-func (s *stubPlayerStore) SetPlayerPasswordHash(_ context.Context, username, passwordHash string) error {
+func (s *stubPlayerStore) SetPlayerPasswordHash(_ context.Context, displayName, passwordHash string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	p, ok := s.byName[username]
+	p, ok := s.byName[displayName]
 	if !ok {
 		return ErrPlayerNotFound
 	}
@@ -522,7 +522,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	}
 }
 
-func TestHandleRegisterSubmit_DuplicateUsername(t *testing.T) {
+func TestHandleRegisterSubmit_DuplicateDisplayName(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
@@ -740,7 +740,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	assertSessionCleared(t, rec)
 
 	// The same row was upgraded - no new row should appear, and the
-	// anonymous username should be gone.
+	// anonymous displayName should be gone.
 	upgraded, err := store.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
@@ -752,15 +752,15 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 		t.Error("upgraded.PasswordHash is empty, want bcrypt hash from claim")
 	}
 	if _, err := store.GetPlayerByDisplayName(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
-		t.Errorf("anonymous row still resolvable by old username; err = %v, want ErrPlayerNotFound", err)
+		t.Errorf("anonymous row still resolvable by old displayName; err = %v, want ErrPlayerNotFound", err)
 	}
 }
 
-// TestHandleRegisterSubmit_ClaimWithTakenUsername returns 409 and leaves
+// TestHandleRegisterSubmit_ClaimWithTakenDisplayName returns 409 and leaves
 // the anonymous row untouched so the visitor can retry with a different
-// username. First-sign-in-wins semantics: the row that already owns the
-// requested username keeps it.
-func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
+// displayName. First-sign-in-wins semantics: the row that already owns the
+// requested displayName keeps it.
+func TestHandleRegisterSubmit_ClaimWithTakenDisplayName(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
@@ -808,7 +808,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenUsername(t *testing.T) {
 		t.Fatalf("GetPlayerByID err = %v, want nil", err)
 	}
 	if got, want := stillAnon.DisplayName, "anon-claimer"; got != want {
-		t.Errorf("anonymous row Username = %q, want %q (should be unchanged)", got, want)
+		t.Errorf("anonymous row DisplayName = %q, want %q (should be unchanged)", got, want)
 	}
 	if !stillAnon.IsAnonymous() {
 		t.Error("anonymous row IsAnonymous() = false, want true (should still be unclaimed)")
@@ -1048,13 +1048,13 @@ func loginDeps(
 // stamped via SendVerifyEmail's ConsumeVerifyToken path; in tests we
 // just toggle the column directly because the verify dance is not
 // what these cases pin.
-func markVerified(t *testing.T, store *stubPlayerStore, username string) {
+func markVerified(t *testing.T, store *stubPlayerStore, displayName string) {
 	t.Helper()
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	p, ok := store.byName[username]
+	p, ok := store.byName[displayName]
 	if !ok {
-		t.Fatalf("markVerified: no stub player named %q", username)
+		t.Fatalf("markVerified: no stub player named %q", displayName)
 	}
 	now := time.Now().UTC()
 	p.EmailVerifiedAt = &now
@@ -1295,11 +1295,11 @@ func TestHandleLoginSubmit_EmailMixedCaseAndWhitespace(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterSubmit_BlankUsername_GeneratesPetname pins the post-
+// TestHandleRegisterSubmit_BlankDisplayName_GeneratesPetname pins the post-
 // #446 contract: a blank display name on the register form falls back to
 // GeneratePetname so register-with-just-email is a valid signup. Pre-446
-// this branch was a 400 "Username is required.".
-func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
+// this branch was a 400 "DisplayName is required.".
+func TestHandleRegisterSubmit_BlankDisplayName_GeneratesPetname(t *testing.T) {
 	t.Parallel()
 
 	store := newStubPlayerStore()
@@ -1313,7 +1313,7 @@ func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "petname@example.test")
-	// The whitespace-only username path falls into GeneratePetname, so
+	// The whitespace-only displayName path falls into GeneratePetname, so
 	// no row should be created under the empty key. The row exists under
 	// the petname; we look it up by email instead.
 	p, err := store.GetPlayerByEmail(t.Context(), "petname@example.test")
@@ -1321,7 +1321,7 @@ func TestHandleRegisterSubmit_BlankUsername_GeneratesPetname(t *testing.T) {
 		t.Fatalf("GetPlayerByEmail err = %v, want nil", err)
 	}
 	if p.DisplayName == "" {
-		t.Error("created Username is empty, want a non-empty petname")
+		t.Error("created DisplayName is empty, want a non-empty petname")
 	}
 }
 

--- a/internal/auth/invite.go
+++ b/internal/auth/invite.go
@@ -227,7 +227,7 @@ func buildInviteLink(baseURL, rawToken string) (string, error) {
 // the reset/verify body shape so the channels read consistently.
 func inviteEmailBody(link string) string {
 	return "You have been invited to join Top Banana.\n\n" +
-		"Click the link below to pick a username and password and set up your account:\n\n" +
+		"Click the link below to pick a displayName and password and set up your account:\n\n" +
 		link + "\n\n" +
 		"This link is valid for 7 days. If you were not expecting this invite,\n" +
 		"you can ignore this email.\n"

--- a/internal/auth/invite.go
+++ b/internal/auth/invite.go
@@ -49,16 +49,16 @@ type LiveInvite struct {
 
 // PendingInvite is one row in the admin pending-invite list (#318). It
 // carries enough to render the management table and drive the per-row
-// resend/revoke actions. InviterUsername is the resolved "invited by X"
+// resend/revoke actions. InviterDisplayName is the resolved "invited by X"
 // label, empty when the invite carries no actor or the inviting admin's
 // row has since been deleted (ON DELETE SET NULL).
 type PendingInvite struct {
-	ID                int64
-	Email             string
-	InvitedByPlayerID int64
-	InviterUsername   string
-	CreatedAt         time.Time
-	ExpiresAt         time.Time
+	ID                 int64
+	Email              string
+	InvitedByPlayerID  int64
+	InviterDisplayName string
+	CreatedAt          time.Time
+	ExpiresAt          time.Time
 }
 
 // InviteStore persists admin-issued invites. Implemented by

--- a/internal/auth/invite_handler.go
+++ b/internal/auth/invite_handler.go
@@ -22,7 +22,7 @@ type invitePageData struct {
 }
 
 // HandleAcceptInviteForm renders GET /accept-invite?token=... The
-// pick-username + password form is only shown when the token decodes
+// pick-displayName + password form is only shown when the token decodes
 // against a live (pending, unexpired) invite; otherwise it short-circuits
 // to an "invite link is no longer valid" page (410) so the recipient is
 // not asked to fill in a form the POST will reject.
@@ -74,9 +74,9 @@ func inviteLivePreflight(r *http.Request, logger *slog.Logger, invites InviteSto
 // PlayerStore) so adding the verify-stamp method here does not force
 // every PlayerStore stub in the codebase to grow a method it never calls.
 type InvitePlayerStore interface {
-	// CreatePlayer creates a credentialled player. Returns ErrUsernameTaken
+	// CreatePlayer creates a credentialled player. Returns ErrDisplayNameTaken
 	// / ErrEmailTaken on UNIQUE collisions.
-	CreatePlayer(ctx context.Context, username, email, passwordHash, requestedRole string) (*Player, error)
+	CreatePlayer(ctx context.Context, displayName, email, passwordHash, requestedRole string) (*Player, error)
 	// MarkPlayerEmailVerifiedIfNew stamps email_verified_at when currently
 	// NULL. Idempotent. Clicking the invite link proves control of the
 	// invited address, so the new account lands verified.
@@ -96,14 +96,14 @@ type AcceptInviteDeps struct {
 }
 
 // HandleAcceptInviteSubmit handles POST /accept-invite. It re-validates
-// the token live, validates the chosen username + password (same length
+// the token live, validates the chosen displayName + password (same length
 // rules as register/reset), creates the player with the email carried by
 // the invite and stamps it email-verified (clicking the link proves
 // control of the address), consumes the invite, and auto-logs the new
 // player in.
 //
 // Ordering avoids burning the token on a recoverable failure: the player
-// is created FIRST, then the invite is consumed. A username collision
+// is created FIRST, then the invite is consumed. A displayName collision
 // fails the create and leaves the invite pending, so the recipient can
 // retry with a different name on the same link. The invite is consumed
 // only after the player row exists; a consume failure after a successful
@@ -131,19 +131,19 @@ func HandleAcceptInviteSubmit(logger *slog.Logger, csrfMgr *csrf.Manager, deps A
 			return
 		}
 
-		username := r.PostFormValue("display_name")
+		displayName := r.PostFormValue("display_name")
 		password := r.PostFormValue("password")
 		confirm := r.PostFormValue("confirm")
-		if msg, ok := validateAcceptInviteInput(username, password, confirm); !ok {
+		if msg, ok := validateAcceptInviteInput(displayName, password, confirm); !ok {
 			render.render(w, r, http.StatusBadRequest, invitePageData{
-				Title: "Accept your invite", Token: raw, DisplayName: username, Message: msg,
+				Title: "Accept your invite", Token: raw, DisplayName: displayName, Message: msg,
 			})
 
 			return
 		}
 
 		acceptInvite(w, r, logger, render, deps, acceptInviteForm{
-			invite: invite, token: raw, username: username, password: password,
+			invite: invite, token: raw, displayName: displayName, password: password,
 		})
 	})
 }
@@ -153,10 +153,10 @@ func HandleAcceptInviteSubmit(logger *slog.Logger, csrfMgr *csrf.Manager, deps A
 // argument-limit. The email is taken from invite, not the form, so the
 // address the admin vetted is the one the account carries.
 type acceptInviteForm struct {
-	invite   *LiveInvite
-	token    string
-	username string
-	password string
+	invite      *LiveInvite
+	token       string
+	displayName string
+	password    string
 }
 
 // acceptInvite runs the create-player -> consume-invite -> auto-login
@@ -178,11 +178,11 @@ func acceptInvite(
 		return
 	}
 
-	player, err := deps.Players.CreatePlayer(r.Context(), form.username, form.invite.Email, hashed, RolePlayer)
+	player, err := deps.Players.CreatePlayer(r.Context(), form.displayName, form.invite.Email, hashed, RolePlayer)
 	if err != nil {
 		if msg, ok := acceptInviteCollisionMessage(err); ok {
 			render.render(w, r, http.StatusConflict, invitePageData{
-				Title: "Accept your invite", Token: form.token, DisplayName: form.username, Message: msg,
+				Title: "Accept your invite", Token: form.token, DisplayName: form.displayName, Message: msg,
 			})
 
 			return
@@ -221,11 +221,11 @@ func acceptInvite(
 	http.Redirect(w, r, landingPathFor(refreshed.Role), http.StatusSeeOther)
 }
 
-// validateAcceptInviteInput pins a non-empty username plus the same
+// validateAcceptInviteInput pins a non-empty displayName plus the same
 // password length + confirm-match rules the register/reset forms use.
 // Returns the user-facing banner text and false when rejected.
-func validateAcceptInviteInput(username, password, confirm string) (string, bool) {
-	if username == "" {
+func validateAcceptInviteInput(displayName, password, confirm string) (string, bool) {
+	if displayName == "" {
 		return "Pick a display name.", false
 	}
 	if len(password) < MinPasswordLength {
@@ -242,14 +242,14 @@ func validateAcceptInviteInput(username, password, confirm string) (string, bool
 }
 
 // acceptInviteCollisionMessage maps the create-time conflict sentinels
-// onto the recipient-facing banner. A taken username re-renders the form
+// onto the recipient-facing banner. A taken displayName re-renders the form
 // (the invite stays pending, so a retry works). A taken email means an
 // account was created for this address between invite-send and accept (a
 // race); the recipient is told to sign in. ok=false for any other error
 // so the caller treats it as a 500.
 func acceptInviteCollisionMessage(err error) (string, bool) {
 	switch {
-	case errors.Is(err, ErrUsernameTaken):
+	case errors.Is(err, ErrDisplayNameTaken):
 		return "That display name is already taken. Pick another.", true
 	case errors.Is(err, ErrEmailTaken):
 		return "An account already exists for this email - sign in instead.", true

--- a/internal/auth/invite_handler.go
+++ b/internal/auth/invite_handler.go
@@ -11,14 +11,14 @@ import (
 	"github.com/starquake/topbanana/internal/session"
 )
 
-// invitePageData backs the accept_invite.gohtml template. Username is
+// invitePageData backs the accept_invite.gohtml template. DisplayName is
 // preserved across a failed submit so the recipient does not retype it;
 // Token rides a hidden field so the POST does not need it on the URL bar.
 type invitePageData struct {
-	Title    string
-	Token    string
-	Username string
-	Message  string
+	Title       string
+	Token       string
+	DisplayName string
+	Message     string
 }
 
 // HandleAcceptInviteForm renders GET /accept-invite?token=... The
@@ -136,7 +136,7 @@ func HandleAcceptInviteSubmit(logger *slog.Logger, csrfMgr *csrf.Manager, deps A
 		confirm := r.PostFormValue("confirm")
 		if msg, ok := validateAcceptInviteInput(username, password, confirm); !ok {
 			render.render(w, r, http.StatusBadRequest, invitePageData{
-				Title: "Accept your invite", Token: raw, Username: username, Message: msg,
+				Title: "Accept your invite", Token: raw, DisplayName: username, Message: msg,
 			})
 
 			return
@@ -182,7 +182,7 @@ func acceptInvite(
 	if err != nil {
 		if msg, ok := acceptInviteCollisionMessage(err); ok {
 			render.render(w, r, http.StatusConflict, invitePageData{
-				Title: "Accept your invite", Token: form.token, Username: form.username, Message: msg,
+				Title: "Accept your invite", Token: form.token, DisplayName: form.username, Message: msg,
 			})
 
 			return

--- a/internal/auth/login_limiter.go
+++ b/internal/auth/login_limiter.go
@@ -23,7 +23,7 @@ func LoginCooldown() time.Duration { return loginCooldown }
 
 // LoginRateLimiter is a per-IP cool-down for POST /login. The handler
 // calls [LoginRateLimiter.Allow] before any credential lookup so the
-// limiter fires whether or not the submitted username exists,
+// limiter fires whether or not the submitted displayName exists,
 // preserving the same response-timing shape the dummy-hash compare
 // already gives the credential-check path.
 //

--- a/internal/auth/login_limiter_test.go
+++ b/internal/auth/login_limiter_test.go
@@ -96,9 +96,9 @@ func TestHandleLoginSubmit_RateLimited(t *testing.T) {
 }
 
 // TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser pins the
-// "always trip regardless of username existence" design constraint:
+// "always trip regardless of displayName existence" design constraint:
 // the limiter check runs BEFORE the credential lookup, so two POSTs
-// against a non-existent username also trip the second response.
+// against a non-existent displayName also trip the second response.
 func TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser(t *testing.T) {
 	t.Parallel()
 
@@ -158,9 +158,9 @@ func TestHandleLoginSubmit_RateLimitedRefusesCorrectCredentials(t *testing.T) {
 	}
 }
 
-func postLogin(t *testing.T, handler http.Handler, username, password string) *httptest.ResponseRecorder {
+func postLogin(t *testing.T, handler http.Handler, displayName, password string) *httptest.ResponseRecorder {
 	t.Helper()
-	form := url.Values{"username": {username}, "password": {password}}
+	form := url.Values{"displayName": {displayName}, "password": {password}}
 	req := httptest.NewRequestWithContext(
 		t.Context(), http.MethodPost, "/login", strings.NewReader(form.Encode()),
 	)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -152,8 +152,8 @@ func RequireGameHost(
 
 		if !player.CanHost() {
 			render.render(w, r, http.StatusForbidden, formData{
-				Title:    "Access denied",
-				Username: player.Username,
+				Title:       "Access denied",
+				DisplayName: player.DisplayName,
 			})
 
 			return

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -14,15 +14,15 @@ import (
 	"github.com/starquake/topbanana/internal/session"
 )
 
-// anonymousUsernamePrefix is the prefix used by the last-resort xid-backed
+// anonymousDisplayNamePrefix is the prefix used by the last-resort xid-backed
 // fallback when GeneratePetname collisions exhaust the retry budget. The
 // petname path is the common case; this prefix only appears in the
 // astronomically unlikely event that the petname pool becomes saturated or
 // the same petname is drawn N times in a row.
-const anonymousUsernamePrefix = "anon-"
+const anonymousDisplayNamePrefix = "anon-"
 
 // petnameMaxAttempts caps how many times EnsurePlayer will retry a petname
-// against the UNIQUE-on-username index before falling back to an xid-backed
+// against the UNIQUE-on-displayName index before falling back to an xid-backed
 // name. With ~15M combinations the chance of one collision is tiny and the
 // chance of five in a row is effectively zero, so five attempts is a safe
 // upper bound that still keeps the request latency bounded.
@@ -104,7 +104,7 @@ func mintAnonymousPlayer(ctx context.Context, players PlayerStore) (*Player, err
 		if err == nil {
 			return player, nil
 		}
-		if !errors.Is(err, ErrUsernameTaken) {
+		if !errors.Is(err, ErrDisplayNameTaken) {
 			return nil, fmt.Errorf("create anonymous player: %w", err)
 		}
 		lastErr = err
@@ -113,7 +113,7 @@ func mintAnonymousPlayer(ctx context.Context, players PlayerStore) (*Player, err
 	// Petname pool collided every attempt. Fall back to an xid-backed name,
 	// which is unique by construction and effectively guarantees the insert
 	// succeeds even if the petname pool ever becomes saturated.
-	player, err := players.CreateAnonymousPlayer(ctx, anonymousUsernamePrefix+xid.New().String())
+	player, err := players.CreateAnonymousPlayer(ctx, anonymousDisplayNamePrefix+xid.New().String())
 	if err != nil {
 		return nil, fmt.Errorf("petname exhausted (last: %w); xid fallback: %w", lastErr, err)
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -108,7 +108,7 @@ func TestRequireGameHost_DeniesPlayer(t *testing.T) {
 		t.Errorf("body should contain %q, got %q", want, got)
 	}
 	if got, want := rec.Body.String(), "bob"; !strings.Contains(got, want) {
-		t.Errorf("body should contain signed-in username %q, got %q", want, got)
+		t.Errorf("body should contain signed-in displayName %q, got %q", want, got)
 	}
 }
 
@@ -368,7 +368,7 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 		t.Errorf("seenPlayer.IsAnonymous() = false, want true (PasswordHash = %q)", seenPlayer.PasswordHash)
 	}
 	// EnsurePlayer should mint a petname-style "Adjective-Adjective-Noun"
-	// username, not the legacy "anon-<xid>" form (the xid form is the
+	// displayName, not the legacy "anon-<xid>" form (the xid form is the
 	// last-resort fallback only).
 	if got := seenPlayer.DisplayName; strings.HasPrefix(got, "anon-") {
 		t.Errorf("seenPlayer.DisplayName = %q, want a petname-style name (no anon- prefix)", got)
@@ -496,7 +496,7 @@ func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
 
 	store := newStubPlayerStore()
 	// Force the first three CreateAnonymousPlayer calls to return
-	// ErrUsernameTaken; the fourth attempt should succeed and produce a
+	// ErrDisplayNameTaken; the fourth attempt should succeed and produce a
 	// regular petname row.
 	store.forceAnonCollisions = 3
 	sessions := session.New([]byte("k"), true)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -66,8 +66,8 @@ func TestRequireGameHost_AllowsAdmin(t *testing.T) {
 	if got, want := seenPlayer.ID, admin.ID; got != want {
 		t.Errorf("player.ID on context = %d, want %d", got, want)
 	}
-	if got, want := seenPlayer.Username, "alice"; got != want {
-		t.Errorf("player.Username on context = %q, want %q", got, want)
+	if got, want := seenPlayer.DisplayName, "alice"; got != want {
+		t.Errorf("player.DisplayName on context = %q, want %q", got, want)
 	}
 }
 
@@ -370,11 +370,15 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 	// EnsurePlayer should mint a petname-style "Adjective-Adjective-Noun"
 	// username, not the legacy "anon-<xid>" form (the xid form is the
 	// last-resort fallback only).
-	if got := seenPlayer.Username; strings.HasPrefix(got, "anon-") {
-		t.Errorf("seenPlayer.Username = %q, want a petname-style name (no anon- prefix)", got)
+	if got := seenPlayer.DisplayName; strings.HasPrefix(got, "anon-") {
+		t.Errorf("seenPlayer.DisplayName = %q, want a petname-style name (no anon- prefix)", got)
 	}
-	if got, want := strings.Count(seenPlayer.Username, "-"), 2; got != want {
-		t.Errorf("seenPlayer.Username = %q, want %d hyphens (Adjective-Adjective-Noun)", seenPlayer.Username, want)
+	if got, want := strings.Count(seenPlayer.DisplayName, "-"), 2; got != want {
+		t.Errorf(
+			"seenPlayer.DisplayName = %q, want %d hyphens (Adjective-Adjective-Noun)",
+			seenPlayer.DisplayName,
+			want,
+		)
 	}
 	cookie, ok := findCookie(rec, session.CookieName)
 	if !ok {
@@ -511,11 +515,11 @@ func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
 	if seenPlayer == nil {
 		t.Fatal("PlayerFromContext returned nil player; middleware should have retried past the collisions")
 	}
-	if got := seenPlayer.Username; strings.HasPrefix(got, "anon-") {
-		t.Errorf("seenPlayer.Username = %q, want a petname-style name (no anon- fallback)", got)
+	if got := seenPlayer.DisplayName; strings.HasPrefix(got, "anon-") {
+		t.Errorf("seenPlayer.DisplayName = %q, want a petname-style name (no anon- fallback)", got)
 	}
-	if got, want := strings.Count(seenPlayer.Username, "-"), 2; got != want {
-		t.Errorf("seenPlayer.Username = %q, want %d hyphens", seenPlayer.Username, want)
+	if got, want := strings.Count(seenPlayer.DisplayName, "-"), 2; got != want {
+		t.Errorf("seenPlayer.DisplayName = %q, want %d hyphens", seenPlayer.DisplayName, want)
 	}
 }
 
@@ -542,8 +546,8 @@ func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
 	if seenPlayer == nil {
 		t.Fatal("PlayerFromContext returned nil player; fallback should have produced one")
 	}
-	if got, want := seenPlayer.Username[:5], "anon-"; got != want {
-		t.Errorf("seenPlayer.Username prefix = %q, want %q (xid fallback after exhausted retries)", got, want)
+	if got, want := seenPlayer.DisplayName[:5], "anon-"; got != want {
+		t.Errorf("seenPlayer.DisplayName prefix = %q, want %q (xid fallback after exhausted retries)", got, want)
 	}
 }
 

--- a/internal/auth/oauth_store.go
+++ b/internal/auth/oauth_store.go
@@ -25,10 +25,10 @@ type OAuthIdentityStore interface {
 	GetPlayerByEmail(ctx context.Context, email string) (*Player, error)
 	// CreatePlayerFromOAuth inserts a new players row for a first-time
 	// OAuth sign-in. password_hash is left NULL, email is the supplied
-	// verified address, and username is the caller-generated petname.
-	// Returns ErrUsernameTaken if the petname collides (the OAuth
+	// verified address, and displayName is the caller-generated petname.
+	// Returns ErrDisplayNameTaken if the petname collides (the OAuth
 	// handler retries with a fresh petname on this sentinel).
-	CreatePlayerFromOAuth(ctx context.Context, username, email string) (*Player, error)
+	CreatePlayerFromOAuth(ctx context.Context, displayName, email string) (*Player, error)
 	// LinkProviderIdentity attaches a (provider, subject) pair to the
 	// given player id. Returns ErrIdentityAlreadyLinked when the
 	// (provider, subject) pair already exists (UNIQUE collision).
@@ -39,7 +39,7 @@ type OAuthIdentityStore interface {
 	// login. Returns ErrPlayerNotFound when the row is missing, has
 	// already been credentialled, or already carries an email - in
 	// each case the caller falls through to the create-fresh-player
-	// path. The username on the row is left untouched.
+	// path. The displayName on the row is left untouched.
 	ClaimPlayerForOAuth(ctx context.Context, playerID int64, email string) (*Player, error)
 	// MarkPlayerEmailVerifiedIfNew stamps email_verified_at when
 	// currently NULL. Idempotent.

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -6,11 +6,11 @@ import (
 	"time"
 )
 
-// ErrPlayerNotFound is returned when a player is not found by username.
+// ErrPlayerNotFound is returned when a player is not found by displayName.
 var ErrPlayerNotFound = errors.New("player not found")
 
-// ErrUsernameTaken is returned when a username is already in use.
-var ErrUsernameTaken = errors.New("username taken")
+// ErrDisplayNameTaken is returned when a displayName is already in use.
+var ErrDisplayNameTaken = errors.New("displayName taken")
 
 // ErrEmailTaken is returned when an email is already in use.
 var ErrEmailTaken = errors.New("email taken")
@@ -19,19 +19,19 @@ var ErrEmailTaken = errors.New("email taken")
 // already has a password_hash set, so it cannot be upgraded again.
 var ErrPlayerAlreadyClaimed = errors.New("player already claimed")
 
-// ErrPlayerNotAnonymous is returned by UpdatePlayerUsername when the target
+// ErrPlayerNotAnonymous is returned by UpdatePlayerDisplayName when the target
 // row exists but already carries a non-anonymous identity (password_hash IS
-// NOT NULL). Username-only changes are reserved for anonymous rows; a
+// NOT NULL). DisplayName-only changes are reserved for anonymous rows; a
 // credentialled account must change its name through a different flow.
 var ErrPlayerNotAnonymous = errors.New("player is not anonymous")
 
-// ErrUsernameEmpty is returned by UpdatePlayerUsername when the supplied
-// username trims to the empty string. Surfaced as a store-level sentinel
+// ErrDisplayNameEmpty is returned by UpdatePlayerDisplayName when the supplied
+// displayName trims to the empty string. Surfaced as a store-level sentinel
 // so callers can map it to a 400 without re-validating themselves.
-var ErrUsernameEmpty = errors.New("username is empty")
+var ErrDisplayNameEmpty = errors.New("displayName is empty")
 
 // ErrIdentityAlreadyLinked is returned by LinkProviderIdentity when the
-// (provider, subject) pair already exists. Distinct from ErrUsernameTaken
+// (provider, subject) pair already exists. Distinct from ErrDisplayNameTaken
 // so the Google callback can distinguish a race between two concurrent
 // first-time sign-ins (handled by retrying the lookup) from a true
 // collision (handled as a 500).
@@ -87,7 +87,7 @@ func (p *Player) IsAnonymous() bool {
 }
 
 // HasCustomName reports whether the player has explicitly picked their
-// username. Anonymous rows start with HasCustomName=false (the username
+// displayName. Anonymous rows start with HasCustomName=false (the displayName
 // is an auto-generated petname); they flip to true on a successful
 // PATCH /api/players/me or via the register flow. Distinct from
 // IsAnonymous() (which is credential-level: no password): a
@@ -288,7 +288,7 @@ type AdminEntry struct {
 const (
 	AdminActionVerify             = "verify"
 	AdminActionEmailSet           = "email_set"
-	AdminActionUsernameSet        = "username_set"
+	AdminActionDisplayNameSet     = "display_name_set"
 	AdminActionPasswordSet        = "password_set"
 	AdminActionCreated            = "created"
 	AdminActionResendVerification = "resend_verification"
@@ -325,9 +325,9 @@ type AdminPlayerStore interface {
 	SetPlayerEmail(ctx context.Context, playerID int64, email string) error
 	// CreatePlayerByAdmin inserts a fresh credentialled row with
 	// email_verified_at stamped. role is fixed to 'player'. Returns
-	// ErrUsernameTaken / ErrEmailTaken on UNIQUE collisions.
+	// ErrDisplayNameTaken / ErrEmailTaken on UNIQUE collisions.
 	CreatePlayerByAdmin(
-		ctx context.Context, username, email, passwordHash string,
+		ctx context.Context, displayName, email, passwordHash string,
 	) (*Player, error)
 	// SetPlayerRole sets the role on the row identified by id (#538), so the
 	// id-based role selector can move a player to any tier. role is one of
@@ -350,10 +350,10 @@ type AdminPlayerStore interface {
 		ctx context.Context, targetPlayerID, limit int64,
 	) ([]*AdminAuditEntry, error)
 	// RenamePlayer changes the display name on the row identified by id,
-	// regardless of password_hash / email / role. Returns ErrUsernameEmpty
-	// for whitespace-only input, ErrUsernameTaken on a UNIQUE collision, and
+	// regardless of password_hash / email / role. Returns ErrDisplayNameEmpty
+	// for whitespace-only input, ErrDisplayNameTaken on a UNIQUE collision, and
 	// ErrPlayerNotFound when the id does not exist.
-	RenamePlayer(ctx context.Context, playerID int64, username string) (*Player, error)
+	RenamePlayer(ctx context.Context, playerID int64, displayName string) (*Player, error)
 	// ChangePlayerPassword atomically rotates password_hash and bumps
 	// session_version on the row identified by id. The session_version bump
 	// invalidates every other live cookie for the same account the moment
@@ -369,7 +369,7 @@ type AdminPlayerStore interface {
 // the other interface slots.
 type AdminListStore interface {
 	AdminPlayerStore
-	// ListAdmins returns every current Admin ordered by username. Empty
+	// ListAdmins returns every current Admin ordered by displayName. Empty
 	// slice when none exist yet.
 	ListAdmins(ctx context.Context) ([]*AdminEntry, error)
 }
@@ -381,7 +381,7 @@ type PlayerStore interface {
 	GetPlayerByDisplayName(ctx context.Context, displayName string) (*Player, error)
 	// GetPlayerByEmail returns the player with the given email.
 	// Returns ErrPlayerNotFound when there is no match. Used by the
-	// forgot-password flow's username-or-email lookup and the Google
+	// forgot-password flow's displayName-or-email lookup and the Google
 	// OAuth link-by-email path.
 	GetPlayerByEmail(ctx context.Context, email string) (*Player, error)
 	// GetPlayerByID returns the player with the given ID.
@@ -390,29 +390,29 @@ type PlayerStore interface {
 	// CreatePlayer creates a player with the given credentials. The
 	// store trims + lowercases the email and atomically promotes the
 	// first password-bearing registrant to admin. Returns
-	// ErrUsernameTaken / ErrEmailTaken on UNIQUE collisions.
-	CreatePlayer(ctx context.Context, username, email, passwordHash, requestedRole string) (*Player, error)
-	// CreateAnonymousPlayer creates a row with the given username, no email,
+	// ErrDisplayNameTaken / ErrEmailTaken on UNIQUE collisions.
+	CreatePlayer(ctx context.Context, displayName, email, passwordHash, requestedRole string) (*Player, error)
+	// CreateAnonymousPlayer creates a row with the given displayName, no email,
 	// no password_hash, and role = "player". Used by EnsurePlayer to back a
 	// brand-new visitor with a real row before they can play. The caller
-	// generates the username (commonly a GeneratePetname result, with an
+	// generates the displayName (commonly a GeneratePetname result, with an
 	// xid-backed "anon-<xid>" form as the last-resort fallback) so the
 	// store stays agnostic about the format.
-	// Returns ErrUsernameTaken when the username collides on the UNIQUE
+	// Returns ErrDisplayNameTaken when the displayName collides on the UNIQUE
 	// index; the petname caller treats this as a retry signal.
-	CreateAnonymousPlayer(ctx context.Context, username string) (*Player, error)
+	CreateAnonymousPlayer(ctx context.Context, displayName string) (*Player, error)
 	// ClaimPlayer upgrades an anonymous row (password_hash IS NULL) in place
 	// with the supplied credentials and requested role. The store mirrors the
 	// "first password-bearing registrant becomes admin" promotion logic of
 	// CreatePlayer so the rule still triggers when a visitor's very first
 	// sign-up flows through the claim path.
 	// Returns ErrPlayerAlreadyClaimed when the target row already has a
-	// password_hash, ErrUsernameTaken when the requested username collides
+	// password_hash, ErrDisplayNameTaken when the requested displayName collides
 	// with another row, and ErrPlayerNotFound when the id does not exist.
 	ClaimPlayer(
 		ctx context.Context,
 		playerID int64,
-		username, email, passwordHash, requestedRole string,
+		displayName, email, passwordHash, requestedRole string,
 	) (*Player, error)
 	// SetPlayerPasswordHash overwrites the password_hash on the row identified
 	// by email. Used by the operator-only -reset-password tool to rotate a
@@ -433,8 +433,8 @@ type PlayerStore interface {
 	// in place. The session cookie keeps pointing at the same row, so the
 	// caller stays "logged in" as the same player; the player remains
 	// anonymous after the rename.
-	// Returns ErrUsernameEmpty when the supplied display name trims to the empty
-	// string, ErrUsernameTaken when the requested display name is already in use,
+	// Returns ErrDisplayNameEmpty when the supplied display name trims to the empty
+	// string, ErrDisplayNameTaken when the requested display name is already in use,
 	// ErrPlayerNotAnonymous when the target row already carries a
 	// password_hash (i.e. it is no longer a valid target for a display-name-only
 	// update), and ErrPlayerNotFound when no row matches the id.
@@ -444,8 +444,8 @@ type PlayerStore interface {
 	// endpoint so authenticated players (password, OAuth, admin) can
 	// update their own name; anonymous rows still go through
 	// UpdatePlayerDisplayName.
-	// Returns ErrUsernameEmpty for whitespace-only input, ErrUsernameTaken
+	// Returns ErrDisplayNameEmpty for whitespace-only input, ErrDisplayNameTaken
 	// on a UNIQUE collision, and ErrPlayerNotFound when the id does not
 	// exist.
-	RenamePlayer(ctx context.Context, playerID int64, username string) (*Player, error)
+	RenamePlayer(ctx context.Context, playerID int64, displayName string) (*Player, error)
 }

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -39,16 +39,16 @@ var ErrIdentityAlreadyLinked = errors.New("identity already linked")
 
 // Player represents an authenticated user (admin or player).
 type Player struct {
-	ID       int64
-	Username string
-	Email    string
+	ID          int64
+	DisplayName string
+	Email       string
 	// EmailVerifiedAt is nil until the address is verified. OAuth-linked
 	// rows are stamped at link time because the provider attests the email.
-	EmailVerifiedAt *time.Time
-	PasswordHash    string
-	Role            string
-	CreatedAt       time.Time
-	UsernameClaimed bool
+	EmailVerifiedAt    *time.Time
+	PasswordHash       string
+	Role               string
+	CreatedAt          time.Time
+	DisplayNameClaimed bool
 	// SessionVersion is bumped on password reset so every in-flight
 	// cookie (which carries the version it was issued at) becomes
 	// invalid the moment the reset commits (#112).
@@ -94,7 +94,7 @@ func (p *Player) IsAnonymous() bool {
 // claimed-but-passwordless visitor has HasCustomName=true and
 // IsAnonymous()=true simultaneously.
 func (p *Player) HasCustomName() bool {
-	return p.UsernameClaimed
+	return p.DisplayNameClaimed
 }
 
 // IsAuthenticated reports whether the visitor has signed in. True for
@@ -130,7 +130,7 @@ type AnonymousGameMigrator interface {
 // page query stays simple.
 type PlayerListRow struct {
 	ID              int64
-	Username        string
+	DisplayName     string
 	Email           string
 	Role            string
 	HasPassword     bool
@@ -230,7 +230,7 @@ type PlayerLister interface {
 // narrow.
 type PlayerDetail struct {
 	ID              int64
-	Username        string
+	DisplayName     string
 	Email           string
 	Role            string
 	HasPassword     bool
@@ -254,24 +254,24 @@ type RecentFinishedGame struct {
 // per-player detail view's "Recent admin actions" section (#450). The
 // raw Payload JSON is passed through as a string; the template decodes
 // the few well-known actions on the way out. ActorPlayerID is 0 and
-// ActorUsername is "" when the actor row has since been deleted (the
+// ActorDisplayName is "" when the actor row has since been deleted (the
 // actor FK is ON DELETE SET NULL, so the audit row outlives its actor).
 type AdminAuditEntry struct {
-	ID             int64
-	ActorPlayerID  int64
-	ActorUsername  string
-	TargetPlayerID int64
-	Action         string
-	Payload        string
-	CreatedAt      time.Time
+	ID               int64
+	ActorPlayerID    int64
+	ActorDisplayName string
+	TargetPlayerID   int64
+	Action           string
+	Payload          string
+	CreatedAt        time.Time
 }
 
 // AdminEntry is one row in the Admins list rendered on the admin settings
 // page (#320/#538). Email is empty when the row has no address on file.
 type AdminEntry struct {
-	ID       int64
-	Username string
-	Email    string
+	ID          int64
+	DisplayName string
+	Email       string
 	// RoleChangedAt is when the player's role last changed (the promotion to
 	// Admin, in practice). Nil for rows whose role predates the column.
 	RoleChangedAt *time.Time
@@ -376,9 +376,9 @@ type AdminListStore interface {
 
 // PlayerStore is the persistence interface used by the auth package.
 type PlayerStore interface {
-	// GetPlayerByUsername returns the player with the given username.
+	// GetPlayerByDisplayName returns the player with the given display name.
 	// Returns ErrPlayerNotFound when there is no match.
-	GetPlayerByUsername(ctx context.Context, username string) (*Player, error)
+	GetPlayerByDisplayName(ctx context.Context, displayName string) (*Player, error)
 	// GetPlayerByEmail returns the player with the given email.
 	// Returns ErrPlayerNotFound when there is no match. Used by the
 	// forgot-password flow's username-or-email lookup and the Google
@@ -429,21 +429,21 @@ type PlayerStore interface {
 	// that path also marks the reset row consumed in the same
 	// transaction. Returns ErrPlayerNotFound when no row matches.
 	ChangePlayerPassword(ctx context.Context, playerID int64, passwordHash string) error
-	// UpdatePlayerUsername renames an anonymous (password_hash IS NULL) row
+	// UpdatePlayerDisplayName renames an anonymous (password_hash IS NULL) row
 	// in place. The session cookie keeps pointing at the same row, so the
 	// caller stays "logged in" as the same player; the player remains
 	// anonymous after the rename.
-	// Returns ErrUsernameEmpty when the supplied username trims to the empty
-	// string, ErrUsernameTaken when the requested username is already in use,
+	// Returns ErrUsernameEmpty when the supplied display name trims to the empty
+	// string, ErrUsernameTaken when the requested display name is already in use,
 	// ErrPlayerNotAnonymous when the target row already carries a
-	// password_hash (i.e. it is no longer a valid target for a username-only
+	// password_hash (i.e. it is no longer a valid target for a display-name-only
 	// update), and ErrPlayerNotFound when no row matches the id.
-	UpdatePlayerUsername(ctx context.Context, playerID int64, username string) (*Player, error)
+	UpdatePlayerDisplayName(ctx context.Context, playerID int64, displayName string) (*Player, error)
 	// RenamePlayer changes the display name on any player row, regardless
 	// of password_hash / email / role. Used by the profile-page rename
 	// endpoint so authenticated players (password, OAuth, admin) can
 	// update their own name; anonymous rows still go through
-	// UpdatePlayerUsername.
+	// UpdatePlayerDisplayName.
 	// Returns ErrUsernameEmpty for whitespace-only input, ErrUsernameTaken
 	// on a UNIQUE collision, and ErrPlayerNotFound when the id does not
 	// exist.

--- a/internal/auth/verify_request_test.go
+++ b/internal/auth/verify_request_test.go
@@ -77,10 +77,10 @@ func TestHandleVerifyEmailRequestSubmit_AlwaysFlashesGenericSuccess(t *testing.T
 			); err != nil {
 				t.Fatalf("CreatePlayer verified err = %v, want nil", err)
 			}
-			if p, err := store.GetPlayerByUsername(t.Context(), "verified"); err == nil {
+			if p, err := store.GetPlayerByDisplayName(t.Context(), "verified"); err == nil {
 				p.EmailVerifiedAt = &verified
 			} else {
-				t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+				t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 			}
 			if _, err := store.CreatePlayer(
 				t.Context(), "unverified", "unverified@example.test", "h", RolePlayer,
@@ -142,10 +142,10 @@ func TestHandleVerifyEmailRequestSubmit_AlreadyVerifiedSendsNoMail(t *testing.T)
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 	verified := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
-	if p, err := store.GetPlayerByUsername(t.Context(), "alice"); err == nil {
+	if p, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err == nil {
 		p.EmailVerifiedAt = &verified
 	} else {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	tokens := &recordingVerifyTokenStore{}
 	sender := &recordingSender{}

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -89,7 +89,7 @@
             <template x-if="isAuthenticated() && !(gameId && !finished)">
                 <p class="mb-6 text-sm text-text-dim text-right">
                     Signed in as
-                    <a href="/profile" class="text-text hover:text-accent underline-offset-2 hover:underline" data-testid="account-profile-link" x-text="player ? player.username : ''"></a>
+                    <a href="/profile" class="text-text hover:text-accent underline-offset-2 hover:underline" data-testid="account-profile-link" x-text="player ? player.displayName : ''"></a>
                 </p>
             </template>
 
@@ -116,7 +116,7 @@
                     <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
                         <div class="min-w-0">
                             <p class="label-eyebrow">Playing as</p>
-                            <p data-testid="claim-cta-name" class="font-mono text-accent text-[1.05rem] break-all" x-text="player ? player.username : ''"></p>
+                            <p data-testid="claim-cta-name" class="font-mono text-accent text-[1.05rem] break-all" x-text="player ? player.displayName : ''"></p>
                         </div>
                         <button class="btn-primary ml-auto" @click="openClaimModal()">
                             <span x-show="!hasCustomName()">Set your name</span>
@@ -280,7 +280,7 @@
                                     <tr :aria-current="entry.isCurrentPlayer ? 'true' : null">
                                         <td x-text="entry.rank"></td>
                                         <td>
-                                            <span x-text="entry.username"></span>
+                                            <span x-text="entry.displayName"></span>
                                             <template x-if="entry.inProgress">
                                                 <span class="leaderboard-in-progress" role="img" aria-label="Still answering" title="Still answering"></span>
                                             </template>
@@ -641,7 +641,7 @@
                          x-data="claimNameForm({
                                 submitLabel: 'Save',
                                 cancelLabel: 'Cancel',
-                                initialValue: hasCustomName() ? player.username : '',
+                                initialValue: hasCustomName() ? player.displayName : '',
                                 onSubmit: (name) => claimFromModal(name),
                                 onCancel: () => closeClaimModal(),
                              })">

--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -101,7 +101,7 @@
                  one. Hidden during gameplay (gameId && !finished) so
                  the player's attention stays on the question. Also
                  hidden for authenticated players (#409) since their
-                 username is stable and changes go through the future
+                 displayName is stable and changes go through the future
                  profile page (#410). The end-of-quiz modal is the
                  one-shot "auto-prompt" path and gates on
                  hasCustomName() instead — see #165. -->
@@ -657,7 +657,7 @@
                                 <input id="claim-name-modal" type="text" class="form-input"
                                        maxlength="64" autocomplete="off"
                                        x-init="$nextTick(() => $el.focus())"
-                                       x-model="username"
+                                       x-model="displayName"
                                        @keydown.enter.prevent="submit()"
                                        :disabled="submitting">
                             </div>

--- a/internal/client/static/js/components/ClaimNameForm.js
+++ b/internal/client/static/js/components/ClaimNameForm.js
@@ -6,7 +6,7 @@
 // from a dismissed pre-leaderboard form.
 //
 // The parent gameApp injects two callbacks via Alpine's $data:
-//   onSubmit(username) -> { ok, message }  (resolves to the
+//   onSubmit(displayName) -> { ok, message }  (resolves to the
 //       PlayerService.claimName result, with errors already mapped to
 //       human-friendly messages)
 //   onCancel()                              (optional; controls how the
@@ -19,14 +19,14 @@
 // the page at once.
 export function claimNameForm({ initialValue = '', cancelLabel = 'Cancel', submitLabel = 'Save', onSubmit, onCancel } = {}) {
     return {
-        username: initialValue,
+        displayName: initialValue,
         submitting: false,
         error: '',
         cancelLabel,
         submitLabel,
         async submit() {
             if (this.submitting) return;
-            const trimmed = (this.username || '').trim();
+            const trimmed = (this.displayName || '').trim();
             if (trimmed === '') {
                 this.error = 'Please enter a name.';
                 return;
@@ -40,7 +40,7 @@ export function claimNameForm({ initialValue = '', cancelLabel = 'Cancel', submi
                     return;
                 }
                 // On success the parent component swaps the surrounding
-                // UI; we deliberately don't reset `username` here so a
+                // UI; we deliberately don't reset `displayName` here so a
                 // reopened form would inherit the saved value if needed.
             } finally {
                 this.submitting = false;

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -281,7 +281,7 @@ export class GameApp {
     // the seeded admin role). The claim-name CTA and end-of-quiz
     // auto-open both gate on the negation of this: a signed-in
     // player already has a stable identity and should never see the
-    // "Set your name" prompt — username changes for them belong on
+    // "Set your name" prompt — displayName changes for them belong on
     // the future profile page (#410), not the in-game modal.
     isAuthenticated() {
         return !!(this.player && this.player.isAuthenticated);
@@ -325,8 +325,8 @@ export class GameApp {
     // (the new name will appear on the next page load) rather than
     // surfacing an error on the success path, since the PATCH itself
     // already succeeded.
-    async claimFromModal(username) {
-        const result = await playerService.claimName(username);
+    async claimFromModal(displayName) {
+        const result = await playerService.claimName(displayName);
         if (result.ok) {
             this.player = result.player;
             this.claimModalOpen = false;
@@ -342,7 +342,7 @@ export class GameApp {
         // #289: the server says this account is already non-anonymous,
         // which means our cached `this.player.hasCustomName` was stale
         // (a logged-in admin with a freshly-set password_hash but
-        // username_claimed still 0 ended up here). Refresh /me so
+        // displayName_claimed still 0 ended up here). Refresh /me so
         // hasCustomName flips to true, then dismiss the modal — there
         // is nothing for the user to do here.
         if (result.kind === 'already_claimed') {
@@ -597,7 +597,7 @@ export class GameApp {
             // Auto-open the claim modal only for visitors who have not
             // both (a) authenticated AND (b) picked a custom name yet.
             // Authenticated players never see the modal — their
-            // username is already stable and changes go through the
+            // displayName is already stable and changes go through the
             // profile page (#410). Anonymous players who claimed a
             // petname via PATCH /api/players/me also skip the prompt
             // (hasCustomName true) so the modal does not re-open on

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -97,7 +97,7 @@ export class GameApp {
         // Current player as returned by GET /api/players/me. Stays null
         // until init() resolves; templates guard with `player &&`. When
         // the player renames, the PATCH response replaces this object
-        // so player.username and player.hasCustomName flow through every
+        // so player.displayName and player.hasCustomName flow through every
         // bound template at once.
         this.player = null;
         // Visibility of the shared claim-name modal. A single piece of

--- a/internal/client/static/js/services/PlayerService.js
+++ b/internal/client/static/js/services/PlayerService.js
@@ -2,7 +2,7 @@
 // "claim your display name" flow. The same anonymous row is returned
 // across requests because EnsurePlayer middleware keeps the cookie
 // stable, so the component can re-fetch /me any time it wants the
-// latest username/isAnonymous/hasCustomName triple.
+// latest displayName/isAnonymous/hasCustomName triple.
 
 // readClaimNameError parses a PATCH /api/players/me error body. The
 // server emits `{code, message}` JSON for the documented error paths
@@ -18,7 +18,7 @@ async function readClaimNameError(response) {
 }
 
 export class PlayerService {
-    // getMe returns {id, username, isAnonymous, hasCustomName}, or null
+    // getMe returns {id, displayName, isAnonymous, hasCustomName}, or null
     // if the server somehow rejects the call (401 from a misconfigured
     // route, network failure, etc.). The component treats null as "skip
     // claim UI" so a broken auth wiring degrades to the previous
@@ -38,7 +38,7 @@ export class PlayerService {
         }
     }
 
-    // claimName PATCHes /api/players/me with a trimmed username and
+    // claimName PATCHes /api/players/me with a trimmed displayName and
     // returns a discriminated result the component can branch on
     // without inspecting raw status codes. The shape is:
     //   { ok: true,  player: {...} }                                       on 200
@@ -51,8 +51,8 @@ export class PlayerService {
     // but the server disagrees, so the component should re-fetch /me
     // and dismiss the modal rather than show "name is taken".
     async claimName(rawUsername) {
-        const username = (rawUsername || '').trim();
-        if (username === '') {
+        const displayName = (rawUsername || '').trim();
+        if (displayName === '') {
             return { ok: false, status: 400, kind: 'empty', message: 'Please enter a name.' };
         }
         let response;
@@ -60,7 +60,7 @@ export class PlayerService {
             response = await fetch('/api/players/me', {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ username })
+                body: JSON.stringify({ displayName })
             });
         } catch {
             return { ok: false, status: 0, kind: 'error', message: "Couldn't save your name — try again later." };

--- a/internal/client/static/js/services/PlayerService.js
+++ b/internal/client/static/js/services/PlayerService.js
@@ -50,8 +50,8 @@ export class PlayerService {
     // state-drift signal: the client thought the player was anonymous
     // but the server disagrees, so the component should re-fetch /me
     // and dismiss the modal rather than show "name is taken".
-    async claimName(rawUsername) {
-        const displayName = (rawUsername || '').trim();
+    async claimName(rawDisplayName) {
+        const displayName = (rawDisplayName || '').trim();
         if (displayName === '') {
             return { ok: false, status: 400, kind: 'empty', message: 'Please enter a name.' };
         }

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -348,7 +348,7 @@ func writeQuizLeaderboardError(
 
 // HandleQuizLeaderboard returns the top scoring players for the given quiz.
 // Each player appears at most once, with their total score for the quiz; ties
-// are broken by ascending username for a stable order. IsCurrentPlayer is set
+// are broken by ascending displayName for a stable order. IsCurrentPlayer is set
 // on the entry that matches the authenticated player on the request context
 // so the client can highlight that row.
 //
@@ -1095,13 +1095,13 @@ func newPlayerResponse(p *auth.Player) playerResponse {
 }
 
 // HandlePlayerGetMe returns a handler for GET /api/players/me that reports
-// the calling player's id, username, whether they are still anonymous
+// the calling player's id, displayName, whether they are still anonymous
 // (no password_hash set), and whether they have explicitly picked a
 // display name. hasCustomName and isAnonymous are deliberately
 // independent concepts: a registered user with a password is never
 // anonymous, but a claimed-but-passwordless visitor still is - callers
 // that care about "did this player choose this name" should look at
-// hasCustomName, not isAnonymous. The username is shown verbatim so a
+// hasCustomName, not isAnonymous. The displayName is shown verbatim so a
 // fresh petname can be displayed as-is until the player renames.
 func HandlePlayerGetMe(logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1125,7 +1125,7 @@ func HandlePlayerGetMe(logger *slog.Logger) http.Handler {
 // HandlePlayerClaimName is the score-claim rename for anonymous
 // visitors: the player keeps the same row and session cookie and stays
 // anonymous after picking a display name. 409 covers both
-// username-taken and already-claimed-via-register; the distinct
+// displayName-taken and already-claimed-via-register; the distinct
 // messages let the client tell them apart.
 func HandlePlayerClaimName(
 	logger *slog.Logger, players auth.PlayerStore, gameService *game.Service,
@@ -1152,7 +1152,7 @@ func HandlePlayerClaimName(
 			return
 		}
 		if strings.TrimSpace(req.DisplayName) == "" {
-			http.Error(w, "username is required", http.StatusBadRequest)
+			http.Error(w, "display name is required", http.StatusBadRequest)
 
 			return
 		}
@@ -1160,9 +1160,9 @@ func HandlePlayerClaimName(
 		updated, err := players.UpdatePlayerDisplayName(ctx, current.ID, req.DisplayName)
 		if err != nil {
 			switch {
-			case errors.Is(err, auth.ErrUsernameTaken):
+			case errors.Is(err, auth.ErrDisplayNameTaken):
 				writeClaimNameError(w, r, logger,
-					http.StatusConflict, "username_taken", "username already taken")
+					http.StatusConflict, "display_name_taken", "display name already taken")
 			case errors.Is(err, auth.ErrPlayerNotAnonymous):
 				// #289: distinct code so the JS can tell "name in use
 				// by someone else" from "this account already has a
@@ -1170,12 +1170,12 @@ func HandlePlayerClaimName(
 				// the client should re-fetch /me and dismiss the
 				// modal, not show "name is taken".
 				writeClaimNameError(w, r, logger,
-					http.StatusConflict, "already_claimed", "username already set for this account")
-			case errors.Is(err, auth.ErrUsernameEmpty):
+					http.StatusConflict, "already_claimed", "display name already set for this account")
+			case errors.Is(err, auth.ErrDisplayNameEmpty):
 				writeClaimNameError(w, r, logger,
-					http.StatusBadRequest, "username_required", "username is required")
+					http.StatusBadRequest, "display_name_required", "display name is required")
 			default:
-				writeInternalError(w, r, logger, "error updating player username", err)
+				writeInternalError(w, r, logger, "error updating player displayName", err)
 			}
 
 			return

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -290,7 +290,7 @@ type quizLeaderboardResponse struct {
 func toEntryResponse(e game.LeaderboardEntry) quizLeaderboardEntryResponse {
 	return quizLeaderboardEntryResponse{
 		PlayerID:        e.PlayerID,
-		Username:        e.Username,
+		Username:        e.DisplayName,
 		Score:           e.Score,
 		Rank:            e.Rank,
 		IsCurrentPlayer: e.IsCurrentPlayer,
@@ -1087,7 +1087,7 @@ type playerResponse struct {
 func newPlayerResponse(p *auth.Player) playerResponse {
 	return playerResponse{
 		ID:              p.ID,
-		Username:        p.Username,
+		Username:        p.DisplayName,
 		IsAnonymous:     p.IsAnonymous(),
 		HasCustomName:   p.HasCustomName(),
 		IsAuthenticated: p.IsAuthenticated(),
@@ -1157,7 +1157,7 @@ func HandlePlayerClaimName(
 			return
 		}
 
-		updated, err := players.UpdatePlayerUsername(ctx, current.ID, req.Username)
+		updated, err := players.UpdatePlayerDisplayName(ctx, current.ID, req.Username)
 		if err != nil {
 			switch {
 			case errors.Is(err, auth.ErrUsernameTaken):

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -272,7 +272,7 @@ const leaderboardLimit = 10
 // positive signal to render the badge.
 type quizLeaderboardEntryResponse struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"username"`
+	DisplayName     string `json:"displayName"`
 	Score           int    `json:"score"`
 	Rank            int    `json:"rank"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
@@ -290,7 +290,7 @@ type quizLeaderboardResponse struct {
 func toEntryResponse(e game.LeaderboardEntry) quizLeaderboardEntryResponse {
 	return quizLeaderboardEntryResponse{
 		PlayerID:        e.PlayerID,
-		Username:        e.DisplayName,
+		DisplayName:     e.DisplayName,
 		Score:           e.Score,
 		Rank:            e.Rank,
 		IsCurrentPlayer: e.IsCurrentPlayer,
@@ -1077,7 +1077,7 @@ func HandleAnswerPost(logger *slog.Logger, service *game.Service) http.Handler {
 // claim-name modal on isAuthenticated.
 type playerResponse struct {
 	ID              int64  `json:"id"`
-	Username        string `json:"username"`
+	DisplayName     string `json:"displayName"`
 	IsAnonymous     bool   `json:"isAnonymous"`
 	HasCustomName   bool   `json:"hasCustomName"`
 	IsAuthenticated bool   `json:"isAuthenticated"`
@@ -1087,7 +1087,7 @@ type playerResponse struct {
 func newPlayerResponse(p *auth.Player) playerResponse {
 	return playerResponse{
 		ID:              p.ID,
-		Username:        p.DisplayName,
+		DisplayName:     p.DisplayName,
 		IsAnonymous:     p.IsAnonymous(),
 		HasCustomName:   p.HasCustomName(),
 		IsAuthenticated: p.IsAuthenticated(),
@@ -1131,7 +1131,7 @@ func HandlePlayerClaimName(
 	logger *slog.Logger, players auth.PlayerStore, gameService *game.Service,
 ) http.Handler {
 	type claimNameRequest struct {
-		Username string `json:"username"`
+		DisplayName string `json:"displayName"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1151,13 +1151,13 @@ func HandlePlayerClaimName(
 
 			return
 		}
-		if strings.TrimSpace(req.Username) == "" {
+		if strings.TrimSpace(req.DisplayName) == "" {
 			http.Error(w, "username is required", http.StatusBadRequest)
 
 			return
 		}
 
-		updated, err := players.UpdatePlayerDisplayName(ctx, current.ID, req.Username)
+		updated, err := players.UpdatePlayerDisplayName(ctx, current.ID, req.DisplayName)
 		if err != nil {
 			switch {
 			case errors.Is(err, auth.ErrUsernameTaken):

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -1379,7 +1379,7 @@ func TestHandleGameResults(t *testing.T) {
 // flat (revive's nested-structs rule).
 type leaderboardTestEntry struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"username"`
+	DisplayName     string `json:"displayName"`
 	Score           int    `json:"score"`
 	Rank            int    `json:"rank"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
@@ -1464,8 +1464,8 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 			t.Fatalf("len(entries) = %d, want %d", got, want)
 		}
 		// bob (2000) should outrank alice (1000).
-		if got, want := body.Entries[0].Username, "bob"; got != want {
-			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		if got, want := body.Entries[0].DisplayName, "bob"; got != want {
+			t.Errorf("entries[0].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := body.Entries[0].Rank, 1; got != want {
 			t.Errorf("entries[0].Rank = %d, want %d", got, want)
@@ -1473,8 +1473,8 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 		if got, want := body.Entries[0].IsCurrentPlayer, false; got != want {
 			t.Errorf("entries[0].IsCurrentPlayer = %v, want %v", got, want)
 		}
-		if got, want := body.Entries[1].Username, "alice"; got != want {
-			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		if got, want := body.Entries[1].DisplayName, "alice"; got != want {
+			t.Errorf("entries[1].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := body.Entries[1].Rank, 2; got != want {
 			t.Errorf("entries[1].Rank = %d, want %d", got, want)

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -1401,13 +1401,13 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 	// black-box test does not need an exported builder. The 10s window with
 	// answeredOffset=0 yields a 1000-point CalculateScore for a correct
 	// answer and 0 for a wrong one.
-	makeAnswer := func(playerID int64, username string, correct bool) *game.LeaderboardAnswer {
+	makeAnswer := func(playerID int64, displayName string, correct bool) *game.LeaderboardAnswer {
 		const window = 10 * time.Second
 		start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 
 		return &game.LeaderboardAnswer{
 			PlayerID:          playerID,
-			DisplayName:       username,
+			DisplayName:       displayName,
 			QuestionStartedAt: start,
 			QuestionExpiredAt: start.Add(window),
 			AnsweredAt:        start,

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -21,7 +21,7 @@ import (
 // when the test exercises a handler that pulls the player off the context
 // (typically because EnsurePlayer would do so in production).
 func withPlayer(ctx context.Context, id int64) context.Context {
-	return auth.WithPlayer(ctx, &auth.Player{ID: id, Username: "stub", Role: auth.RolePlayer})
+	return auth.WithPlayer(ctx, &auth.Player{ID: id, DisplayName: "stub", Role: auth.RolePlayer})
 }
 
 var errStub = errors.New("stub error")
@@ -334,7 +334,7 @@ func (s stubGameStore) ListParticipantsForQuizLeaderboard(
 		}
 		seen[a.PlayerID] = len(out)
 		out = append(out, &game.LeaderboardParticipant{
-			PlayerID: a.PlayerID, Username: a.Username, IsCompleted: a.IsCompleted,
+			PlayerID: a.PlayerID, DisplayName: a.DisplayName, IsCompleted: a.IsCompleted,
 		})
 	}
 
@@ -1407,7 +1407,7 @@ func TestHandleQuizLeaderboard(t *testing.T) {
 
 		return &game.LeaderboardAnswer{
 			PlayerID:          playerID,
-			Username:          username,
+			DisplayName:       username,
 			QuestionStartedAt: start,
 			QuestionExpiredAt: start.Add(window),
 			AnsweredAt:        start,

--- a/internal/db/admin.sql.go
+++ b/internal/db/admin.sql.go
@@ -81,7 +81,7 @@ func (q *Queries) CountPlayersInOnboardingState(ctx context.Context, state strin
 }
 
 const createPlayerByAdmin = `-- name: CreatePlayerByAdmin :one
-INSERT INTO players (username, email, password_hash, email_verified_at, role, username_claimed)
+INSERT INTO players (display_name, email, password_hash, email_verified_at, role, display_name_claimed)
 VALUES (
     ?1,
     ?2,
@@ -90,11 +90,11 @@ VALUES (
     'player',
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type CreatePlayerByAdminParams struct {
-	Username     string
+	DisplayName  string
 	Email        sql.NullString
 	PasswordHash sql.NullString
 }
@@ -106,16 +106,16 @@ type CreatePlayerByAdminParams struct {
 // the row can log in immediately. role is fixed to 'player' - the admin
 // promotion CASE only fires on the public register/oauth paths.
 func (q *Queries) CreatePlayerByAdmin(ctx context.Context, arg CreatePlayerByAdminParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, createPlayerByAdmin, arg.Username, arg.Email, arg.PasswordHash)
+	row := q.db.QueryRowContext(ctx, createPlayerByAdmin, arg.DisplayName, arg.Email, arg.PasswordHash)
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -125,7 +125,7 @@ func (q *Queries) CreatePlayerByAdmin(ctx context.Context, arg CreatePlayerByAdm
 
 const getPlayerWithOnboardingState = `-- name: GetPlayerWithOnboardingState :one
 SELECT
-    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at, p.session_version, p.role_changed_at,
+    p.id, p.display_name, p.email, p.password_hash, p.role, p.created_at, p.display_name_claimed, p.email_verified_at, p.session_version, p.role_changed_at,
     EXISTS (SELECT 1 FROM player_identities pi WHERE pi.player_id = p.id) AS has_oauth,
     CAST(COALESCE(
         (SELECT pi.provider FROM player_identities pi WHERE pi.player_id = p.id ORDER BY pi.provider LIMIT 1),
@@ -145,19 +145,19 @@ LIMIT 1
 `
 
 type GetPlayerWithOnboardingStateRow struct {
-	ID              int64
-	Username        string
-	Email           sql.NullString
-	PasswordHash    sql.NullString
-	Role            string
-	CreatedAt       time.Time
-	UsernameClaimed int64
-	EmailVerifiedAt sql.NullTime
-	SessionVersion  int64
-	RoleChangedAt   sql.NullTime
-	HasOauth        bool
-	OauthProvider   string
-	OnboardingState string
+	ID                 int64
+	DisplayName        string
+	Email              sql.NullString
+	PasswordHash       sql.NullString
+	Role               string
+	CreatedAt          time.Time
+	DisplayNameClaimed int64
+	EmailVerifiedAt    sql.NullTime
+	SessionVersion     int64
+	RoleChangedAt      sql.NullTime
+	HasOauth           bool
+	OauthProvider      string
+	OnboardingState    string
 }
 
 // Single-row variant used by the per-player detail view. Returns the
@@ -169,12 +169,12 @@ func (q *Queries) GetPlayerWithOnboardingState(ctx context.Context, id int64) (G
 	var i GetPlayerWithOnboardingStateRow
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -221,7 +221,7 @@ const listAdminAuditForTarget = `-- name: ListAdminAuditForTarget :many
 SELECT
     a.id,
     a.actor_player_id,
-    CAST(COALESCE(p.username, '') AS TEXT) AS actor_username,
+    CAST(COALESCE(p.display_name, '') AS TEXT) AS actor_display_name,
     a.target_player_id,
     a.action,
     a.payload,
@@ -239,13 +239,13 @@ type ListAdminAuditForTargetParams struct {
 }
 
 type ListAdminAuditForTargetRow struct {
-	ID             int64
-	ActorPlayerID  sql.NullInt64
-	ActorUsername  string
-	TargetPlayerID int64
-	Action         string
-	Payload        string
-	CreatedAt      time.Time
+	ID               int64
+	ActorPlayerID    sql.NullInt64
+	ActorDisplayName string
+	TargetPlayerID   int64
+	Action           string
+	Payload          string
+	CreatedAt        time.Time
 }
 
 // Returns the most-recent admin actions taken against the given target
@@ -265,7 +265,7 @@ func (q *Queries) ListAdminAuditForTarget(ctx context.Context, arg ListAdminAudi
 		if err := rows.Scan(
 			&i.ID,
 			&i.ActorPlayerID,
-			&i.ActorUsername,
+			&i.ActorDisplayName,
 			&i.TargetPlayerID,
 			&i.Action,
 			&i.Payload,
@@ -286,7 +286,7 @@ func (q *Queries) ListAdminAuditForTarget(ctx context.Context, arg ListAdminAudi
 
 const listPlayersByOnboardingState = `-- name: ListPlayersByOnboardingState :many
 SELECT
-    p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at, p.session_version, p.role_changed_at,
+    p.id, p.display_name, p.email, p.password_hash, p.role, p.created_at, p.display_name_claimed, p.email_verified_at, p.session_version, p.role_changed_at,
     EXISTS (SELECT 1 FROM player_identities pi WHERE pi.player_id = p.id) AS has_oauth,
     CAST(COALESCE(
         (SELECT pi.provider FROM player_identities pi WHERE pi.player_id = p.id ORDER BY pi.provider LIMIT 1),
@@ -322,19 +322,19 @@ type ListPlayersByOnboardingStateParams struct {
 }
 
 type ListPlayersByOnboardingStateRow struct {
-	ID              int64
-	Username        string
-	Email           sql.NullString
-	PasswordHash    sql.NullString
-	Role            string
-	CreatedAt       time.Time
-	UsernameClaimed int64
-	EmailVerifiedAt sql.NullTime
-	SessionVersion  int64
-	RoleChangedAt   sql.NullTime
-	HasOauth        bool
-	OauthProvider   string
-	OnboardingState string
+	ID                 int64
+	DisplayName        string
+	Email              sql.NullString
+	PasswordHash       sql.NullString
+	Role               string
+	CreatedAt          time.Time
+	DisplayNameClaimed int64
+	EmailVerifiedAt    sql.NullTime
+	SessionVersion     int64
+	RoleChangedAt      sql.NullTime
+	HasOauth           bool
+	OauthProvider      string
+	OnboardingState    string
 }
 
 // Page of players ordered by created_at DESC for the admin list (#450).
@@ -355,12 +355,12 @@ func (q *Queries) ListPlayersByOnboardingState(ctx context.Context, arg ListPlay
 		var i ListPlayersByOnboardingStateRow
 		if err := rows.Scan(
 			&i.ID,
-			&i.Username,
+			&i.DisplayName,
 			&i.Email,
 			&i.PasswordHash,
 			&i.Role,
 			&i.CreatedAt,
-			&i.UsernameClaimed,
+			&i.DisplayNameClaimed,
 			&i.EmailVerifiedAt,
 			&i.SessionVersion,
 			&i.RoleChangedAt,

--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -317,7 +317,7 @@ func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlaye
 }
 
 const getPlayer = `-- name: GetPlayer :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+SELECT id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 FROM players
 WHERE id = ?
 `
@@ -327,12 +327,12 @@ func (q *Queries) GetPlayer(ctx context.Context, id int64) (Player, error) {
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -420,7 +420,7 @@ func (q *Queries) ListAnswersByGameQuestionID(ctx context.Context, gameQuestionI
 
 const listAnswersForQuizLeaderboard = `-- name: ListAnswersForQuizLeaderboard :many
 SELECT ga.player_id        AS player_id,
-       p.username           AS username,
+       p.display_name           AS display_name,
        gq.started_at        AS question_started_at,
        gq.expired_at        AS question_expired_at,
        ga.answered_at       AS answered_at,
@@ -439,7 +439,7 @@ WHERE g.quiz_id = ?
 
 type ListAnswersForQuizLeaderboardRow struct {
 	PlayerID          int64
-	Username          string
+	DisplayName       string
 	QuestionStartedAt time.Time
 	QuestionExpiredAt time.Time
 	AnsweredAt        time.Time
@@ -469,7 +469,7 @@ func (q *Queries) ListAnswersForQuizLeaderboard(ctx context.Context, quizID int6
 		var i ListAnswersForQuizLeaderboardRow
 		if err := rows.Scan(
 			&i.PlayerID,
-			&i.Username,
+			&i.DisplayName,
 			&i.QuestionStartedAt,
 			&i.QuestionExpiredAt,
 			&i.AnsweredAt,
@@ -674,7 +674,7 @@ func (q *Queries) ListParticipantsByGameID(ctx context.Context, gameID string) (
 
 const listParticipantsForQuizLeaderboard = `-- name: ListParticipantsForQuizLeaderboard :many
 SELECT gp.player_id AS player_id,
-       p.username   AS username,
+       p.display_name   AS display_name,
        CASE WHEN (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id) > 0
              AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = gp.game_id) >=
                  (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
@@ -699,7 +699,7 @@ type ListParticipantsForQuizLeaderboardParams struct {
 
 type ListParticipantsForQuizLeaderboardRow struct {
 	PlayerID    int64
-	Username    string
+	DisplayName string
 	IsCompleted int64
 	IsStale     int64
 }
@@ -723,7 +723,7 @@ func (q *Queries) ListParticipantsForQuizLeaderboard(ctx context.Context, arg Li
 		var i ListParticipantsForQuizLeaderboardRow
 		if err := rows.Scan(
 			&i.PlayerID,
-			&i.Username,
+			&i.DisplayName,
 			&i.IsCompleted,
 			&i.IsStale,
 		); err != nil {

--- a/internal/db/home.sql.go
+++ b/internal/db/home.sql.go
@@ -12,23 +12,23 @@ import (
 
 const listMostActivePlayers = `-- name: ListMostActivePlayers :many
 SELECT p.id              AS id,
-       p.username        AS username,
+       p.display_name        AS display_name,
        COUNT(DISTINCT g.id) AS finished_count
 FROM players p
 JOIN game_participants gp ON gp.player_id = p.id
 JOIN games g ON g.id = gp.game_id
 WHERE g.created_at >= datetime('now', '-30 days')
-  AND p.username_claimed = 1
+  AND p.display_name_claimed = 1
   AND EXISTS (SELECT 1 FROM questions qe WHERE qe.quiz_id = g.quiz_id)
   AND (SELECT COUNT(*) FROM game_questions gq WHERE gq.game_id = g.id) >=
       (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
 GROUP BY p.id
-ORDER BY finished_count DESC, p.username ASC
+ORDER BY finished_count DESC, p.display_name ASC
 `
 
 type ListMostActivePlayersRow struct {
 	ID            int64
-	Username      string
+	DisplayName   string
 	FinishedCount int64
 }
 
@@ -40,7 +40,7 @@ type ListMostActivePlayersRow struct {
 // and a long-dormant player could outrank a current one (#355).
 //
 // Anonymous (auto-petname) players are filtered out via
-// username_claimed = 1 so the public list only shows names a player
+// display_name_claimed = 1 so the public list only shows names a player
 // deliberately picked. The start-page leaderboard would otherwise be
 // cluttered with throwaway "happy-banana-xyz" entries from one-shot
 // visitors.
@@ -58,7 +58,7 @@ func (q *Queries) ListMostActivePlayers(ctx context.Context) ([]ListMostActivePl
 	var items []ListMostActivePlayersRow
 	for rows.Next() {
 		var i ListMostActivePlayersRow
-		if err := rows.Scan(&i.ID, &i.Username, &i.FinishedCount); err != nil {
+		if err := rows.Scan(&i.ID, &i.DisplayName, &i.FinishedCount); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/invites.sql.go
+++ b/internal/db/invites.sql.go
@@ -131,7 +131,7 @@ SELECT
     invites.id,
     invites.email,
     invites.invited_by_player_id,
-    players.username AS inviter_username,
+    players.display_name AS inviter_display_name,
     invites.created_at,
     invites.expires_at
 FROM invites
@@ -141,17 +141,17 @@ ORDER BY invites.created_at DESC, invites.id DESC
 `
 
 type ListPendingInvitesRow struct {
-	ID                int64
-	Email             string
-	InvitedByPlayerID sql.NullInt64
-	InviterUsername   sql.NullString
-	CreatedAt         time.Time
-	ExpiresAt         time.Time
+	ID                 int64
+	Email              string
+	InvitedByPlayerID  sql.NullInt64
+	InviterDisplayName sql.NullString
+	CreatedAt          time.Time
+	ExpiresAt          time.Time
 }
 
 // Lists every still-pending invite for the admin management view (#318),
-// newest first. LEFT JOIN players surfaces the inviter's username for the
-// "invited by X" column; inviter_username is NULL when the invite carries
+// newest first. LEFT JOIN players surfaces the inviter's display_name for the
+// "invited by X" column; inviter_display_name is NULL when the invite carries
 // no actor (invited_by_player_id NULL) or the inviting admin's row has since
 // been deleted (ON DELETE SET NULL). Includes still-expired-but-not-swept
 // rows so the list matches what the sweep has actually pruned; the template
@@ -169,7 +169,7 @@ func (q *Queries) ListPendingInvites(ctx context.Context) ([]ListPendingInvitesR
 			&i.ID,
 			&i.Email,
 			&i.InvitedByPlayerID,
-			&i.InviterUsername,
+			&i.InviterDisplayName,
 			&i.CreatedAt,
 			&i.ExpiresAt,
 		); err != nil {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -94,16 +94,16 @@ type PasswordResetToken struct {
 }
 
 type Player struct {
-	ID              int64
-	Username        string
-	Email           sql.NullString
-	PasswordHash    sql.NullString
-	Role            string
-	CreatedAt       time.Time
-	UsernameClaimed int64
-	EmailVerifiedAt sql.NullTime
-	SessionVersion  int64
-	RoleChangedAt   sql.NullTime
+	ID                 int64
+	DisplayName        string
+	Email              sql.NullString
+	PasswordHash       sql.NullString
+	Role               string
+	CreatedAt          time.Time
+	DisplayNameClaimed int64
+	EmailVerifiedAt    sql.NullTime
+	SessionVersion     int64
+	RoleChangedAt      sql.NullTime
 }
 
 type PlayerIdentity struct {

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -14,7 +14,7 @@ import (
 
 const claimPlayer = `-- name: ClaimPlayer :one
 UPDATE players
-SET username = ?1,
+SET display_name = ?1,
     password_hash = ?2,
     email = ?3,
     role = CASE
@@ -35,15 +35,15 @@ SET username = ?1,
         ) THEN CURRENT_TIMESTAMP
         ELSE NULL
     END,
-    username_claimed = 1
+    display_name_claimed = 1
 WHERE players.id = ?5
   AND players.password_hash IS NULL
   AND players.email IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type ClaimPlayerParams struct {
-	Username      string
+	DisplayName   string
 	PasswordHash  sql.NullString
 	Email         sql.NullString
 	RequestedRole string
@@ -69,14 +69,14 @@ type ClaimPlayerParams struct {
 // claim path lands on Admin. Host is never granted at registration.
 // role_changed_at is stamped when the row becomes admin.
 //
-// username_claimed is set to 1 because the visitor is explicitly choosing
-// their username via the register form. This is the register-after-playing
+// display_name_claimed is set to 1 because the visitor is explicitly choosing
+// their display_name via the register form. This is the register-after-playing
 // path: the row now represents a player who picked their own name, so it
 // must look identical to a CreatePlayerWithCredentials row to downstream
 // callers.
 func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, claimPlayer,
-		arg.Username,
+		arg.DisplayName,
 		arg.PasswordHash,
 		arg.Email,
 		arg.RequestedRole,
@@ -85,12 +85,12 @@ func (q *Queries) ClaimPlayer(ctx context.Context, arg ClaimPlayerParams) (Playe
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -121,7 +121,7 @@ SET email = ?1,
 WHERE players.id = ?2
   AND players.password_hash IS NULL
   AND players.email IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type ClaimPlayerForOAuthParams struct {
@@ -132,8 +132,8 @@ type ClaimPlayerForOAuthParams struct {
 // Upgrades a fully anonymous players row (no password_hash, no email)
 // in place by attaching the OAuth-verified email. Lets a visitor who
 // played anonymously keep their existing player_id (and therefore
-// their game history and any custom username) when they sign in with
-// Google for the first time. The username is left untouched: the
+// their game history and any custom display_name) when they sign in with
+// Google for the first time. The display_name is left untouched: the
 // visitor's auto-petname or PATCH-claimed name carries through onto
 // the OAuth-linked row.
 //
@@ -154,12 +154,12 @@ func (q *Queries) ClaimPlayerForOAuth(ctx context.Context, arg ClaimPlayerForOAu
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -250,9 +250,9 @@ func (q *Queries) CountAdmins(ctx context.Context) (int64, error) {
 }
 
 const createAnonymousPlayer = `-- name: CreateAnonymousPlayer :one
-INSERT INTO players (username, role)
+INSERT INTO players (display_name, role)
 VALUES (?1, 'player')
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 // Used by the EnsurePlayer middleware to back a fresh visitor with a real
@@ -261,20 +261,20 @@ RETURNING id, username, email, password_hash, role, created_at, username_claimed
 // becomes admin" SQL above filters by password_hash IS NOT NULL, so an
 // anonymous row never qualifies for promotion.
 //
-// username_claimed defaults to 0: the auto-generated petname is not a name
+// display_name_claimed defaults to 0: the auto-generated petname is not a name
 // the visitor picked, so the row is unclaimed until they rename via the
 // PATCH /api/players/me endpoint or sign up through ClaimPlayer below.
-func (q *Queries) CreateAnonymousPlayer(ctx context.Context, username string) (Player, error) {
-	row := q.db.QueryRowContext(ctx, createAnonymousPlayer, username)
+func (q *Queries) CreateAnonymousPlayer(ctx context.Context, displayName string) (Player, error) {
+	row := q.db.QueryRowContext(ctx, createAnonymousPlayer, displayName)
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -334,7 +334,7 @@ func (q *Queries) CreatePasswordResetToken(ctx context.Context, arg CreatePasswo
 }
 
 const createPlayerFromOAuth = `-- name: CreatePlayerFromOAuth :one
-INSERT INTO players (username, email, email_verified_at, role, role_changed_at, username_claimed)
+INSERT INTO players (display_name, email, email_verified_at, role, role_changed_at, display_name_claimed)
 VALUES (
     ?1,
     ?2,
@@ -357,17 +357,17 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type CreatePlayerFromOAuthParams struct {
-	Username string
-	Email    sql.NullString
+	DisplayName string
+	Email       sql.NullString
 }
 
 // Insert a brand-new player row for a first-time OAuth sign-in. No
 // password_hash (the player has no local credential), email comes from
-// the verified id-token claim, username_claimed is set to 1 because the
+// the verified id-token claim, display_name_claimed is set to 1 because the
 // caller supplies an auto-generated petname that the player will be
 // prompted to change via the existing claim-name modal.
 //
@@ -381,16 +381,16 @@ type CreatePlayerFromOAuthParams struct {
 // the second-and-onward Google sign-ins on a fresh DB would all see
 // count(password_hash IS NOT NULL) == 0 and become admin.
 func (q *Queries) CreatePlayerFromOAuth(ctx context.Context, arg CreatePlayerFromOAuthParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, createPlayerFromOAuth, arg.Username, arg.Email)
+	row := q.db.QueryRowContext(ctx, createPlayerFromOAuth, arg.DisplayName, arg.Email)
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -399,7 +399,7 @@ func (q *Queries) CreatePlayerFromOAuth(ctx context.Context, arg CreatePlayerFro
 }
 
 const createPlayerWithCredentials = `-- name: CreatePlayerWithCredentials :one
-INSERT INTO players (username, password_hash, email, role, role_changed_at, username_claimed)
+INSERT INTO players (display_name, password_hash, email, role, role_changed_at, display_name_claimed)
 VALUES (
     ?1,
     ?2,
@@ -424,11 +424,11 @@ VALUES (
     END,
     1
 )
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type CreatePlayerWithCredentialsParams struct {
-	Username      string
+	DisplayName   string
 	PasswordHash  sql.NullString
 	Email         sql.NullString
 	RequestedRole string
@@ -456,13 +456,13 @@ type CreatePlayerWithCredentialsParams struct {
 // stamped only when the row is written as admin, so the settings list can show
 // a "promoted" timestamp.
 //
-// username_claimed is set to 1 because a registering user explicitly chose
-// their username at the register form. The column tracks "did the player
+// display_name_claimed is set to 1 because a registering user explicitly chose
+// their display_name at the register form. The column tracks "did the player
 // pick this name themselves" (vs auto-generated petname), so a fresh
 // registrant must be marked as claimed from the moment the row is written.
 func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePlayerWithCredentialsParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, createPlayerWithCredentials,
-		arg.Username,
+		arg.DisplayName,
 		arg.PasswordHash,
 		arg.Email,
 		arg.RequestedRole,
@@ -470,12 +470,12 @@ func (q *Queries) CreatePlayerWithCredentials(ctx context.Context, arg CreatePla
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -555,8 +555,33 @@ func (q *Queries) GetPasswordResetToken(ctx context.Context, tokenHash string) (
 	return i, err
 }
 
+const getPlayerByDisplayName = `-- name: GetPlayerByDisplayName :one
+SELECT id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
+FROM players
+WHERE display_name = ?
+LIMIT 1
+`
+
+func (q *Queries) GetPlayerByDisplayName(ctx context.Context, displayName string) (Player, error) {
+	row := q.db.QueryRowContext(ctx, getPlayerByDisplayName, displayName)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.DisplayName,
+		&i.Email,
+		&i.PasswordHash,
+		&i.Role,
+		&i.CreatedAt,
+		&i.DisplayNameClaimed,
+		&i.EmailVerifiedAt,
+		&i.SessionVersion,
+		&i.RoleChangedAt,
+	)
+	return i, err
+}
+
 const getPlayerByEmail = `-- name: GetPlayerByEmail :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+SELECT id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 FROM players
 WHERE email = ?
 LIMIT 1
@@ -571,12 +596,12 @@ func (q *Queries) GetPlayerByEmail(ctx context.Context, email sql.NullString) (P
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -585,7 +610,7 @@ func (q *Queries) GetPlayerByEmail(ctx context.Context, email sql.NullString) (P
 }
 
 const getPlayerByProviderSubject = `-- name: GetPlayerByProviderSubject :one
-SELECT p.id, p.username, p.email, p.password_hash, p.role, p.created_at, p.username_claimed, p.email_verified_at, p.session_version, p.role_changed_at
+SELECT p.id, p.display_name, p.email, p.password_hash, p.role, p.created_at, p.display_name_claimed, p.email_verified_at, p.session_version, p.role_changed_at
 FROM players p
 JOIN player_identities pi ON pi.player_id = p.id
 WHERE pi.provider = ? AND pi.subject = ?
@@ -606,37 +631,12 @@ func (q *Queries) GetPlayerByProviderSubject(ctx context.Context, arg GetPlayerB
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
-		&i.EmailVerifiedAt,
-		&i.SessionVersion,
-		&i.RoleChangedAt,
-	)
-	return i, err
-}
-
-const getPlayerByUsername = `-- name: GetPlayerByUsername :one
-SELECT id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
-FROM players
-WHERE username = ?
-LIMIT 1
-`
-
-func (q *Queries) GetPlayerByUsername(ctx context.Context, username string) (Player, error) {
-	row := q.db.QueryRowContext(ctx, getPlayerByUsername, username)
-	var i Player
-	err := row.Scan(
-		&i.ID,
-		&i.Username,
-		&i.Email,
-		&i.PasswordHash,
-		&i.Role,
-		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -666,20 +666,20 @@ func (q *Queries) LinkProviderIdentity(ctx context.Context, arg LinkProviderIden
 }
 
 const listAdmins = `-- name: ListAdmins :many
-SELECT id, username, email, role_changed_at
+SELECT id, display_name, email, role_changed_at
 FROM players
 WHERE role = 'admin'
-ORDER BY username, id
+ORDER BY display_name, id
 `
 
 type ListAdminsRow struct {
 	ID            int64
-	Username      string
+	DisplayName   string
 	Email         sql.NullString
 	RoleChangedAt sql.NullTime
 }
 
-// Every current Admin, ordered by username so the admin settings page
+// Every current Admin, ordered by display_name so the admin settings page
 // (#320/#538) renders a stable list. Only the columns the list needs are
 // selected. role_changed_at is when the role last changed (NULL for rows whose
 // role predates the column).
@@ -694,7 +694,7 @@ func (q *Queries) ListAdmins(ctx context.Context) ([]ListAdminsRow, error) {
 		var i ListAdminsRow
 		if err := rows.Scan(
 			&i.ID,
-			&i.Username,
+			&i.DisplayName,
 			&i.Email,
 			&i.RoleChangedAt,
 		); err != nil {
@@ -795,40 +795,40 @@ func (q *Queries) MarkPlayerEmailVerifiedIfNew(ctx context.Context, id int64) (i
 
 const renamePlayer = `-- name: RenamePlayer :one
 UPDATE players
-SET username = ?1,
-    username_claimed = 1
+SET display_name = ?1,
+    display_name_claimed = 1
 WHERE id = ?2
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
 type RenamePlayerParams struct {
-	Username string
-	ID       int64
+	DisplayName string
+	ID          int64
 }
 
 // Renames any player row by id, regardless of password / email / role.
 // The dedicated profile-page endpoint (POST /profile/username, #410)
 // uses this so authenticated players (password, OAuth, admin) can
 // change their display name. Anonymous rows have their own narrower
-// path via UpdatePlayerUsername above; this query is intentionally
+// path via UpdatePlayerDisplayName above; this query is intentionally
 // not gated by password_hash so the OAuth-only and admin cases also
 // work.
 //
 // Returns the updated row when one was affected; the store wrapper
 // maps sql.ErrNoRows to ErrPlayerNotFound and a UNIQUE constraint
-// failure on players.username to ErrUsernameTaken so the handler can
+// failure on players.display_name to ErrUsernameTaken so the handler can
 // map both onto user-facing form errors.
 func (q *Queries) RenamePlayer(ctx context.Context, arg RenamePlayerParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, renamePlayer, arg.Username, arg.ID)
+	row := q.db.QueryRowContext(ctx, renamePlayer, arg.DisplayName, arg.ID)
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,
@@ -865,7 +865,7 @@ func (q *Queries) ResetPlayerPassword(ctx context.Context, arg ResetPlayerPasswo
 const setPlayerPasswordHash = `-- name: SetPlayerPasswordHash :execrows
 UPDATE players
 SET password_hash    = ?1,
-    username_claimed = 1
+    display_name_claimed = 1
 WHERE email = ?2
 `
 
@@ -875,17 +875,17 @@ type SetPlayerPasswordHashParams struct {
 }
 
 // Used by the cmd/server -reset-password operator tool to rotate a single
-// player's password without disturbing username / role / email. Returns the
+// player's password without disturbing display_name / role / email. Returns the
 // number of affected rows so the caller can map "no rows" to an "email
 // not found" error. The lookup is by email (the post-#446 login credential)
 // so the operator's reset target matches what the player types into /login.
 //
-// username_claimed is set to 1 alongside the password because once an
-// operator has set a password on a row, the username is no longer an
+// display_name_claimed is set to 1 alongside the password because once an
+// operator has set a password on a row, the display_name is no longer an
 // auto-assigned petname the player should be nudged to replace (#289). The
 // migration 20260511120000 ran the same backfill at the time, but only for
 // rows that already had a password_hash; later password sets via this
-// query previously left username_claimed at 0, which made the seed
+// query previously left display_name_claimed at 0, which made the seed
 // admin (id=1) keep popping the claim-name modal in the player client.
 func (q *Queries) SetPlayerPasswordHash(ctx context.Context, arg SetPlayerPasswordHashParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, setPlayerPasswordHash, arg.PasswordHash, arg.Email)
@@ -952,42 +952,42 @@ func (q *Queries) SwapPlayerEmail(ctx context.Context, arg SwapPlayerEmailParams
 	return result.RowsAffected()
 }
 
-const updatePlayerUsername = `-- name: UpdatePlayerUsername :one
+const updatePlayerDisplayName = `-- name: UpdatePlayerDisplayName :one
 UPDATE players
-SET username = ?1,
-    username_claimed = 1
+SET display_name = ?1,
+    display_name_claimed = 1
 WHERE id = ?2 AND password_hash IS NULL
-RETURNING id, username, email, password_hash, role, created_at, username_claimed, email_verified_at, session_version, role_changed_at
+RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
 `
 
-type UpdatePlayerUsernameParams struct {
-	Username string
-	ID       int64
+type UpdatePlayerDisplayNameParams struct {
+	DisplayName string
+	ID          int64
 }
 
-// Updates the username on an anonymous player row in place. The WHERE
+// Updates the display_name on an anonymous player row in place. The WHERE
 // clause refuses the update when the player has already claimed a
 // non-anonymous identity (password_hash IS NOT NULL), so the SQL is the
 // atomic guard against a stale anonymous check in the service layer.
 // Returns the updated row when one was affected; the wrapper distinguishes
-// "not anonymous anymore" (sql.ErrNoRows) from "username collision"
-// (UNIQUE constraint failure on players.username).
+// "not anonymous anymore" (sql.ErrNoRows) from "display_name collision"
+// (UNIQUE constraint failure on players.display_name).
 //
-// username_claimed is set to 1 because this is the dedicated claim-name
+// display_name_claimed is set to 1 because this is the dedicated claim-name
 // endpoint (PATCH /api/players/me); the visitor is explicitly picking
 // their display name. After this update the row reads as "player chose
 // this name" identically to the credentialled-registration path.
-func (q *Queries) UpdatePlayerUsername(ctx context.Context, arg UpdatePlayerUsernameParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, updatePlayerUsername, arg.Username, arg.ID)
+func (q *Queries) UpdatePlayerDisplayName(ctx context.Context, arg UpdatePlayerDisplayNameParams) (Player, error) {
+	row := q.db.QueryRowContext(ctx, updatePlayerDisplayName, arg.DisplayName, arg.ID)
 	var i Player
 	err := row.Scan(
 		&i.ID,
-		&i.Username,
+		&i.DisplayName,
 		&i.Email,
 		&i.PasswordHash,
 		&i.Role,
 		&i.CreatedAt,
-		&i.UsernameClaimed,
+		&i.DisplayNameClaimed,
 		&i.EmailVerifiedAt,
 		&i.SessionVersion,
 		&i.RoleChangedAt,

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -807,7 +807,7 @@ type RenamePlayerParams struct {
 }
 
 // Renames any player row by id, regardless of password / email / role.
-// The dedicated profile-page endpoint (POST /profile/username, #410)
+// The dedicated profile-page endpoint (POST /profile/display-name, #410)
 // uses this so authenticated players (password, OAuth, admin) can
 // change their display name. Anonymous rows have their own narrower
 // path via UpdatePlayerDisplayName above; this query is intentionally
@@ -816,7 +816,7 @@ type RenamePlayerParams struct {
 //
 // Returns the updated row when one was affected; the store wrapper
 // maps sql.ErrNoRows to ErrPlayerNotFound and a UNIQUE constraint
-// failure on players.display_name to ErrUsernameTaken so the handler can
+// failure on players.display_name to ErrDisplayNameTaken so the handler can
 // map both onto user-facing form errors.
 func (q *Queries) RenamePlayer(ctx context.Context, arg RenamePlayerParams) (Player, error) {
 	row := q.db.QueryRowContext(ctx, renamePlayer, arg.DisplayName, arg.ID)

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -239,7 +239,7 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 WHERE q.id = ?
@@ -247,20 +247,20 @@ LIMIT 1
 `
 
 type GetQuizRow struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	CreatedByPlayerID int64
-	TimeLimitSeconds  int64
-	Visibility        string
-	CreatedByUsername string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CreatedByPlayerID    int64
+	TimeLimitSeconds     int64
+	Visibility           string
+	CreatedByDisplayName string
 }
 
 // Same INNER JOIN as ListQuizzes so single-quiz fetches carry the
-// creator's username for the admin view's "Created by ..." line. See
+// creator's display_name for the admin view's "Created by ..." line. See
 // ListQuizzes for why the LEFT JOIN was dropped (#359).
 func (q *Queries) GetQuiz(ctx context.Context, id int64) (GetQuizRow, error) {
 	row := q.db.QueryRowContext(ctx, getQuiz, id)
@@ -275,7 +275,7 @@ func (q *Queries) GetQuiz(ctx context.Context, id int64) (GetQuizRow, error) {
 		&i.CreatedByPlayerID,
 		&i.TimeLimitSeconds,
 		&i.Visibility,
-		&i.CreatedByUsername,
+		&i.CreatedByDisplayName,
 	)
 	return i, err
 }
@@ -353,7 +353,7 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 WHERE q.visibility = 'public'
@@ -361,16 +361,16 @@ ORDER BY q.updated_at DESC, q.id DESC
 `
 
 type ListPublicQuizzesRow struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	CreatedByPlayerID int64
-	TimeLimitSeconds  int64
-	Visibility        string
-	CreatedByUsername string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CreatedByPlayerID    int64
+	TimeLimitSeconds     int64
+	Visibility           string
+	CreatedByDisplayName string
 }
 
 // Public-facing variant of ListQuizzes (#103). Filters to visibility =
@@ -395,7 +395,7 @@ func (q *Queries) ListPublicQuizzes(ctx context.Context) ([]ListPublicQuizzesRow
 			&i.CreatedByPlayerID,
 			&i.TimeLimitSeconds,
 			&i.Visibility,
-			&i.CreatedByUsername,
+			&i.CreatedByDisplayName,
 		); err != nil {
 			return nil, err
 		}
@@ -488,23 +488,23 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 ORDER BY q.updated_at DESC, q.id DESC
 `
 
 type ListQuizzesRow struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	CreatedByPlayerID int64
-	TimeLimitSeconds  int64
-	Visibility        string
-	CreatedByUsername string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CreatedByPlayerID    int64
+	TimeLimitSeconds     int64
+	Visibility           string
+	CreatedByDisplayName string
 }
 
 // INNER JOIN on players so the admin list can render "Created by ..."
@@ -539,7 +539,7 @@ func (q *Queries) ListQuizzes(ctx context.Context) ([]ListQuizzesRow, error) {
 			&i.CreatedByPlayerID,
 			&i.TimeLimitSeconds,
 			&i.Visibility,
-			&i.CreatedByUsername,
+			&i.CreatedByDisplayName,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -91,10 +91,10 @@ type Game struct {
 
 // Player represents a player.
 type Player struct {
-	ID        int64
-	Username  string
-	Email     string
-	CreatedAt time.Time
+	ID          int64
+	DisplayName string
+	Email       string
+	CreatedAt   time.Time
 }
 
 // Participant represents a player participating in a game. QuizID is
@@ -238,7 +238,7 @@ type Results struct {
 // predicate on it.
 type LeaderboardAnswer struct {
 	PlayerID          int64
-	Username          string
+	DisplayName       string
 	QuestionStartedAt time.Time
 	QuestionExpiredAt time.Time
 	AnsweredAt        time.Time
@@ -255,8 +255,8 @@ type LeaderboardAnswer struct {
 // in the per-answer scoring inputs from
 // [Store.ListAnswersForQuizLeaderboard].
 type LeaderboardParticipant struct {
-	PlayerID int64
-	Username string
+	PlayerID    int64
+	DisplayName string
 	// IsCompleted: every quiz question has been issued to this game.
 	IsCompleted bool
 	// IsStale: latest game_question is unanswered and expired before
@@ -277,7 +277,7 @@ type LeaderboardParticipant struct {
 // InProgress; admin "Played by" filters on Completed.
 type LeaderboardEntry struct {
 	PlayerID        int64
-	Username        string
+	DisplayName     string
 	Score           int
 	Rank            int
 	IsCurrentPlayer bool
@@ -1101,7 +1101,7 @@ func (s *Service) GetQuizLeaderboard(
 	for _, p := range participants {
 		entries = append(entries, LeaderboardEntry{
 			PlayerID:        p.PlayerID,
-			Username:        p.Username,
+			DisplayName:     p.DisplayName,
 			Score:           playerTotals[p.PlayerID],
 			IsCurrentPlayer: p.PlayerID == currentPlayerID,
 			Completed:       p.IsCompleted,
@@ -1116,7 +1116,7 @@ func (s *Service) GetQuizLeaderboard(
 			return c
 		}
 
-		return strings.Compare(a.Username, b.Username)
+		return strings.Compare(a.DisplayName, b.DisplayName)
 	})
 
 	return finalizeLeaderboardInPlace(entries, currentPlayerID, limit), nil

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -232,7 +232,7 @@ type Results struct {
 
 // LeaderboardAnswer is a flat row for the per-quiz leaderboard. It
 // carries every field [Service.CalculateScore] needs plus the player's
-// username and ID, for both finished and in-progress games.
+// displayName and ID, for both finished and in-progress games.
 // IsCompleted is kept on the wire even though GetQuizLeaderboard no
 // longer reads it - the store-level test pins the completion
 // predicate on it.
@@ -248,7 +248,7 @@ type LeaderboardAnswer struct {
 
 // LeaderboardParticipant is the minimum needed to surface a player on
 // the live leaderboard before their first answer commits (#335):
-// player_id and username for the row, and the same is_completed flag
+// player_id and displayName for the row, and the same is_completed flag
 // the answer rows carry so the entry can be marked in-progress. The
 // store returns one of these per participant; [Service.GetQuizLeaderboard]
 // uses the list as the canonical set of leaderboard entries and folds
@@ -1044,7 +1044,7 @@ func (s *Service) GetResults(ctx context.Context, gameID string, playerID int64)
 
 // GetQuizLeaderboard returns the top scoring players for a quiz.
 // Mid-quiz players appear with their running partial score so the live
-// view shows everyone who has joined. Ties are broken by username so
+// view shows everyone who has joined. Ties are broken by displayName so
 // the ordering is stable across requests. currentPlayerID flags the
 // requester's entry (and drives CurrentPlayer when they fall outside
 // top-N, #181); pass 0 to flag nothing. limit defaults to 10.
@@ -1111,7 +1111,7 @@ func (s *Service) GetQuizLeaderboard(
 	}
 
 	slices.SortFunc(entries, func(a, b LeaderboardEntry) int {
-		// Higher scores first; ties broken by ascending username.
+		// Higher scores first; ties broken by ascending displayName.
 		if c := cmp.Compare(b.Score, a.Score); c != 0 {
 			return c
 		}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1243,20 +1243,20 @@ func TestService_CalculateScore_EarlyAnswerClamps(t *testing.T) {
 // makeAnswer produces a flat LeaderboardAnswer answered at the start of the
 // 10s answer window (matching defaultExpiration) so CalculateScore yields a
 // predictable maxPoints (1000) for a correct answer or 0 for a wrong one.
-func makeAnswer(playerID int64, username string, correct bool) *LeaderboardAnswer {
-	return makeAnswerCompleted(playerID, username, correct, true)
+func makeAnswer(playerID int64, displayName string, correct bool) *LeaderboardAnswer {
+	return makeAnswerCompleted(playerID, displayName, correct, true)
 }
 
 // makeAnswerCompleted is the long-form factory used by the #244
 // in-progress test cases. The default makeAnswer keeps IsCompleted=true
 // so existing tests don't need to know about the flag.
-func makeAnswerCompleted(playerID int64, username string, correct, isCompleted bool) *LeaderboardAnswer {
+func makeAnswerCompleted(playerID int64, displayName string, correct, isCompleted bool) *LeaderboardAnswer {
 	const window = 10 * time.Second
 	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	return &LeaderboardAnswer{
 		PlayerID:          playerID,
-		DisplayName:       username,
+		DisplayName:       displayName,
 		QuestionStartedAt: start,
 		QuestionExpiredAt: start.Add(window),
 		AnsweredAt:        start,
@@ -1502,14 +1502,14 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		}
 	})
 
-	t.Run("breaks ties by ascending username", func(t *testing.T) {
+	t.Run("breaks ties by ascending displayName", func(t *testing.T) {
 		t.Parallel()
 
 		svc := NewService(
 			stubStore{
 				listAnswersForQuizLeaderboard: func(_ context.Context, _ int64) ([]*LeaderboardAnswer, error) {
 					// Three players with identical 1000-point runs but
-					// usernames intentionally out of order.
+					// displayNames intentionally out of order.
 					return []*LeaderboardAnswer{
 						makeAnswer(1, "charlie", true),
 						makeAnswer(2, "alice", true),
@@ -1537,7 +1537,7 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		}
 		wantNames := []string{"alice", "bob", "charlie"}
 		if diff := cmp.Diff(wantNames, gotNames); diff != "" {
-			t.Errorf("username order mismatch (-want +got):\n%s", diff)
+			t.Errorf("displayName order mismatch (-want +got):\n%s", diff)
 		}
 	})
 

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -104,7 +104,7 @@ func (s stubStore) ListParticipantsForQuizLeaderboard(
 		}
 		seen[a.PlayerID] = len(out)
 		out = append(out, &LeaderboardParticipant{
-			PlayerID: a.PlayerID, Username: a.Username, IsCompleted: a.IsCompleted,
+			PlayerID: a.PlayerID, DisplayName: a.DisplayName, IsCompleted: a.IsCompleted,
 		})
 	}
 
@@ -756,7 +756,7 @@ func TestService_GetResults(t *testing.T) {
 			t.Fatalf("failed to get next question: %v", err)
 		}
 
-		insertPlayer2 := `INSERT INTO players (id, username, email, created_at) VALUES (2, 'player2', 'player2@test.com', CURRENT_TIMESTAMP)`
+		insertPlayer2 := `INSERT INTO players (id, display_name, email, created_at) VALUES (2, 'player2', 'player2@test.com', CURRENT_TIMESTAMP)`
 		if _, err = db.ExecContext(ctx, insertPlayer2); err != nil {
 			t.Fatalf("failed to insert player 2: %v", err)
 		}
@@ -817,7 +817,7 @@ func TestService_GetResults(t *testing.T) {
 			t.Fatalf("failed to get next question: %v", err)
 		}
 
-		insertPlayer2 := `INSERT INTO players (id, username, email, created_at) VALUES (2, 'player2', 'player2@test.com', CURRENT_TIMESTAMP)`
+		insertPlayer2 := `INSERT INTO players (id, display_name, email, created_at) VALUES (2, 'player2', 'player2@test.com', CURRENT_TIMESTAMP)`
 		if _, err = db.ExecContext(ctx, insertPlayer2); err != nil {
 			t.Fatalf("failed to insert player 2: %v", err)
 		}
@@ -1256,7 +1256,7 @@ func makeAnswerCompleted(playerID int64, username string, correct, isCompleted b
 
 	return &LeaderboardAnswer{
 		PlayerID:          playerID,
-		Username:          username,
+		DisplayName:       username,
 		QuestionStartedAt: start,
 		QuestionExpiredAt: start.Add(window),
 		AnsweredAt:        start,
@@ -1344,8 +1344,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		if got, want := result.Entries[0].PlayerID, int64(1); got != want {
 			t.Errorf("entries[0].PlayerID = %d, want %d", got, want)
 		}
-		if got, want := result.Entries[0].Username, "alice"; got != want {
-			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		if got, want := result.Entries[0].DisplayName, "alice"; got != want {
+			t.Errorf("entries[0].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := result.Entries[0].Score, 2000; got != want {
 			t.Errorf("entries[0].Score = %d, want %d", got, want)
@@ -1373,8 +1373,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 				listParticipantsForQuizLeaderboard: func(_ context.Context, _ int64, _ time.Time) ([]*LeaderboardParticipant, error) {
 					return []*LeaderboardParticipant{
-						{PlayerID: 1, Username: "alice", IsCompleted: false},
-						{PlayerID: 2, Username: "bob", IsCompleted: false},
+						{PlayerID: 1, DisplayName: "alice", IsCompleted: false},
+						{PlayerID: 2, DisplayName: "bob", IsCompleted: false},
 					}, nil
 				},
 			},
@@ -1393,8 +1393,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		if got, want := len(result.Entries), 2; got != want {
 			t.Fatalf("len(entries) = %d, want %d", got, want)
 		}
-		if got, want := result.Entries[0].Username, "bob"; got != want {
-			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		if got, want := result.Entries[0].DisplayName, "bob"; got != want {
+			t.Errorf("entries[0].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := result.Entries[0].Score, 2000; got != want {
 			t.Errorf("entries[0].Score = %d, want %d", got, want)
@@ -1405,8 +1405,8 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		if got, want := result.Entries[0].Completed, false; got != want {
 			t.Errorf("entries[0].Completed = %v, want %v (bob's participant row has IsCompleted=false)", got, want)
 		}
-		if got, want := result.Entries[1].Username, "alice"; got != want {
-			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		if got, want := result.Entries[1].DisplayName, "alice"; got != want {
+			t.Errorf("entries[1].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := result.Entries[1].Score, 0; got != want {
 			t.Errorf("entries[1].Score = %d, want %d (no-answer participant)", got, want)
@@ -1488,11 +1488,11 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 		if got, want := len(result.Entries), 2; got != want {
 			t.Fatalf("len(entries) = %d, want %d", got, want)
 		}
-		if got, want := result.Entries[0].Username, "bob"; got != want {
-			t.Errorf("entries[0].Username = %q, want %q", got, want)
+		if got, want := result.Entries[0].DisplayName, "bob"; got != want {
+			t.Errorf("entries[0].DisplayName = %q, want %q", got, want)
 		}
-		if got, want := result.Entries[1].Username, "alice"; got != want {
-			t.Errorf("entries[1].Username = %q, want %q", got, want)
+		if got, want := result.Entries[1].DisplayName, "alice"; got != want {
+			t.Errorf("entries[1].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := result.Entries[0].Rank, 1; got != want {
 			t.Errorf("entries[0].Rank = %d, want %d", got, want)
@@ -1530,7 +1530,11 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		gotNames := []string{result.Entries[0].Username, result.Entries[1].Username, result.Entries[2].Username}
+		gotNames := []string{
+			result.Entries[0].DisplayName,
+			result.Entries[1].DisplayName,
+			result.Entries[2].DisplayName,
+		}
 		wantNames := []string{"alice", "bob", "charlie"}
 		if diff := cmp.Diff(wantNames, gotNames); diff != "" {
 			t.Errorf("username order mismatch (-want +got):\n%s", diff)
@@ -1767,9 +1771,9 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 				},
 				listParticipantsForQuizLeaderboard: func(_ context.Context, _ int64, _ time.Time) ([]*LeaderboardParticipant, error) {
 					return []*LeaderboardParticipant{
-						{PlayerID: 1, Username: "alice", IsCompleted: false, IsStale: false},
-						{PlayerID: 2, Username: "bob", IsCompleted: true, IsStale: false},
-						{PlayerID: 3, Username: "carol", IsCompleted: false, IsStale: true},
+						{PlayerID: 1, DisplayName: "alice", IsCompleted: false, IsStale: false},
+						{PlayerID: 2, DisplayName: "bob", IsCompleted: true, IsStale: false},
+						{PlayerID: 3, DisplayName: "carol", IsCompleted: false, IsStale: true},
 					}, nil
 				},
 			},
@@ -1791,7 +1795,7 @@ func TestService_GetQuizLeaderboard(t *testing.T) {
 
 		byName := make(map[string]LeaderboardEntry, len(result.Entries))
 		for _, e := range result.Entries {
-			byName[e.Username] = e
+			byName[e.DisplayName] = e
 		}
 
 		alice := byName["alice"]

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -18,7 +18,7 @@ const (
 
 // maxJSONBodySize caps the request body for /api/* JSON endpoints. 64 KiB is
 // generous for the small request shapes the API accepts (a quiz ID, an option
-// ID, a username) and denies an unauthenticated client the ability to
+// ID, a displayName) and denies an unauthenticated client the ability to
 // exhaust memory by streaming a multi-megabyte body into [json.Decoder].
 const maxJSONBodySize = 64 * 1024
 

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -42,7 +42,7 @@ type PopularQuiz struct {
 // the request is anonymous (no session, or a session pointing at an
 // EnsurePlayer auto-petname row).
 type Viewer struct {
-	Username string
+	DisplayName string
 }
 
 // ViewerFunc resolves the signed-in player for a request, or returns
@@ -70,7 +70,7 @@ func (p PopularQuiz) PlayURL() string {
 // all quizzes; the template renders it as a coarse activity score.
 type ActivePlayer struct {
 	ID            int64
-	Username      string
+	DisplayName   string
 	FinishedCount int
 }
 
@@ -143,12 +143,12 @@ type QuizLister interface {
 // type - no behaviour beyond [AllQuizRow.PlayURL] - so the template
 // doesn't need to know anything about quiz.Quiz internals.
 type AllQuizRow struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	QuestionCount     int
-	CreatedByUsername string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	QuestionCount        int
+	CreatedByDisplayName string
 }
 
 // PlayURL is the share-able deep link the row card points at. Mirrors
@@ -203,12 +203,12 @@ func HandleAllQuizzes(
 		data.Quizzes = make([]*AllQuizRow, 0, len(quizzes))
 		for _, qz := range quizzes {
 			data.Quizzes = append(data.Quizzes, &AllQuizRow{
-				ID:                qz.ID,
-				Title:             qz.Title,
-				Slug:              qz.Slug,
-				Description:       qz.Description,
-				QuestionCount:     counts[qz.ID],
-				CreatedByUsername: qz.CreatedByUsername,
+				ID:                   qz.ID,
+				Title:                qz.Title,
+				Slug:                 qz.Slug,
+				Description:          qz.Description,
+				QuestionCount:        counts[qz.ID],
+				CreatedByDisplayName: qz.CreatedByDisplayName,
 			})
 		}
 

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -47,8 +47,8 @@ func TestHandle_RendersPopularAndActiveSections(t *testing.T) {
 			{ID: 9, Title: "Capital Cities", Slug: "capital-cities", Description: "Quickfire geography.", PlayCount: 3},
 		},
 		active: []*ActivePlayer{
-			{ID: 1, Username: "alice", FinishedCount: 4},
-			{ID: 2, Username: "bob", FinishedCount: 2},
+			{ID: 1, DisplayName: "alice", FinishedCount: 4},
+			{ID: 2, DisplayName: "bob", FinishedCount: 2},
 		},
 	}
 
@@ -81,7 +81,7 @@ func TestHandle_SingularPlayAndQuizPluralization(t *testing.T) {
 			{ID: 11, Title: "Solo", Slug: "solo", PlayCount: 1},
 		},
 		active: []*ActivePlayer{
-			{ID: 1, Username: "carol", FinishedCount: 1},
+			{ID: 1, DisplayName: "carol", FinishedCount: 1},
 		},
 	}
 	body := serve(t, store)

--- a/internal/migrations/20260601000000_rename_username_to_display_name.sql
+++ b/internal/migrations/20260601000000_rename_username_to_display_name.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE players RENAME COLUMN username TO display_name;
+ALTER TABLE players RENAME COLUMN username_claimed TO display_name_claimed;
+
+-- +goose Down
+ALTER TABLE players RENAME COLUMN display_name TO username;
+ALTER TABLE players RENAME COLUMN display_name_claimed TO username_claimed;

--- a/internal/profile/email_handler_test.go
+++ b/internal/profile/email_handler_test.go
@@ -27,7 +27,7 @@ func (*emailStubStore) GetPlayerByEmail(_ context.Context, _ string) (*auth.Play
 	return nil, auth.ErrPlayerNotFound
 }
 
-func (*emailStubStore) GetPlayerByUsername(_ context.Context, _ string) (*auth.Player, error) {
+func (*emailStubStore) GetPlayerByDisplayName(_ context.Context, _ string) (*auth.Player, error) {
 	return nil, errors.ErrUnsupported
 }
 
@@ -59,7 +59,7 @@ func (*emailStubStore) ChangePlayerPassword(_ context.Context, _ int64, _ string
 	return errors.ErrUnsupported
 }
 
-func (*emailStubStore) UpdatePlayerUsername(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+func (*emailStubStore) UpdatePlayerDisplayName(_ context.Context, _ int64, _ string) (*auth.Player, error) {
 	return nil, errors.ErrUnsupported
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -32,15 +32,15 @@ import (
 const maxFormBodySize = 16 * 1024
 
 // pageData feeds profile.gohtml. Title flows into the auth layout's
-// <title>. Username is the value pre-filled into the input. Message
-// surfaces server-side validation errors (taken username, empty
+// <title>. DisplayName is the value pre-filled into the input. Message
+// surfaces server-side validation errors (taken display name, empty
 // input, etc.). Saved is true on a successful POST so the template
 // can show a small confirmation banner.
 type pageData struct {
-	Title    string
-	Username string
-	Message  string
-	Saved    bool
+	Title       string
+	DisplayName string
+	Message     string
+	Saved       bool
 }
 
 // HandleProfile returns the [http.Handler] for GET /profile. The
@@ -62,8 +62,8 @@ func HandleProfile(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler {
 		}
 
 		render.render(w, r, http.StatusOK, pageData{
-			Title:    "Profile",
-			Username: player.Username,
+			Title:       "Profile",
+			DisplayName: player.DisplayName,
 		})
 	})
 }
@@ -107,15 +107,15 @@ func HandleProfileUsername(
 
 		updated, err := players.RenamePlayer(r.Context(), player.ID, cleaned)
 		if err != nil {
-			renderRenameError(render, logger, w, r, player.ID, player.Username, raw, err)
+			renderRenameError(render, logger, w, r, player.ID, player.DisplayName, raw, err)
 
 			return
 		}
 
 		render.render(w, r, http.StatusOK, pageData{
-			Title:    "Profile",
-			Username: updated.Username,
-			Saved:    true,
+			Title:       "Profile",
+			DisplayName: updated.DisplayName,
+			Saved:       true,
 		})
 	})
 }
@@ -137,7 +137,7 @@ func renderRenameError(
 	w http.ResponseWriter,
 	r *http.Request,
 	playerID int64,
-	currentUsername, attempted string,
+	currentDisplayName, attempted string,
 	err error,
 ) {
 	switch {
@@ -145,17 +145,17 @@ func renderRenameError(
 		logger.InfoContext(r.Context(), "profile rename rejected: empty name",
 			slog.Int64("player_id", playerID))
 		render.render(w, r, http.StatusBadRequest, pageData{
-			Title:    "Profile",
-			Username: currentUsername,
-			Message:  "Display name is required.",
+			Title:       "Profile",
+			DisplayName: currentDisplayName,
+			Message:     "Display name is required.",
 		})
 	case errors.Is(err, auth.ErrUsernameTaken):
 		logger.InfoContext(r.Context(), "profile rename rejected: name taken",
 			slog.Int64("player_id", playerID), slog.String("attempted", attempted))
 		render.render(w, r, http.StatusConflict, pageData{
-			Title:    "Profile",
-			Username: attempted,
-			Message:  "That name is already taken. Pick a different one.",
+			Title:       "Profile",
+			DisplayName: attempted,
+			Message:     "That name is already taken. Pick a different one.",
 		})
 	default:
 		logger.ErrorContext(r.Context(), "profile rename failed",

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,9 +1,9 @@
 // Package profile renders the signed-in player's profile page at
 // GET /profile and handles the rename submission at POST
-// /profile/username (#410). The page is the future home for
+// /profile/display-name (#410). The page is the future home for
 // account-level controls: email change (depends on #111), password
 // change (depends on #112), linked OAuth identities, etc. Today it
-// hosts the username editor only; everything else is scoped out of
+// hosts the displayName editor only; everything else is scoped out of
 // the initial cut.
 //
 // Authorisation lives entirely in auth.RequireAuthenticated upstream
@@ -27,7 +27,7 @@ import (
 )
 
 // maxFormBodySize caps the rename POST body. 16 KiB is generous for
-// a single username field + csrf token; mirrors the pattern in
+// a single displayName field + csrf token; mirrors the pattern in
 // internal/auth/handler.go.
 const maxFormBodySize = 16 * 1024
 
@@ -68,17 +68,17 @@ func HandleProfile(logger *slog.Logger, csrfMgr *csrf.Manager) http.Handler {
 	})
 }
 
-// HandleProfileUsername returns the [http.Handler] for POST
-// /profile/username. Parses the form, calls RenamePlayer, and
-// re-renders the page with either the new username + a success
-// banner or the old username + an error banner.
+// HandleProfileDisplayName returns the [http.Handler] for POST
+// /profile/display-name. Parses the form, calls RenamePlayer, and
+// re-renders the page with either the new displayName + a success
+// banner or the old displayName + an error banner.
 //
-// The store enforces the UNIQUE-on-username constraint atomically,
+// The store enforces the UNIQUE-on-displayName constraint atomically,
 // so a concurrent rename to the same target by another player
-// produces a clean ErrUsernameTaken without any application-side
-// race. ErrUsernameEmpty is mapped to a 400 with the same form;
-// ErrUsernameTaken to a 409. Anything else is a 500.
-func HandleProfileUsername(
+// produces a clean ErrDisplayNameTaken without any application-side
+// race. ErrDisplayNameEmpty is mapped to a 400 with the same form;
+// ErrDisplayNameTaken to a 409. Anything else is a 500.
+func HandleProfileDisplayName(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
 	players auth.PlayerStore,
@@ -141,7 +141,7 @@ func renderRenameError(
 	err error,
 ) {
 	switch {
-	case errors.Is(err, auth.ErrUsernameEmpty):
+	case errors.Is(err, auth.ErrDisplayNameEmpty):
 		logger.InfoContext(r.Context(), "profile rename rejected: empty name",
 			slog.Int64("player_id", playerID))
 		render.render(w, r, http.StatusBadRequest, pageData{
@@ -149,7 +149,7 @@ func renderRenameError(
 			DisplayName: currentDisplayName,
 			Message:     "Display name is required.",
 		})
-	case errors.Is(err, auth.ErrUsernameTaken):
+	case errors.Is(err, auth.ErrDisplayNameTaken):
 		logger.InfoContext(r.Context(), "profile rename rejected: name taken",
 			slog.Int64("player_id", playerID), slog.String("attempted", attempted))
 		render.render(w, r, http.StatusConflict, pageData{

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -28,10 +28,10 @@ func (s *renameStubStore) RenamePlayer(_ context.Context, _ int64, username stri
 		return nil, s.renameErr
 	}
 
-	return &auth.Player{ID: 7, Username: username}, nil
+	return &auth.Player{ID: 7, DisplayName: username}, nil
 }
 
-func (*renameStubStore) GetPlayerByUsername(_ context.Context, _ string) (*auth.Player, error) {
+func (*renameStubStore) GetPlayerByDisplayName(_ context.Context, _ string) (*auth.Player, error) {
 	return nil, errors.ErrUnsupported
 }
 
@@ -67,7 +67,7 @@ func (*renameStubStore) ChangePlayerPassword(_ context.Context, _ int64, _ strin
 	return errors.ErrUnsupported
 }
 
-func (*renameStubStore) UpdatePlayerUsername(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+func (*renameStubStore) UpdatePlayerDisplayName(_ context.Context, _ int64, _ string) (*auth.Player, error) {
 	return nil, errors.ErrUnsupported
 }
 
@@ -86,7 +86,7 @@ func postRename(t *testing.T, store auth.PlayerStore, newName string) (string, *
 		strings.NewReader(form.Encode()),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: 7, Username: "current-name"}))
+	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: 7, DisplayName: "current-name"}))
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -17,18 +17,18 @@ import (
 )
 
 // renameStubStore implements auth.PlayerStore for the
-// HandleProfileUsername tests. Only RenamePlayer does anything; the
+// HandleProfileDisplayName tests. Only RenamePlayer does anything; the
 // rest return a sentinel so an accidental call is loud.
 type renameStubStore struct {
 	renameErr error
 }
 
-func (s *renameStubStore) RenamePlayer(_ context.Context, _ int64, username string) (*auth.Player, error) {
+func (s *renameStubStore) RenamePlayer(_ context.Context, _ int64, displayName string) (*auth.Player, error) {
 	if s.renameErr != nil {
 		return nil, s.renameErr
 	}
 
-	return &auth.Player{ID: 7, DisplayName: username}, nil
+	return &auth.Player{ID: 7, DisplayName: displayName}, nil
 }
 
 func (*renameStubStore) GetPlayerByDisplayName(_ context.Context, _ string) (*auth.Player, error) {
@@ -71,18 +71,18 @@ func (*renameStubStore) UpdatePlayerDisplayName(_ context.Context, _ int64, _ st
 	return nil, errors.ErrUnsupported
 }
 
-// postRename drives HandleProfileUsername with the given store and form
+// postRename drives HandleProfileDisplayName with the given store and form
 // value, returning the captured log output and the response recorder.
 func postRename(t *testing.T, store auth.PlayerStore, newName string) (string, *httptest.ResponseRecorder) {
 	t.Helper()
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	csrfMgr := csrf.New([]byte("test-key-32-bytes-test-key-32byt"), false)
-	handler := HandleProfileUsername(logger, csrfMgr, store)
+	handler := HandleProfileDisplayName(logger, csrfMgr, store)
 
 	form := url.Values{"display_name": {newName}}
 	req := httptest.NewRequestWithContext(
-		t.Context(), http.MethodPost, "/profile/username",
+		t.Context(), http.MethodPost, "/profile/display-name",
 		strings.NewReader(form.Encode()),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -94,10 +94,10 @@ func postRename(t *testing.T, store auth.PlayerStore, newName string) (string, *
 	return logs.String(), rec
 }
 
-func TestHandleProfileUsername_LogsTakenRejection(t *testing.T) {
+func TestHandleProfileDisplayName_LogsTakenRejection(t *testing.T) {
 	t.Parallel()
 
-	logs, rec := postRename(t, &renameStubStore{renameErr: auth.ErrUsernameTaken}, "taken-name")
+	logs, rec := postRename(t, &renameStubStore{renameErr: auth.ErrDisplayNameTaken}, "taken-name")
 
 	if got, want := rec.Code, http.StatusConflict; got != want {
 		t.Errorf("status = %d, want %d", got, want)
@@ -111,10 +111,10 @@ func TestHandleProfileUsername_LogsTakenRejection(t *testing.T) {
 	}
 }
 
-func TestHandleProfileUsername_LogsEmptyRejection(t *testing.T) {
+func TestHandleProfileDisplayName_LogsEmptyRejection(t *testing.T) {
 	t.Parallel()
 
-	logs, rec := postRename(t, &renameStubStore{renameErr: auth.ErrUsernameEmpty}, "ignored")
+	logs, rec := postRename(t, &renameStubStore{renameErr: auth.ErrDisplayNameEmpty}, "ignored")
 
 	if got, want := rec.Code, http.StatusBadRequest; got != want {
 		t.Errorf("status = %d, want %d", got, want)
@@ -124,7 +124,7 @@ func TestHandleProfileUsername_LogsEmptyRejection(t *testing.T) {
 	}
 }
 
-func TestHandleProfileUsername_LogsUnexpectedErrorAtError(t *testing.T) {
+func TestHandleProfileDisplayName_LogsUnexpectedErrorAtError(t *testing.T) {
 	t.Parallel()
 
 	logs, rec := postRename(t, &renameStubStore{renameErr: errors.New("db exploded")}, "any-name")

--- a/internal/queries/admin.sql
+++ b/internal/queries/admin.sql
@@ -21,7 +21,7 @@ VALUES (
 SELECT
     a.id,
     a.actor_player_id,
-    CAST(COALESCE(p.username, '') AS TEXT) AS actor_username,
+    CAST(COALESCE(p.display_name, '') AS TEXT) AS actor_display_name,
     a.target_player_id,
     a.action,
     a.payload,
@@ -179,9 +179,9 @@ WHERE id = sqlc.arg('id');
 -- is nullable on the column but the handler enforces a non-empty hash so
 -- the row can log in immediately. role is fixed to 'player' - the admin
 -- promotion CASE only fires on the public register/oauth paths.
-INSERT INTO players (username, email, password_hash, email_verified_at, role, username_claimed)
+INSERT INTO players (display_name, email, password_hash, email_verified_at, role, display_name_claimed)
 VALUES (
-    sqlc.arg('username'),
+    sqlc.arg('display_name'),
     sqlc.arg('email'),
     sqlc.arg('password_hash'),
     CURRENT_TIMESTAMP,

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -86,7 +86,7 @@ RETURNING *;
 -- count). The Go layer collapses one row per (player, game) into a
 -- single LeaderboardEntry with the per-player Completed flag.
 SELECT ga.player_id        AS player_id,
-       p.username           AS username,
+       p.display_name           AS display_name,
        gq.started_at        AS question_started_at,
        gq.expired_at        AS question_expired_at,
        ga.answered_at       AS answered_at,
@@ -112,7 +112,7 @@ WHERE g.quiz_id = ?;
 -- NULL); game_participants.quiz_id is nullable in the schema, which
 -- would otherwise force sqlc to infer sql.NullInt64 for the parameter.
 SELECT gp.player_id AS player_id,
-       p.username   AS username,
+       p.display_name   AS display_name,
        CASE WHEN (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id) > 0
              AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = gp.game_id) >=
                  (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)

--- a/internal/queries/home.sql
+++ b/internal/queries/home.sql
@@ -45,7 +45,7 @@ ORDER BY play_count DESC, q.updated_at DESC;
 -- and a long-dormant player could outrank a current one (#355).
 --
 -- Anonymous (auto-petname) players are filtered out via
--- username_claimed = 1 so the public list only shows names a player
+-- display_name_claimed = 1 so the public list only shows names a player
 -- deliberately picked. The start-page leaderboard would otherwise be
 -- cluttered with throwaway "happy-banana-xyz" entries from one-shot
 -- visitors.
@@ -55,15 +55,15 @@ ORDER BY play_count DESC, q.updated_at DESC;
 --
 -- LIMIT applied by the caller; see ListPopularQuizzes above for why.
 SELECT p.id              AS id,
-       p.username        AS username,
+       p.display_name        AS display_name,
        COUNT(DISTINCT g.id) AS finished_count
 FROM players p
 JOIN game_participants gp ON gp.player_id = p.id
 JOIN games g ON g.id = gp.game_id
 WHERE g.created_at >= datetime('now', '-30 days')
-  AND p.username_claimed = 1
+  AND p.display_name_claimed = 1
   AND EXISTS (SELECT 1 FROM questions qe WHERE qe.quiz_id = g.quiz_id)
   AND (SELECT COUNT(*) FROM game_questions gq WHERE gq.game_id = g.id) >=
       (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
 GROUP BY p.id
-ORDER BY finished_count DESC, p.username ASC;
+ORDER BY finished_count DESC, p.display_name ASC;

--- a/internal/queries/invites.sql
+++ b/internal/queries/invites.sql
@@ -56,8 +56,8 @@ WHERE status = 'pending'
 
 -- name: ListPendingInvites :many
 -- Lists every still-pending invite for the admin management view (#318),
--- newest first. LEFT JOIN players surfaces the inviter's username for the
--- "invited by X" column; inviter_username is NULL when the invite carries
+-- newest first. LEFT JOIN players surfaces the inviter's display_name for the
+-- "invited by X" column; inviter_display_name is NULL when the invite carries
 -- no actor (invited_by_player_id NULL) or the inviting admin's row has since
 -- been deleted (ON DELETE SET NULL). Includes still-expired-but-not-swept
 -- rows so the list matches what the sweep has actually pruned; the template
@@ -66,7 +66,7 @@ SELECT
     invites.id,
     invites.email,
     invites.invited_by_player_id,
-    players.username AS inviter_username,
+    players.display_name AS inviter_display_name,
     invites.created_at,
     invites.expires_at
 FROM invites

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -307,7 +307,7 @@ RETURNING *;
 
 -- name: RenamePlayer :one
 -- Renames any player row by id, regardless of password / email / role.
--- The dedicated profile-page endpoint (POST /profile/username, #410)
+-- The dedicated profile-page endpoint (POST /profile/display-name, #410)
 -- uses this so authenticated players (password, OAuth, admin) can
 -- change their display name. Anonymous rows have their own narrower
 -- path via UpdatePlayerDisplayName above; this query is intentionally
@@ -316,7 +316,7 @@ RETURNING *;
 --
 -- Returns the updated row when one was affected; the store wrapper
 -- maps sql.ErrNoRows to ErrPlayerNotFound and a UNIQUE constraint
--- failure on players.display_name to ErrUsernameTaken so the handler can
+-- failure on players.display_name to ErrDisplayNameTaken so the handler can
 -- map both onto user-facing form errors.
 UPDATE players
 SET display_name = sqlc.arg('display_name'),

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -1,7 +1,7 @@
--- name: GetPlayerByUsername :one
+-- name: GetPlayerByDisplayName :one
 SELECT *
 FROM players
-WHERE username = ?
+WHERE display_name = ?
 LIMIT 1;
 
 -- name: CreatePlayerWithCredentials :one
@@ -27,13 +27,13 @@ LIMIT 1;
 -- stamped only when the row is written as admin, so the settings list can show
 -- a "promoted" timestamp.
 --
--- username_claimed is set to 1 because a registering user explicitly chose
--- their username at the register form. The column tracks "did the player
+-- display_name_claimed is set to 1 because a registering user explicitly chose
+-- their display_name at the register form. The column tracks "did the player
 -- pick this name themselves" (vs auto-generated petname), so a fresh
 -- registrant must be marked as claimed from the moment the row is written.
-INSERT INTO players (username, password_hash, email, role, role_changed_at, username_claimed)
+INSERT INTO players (display_name, password_hash, email, role, role_changed_at, display_name_claimed)
 VALUES (
-    sqlc.arg('username'),
+    sqlc.arg('display_name'),
     sqlc.arg('password_hash'),
     sqlc.arg('email'),
     CASE
@@ -65,11 +65,11 @@ RETURNING *;
 -- becomes admin" SQL above filters by password_hash IS NOT NULL, so an
 -- anonymous row never qualifies for promotion.
 --
--- username_claimed defaults to 0: the auto-generated petname is not a name
+-- display_name_claimed defaults to 0: the auto-generated petname is not a name
 -- the visitor picked, so the row is unclaimed until they rename via the
 -- PATCH /api/players/me endpoint or sign up through ClaimPlayer below.
-INSERT INTO players (username, role)
-VALUES (sqlc.arg('username'), 'player')
+INSERT INTO players (display_name, role)
+VALUES (sqlc.arg('display_name'), 'player')
 RETURNING *;
 
 -- name: ClaimPlayer :one
@@ -92,13 +92,13 @@ RETURNING *;
 -- claim path lands on Admin. Host is never granted at registration.
 -- role_changed_at is stamped when the row becomes admin.
 --
--- username_claimed is set to 1 because the visitor is explicitly choosing
--- their username via the register form. This is the register-after-playing
+-- display_name_claimed is set to 1 because the visitor is explicitly choosing
+-- their display_name via the register form. This is the register-after-playing
 -- path: the row now represents a player who picked their own name, so it
 -- must look identical to a CreatePlayerWithCredentials row to downstream
 -- callers.
 UPDATE players
-SET username = sqlc.arg('username'),
+SET display_name = sqlc.arg('display_name'),
     password_hash = sqlc.arg('password_hash'),
     email = sqlc.arg('email'),
     role = CASE
@@ -119,7 +119,7 @@ SET username = sqlc.arg('username'),
         ) THEN CURRENT_TIMESTAMP
         ELSE NULL
     END,
-    username_claimed = 1
+    display_name_claimed = 1
 WHERE players.id = sqlc.arg('id')
   AND players.password_hash IS NULL
   AND players.email IS NULL
@@ -127,21 +127,21 @@ RETURNING *;
 
 -- name: SetPlayerPasswordHash :execrows
 -- Used by the cmd/server -reset-password operator tool to rotate a single
--- player's password without disturbing username / role / email. Returns the
+-- player's password without disturbing display_name / role / email. Returns the
 -- number of affected rows so the caller can map "no rows" to an "email
 -- not found" error. The lookup is by email (the post-#446 login credential)
 -- so the operator's reset target matches what the player types into /login.
 --
--- username_claimed is set to 1 alongside the password because once an
--- operator has set a password on a row, the username is no longer an
+-- display_name_claimed is set to 1 alongside the password because once an
+-- operator has set a password on a row, the display_name is no longer an
 -- auto-assigned petname the player should be nudged to replace (#289). The
 -- migration 20260511120000 ran the same backfill at the time, but only for
 -- rows that already had a password_hash; later password sets via this
--- query previously left username_claimed at 0, which made the seed
+-- query previously left display_name_claimed at 0, which made the seed
 -- admin (id=1) keep popping the claim-name modal in the player client.
 UPDATE players
 SET password_hash    = sqlc.arg('password_hash'),
-    username_claimed = 1
+    display_name_claimed = 1
 WHERE email = sqlc.arg('email');
 
 -- name: GetPlayerByEmail :one
@@ -168,7 +168,7 @@ LIMIT 1;
 -- name: CreatePlayerFromOAuth :one
 -- Insert a brand-new player row for a first-time OAuth sign-in. No
 -- password_hash (the player has no local credential), email comes from
--- the verified id-token claim, username_claimed is set to 1 because the
+-- the verified id-token claim, display_name_claimed is set to 1 because the
 -- caller supplies an auto-generated petname that the player will be
 -- prompted to change via the existing claim-name modal.
 --
@@ -181,9 +181,9 @@ LIMIT 1;
 -- deployments from promoting *every* sign-in to admin. Without this,
 -- the second-and-onward Google sign-ins on a fresh DB would all see
 -- count(password_hash IS NOT NULL) == 0 and become admin.
-INSERT INTO players (username, email, email_verified_at, role, role_changed_at, username_claimed)
+INSERT INTO players (display_name, email, email_verified_at, role, role_changed_at, display_name_claimed)
 VALUES (
-    sqlc.arg('username'),
+    sqlc.arg('display_name'),
     sqlc.arg('email'),
     CURRENT_TIMESTAMP,
     CASE
@@ -219,8 +219,8 @@ VALUES (?, ?, ?);
 -- Upgrades a fully anonymous players row (no password_hash, no email)
 -- in place by attaching the OAuth-verified email. Lets a visitor who
 -- played anonymously keep their existing player_id (and therefore
--- their game history and any custom username) when they sign in with
--- Google for the first time. The username is left untouched: the
+-- their game history and any custom display_name) when they sign in with
+-- Google for the first time. The display_name is left untouched: the
 -- visitor's auto-petname or PATCH-claimed name carries through onto
 -- the OAuth-linked row.
 --
@@ -286,22 +286,22 @@ WHERE gp.player_id IN (sqlc.slice('player_ids'))
       (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
 GROUP BY gp.player_id;
 
--- name: UpdatePlayerUsername :one
--- Updates the username on an anonymous player row in place. The WHERE
+-- name: UpdatePlayerDisplayName :one
+-- Updates the display_name on an anonymous player row in place. The WHERE
 -- clause refuses the update when the player has already claimed a
 -- non-anonymous identity (password_hash IS NOT NULL), so the SQL is the
 -- atomic guard against a stale anonymous check in the service layer.
 -- Returns the updated row when one was affected; the wrapper distinguishes
--- "not anonymous anymore" (sql.ErrNoRows) from "username collision"
--- (UNIQUE constraint failure on players.username).
+-- "not anonymous anymore" (sql.ErrNoRows) from "display_name collision"
+-- (UNIQUE constraint failure on players.display_name).
 --
--- username_claimed is set to 1 because this is the dedicated claim-name
+-- display_name_claimed is set to 1 because this is the dedicated claim-name
 -- endpoint (PATCH /api/players/me); the visitor is explicitly picking
 -- their display name. After this update the row reads as "player chose
 -- this name" identically to the credentialled-registration path.
 UPDATE players
-SET username = sqlc.arg('username'),
-    username_claimed = 1
+SET display_name = sqlc.arg('display_name'),
+    display_name_claimed = 1
 WHERE id = sqlc.arg('id') AND password_hash IS NULL
 RETURNING *;
 
@@ -310,17 +310,17 @@ RETURNING *;
 -- The dedicated profile-page endpoint (POST /profile/username, #410)
 -- uses this so authenticated players (password, OAuth, admin) can
 -- change their display name. Anonymous rows have their own narrower
--- path via UpdatePlayerUsername above; this query is intentionally
+-- path via UpdatePlayerDisplayName above; this query is intentionally
 -- not gated by password_hash so the OAuth-only and admin cases also
 -- work.
 --
 -- Returns the updated row when one was affected; the store wrapper
 -- maps sql.ErrNoRows to ErrPlayerNotFound and a UNIQUE constraint
--- failure on players.username to ErrUsernameTaken so the handler can
+-- failure on players.display_name to ErrUsernameTaken so the handler can
 -- map both onto user-facing form errors.
 UPDATE players
-SET username = sqlc.arg('username'),
-    username_claimed = 1
+SET display_name = sqlc.arg('display_name'),
+    display_name_claimed = 1
 WHERE id = sqlc.arg('id')
 RETURNING *;
 
@@ -454,14 +454,14 @@ FROM players
 WHERE role = 'admin';
 
 -- name: ListAdmins :many
--- Every current Admin, ordered by username so the admin settings page
+-- Every current Admin, ordered by display_name so the admin settings page
 -- (#320/#538) renders a stable list. Only the columns the list needs are
 -- selected. role_changed_at is when the role last changed (NULL for rows whose
 -- role predates the column).
-SELECT id, username, email, role_changed_at
+SELECT id, display_name, email, role_changed_at
 FROM players
 WHERE role = 'admin'
-ORDER BY username, id;
+ORDER BY display_name, id;
 
 -- name: ResetPlayerPassword :execrows
 -- Atomically rotates password_hash and bumps session_version on the

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -21,7 +21,7 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 ORDER BY q.updated_at DESC, q.id DESC;
@@ -39,7 +39,7 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 WHERE q.visibility = 'public'
@@ -56,7 +56,7 @@ GROUP BY quiz_id;
 
 -- name: GetQuiz :one
 -- Same INNER JOIN as ListQuizzes so single-quiz fetches carry the
--- creator's username for the admin view's "Created by ..." line. See
+-- creator's display_name for the admin view's "Created by ..." line. See
 -- ListQuizzes for why the LEFT JOIN was dropped (#359).
 SELECT q.id,
        q.title,
@@ -67,7 +67,7 @@ SELECT q.id,
        q.created_by_player_id,
        q.time_limit_seconds,
        q.visibility,
-       p.username AS created_by_username
+       p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
 WHERE q.id = ?

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -222,7 +222,7 @@ func IsValidVisibility(v string) bool {
 	return slices.Contains(VisibilityValues(), v)
 }
 
-// Quiz represents a quiz. CreatedByPlayerID + CreatedByUsername were
+// Quiz represents a quiz. CreatedByPlayerID + CreatedByDisplayName were
 // added in migration 20260520200000 to support the creator-only-edit
 // rule from #281. CreatedByPlayerID is NOT NULL at the DB level;
 // existing rows were backfilled to the lowest-id admin during the
@@ -230,14 +230,14 @@ func IsValidVisibility(v string) bool {
 // [QuizStore.CreateQuiz] surfaces ErrCreatorRequired rather than
 // letting the FK insert fail at the wire.
 type Quiz struct {
-	ID                int64
-	Title             string
-	Slug              string
-	Description       string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-	CreatedByPlayerID int64
-	CreatedByUsername string
+	ID                   int64
+	Title                string
+	Slug                 string
+	Description          string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CreatedByPlayerID    int64
+	CreatedByDisplayName string
 	// TimeLimitSeconds is the default per-question answer window in
 	// seconds. The game service resolves the priority chain
 	// (Question.TimeLimitSeconds -> Quiz.TimeLimitSeconds -> defaultExpiration)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -315,7 +315,7 @@ func addProfileRoutes(
 	mux.Handle("GET /profile", requireAuthn(profile.HandleProfile(logger, csrfMgr)))
 	mux.Handle(
 		"POST /profile/display-name",
-		csrfMW(requireAuthn(profile.HandleProfileUsername(logger, csrfMgr, stores.Players))),
+		csrfMW(requireAuthn(profile.HandleProfileDisplayName(logger, csrfMgr, stores.Players))),
 	)
 	mux.Handle("GET /profile/password", requireAuthn(profile.HandleProfilePassword(logger, csrfMgr)))
 	mux.Handle(
@@ -482,7 +482,7 @@ func addAdminSettingsRoutes(
 // addAdminPlayerRoutes registers the admin player-management routes (#450).
 // Every route - the per-player detail view, the verify/resend/email actions,
 // the create-without-verification pair, the id-based role endpoint (#538), and
-// the username + password actions (#535) - is Admin-only (#538): player
+// the displayName + password actions (#535) - is Admin-only (#538): player
 // management moved from the old admin-wide gate up to the top tier.
 // MaxFormSizeMiddleware fronts every POST in front of csrfMW so the CSRF
 // validator's ParseForm sees a bounded body; csrfMW fronts the auth wrapper so
@@ -543,7 +543,7 @@ func addAdminPlayerRoutes(
 	mux.Handle(
 		"POST /admin/players/{playerID}/display-name",
 		admin.MaxFormSizeMiddleware(csrfMW(requireAdmin(
-			admin.HandlePlayerSetUsername(logger, stores.AdminPlayers, deps.flash),
+			admin.HandlePlayerSetDisplayName(logger, stores.AdminPlayers, deps.flash),
 		))),
 	)
 	mux.Handle(

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -190,7 +190,7 @@ func homeViewerFunc(players auth.PlayerStore, sessions *session.Manager) home.Vi
 			return nil
 		}
 
-		return &home.Viewer{Username: p.Username}
+		return &home.Viewer{DisplayName: p.DisplayName}
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -314,7 +314,7 @@ func addProfileRoutes(
 
 	mux.Handle("GET /profile", requireAuthn(profile.HandleProfile(logger, csrfMgr)))
 	mux.Handle(
-		"POST /profile/username",
+		"POST /profile/display-name",
 		csrfMW(requireAuthn(profile.HandleProfileUsername(logger, csrfMgr, stores.Players))),
 	)
 	mux.Handle("GET /profile/password", requireAuthn(profile.HandleProfilePassword(logger, csrfMgr)))
@@ -541,7 +541,7 @@ func addAdminPlayerRoutes(
 		))),
 	)
 	mux.Handle(
-		"POST /admin/players/{playerID}/username",
+		"POST /admin/players/{playerID}/display-name",
 		admin.MaxFormSizeMiddleware(csrfMW(requireAdmin(
 			admin.HandlePlayerSetUsername(logger, stores.AdminPlayers, deps.flash),
 		))),

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -26,7 +26,7 @@ import (
 
 type stubPlayerStore struct{}
 
-func (stubPlayerStore) GetPlayerByUsername(_ context.Context, _ string) (*auth.Player, error) {
+func (stubPlayerStore) GetPlayerByDisplayName(_ context.Context, _ string) (*auth.Player, error) {
 	return nil, auth.ErrPlayerNotFound
 }
 
@@ -58,7 +58,7 @@ func (stubPlayerStore) ChangePlayerPassword(_ context.Context, _ int64, _ string
 	return errRouteStub
 }
 
-func (stubPlayerStore) UpdatePlayerUsername(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+func (stubPlayerStore) UpdatePlayerDisplayName(_ context.Context, _ int64, _ string) (*auth.Player, error) {
 	return nil, errRouteStub
 }
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -420,8 +420,8 @@ func TestAddRoutes_LoginPOST_RejectsMissingCSRF(t *testing.T) {
 		t.Parallel()
 
 		body := url.Values{
-			"username": {"any"},
-			"password": {"any"},
+			"displayName": {"any"},
+			"password":    {"any"},
 		}.Encode()
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/login", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -470,9 +470,9 @@ func TestAddRoutes_LoginPOST_RejectsMissingCSRF(t *testing.T) {
 		// handler, which in turn returns 401 for the unknown user - that's
 		// fine, the assertion here is "not 403".
 		body := url.Values{
-			"username":   {"ghost"},
-			"password":   {"correctbatterystaple"},
-			"csrf_token": {token},
+			"displayName": {"ghost"},
+			"password":    {"correctbatterystaple"},
+			"csrf_token":  {token},
 		}.Encode()
 		postReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/login", strings.NewReader(body))
 		postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -346,7 +346,7 @@ func (s *GameStore) ListAnswersForQuizLeaderboard(
 	for _, r := range rows {
 		answers = append(answers, &game.LeaderboardAnswer{
 			PlayerID:          r.PlayerID,
-			Username:          r.Username,
+			DisplayName:       r.DisplayName,
 			QuestionStartedAt: r.QuestionStartedAt,
 			QuestionExpiredAt: r.QuestionExpiredAt,
 			AnsweredAt:        r.AnsweredAt,
@@ -378,8 +378,8 @@ func (s *GameStore) ListParticipantsForQuizLeaderboard(
 	participants := make([]*game.LeaderboardParticipant, 0, len(rows))
 	for _, r := range rows {
 		participants = append(participants, &game.LeaderboardParticipant{
-			PlayerID: r.PlayerID,
-			Username: r.Username,
+			PlayerID:    r.PlayerID,
+			DisplayName: r.DisplayName,
 			// CASE returns 1/0.
 			IsCompleted: r.IsCompleted != 0,
 			IsStale:     r.IsStale != 0,

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -557,8 +557,8 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 		if got, want := rows[0].PlayerID, player.ID; got != want {
 			t.Errorf("rows[0].PlayerID = %d, want %d", got, want)
 		}
-		if got, want := rows[0].Username, player.Username; got != want {
-			t.Errorf("rows[0].Username = %q, want %q", got, want)
+		if got, want := rows[0].DisplayName, player.DisplayName; got != want {
+			t.Errorf("rows[0].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := rows[0].Correct, correctOption.Correct; got != want {
 			t.Errorf("rows[0].Correct = %v, want %v", got, want)
@@ -746,8 +746,8 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 		if got, want := rows[0].PlayerID, player.ID; got != want {
 			t.Errorf("rows[0].PlayerID = %d, want %d", got, want)
 		}
-		if got, want := rows[0].Username, player.Username; got != want {
-			t.Errorf("rows[0].Username = %q, want %q", got, want)
+		if got, want := rows[0].DisplayName, player.DisplayName; got != want {
+			t.Errorf("rows[0].DisplayName = %q, want %q", got, want)
 		}
 		if got, want := rows[0].IsCompleted, false; got != want {
 			t.Errorf("rows[0].IsCompleted = %v, want %v", got, want)

--- a/internal/store/home.go
+++ b/internal/store/home.go
@@ -63,7 +63,7 @@ func (s *HomeStore) ListMostActivePlayers(ctx context.Context) ([]*home.ActivePl
 	for _, r := range rows {
 		out = append(out, &home.ActivePlayer{
 			ID:            r.ID,
-			Username:      r.Username,
+			DisplayName:   r.DisplayName,
 			FinishedCount: int(r.FinishedCount),
 		})
 	}

--- a/internal/store/home_test.go
+++ b/internal/store/home_test.go
@@ -217,7 +217,7 @@ func TestHomeStore_ListMostActivePlayers(t *testing.T) {
 	// Defensive: the anonymous player's auto-petname username must not
 	// appear in any returned row.
 	for _, r := range rows {
-		if r.Username == "ghost-petname" {
+		if r.DisplayName == "ghost-petname" {
 			t.Errorf("anonymous player surfaced in active list: %+v", r)
 		}
 	}

--- a/internal/store/home_test.go
+++ b/internal/store/home_test.go
@@ -96,7 +96,7 @@ func seedHomeDB(t *testing.T) homeSeed {
 		t.Fatalf("CreatePlayer bob err = %v, want nil", err)
 	}
 	// Anonymous player - must not surface in the active list because the
-	// query filters on username_claimed = 1.
+	// query filters on displayName_claimed = 1.
 	ghost, err := players.CreateAnonymousPlayer(t.Context(), "ghost-petname")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer ghost err = %v, want nil", err)
@@ -108,7 +108,7 @@ func seedHomeDB(t *testing.T) homeSeed {
 	// bob: quiz1 = 1 finished total
 	finishGameFor(t, games, bob.ID, quiz1, quiz1.ID)
 	// ghost: quiz1 = 1 finished, bumps quiz1 play count to 3 but must
-	// NOT show up in the active list (unclaimed username).
+	// NOT show up in the active list (unclaimed displayName).
 	finishGameFor(t, games, ghost.ID, quiz1, quiz1.ID)
 
 	// In-progress game on quiz1 by a fresh anonymous bystander: created,
@@ -196,7 +196,7 @@ func TestHomeStore_ListMostActivePlayers(t *testing.T) {
 		t.Fatalf("ListMostActivePlayers err = %v, want nil", err)
 	}
 	// Anonymous "ghost-petname" finished a game but must be filtered out
-	// because username_claimed = 0; only alice and bob remain.
+	// because displayName_claimed = 0; only alice and bob remain.
 	if got, want := len(rows), 2; got != want {
 		t.Fatalf("len(rows) = %d, want %d (rows=%+v)", got, want, rows)
 	}
@@ -214,7 +214,7 @@ func TestHomeStore_ListMostActivePlayers(t *testing.T) {
 		t.Errorf("rows[1].FinishedCount = %d, want %d", got, want)
 	}
 
-	// Defensive: the anonymous player's auto-petname username must not
+	// Defensive: the anonymous player's auto-petname displayName must not
 	// appear in any returned row.
 	for _, r := range rows {
 		if r.DisplayName == "ghost-petname" {

--- a/internal/store/invite.go
+++ b/internal/store/invite.go
@@ -106,12 +106,12 @@ func (s *PlayerStore) ListPendingInvites(ctx context.Context) ([]*auth.PendingIn
 	invites := make([]*auth.PendingInvite, 0, len(rows))
 	for _, row := range rows {
 		invites = append(invites, &auth.PendingInvite{
-			ID:                row.ID,
-			Email:             row.Email,
-			InvitedByPlayerID: row.InvitedByPlayerID.Int64,
-			InviterUsername:   row.InviterUsername.String,
-			CreatedAt:         row.CreatedAt,
-			ExpiresAt:         row.ExpiresAt,
+			ID:                 row.ID,
+			Email:              row.Email,
+			InvitedByPlayerID:  row.InvitedByPlayerID.Int64,
+			InviterDisplayName: row.InviterDisplayName.String,
+			CreatedAt:          row.CreatedAt,
+			ExpiresAt:          row.ExpiresAt,
 		})
 	}
 

--- a/internal/store/invite.go
+++ b/internal/store/invite.go
@@ -93,7 +93,7 @@ func (s *PlayerStore) DeleteExpiredInvites(ctx context.Context) error {
 }
 
 // ListPendingInvites returns every still-pending invite, newest first,
-// for the admin management view (#318). The inviter username is resolved
+// for the admin management view (#318). The inviter displayName is resolved
 // via a LEFT JOIN; a NULL (no actor or deleted admin) maps to an empty
 // string so the template renders a neutral dash instead of a Go zero
 // value sneaking through.

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -38,20 +38,20 @@ func (s *PlayerStore) Ping(ctx context.Context) error {
 	return nil
 }
 
-// GetPlayerByUsername returns the player with the given username.
-// Returns auth.ErrPlayerNotFound if no player matches the username.
+// GetPlayerByDisplayName returns the player with the given display name.
+// Returns auth.ErrPlayerNotFound if no player matches the display name.
 //
-// Whitespace around the username is trimmed before lookup so callers cannot
+// Whitespace around the display name is trimmed before lookup so callers cannot
 // accidentally treat "alice" and " alice " as different users. The matching
 // trim happens in CreatePlayer too - defense in depth at the storage layer.
-func (s *PlayerStore) GetPlayerByUsername(ctx context.Context, username string) (*auth.Player, error) {
-	row, err := s.q.GetPlayerByUsername(ctx, strings.TrimSpace(username))
+func (s *PlayerStore) GetPlayerByDisplayName(ctx context.Context, displayName string) (*auth.Player, error) {
+	row, err := s.q.GetPlayerByDisplayName(ctx, strings.TrimSpace(displayName))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, auth.ErrPlayerNotFound
 		}
 
-		return nil, fmt.Errorf("failed to get player by username: %w", err)
+		return nil, fmt.Errorf("failed to get player by display name: %w", err)
 	}
 
 	return playerFromRow(row), nil
@@ -80,16 +80,16 @@ func (s *PlayerStore) CreatePlayer(
 	ctx context.Context,
 	username, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
-	cleanedUsername := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(username)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.CreatePlayerWithCredentials(ctx, db.CreatePlayerWithCredentialsParams{
-		Username:      cleanedUsername,
+		DisplayName:   cleanedDisplayName,
 		PasswordHash:  sql.NullString{String: passwordHash, Valid: true},
 		Email:         sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		RequestedRole: requestedRole,
 	})
 	if err != nil {
-		return nil, s.classifyCredentialConflict(ctx, cleanedUsername, cleanedEmail, err)
+		return nil, s.classifyCredentialConflict(ctx, cleanedDisplayName, cleanedEmail, err)
 	}
 
 	return playerFromRow(row), nil
@@ -128,43 +128,43 @@ func (s *PlayerStore) ClaimPlayer(
 	playerID int64,
 	username, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
-	cleanedUsername := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(username)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.ClaimPlayer(ctx, db.ClaimPlayerParams{
-		Username:      cleanedUsername,
+		DisplayName:   cleanedDisplayName,
 		PasswordHash:  sql.NullString{String: passwordHash, Valid: true},
 		Email:         sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		RequestedRole: requestedRole,
 		ID:            playerID,
 	})
 	if err != nil {
-		return nil, s.classifyClaimErr(ctx, playerID, cleanedUsername, cleanedEmail, err)
+		return nil, s.classifyClaimErr(ctx, playerID, cleanedDisplayName, cleanedEmail, err)
 	}
 
 	return playerFromRow(row), nil
 }
 
-// UpdatePlayerUsername renames an anonymous (password_hash IS NULL)
+// UpdatePlayerDisplayName renames an anonymous (password_hash IS NULL)
 // row in place. Returns ErrUsernameTaken on collision,
 // ErrPlayerNotAnonymous when the row already has a password_hash
 // (filtered out by the WHERE guard), and ErrPlayerNotFound when the
 // row genuinely does not exist (disambiguated by a follow-up query).
-func (s *PlayerStore) UpdatePlayerUsername(
+func (s *PlayerStore) UpdatePlayerDisplayName(
 	ctx context.Context,
 	playerID int64,
-	username string,
+	displayName string,
 ) (*auth.Player, error) {
-	cleaned := strings.TrimSpace(username)
+	cleaned := strings.TrimSpace(displayName)
 	if cleaned == "" {
 		return nil, auth.ErrUsernameEmpty
 	}
 
-	row, err := s.q.UpdatePlayerUsername(ctx, db.UpdatePlayerUsernameParams{
-		Username: cleaned,
-		ID:       playerID,
+	row, err := s.q.UpdatePlayerDisplayName(ctx, db.UpdatePlayerDisplayNameParams{
+		DisplayName: cleaned,
+		ID:          playerID,
 	})
 	if err != nil {
-		return nil, s.classifyUpdateUsernameErr(ctx, playerID, err)
+		return nil, s.classifyUpdateDisplayNameErr(ctx, playerID, err)
 	}
 
 	return playerFromRow(row), nil
@@ -187,8 +187,8 @@ func (s *PlayerStore) RenamePlayer(
 	}
 
 	row, err := s.q.RenamePlayer(ctx, db.RenamePlayerParams{
-		Username: cleaned,
-		ID:       playerID,
+		DisplayName: cleaned,
+		ID:          playerID,
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -257,8 +257,8 @@ func (s *PlayerStore) CreatePlayerFromOAuth(
 	username, email string,
 ) (*auth.Player, error) {
 	row, err := s.q.CreatePlayerFromOAuth(ctx, db.CreatePlayerFromOAuthParams{
-		Username: strings.TrimSpace(username),
-		Email:    sql.NullString{String: strings.ToLower(strings.TrimSpace(email)), Valid: true},
+		DisplayName: strings.TrimSpace(username),
+		Email:       sql.NullString{String: strings.ToLower(strings.TrimSpace(email)), Valid: true},
 	})
 	if err != nil {
 		var sqliteErr *sqlite.Error
@@ -650,7 +650,7 @@ func (s *PlayerStore) ListPlayersByOnboardingState(
 	for _, r := range rows {
 		row := &auth.PlayerListRow{
 			ID:              r.ID,
-			Username:        r.Username,
+			DisplayName:     r.DisplayName,
 			Email:           r.Email.String,
 			Role:            r.Role,
 			HasPassword:     r.PasswordHash.Valid,
@@ -741,7 +741,7 @@ func (s *PlayerStore) GetPlayerDetail(ctx context.Context, id int64) (*auth.Play
 
 	detail := &auth.PlayerDetail{
 		ID:              row.ID,
-		Username:        row.Username,
+		DisplayName:     row.DisplayName,
 		Email:           row.Email.String,
 		Role:            row.Role,
 		HasPassword:     row.PasswordHash.Valid,
@@ -837,15 +837,15 @@ func (s *PlayerStore) SetPlayerEmail(ctx context.Context, playerID int64, email 
 func (s *PlayerStore) CreatePlayerByAdmin(
 	ctx context.Context, username, email, passwordHash string,
 ) (*auth.Player, error) {
-	cleanedUsername := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(username)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.CreatePlayerByAdmin(ctx, db.CreatePlayerByAdminParams{
-		Username:     cleanedUsername,
+		DisplayName:  cleanedDisplayName,
 		Email:        sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		PasswordHash: sql.NullString{String: passwordHash, Valid: passwordHash != ""},
 	})
 	if err != nil {
-		return nil, s.classifyCredentialConflict(ctx, cleanedUsername, cleanedEmail, err)
+		return nil, s.classifyCredentialConflict(ctx, cleanedDisplayName, cleanedEmail, err)
 	}
 
 	return playerFromRow(row), nil
@@ -900,9 +900,9 @@ func (s *PlayerStore) ListAdmins(ctx context.Context) ([]*auth.AdminEntry, error
 	out := make([]*auth.AdminEntry, 0, len(rows))
 	for _, r := range rows {
 		entry := &auth.AdminEntry{
-			ID:       r.ID,
-			Username: r.Username,
-			Email:    r.Email.String,
+			ID:          r.ID,
+			DisplayName: r.DisplayName,
+			Email:       r.Email.String,
 		}
 		if r.RoleChangedAt.Valid {
 			changed := r.RoleChangedAt.Time
@@ -943,13 +943,13 @@ func (s *PlayerStore) ListAdminAuditForTarget(
 	out := make([]*auth.AdminAuditEntry, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, &auth.AdminAuditEntry{
-			ID:             r.ID,
-			ActorPlayerID:  r.ActorPlayerID.Int64,
-			ActorUsername:  r.ActorUsername,
-			TargetPlayerID: r.TargetPlayerID,
-			Action:         r.Action,
-			Payload:        r.Payload,
-			CreatedAt:      r.CreatedAt,
+			ID:               r.ID,
+			ActorPlayerID:    r.ActorPlayerID.Int64,
+			ActorDisplayName: r.ActorDisplayName,
+			TargetPlayerID:   r.TargetPlayerID,
+			Action:           r.Action,
+			Payload:          r.Payload,
+			CreatedAt:        r.CreatedAt,
 		})
 	}
 
@@ -973,17 +973,17 @@ func parseSQLiteTimestamp(raw string) *time.Time {
 	return nil
 }
 
-// classifyUpdateUsernameErr maps an UpdatePlayerUsername storage error onto
-// the auth-package sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous
+// classifyUpdateDisplayNameErr maps an UpdatePlayerDisplayName storage error
+// onto the auth-package sentinels. [sql.ErrNoRows] from the UPDATE is ambiguous
 // (the id might not exist OR the row already carries a password_hash), so it
 // re-queries by id to disambiguate.
-func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID int64, err error) error {
+func (s *PlayerStore) classifyUpdateDisplayNameErr(ctx context.Context, playerID int64, err error) error {
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
 		return auth.ErrUsernameTaken
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("failed to update player username: %w", err)
+		return fmt.Errorf("failed to update player display name: %w", err)
 	}
 
 	if _, getErr := s.q.GetPlayer(ctx, playerID); getErr != nil {
@@ -991,7 +991,7 @@ func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID in
 			return auth.ErrPlayerNotFound
 		}
 
-		return fmt.Errorf("failed to verify player after username update: %w", getErr)
+		return fmt.Errorf("failed to verify player after display name update: %w", getErr)
 	}
 
 	return auth.ErrPlayerNotAnonymous
@@ -1002,11 +1002,11 @@ func (s *PlayerStore) classifyUpdateUsernameErr(ctx context.Context, playerID in
 // not exist OR the row has already been claimed), so it re-queries by id
 // to disambiguate.
 func (s *PlayerStore) classifyClaimErr(
-	ctx context.Context, playerID int64, cleanedUsername, cleanedEmail string, err error,
+	ctx context.Context, playerID int64, cleanedDisplayName, cleanedEmail string, err error,
 ) error {
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-		return s.classifyCredentialConflict(ctx, cleanedUsername, cleanedEmail, err)
+		return s.classifyCredentialConflict(ctx, cleanedDisplayName, cleanedEmail, err)
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to claim player: %w", err)
@@ -1027,13 +1027,13 @@ func (s *PlayerStore) classifyClaimErr(
 // ErrUsernameTaken or ErrEmailTaken by looking up which column the
 // caller already took. Any other error wraps through unchanged.
 func (s *PlayerStore) classifyCredentialConflict(
-	ctx context.Context, cleanedUsername, cleanedEmail string, err error,
+	ctx context.Context, cleanedDisplayName, cleanedEmail string, err error,
 ) error {
 	var sqliteErr *sqlite.Error
 	if !errors.As(err, &sqliteErr) || sqliteErr.Code() != sqlite3.SQLITE_CONSTRAINT_UNIQUE {
 		return fmt.Errorf("failed to create player: %w", err)
 	}
-	if _, lookupErr := s.q.GetPlayerByUsername(ctx, cleanedUsername); lookupErr == nil {
+	if _, lookupErr := s.q.GetPlayerByDisplayName(ctx, cleanedDisplayName); lookupErr == nil {
 		return auth.ErrUsernameTaken
 	}
 	if cleanedEmail != "" {
@@ -1050,12 +1050,12 @@ func (s *PlayerStore) classifyCredentialConflict(
 
 func playerFromRow(row db.Player) *auth.Player {
 	p := &auth.Player{
-		ID:              row.ID,
-		Username:        row.Username,
-		Role:            row.Role,
-		CreatedAt:       row.CreatedAt,
-		UsernameClaimed: row.UsernameClaimed != 0,
-		SessionVersion:  row.SessionVersion,
+		ID:                 row.ID,
+		DisplayName:        row.DisplayName,
+		Role:               row.Role,
+		CreatedAt:          row.CreatedAt,
+		DisplayNameClaimed: row.DisplayNameClaimed != 0,
+		SessionVersion:     row.SessionVersion,
 	}
 	if row.Email.Valid {
 		p.Email = row.Email.String

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -73,14 +73,14 @@ func (s *PlayerStore) GetPlayerByID(ctx context.Context, id int64) (*auth.Player
 }
 
 // CreatePlayer creates a credentialled player. Email is trimmed and
-// lowercased before insert. Returns auth.ErrUsernameTaken or
+// lowercased before insert. Returns auth.ErrDisplayNameTaken or
 // auth.ErrEmailTaken on UNIQUE collisions; the underlying SQL
 // promotes the first password-bearing registrant to admin.
 func (s *PlayerStore) CreatePlayer(
 	ctx context.Context,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
-	cleanedDisplayName := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(displayName)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.CreatePlayerWithCredentials(ctx, db.CreatePlayerWithCredentialsParams{
 		DisplayName:   cleanedDisplayName,
@@ -95,16 +95,16 @@ func (s *PlayerStore) CreatePlayer(
 	return playerFromRow(row), nil
 }
 
-// CreateAnonymousPlayer inserts a row with the given username, no email, no
+// CreateAnonymousPlayer inserts a row with the given displayName, no email, no
 // password_hash, role = 'player'. Callers (EnsurePlayer) generate a random
-// "anon-<xid>" username so collisions on the unique index are not a concern;
-// if one happens anyway it surfaces as auth.ErrUsernameTaken.
-func (s *PlayerStore) CreateAnonymousPlayer(ctx context.Context, username string) (*auth.Player, error) {
-	row, err := s.q.CreateAnonymousPlayer(ctx, strings.TrimSpace(username))
+// "anon-<xid>" displayName so collisions on the unique index are not a concern;
+// if one happens anyway it surfaces as auth.ErrDisplayNameTaken.
+func (s *PlayerStore) CreateAnonymousPlayer(ctx context.Context, displayName string) (*auth.Player, error) {
+	row, err := s.q.CreateAnonymousPlayer(ctx, strings.TrimSpace(displayName))
 	if err != nil {
 		var sqliteErr *sqlite.Error
 		if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-			return nil, auth.ErrUsernameTaken
+			return nil, auth.ErrDisplayNameTaken
 		}
 
 		return nil, fmt.Errorf("failed to create anonymous player: %w", err)
@@ -119,16 +119,16 @@ func (s *PlayerStore) CreateAnonymousPlayer(ctx context.Context, username string
 // sign-up that flows through the claim path still triggers the promotion
 // atomically.
 //
-// Returns auth.ErrUsernameTaken when the new username collides with another
+// Returns auth.ErrDisplayNameTaken when the new displayName collides with another
 // row, auth.ErrPlayerAlreadyClaimed when the row already has credentials
 // (the WHERE password_hash IS NULL guard filters it out and the UPDATE
 // returns no rows), and auth.ErrPlayerNotFound when no row matches the id.
 func (s *PlayerStore) ClaimPlayer(
 	ctx context.Context,
 	playerID int64,
-	username, email, passwordHash, requestedRole string,
+	displayName, email, passwordHash, requestedRole string,
 ) (*auth.Player, error) {
-	cleanedDisplayName := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(displayName)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.ClaimPlayer(ctx, db.ClaimPlayerParams{
 		DisplayName:   cleanedDisplayName,
@@ -145,7 +145,7 @@ func (s *PlayerStore) ClaimPlayer(
 }
 
 // UpdatePlayerDisplayName renames an anonymous (password_hash IS NULL)
-// row in place. Returns ErrUsernameTaken on collision,
+// row in place. Returns ErrDisplayNameTaken on collision,
 // ErrPlayerNotAnonymous when the row already has a password_hash
 // (filtered out by the WHERE guard), and ErrPlayerNotFound when the
 // row genuinely does not exist (disambiguated by a follow-up query).
@@ -156,7 +156,7 @@ func (s *PlayerStore) UpdatePlayerDisplayName(
 ) (*auth.Player, error) {
 	cleaned := strings.TrimSpace(displayName)
 	if cleaned == "" {
-		return nil, auth.ErrUsernameEmpty
+		return nil, auth.ErrDisplayNameEmpty
 	}
 
 	row, err := s.q.UpdatePlayerDisplayName(ctx, db.UpdatePlayerDisplayNameParams{
@@ -172,18 +172,18 @@ func (s *PlayerStore) UpdatePlayerDisplayName(
 
 // RenamePlayer changes the display name on an arbitrary player row,
 // not just an anonymous one. Used by the profile-page rename endpoint
-// (POST /profile/username, #410) so authenticated players (password,
-// OAuth, admin) can edit their own name. Returns auth.ErrUsernameEmpty
-// when the input trims to "", auth.ErrUsernameTaken on a UNIQUE
+// (POST /profile/display-name, #410) so authenticated players (password,
+// OAuth, admin) can edit their own name. Returns auth.ErrDisplayNameEmpty
+// when the input trims to "", auth.ErrDisplayNameTaken on a UNIQUE
 // collision, and auth.ErrPlayerNotFound when no row matches the id.
 func (s *PlayerStore) RenamePlayer(
 	ctx context.Context,
 	playerID int64,
-	username string,
+	displayName string,
 ) (*auth.Player, error) {
-	cleaned := strings.TrimSpace(username)
+	cleaned := strings.TrimSpace(displayName)
 	if cleaned == "" {
-		return nil, auth.ErrUsernameEmpty
+		return nil, auth.ErrDisplayNameEmpty
 	}
 
 	row, err := s.q.RenamePlayer(ctx, db.RenamePlayerParams{
@@ -196,7 +196,7 @@ func (s *PlayerStore) RenamePlayer(
 		}
 		var sqliteErr *sqlite.Error
 		if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-			return nil, auth.ErrUsernameTaken
+			return nil, auth.ErrDisplayNameTaken
 		}
 
 		return nil, fmt.Errorf("failed to rename player: %w", err)
@@ -249,21 +249,21 @@ func (s *PlayerStore) GetPlayerByProviderSubject(
 }
 
 // CreatePlayerFromOAuth inserts a new players row with the supplied
-// username + email and no password_hash. Returns auth.ErrUsernameTaken
-// when the username collides (the OAuth handler retries on this
+// displayName + email and no password_hash. Returns auth.ErrDisplayNameTaken
+// when the displayName collides (the OAuth handler retries on this
 // sentinel with a fresh petname).
 func (s *PlayerStore) CreatePlayerFromOAuth(
 	ctx context.Context,
-	username, email string,
+	displayName, email string,
 ) (*auth.Player, error) {
 	row, err := s.q.CreatePlayerFromOAuth(ctx, db.CreatePlayerFromOAuthParams{
-		DisplayName: strings.TrimSpace(username),
+		DisplayName: strings.TrimSpace(displayName),
 		Email:       sql.NullString{String: strings.ToLower(strings.TrimSpace(email)), Valid: true},
 	})
 	if err != nil {
 		var sqliteErr *sqlite.Error
 		if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-			return nil, auth.ErrUsernameTaken
+			return nil, auth.ErrDisplayNameTaken
 		}
 
 		return nil, fmt.Errorf("failed to create player from oauth: %w", err)
@@ -832,12 +832,12 @@ func (s *PlayerStore) SetPlayerEmail(ctx context.Context, playerID int64, email 
 // CreatePlayerByAdmin inserts a fresh credentialled row with
 // email_verified_at stamped (#450). Email is trimmed + lowercased;
 // passwordHash must be non-empty (the handler enforces it before
-// reaching the store). Returns auth.ErrUsernameTaken / auth.ErrEmailTaken
+// reaching the store). Returns auth.ErrDisplayNameTaken / auth.ErrEmailTaken
 // on UNIQUE collisions.
 func (s *PlayerStore) CreatePlayerByAdmin(
-	ctx context.Context, username, email, passwordHash string,
+	ctx context.Context, displayName, email, passwordHash string,
 ) (*auth.Player, error) {
-	cleanedDisplayName := strings.TrimSpace(username)
+	cleanedDisplayName := strings.TrimSpace(displayName)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
 	row, err := s.q.CreatePlayerByAdmin(ctx, db.CreatePlayerByAdminParams{
 		DisplayName:  cleanedDisplayName,
@@ -889,7 +889,7 @@ func (s *PlayerStore) SetPlayerRole(ctx context.Context, playerID int64, role st
 	return nil
 }
 
-// ListAdmins returns every current Admin ordered by username (#320/#538).
+// ListAdmins returns every current Admin ordered by displayName (#320/#538).
 // Empty slice when no Admin exists yet.
 func (s *PlayerStore) ListAdmins(ctx context.Context) ([]*auth.AdminEntry, error) {
 	rows, err := s.q.ListAdmins(ctx)
@@ -980,7 +980,7 @@ func parseSQLiteTimestamp(raw string) *time.Time {
 func (s *PlayerStore) classifyUpdateDisplayNameErr(ctx context.Context, playerID int64, err error) error {
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) && sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-		return auth.ErrUsernameTaken
+		return auth.ErrDisplayNameTaken
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to update player display name: %w", err)
@@ -1024,7 +1024,7 @@ func (s *PlayerStore) classifyClaimErr(
 }
 
 // classifyCredentialConflict maps a SQLITE UNIQUE violation onto
-// ErrUsernameTaken or ErrEmailTaken by looking up which column the
+// ErrDisplayNameTaken or ErrEmailTaken by looking up which column the
 // caller already took. Any other error wraps through unchanged.
 func (s *PlayerStore) classifyCredentialConflict(
 	ctx context.Context, cleanedDisplayName, cleanedEmail string, err error,
@@ -1034,7 +1034,7 @@ func (s *PlayerStore) classifyCredentialConflict(
 		return fmt.Errorf("failed to create player: %w", err)
 	}
 	if _, lookupErr := s.q.GetPlayerByDisplayName(ctx, cleanedDisplayName); lookupErr == nil {
-		return auth.ErrUsernameTaken
+		return auth.ErrDisplayNameTaken
 	}
 	if cleanedEmail != "" {
 		if _, lookupErr := s.q.GetPlayerByEmail(

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -57,7 +57,7 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	if got, want := created.Username, "alice"; got != want {
+	if got, want := created.DisplayName, "alice"; got != want {
 		t.Errorf("CreatePlayer Username = %q, want %q", got, want)
 	}
 	if got, want := created.Role, auth.RoleAdmin; got != want {
@@ -72,18 +72,18 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 		t.Errorf("CreatePlayer HasCustomName() = %v, want %v", got, want)
 	}
 
-	fetched, err := ps.GetPlayerByUsername(t.Context(), "alice")
+	fetched, err := ps.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := fetched.ID, created.ID; got != want {
-		t.Errorf("GetPlayerByUsername ID = %d, want %d", got, want)
+		t.Errorf("GetPlayerByDisplayName ID = %d, want %d", got, want)
 	}
 	if got, want := fetched.Role, auth.RoleAdmin; got != want {
-		t.Errorf("GetPlayerByUsername Role = %q, want %q", got, want)
+		t.Errorf("GetPlayerByDisplayName Role = %q, want %q", got, want)
 	}
 	if got, want := fetched.HasCustomName(), true; got != want {
-		t.Errorf("GetPlayerByUsername HasCustomName() = %v, want %v (re-fetch must persist the flag)", got, want)
+		t.Errorf("GetPlayerByDisplayName HasCustomName() = %v, want %v (re-fetch must persist the flag)", got, want)
 	}
 }
 
@@ -167,22 +167,22 @@ func TestPlayerStore_TrimsWhitespaceOnCreateAndLookup(t *testing.T) {
 	}
 
 	// Lookup with a trailing space matches because the store trims.
-	fetched, err := ps.GetPlayerByUsername(t.Context(), "alice ")
+	fetched, err := ps.GetPlayerByDisplayName(t.Context(), "alice ")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
-	if got, want := fetched.Username, "alice"; got != want {
+	if got, want := fetched.DisplayName, "alice"; got != want {
 		t.Errorf("Username = %q, want %q (whitespace should have been trimmed)", got, want)
 	}
 }
 
-func TestPlayerStore_GetPlayerByUsername_NotFound(t *testing.T) {
+func TestPlayerStore_GetPlayerByDisplayName_NotFound(t *testing.T) {
 	t.Parallel()
 
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	_, err := ps.GetPlayerByUsername(t.Context(), "ghost")
+	_, err := ps.GetPlayerByDisplayName(t.Context(), "ghost")
 	if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -351,7 +351,7 @@ func TestPlayerStore_CreateAnonymousPlayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
-	if got, want := created.Username, "anon-foo"; got != want {
+	if got, want := created.DisplayName, "anon-foo"; got != want {
 		t.Errorf("Username = %q, want %q", got, want)
 	}
 	if got, want := created.PasswordHash, ""; got != want {
@@ -427,8 +427,8 @@ func TestPlayerStore_ClaimPlayer_UpgradesAnonymousRow(t *testing.T) {
 	if got, want := claimed.ID, anon.ID; got != want {
 		t.Errorf("claimed.ID = %d, want %d (claim must preserve player ID)", got, want)
 	}
-	if got, want := claimed.Username, "alice"; got != want {
-		t.Errorf("claimed.Username = %q, want %q", got, want)
+	if got, want := claimed.DisplayName, "alice"; got != want {
+		t.Errorf("claimed.DisplayName = %q, want %q", got, want)
 	}
 	if got, want := claimed.PasswordHash, "hash"; got != want {
 		t.Errorf("claimed.PasswordHash = %q, want %q", got, want)
@@ -473,9 +473,9 @@ func TestPlayerStore_ClaimPlayer_AlreadyClaimed_ReturnsSentinel(t *testing.T) {
 	}
 
 	// Make sure the original claim was not clobbered by the second attempt.
-	stored, err := ps.GetPlayerByUsername(t.Context(), "alice")
+	stored, err := ps.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := stored.ID, anon.ID; got != want {
 		t.Errorf("stored.ID = %d, want %d (first claim should win)", got, want)
@@ -514,7 +514,7 @@ func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
 	}
 }
 
-func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
+func TestPlayerStore_UpdatePlayerDisplayName(t *testing.T) {
 	t.Parallel()
 
 	t.Run("renames an anonymous player in place", func(t *testing.T) {
@@ -533,15 +533,15 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 			t.Fatalf("precondition anon.HasCustomName() = %v, want %v", got, want)
 		}
 
-		updated, err := ps.UpdatePlayerUsername(t.Context(), anon.ID, "alice")
+		updated, err := ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "alice")
 		if err != nil {
-			t.Fatalf("UpdatePlayerUsername err = %v, want nil", err)
+			t.Fatalf("UpdatePlayerDisplayName err = %v, want nil", err)
 		}
 		if got, want := updated.ID, anon.ID; got != want {
 			t.Errorf("updated.ID = %d, want %d (same row)", got, want)
 		}
-		if got, want := updated.Username, "alice"; got != want {
-			t.Errorf("updated.Username = %q, want %q", got, want)
+		if got, want := updated.DisplayName, "alice"; got != want {
+			t.Errorf("updated.DisplayName = %q, want %q", got, want)
 		}
 		if got, want := updated.IsAnonymous(), true; got != want {
 			t.Errorf("updated.IsAnonymous() = %v, want %v (no password set)", got, want)
@@ -574,12 +574,12 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 		}
 
-		updated, err := ps.UpdatePlayerUsername(t.Context(), anon.ID, "  bob  ")
+		updated, err := ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "  bob  ")
 		if err != nil {
-			t.Fatalf("UpdatePlayerUsername err = %v, want nil", err)
+			t.Fatalf("UpdatePlayerDisplayName err = %v, want nil", err)
 		}
-		if got, want := updated.Username, "bob"; got != want {
-			t.Errorf("updated.Username = %q, want %q (whitespace trimmed)", got, want)
+		if got, want := updated.DisplayName, "bob"; got != want {
+			t.Errorf("updated.DisplayName = %q, want %q (whitespace trimmed)", got, want)
 		}
 	})
 
@@ -593,7 +593,7 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 		}
 
-		_, err = ps.UpdatePlayerUsername(t.Context(), anon.ID, "   ")
+		_, err = ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "   ")
 		if got, want := err, auth.ErrUsernameEmpty; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
@@ -618,7 +618,7 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 		}
 
-		_, err = ps.UpdatePlayerUsername(t.Context(), anon.ID, "claimed")
+		_, err = ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "claimed")
 		if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
@@ -640,7 +640,7 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 			t.Fatalf("CreatePlayer err = %v, want nil", err)
 		}
 
-		_, err = ps.UpdatePlayerUsername(t.Context(), credentialled.ID, "newname")
+		_, err = ps.UpdatePlayerDisplayName(t.Context(), credentialled.ID, "newname")
 		if got, want := err, auth.ErrPlayerNotAnonymous; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
@@ -651,7 +651,7 @@ func TestPlayerStore_UpdatePlayerUsername(t *testing.T) {
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
 
-		_, err := ps.UpdatePlayerUsername(t.Context(), 99999, "ghost")
+		_, err := ps.UpdatePlayerDisplayName(t.Context(), 99999, "ghost")
 		if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
@@ -903,7 +903,7 @@ func TestPlayerStore_SetPlayerPasswordHash_AlsoMarksUsernameClaimed(t *testing.T
 	// UPDATE. Production code never does this; the test is exercising
 	// the SetPlayerPasswordHash side effect, not the typical lifecycle.
 	if _, execErr := db.ExecContext(
-		t.Context(), "UPDATE players SET username_claimed = 0 WHERE id = ?", row.ID,
+		t.Context(), "UPDATE players SET display_name_claimed = 0 WHERE id = ?", row.ID,
 	); execErr != nil {
 		t.Fatalf("seed UPDATE err = %v, want nil", execErr)
 	}
@@ -1095,7 +1095,7 @@ func TestPlayerStore_ListAdminAuditForTarget_SurvivesActorDeletion(t *testing.T)
 	if got, want := len(entries), 1; got != want {
 		t.Fatalf("audit entry count = %d, want %d (row must survive actor deletion)", got, want)
 	}
-	if got, want := entries[0].ActorUsername, ""; got != want {
+	if got, want := entries[0].ActorDisplayName, ""; got != want {
 		t.Errorf("ActorUsername = %q, want %q (deleted actor renders blank)", got, want)
 	}
 	if got, want := entries[0].ActorPlayerID, int64(0); got != want {

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -58,7 +58,7 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 	if got, want := created.DisplayName, "alice"; got != want {
-		t.Errorf("CreatePlayer Username = %q, want %q", got, want)
+		t.Errorf("CreatePlayer DisplayName = %q, want %q", got, want)
 	}
 	if got, want := created.Role, auth.RoleAdmin; got != want {
 		t.Errorf("CreatePlayer Role = %q, want %q", got, want)
@@ -66,7 +66,7 @@ func TestPlayerStore_CreateAndGetPlayer(t *testing.T) {
 	if got, want := created.PasswordHash, "hashed-secret"; got != want {
 		t.Errorf("CreatePlayer PasswordHash = %q, want %q", got, want)
 	}
-	// A registered user explicitly picked their username at the form, so
+	// A registered user explicitly picked their displayName at the form, so
 	// the frontend must see hasCustomName=true and skip the claim modal.
 	if got, want := created.HasCustomName(), true; got != want {
 		t.Errorf("CreatePlayer HasCustomName() = %v, want %v", got, want)
@@ -172,7 +172,7 @@ func TestPlayerStore_TrimsWhitespaceOnCreateAndLookup(t *testing.T) {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if got, want := fetched.DisplayName, "alice"; got != want {
-		t.Errorf("Username = %q, want %q (whitespace should have been trimmed)", got, want)
+		t.Errorf("DisplayName = %q, want %q (whitespace should have been trimmed)", got, want)
 	}
 }
 
@@ -188,7 +188,7 @@ func TestPlayerStore_GetPlayerByDisplayName_NotFound(t *testing.T) {
 	}
 }
 
-func TestPlayerStore_CreatePlayer_DuplicateUsername(t *testing.T) {
+func TestPlayerStore_CreatePlayer_DuplicateDisplayName(t *testing.T) {
 	t.Parallel()
 
 	db := dbtest.Open(t)
@@ -198,9 +198,9 @@ func TestPlayerStore_CreatePlayer_DuplicateUsername(t *testing.T) {
 		t.Fatalf("CreatePlayer first call err = %v, want nil", err)
 	}
 
-	// Different email, same username -> ErrUsernameTaken.
+	// Different email, same displayName -> ErrDisplayNameTaken.
 	_, err := ps.CreatePlayer(t.Context(), "alice", "alice-other@example.test", "other", auth.RolePlayer)
-	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+	if got, want := err, auth.ErrDisplayNameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }
@@ -352,7 +352,7 @@ func TestPlayerStore_CreateAnonymousPlayer(t *testing.T) {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 	if got, want := created.DisplayName, "anon-foo"; got != want {
-		t.Errorf("Username = %q, want %q", got, want)
+		t.Errorf("DisplayName = %q, want %q", got, want)
 	}
 	if got, want := created.PasswordHash, ""; got != want {
 		t.Errorf("PasswordHash = %q, want %q (anonymous row should have NULL hash)", got, want)
@@ -371,7 +371,7 @@ func TestPlayerStore_CreateAnonymousPlayer(t *testing.T) {
 	}
 }
 
-func TestPlayerStore_CreateAnonymousPlayer_DuplicateUsername(t *testing.T) {
+func TestPlayerStore_CreateAnonymousPlayer_DuplicateDisplayName(t *testing.T) {
 	t.Parallel()
 
 	db := dbtest.Open(t)
@@ -382,8 +382,8 @@ func TestPlayerStore_CreateAnonymousPlayer_DuplicateUsername(t *testing.T) {
 	}
 
 	_, err := ps.CreateAnonymousPlayer(t.Context(), "anon-clash")
-	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
-		t.Errorf("err = %v, want %v (UNIQUE violation should map to ErrUsernameTaken)", got, want)
+	if got, want := err, auth.ErrDisplayNameTaken; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v (UNIQUE violation should map to ErrDisplayNameTaken)", got, want)
 	}
 }
 
@@ -439,7 +439,7 @@ func TestPlayerStore_ClaimPlayer_UpgradesAnonymousRow(t *testing.T) {
 		t.Errorf("claimed.Role = %q, want %q", got, want)
 	}
 	assertRoleState(t, db, claimed.ID, auth.RoleAdmin, true)
-	// The claim flow is an explicit username choice: the player typed it
+	// The claim flow is an explicit displayName choice: the player typed it
 	// into the register form, so the flag must flip alongside the password.
 	if got, want := claimed.HasCustomName(), true; got != want {
 		t.Errorf("claimed.HasCustomName() = %v, want %v", got, want)
@@ -494,7 +494,7 @@ func TestPlayerStore_ClaimPlayer_UnknownPlayerID_ReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
+func TestPlayerStore_ClaimPlayer_DisplayNameTaken(t *testing.T) {
 	t.Parallel()
 
 	db := dbtest.Open(t)
@@ -509,7 +509,7 @@ func TestPlayerStore_ClaimPlayer_UsernameTaken(t *testing.T) {
 	}
 
 	_, err = ps.ClaimPlayer(t.Context(), anon.ID, "alice", "alice"+"@example.test", "h", auth.RolePlayer)
-	if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+	if got, want := err, auth.ErrDisplayNameTaken; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }
@@ -527,7 +527,7 @@ func TestPlayerStore_UpdatePlayerDisplayName(t *testing.T) {
 			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 		}
 		// Sanity-check the precondition: a fresh anonymous row has not
-		// claimed its username yet - that is what makes this scenario
+		// claimed its displayName yet - that is what makes this scenario
 		// meaningful.
 		if got, want := anon.HasCustomName(), false; got != want {
 			t.Fatalf("precondition anon.HasCustomName() = %v, want %v", got, want)
@@ -583,7 +583,7 @@ func TestPlayerStore_UpdatePlayerDisplayName(t *testing.T) {
 		}
 	})
 
-	t.Run("empty username returns ErrUsernameEmpty", func(t *testing.T) {
+	t.Run("empty displayName returns ErrDisplayNameEmpty", func(t *testing.T) {
 		t.Parallel()
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
@@ -594,12 +594,12 @@ func TestPlayerStore_UpdatePlayerDisplayName(t *testing.T) {
 		}
 
 		_, err = ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "   ")
-		if got, want := err, auth.ErrUsernameEmpty; !errors.Is(got, want) {
+		if got, want := err, auth.ErrDisplayNameEmpty; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
 	})
 
-	t.Run("collision returns ErrUsernameTaken", func(t *testing.T) {
+	t.Run("collision returns ErrDisplayNameTaken", func(t *testing.T) {
 		t.Parallel()
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
@@ -619,7 +619,7 @@ func TestPlayerStore_UpdatePlayerDisplayName(t *testing.T) {
 		}
 
 		_, err = ps.UpdatePlayerDisplayName(t.Context(), anon.ID, "claimed")
-		if got, want := err, auth.ErrUsernameTaken; !errors.Is(got, want) {
+		if got, want := err, auth.ErrDisplayNameTaken; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
 		}
 	})
@@ -871,10 +871,10 @@ func TestPlayerStore_ListPlayerFinishStats_NoGames(t *testing.T) {
 	}
 }
 
-// TestPlayerStore_SetPlayerPasswordHash_AlsoMarksUsernameClaimed pins
+// TestPlayerStore_SetPlayerPasswordHash_AlsoMarksDisplayNameClaimed pins
 // the #289 fix: the operator's -reset-password CLI eventually calls
 // this store method to give a player a password. Before the fix the
-// SQL only updated password_hash, leaving username_claimed=0 on a
+// SQL only updated password_hash, leaving displayName_claimed=0 on a
 // row whose `password_hash IS NOT NULL` - which dragged the player
 // client into the "claim your name" modal for a logged-in admin. The
 // combined update now keeps the two columns in lockstep.
@@ -883,23 +883,23 @@ func TestPlayerStore_ListPlayerFinishStats_NoGames(t *testing.T) {
 // login credential) and the CHECK constraint on players forbids
 // setting password_hash on a row whose email is NULL, so the seed
 // row created below carries an email from the start.
-func TestPlayerStore_SetPlayerPasswordHash_AlsoMarksUsernameClaimed(t *testing.T) {
+func TestPlayerStore_SetPlayerPasswordHash_AlsoMarksDisplayNameClaimed(t *testing.T) {
 	t.Parallel()
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
 	// CreatePlayer-without-password is not exposed, so seed via the
 	// OAuth helper: it inserts a row with email but no password_hash
-	// and username_claimed=1 already. To exercise the
-	// username_claimed=0 -> 1 flip we then rename to keep the row in
+	// and displayName_claimed=1 already. To exercise the
+	// displayName_claimed=0 -> 1 flip we then rename to keep the row in
 	// the "needs claim" state, then run SetPlayerPasswordHash.
 	const email = "set-hash-test@example.test"
 	row, err := ps.CreatePlayerFromOAuth(t.Context(), "anon-claim-after-pw", email)
 	if err != nil {
 		t.Fatalf("CreatePlayerFromOAuth err = %v, want nil", err)
 	}
-	// CreatePlayerFromOAuth sets username_claimed=1; this test wants
-	// the username_claimed=0 starting state, so reset it via a raw
+	// CreatePlayerFromOAuth sets displayName_claimed=1; this test wants
+	// the displayName_claimed=0 starting state, so reset it via a raw
 	// UPDATE. Production code never does this; the test is exercising
 	// the SetPlayerPasswordHash side effect, not the typical lifecycle.
 	if _, execErr := db.ExecContext(
@@ -920,7 +920,7 @@ func TestPlayerStore_SetPlayerPasswordHash_AlsoMarksUsernameClaimed(t *testing.T
 		t.Error("PasswordHash empty after reset, want a non-empty hash")
 	}
 	if got, want := got.HasCustomName(), true; got != want {
-		t.Errorf("HasCustomName() = %v, want %v (SetPlayerPasswordHash must also flip username_claimed)", got, want)
+		t.Errorf("HasCustomName() = %v, want %v (SetPlayerPasswordHash must also flip displayName_claimed)", got, want)
 	}
 }
 
@@ -1096,7 +1096,7 @@ func TestPlayerStore_ListAdminAuditForTarget_SurvivesActorDeletion(t *testing.T)
 		t.Fatalf("audit entry count = %d, want %d (row must survive actor deletion)", got, want)
 	}
 	if got, want := entries[0].ActorDisplayName, ""; got != want {
-		t.Errorf("ActorUsername = %q, want %q (deleted actor renders blank)", got, want)
+		t.Errorf("ActorDisplayName = %q, want %q (deleted actor renders blank)", got, want)
 	}
 	if got, want := entries[0].ActorPlayerID, int64(0); got != want {
 		t.Errorf("ActorPlayerID = %d, want %d (NULL actor maps to zero)", got, want)

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -60,7 +60,7 @@ func (s *QuizStore) ListQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 			Visibility:        r.Visibility,
 			// INNER JOIN on players makes this a plain string (#359);
 			// the FK guarantees a creator row exists.
-			CreatedByUsername: r.CreatedByUsername,
+			CreatedByDisplayName: r.CreatedByDisplayName,
 		}
 		quizzes = append(quizzes, qz)
 	}
@@ -90,7 +90,7 @@ func (s *QuizStore) ListPublicQuizzes(ctx context.Context) ([]*quiz.Quiz, error)
 			TimeLimitSeconds:  int(r.TimeLimitSeconds),
 			Visibility:        r.Visibility,
 			// INNER JOIN, see ListQuizzes (#359).
-			CreatedByUsername: r.CreatedByUsername,
+			CreatedByDisplayName: r.CreatedByDisplayName,
 		}
 		quizzes = append(quizzes, qz)
 	}
@@ -152,7 +152,7 @@ func (s *QuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
 		TimeLimitSeconds:  int(row.TimeLimitSeconds),
 		Visibility:        row.Visibility,
 		// INNER JOIN, see ListQuizzes (#359).
-		CreatedByUsername: row.CreatedByUsername,
+		CreatedByDisplayName: row.CreatedByDisplayName,
 	}
 
 	questions, err := s.ListQuestions(ctx, id)

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -32,8 +32,8 @@ var (
 // hard-codes id = 1, so reference the constant here rather than
 // duplicating the literal in every fixture.
 const (
-	seededAdminID       int64 = 1
-	seededAdminUsername       = "admin"
+	seededAdminID          int64 = 1
+	seededAdminDisplayName       = "admin"
 )
 
 func newTestQuizzes() []*quiz.Quiz {
@@ -43,7 +43,7 @@ func newTestQuizzes() []*quiz.Quiz {
 			Slug:                 "quiz-1",
 			Description:          "Quiz 1 Description",
 			CreatedByPlayerID:    seededAdminID,
-			CreatedByDisplayName: seededAdminUsername,
+			CreatedByDisplayName: seededAdminDisplayName,
 			// #99 / #103: the store normalises a zero TimeLimitSeconds
 			// to the project-wide default and a blank Visibility to
 			// public before INSERT; the fixture mirrors that so
@@ -79,7 +79,7 @@ func newTestQuizzes() []*quiz.Quiz {
 			Slug:                 "quiz-2",
 			Description:          "Quiz 2 Description",
 			CreatedByPlayerID:    seededAdminID,
-			CreatedByDisplayName: seededAdminUsername,
+			CreatedByDisplayName: seededAdminDisplayName,
 			TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
 			Visibility:           quiz.VisibilityPublic,
 			Questions: []*quiz.Question{
@@ -116,7 +116,7 @@ func existingTestQuizzes() []*quiz.Quiz {
 			Slug:                 "quiz-1",
 			Description:          "Quiz 1 Description",
 			CreatedByPlayerID:    seededAdminID,
-			CreatedByDisplayName: seededAdminUsername,
+			CreatedByDisplayName: seededAdminDisplayName,
 			// #99 / #103: the store normalises a zero TimeLimitSeconds
 			// to the project-wide default and a blank Visibility to
 			// public before INSERT; the fixture mirrors that so
@@ -154,7 +154,7 @@ func existingTestQuizzes() []*quiz.Quiz {
 			Slug:                 "quiz-2",
 			Description:          "Quiz 2 Description",
 			CreatedByPlayerID:    seededAdminID,
-			CreatedByDisplayName: seededAdminUsername,
+			CreatedByDisplayName: seededAdminDisplayName,
 			TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
 			Visibility:           quiz.VisibilityPublic,
 			Questions: []*quiz.Question{

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -39,11 +39,11 @@ const (
 func newTestQuizzes() []*quiz.Quiz {
 	return []*quiz.Quiz{
 		{
-			Title:             "Quiz 1",
-			Slug:              "quiz-1",
-			Description:       "Quiz 1 Description",
-			CreatedByPlayerID: seededAdminID,
-			CreatedByUsername: seededAdminUsername,
+			Title:                "Quiz 1",
+			Slug:                 "quiz-1",
+			Description:          "Quiz 1 Description",
+			CreatedByPlayerID:    seededAdminID,
+			CreatedByDisplayName: seededAdminUsername,
 			// #99 / #103: the store normalises a zero TimeLimitSeconds
 			// to the project-wide default and a blank Visibility to
 			// public before INSERT; the fixture mirrors that so
@@ -75,13 +75,13 @@ func newTestQuizzes() []*quiz.Quiz {
 			},
 		},
 		{
-			Title:             "Quiz 2",
-			Slug:              "quiz-2",
-			Description:       "Quiz 2 Description",
-			CreatedByPlayerID: seededAdminID,
-			CreatedByUsername: seededAdminUsername,
-			TimeLimitSeconds:  quiz.DefaultTimeLimitSeconds,
-			Visibility:        quiz.VisibilityPublic,
+			Title:                "Quiz 2",
+			Slug:                 "quiz-2",
+			Description:          "Quiz 2 Description",
+			CreatedByPlayerID:    seededAdminID,
+			CreatedByDisplayName: seededAdminUsername,
+			TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
+			Visibility:           quiz.VisibilityPublic,
 			Questions: []*quiz.Question{
 				{
 					Text:     "Question 2-1",
@@ -111,12 +111,12 @@ func newTestQuizzes() []*quiz.Quiz {
 func existingTestQuizzes() []*quiz.Quiz {
 	return []*quiz.Quiz{
 		{
-			ID:                1,
-			Title:             "Quiz 1",
-			Slug:              "quiz-1",
-			Description:       "Quiz 1 Description",
-			CreatedByPlayerID: seededAdminID,
-			CreatedByUsername: seededAdminUsername,
+			ID:                   1,
+			Title:                "Quiz 1",
+			Slug:                 "quiz-1",
+			Description:          "Quiz 1 Description",
+			CreatedByPlayerID:    seededAdminID,
+			CreatedByDisplayName: seededAdminUsername,
 			// #99 / #103: the store normalises a zero TimeLimitSeconds
 			// to the project-wide default and a blank Visibility to
 			// public before INSERT; the fixture mirrors that so
@@ -150,13 +150,13 @@ func existingTestQuizzes() []*quiz.Quiz {
 			},
 		},
 		{
-			Title:             "Quiz 2",
-			Slug:              "quiz-2",
-			Description:       "Quiz 2 Description",
-			CreatedByPlayerID: seededAdminID,
-			CreatedByUsername: seededAdminUsername,
-			TimeLimitSeconds:  quiz.DefaultTimeLimitSeconds,
-			Visibility:        quiz.VisibilityPublic,
+			Title:                "Quiz 2",
+			Slug:                 "quiz-2",
+			Description:          "Quiz 2 Description",
+			CreatedByPlayerID:    seededAdminID,
+			CreatedByDisplayName: seededAdminUsername,
+			TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
+			Visibility:           quiz.VisibilityPublic,
 			Questions: []*quiz.Question{
 				{
 					ID:       3,
@@ -266,16 +266,16 @@ func TestQuizStore_ListQuizzes(t *testing.T) {
 	summaries := make([]*quiz.Quiz, 0, len(testQuizzes))
 	for _, qz := range testQuizzes {
 		summaries = append(summaries, &quiz.Quiz{
-			ID:                qz.ID,
-			Title:             qz.Title,
-			Slug:              qz.Slug,
-			Description:       qz.Description,
-			CreatedAt:         qz.CreatedAt,
-			UpdatedAt:         qz.UpdatedAt,
-			CreatedByPlayerID: qz.CreatedByPlayerID,
-			CreatedByUsername: qz.CreatedByUsername,
-			TimeLimitSeconds:  qz.TimeLimitSeconds,
-			Visibility:        qz.Visibility,
+			ID:                   qz.ID,
+			Title:                qz.Title,
+			Slug:                 qz.Slug,
+			Description:          qz.Description,
+			CreatedAt:            qz.CreatedAt,
+			UpdatedAt:            qz.UpdatedAt,
+			CreatedByPlayerID:    qz.CreatedByPlayerID,
+			CreatedByDisplayName: qz.CreatedByDisplayName,
+			TimeLimitSeconds:     qz.TimeLimitSeconds,
+			Visibility:           qz.Visibility,
 		})
 	}
 
@@ -802,16 +802,16 @@ func TestQuizStore_UpdateQuiz(t *testing.T) {
 	}
 
 	updatedQuiz := &quiz.Quiz{
-		ID:                originalQuiz.ID,
-		Title:             originalQuiz.Title + " Updated",
-		Slug:              originalQuiz.Slug + "-updated",
-		Description:       originalQuiz.Description + " Updated",
-		CreatedAt:         originalQuiz.CreatedAt,
-		UpdatedAt:         originalQuiz.UpdatedAt,
-		CreatedByPlayerID: originalQuiz.CreatedByPlayerID,
-		CreatedByUsername: originalQuiz.CreatedByUsername,
-		TimeLimitSeconds:  originalQuiz.TimeLimitSeconds,
-		Visibility:        originalQuiz.Visibility,
+		ID:                   originalQuiz.ID,
+		Title:                originalQuiz.Title + " Updated",
+		Slug:                 originalQuiz.Slug + "-updated",
+		Description:          originalQuiz.Description + " Updated",
+		CreatedAt:            originalQuiz.CreatedAt,
+		UpdatedAt:            originalQuiz.UpdatedAt,
+		CreatedByPlayerID:    originalQuiz.CreatedByPlayerID,
+		CreatedByDisplayName: originalQuiz.CreatedByDisplayName,
+		TimeLimitSeconds:     originalQuiz.TimeLimitSeconds,
+		Visibility:           originalQuiz.Visibility,
 		Questions: []*quiz.Question{
 			{
 				ID:     originalQuiz.Questions[0].ID,

--- a/internal/store/roles_migration_test.go
+++ b/internal/store/roles_migration_test.go
@@ -60,7 +60,7 @@ func TestRolesMigration_RemapsTiers(t *testing.T) {
 	for username, wantRole := range want {
 		var gotRole string
 		if err := db.QueryRowContext(
-			t.Context(), "SELECT role FROM players WHERE username = ?", username,
+			t.Context(), "SELECT role FROM players WHERE display_name = ?", username,
 		).Scan(&gotRole); err != nil {
 			t.Fatalf("read role for %q: %v", username, err)
 		}

--- a/internal/store/roles_migration_test.go
+++ b/internal/store/roles_migration_test.go
@@ -30,21 +30,24 @@ func TestRolesMigration_RemapsTiers(t *testing.T) {
 	// id=1 is the seed admin (role='admin', is_super_admin=0) from
 	// 20260111110308_add_admin_player.sql; it is already present.
 	seed := []struct {
-		username     string
+		displayName  string
 		role         string
 		isSuperAdmin int
 	}{
-		{username: "plain_player", role: "player", isSuperAdmin: 0},
-		{username: "plain_admin", role: "admin", isSuperAdmin: 0},
-		{username: "super_admin", role: "admin", isSuperAdmin: 1},
+		{displayName: "plain_player", role: "player", isSuperAdmin: 0},
+		{displayName: "plain_admin", role: "admin", isSuperAdmin: 0},
+		{displayName: "super_admin", role: "admin", isSuperAdmin: 1},
 	}
 	for _, s := range seed {
+		// The column is still named username at versionBeforeRolesRemap; a
+		// later migration that goose.Up applies below renames it to
+		// display_name, which is why the assertion query reads display_name.
 		if _, err := db.ExecContext(
 			t.Context(),
 			"INSERT INTO players (username, role, is_super_admin) VALUES (?, ?, ?)",
-			s.username, s.role, s.isSuperAdmin,
+			s.displayName, s.role, s.isSuperAdmin,
 		); err != nil {
-			t.Fatalf("seed %q: %v", s.username, err)
+			t.Fatalf("seed %q: %v", s.displayName, err)
 		}
 	}
 
@@ -57,15 +60,15 @@ func TestRolesMigration_RemapsTiers(t *testing.T) {
 		"plain_admin":  "host",
 		"super_admin":  "admin",
 	}
-	for username, wantRole := range want {
+	for displayName, wantRole := range want {
 		var gotRole string
 		if err := db.QueryRowContext(
-			t.Context(), "SELECT role FROM players WHERE display_name = ?", username,
+			t.Context(), "SELECT role FROM players WHERE display_name = ?", displayName,
 		).Scan(&gotRole); err != nil {
-			t.Fatalf("read role for %q: %v", username, err)
+			t.Fatalf("read role for %q: %v", displayName, err)
 		}
 		if gotRole != wantRole {
-			t.Errorf("role for %q = %q, want %q", username, gotRole, wantRole)
+			t.Errorf("role for %q = %q, want %q", displayName, gotRole, wantRole)
 		}
 	}
 

--- a/internal/store/round_test.go
+++ b/internal/store/round_test.go
@@ -14,13 +14,13 @@ func newTestQuizForGroups(t *testing.T, qs *QuizStore) *quiz.Quiz {
 	t.Helper()
 
 	qz := &quiz.Quiz{
-		Title:             "Quiz With Groups",
-		Slug:              "quiz-with-rounds",
-		Description:       "fixture for round tests",
-		CreatedByPlayerID: seededAdminID,
-		CreatedByUsername: seededAdminUsername,
-		TimeLimitSeconds:  quiz.DefaultTimeLimitSeconds,
-		Visibility:        quiz.VisibilityPublic,
+		Title:                "Quiz With Groups",
+		Slug:                 "quiz-with-rounds",
+		Description:          "fixture for round tests",
+		CreatedByPlayerID:    seededAdminID,
+		CreatedByDisplayName: seededAdminUsername,
+		TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
+		Visibility:           quiz.VisibilityPublic,
 	}
 	if err := qs.CreateQuiz(t.Context(), qz); err != nil {
 		t.Fatalf("failed to create quiz fixture: %v", err)

--- a/internal/store/round_test.go
+++ b/internal/store/round_test.go
@@ -18,7 +18,7 @@ func newTestQuizForGroups(t *testing.T, qs *QuizStore) *quiz.Quiz {
 		Slug:                 "quiz-with-rounds",
 		Description:          "fixture for round tests",
 		CreatedByPlayerID:    seededAdminID,
-		CreatedByDisplayName: seededAdminUsername,
+		CreatedByDisplayName: seededAdminDisplayName,
 		TimeLimitSeconds:     quiz.DefaultTimeLimitSeconds,
 		Visibility:           quiz.VisibilityPublic,
 	}

--- a/internal/store/rounds_migration_test.go
+++ b/internal/store/rounds_migration_test.go
@@ -166,7 +166,7 @@ func seedPlayer(t *testing.T, db *sql.DB) int64 {
 	t.Helper()
 	res, err := db.ExecContext(
 		context.Background(),
-		"INSERT INTO players (username, role) VALUES ('mig-admin', 'host')",
+		"INSERT INTO players (display_name, role) VALUES ('mig-admin', 'host')",
 	)
 	if err != nil {
 		t.Fatalf("seed player err = %v, want nil", err)

--- a/internal/web/tmpl/admin/pages/invites.gohtml
+++ b/internal/web/tmpl/admin/pages/invites.gohtml
@@ -12,7 +12,7 @@
     <header class="mb-8">
         <h1 class="font-display font-bold text-3xl leading-[1.15] tracking-tight">Invites</h1>
         <p class="mt-1.5 max-w-[540px] text-text-dim text-[0.95rem]">
-            Send an email invite. The recipient picks their own username and password from
+            Send an email invite. The recipient picks their own displayName and password from
             the link; their account lands already email-verified. The link is valid for 7 days.
         </p>
     </header>

--- a/internal/web/tmpl/admin/pages/playerdetail.gohtml
+++ b/internal/web/tmpl/admin/pages/playerdetail.gohtml
@@ -5,14 +5,14 @@
             <li class="text-text-mute" aria-hidden="true">/</li>
             <li><a href="/admin/players" class="px-2 text-text-dim hover:text-text">Players</a></li>
             <li class="text-text-mute" aria-hidden="true">/</li>
-            <li><span class="pl-2 text-text" aria-current="page">{{.Player.Username}}</span></li>
+            <li><span class="pl-2 text-text" aria-current="page">{{.Player.DisplayName}}</span></li>
         </ol>
     </nav>
 
     <header class="mb-8 flex flex-col md:flex-row md:items-start md:justify-between gap-5">
         <div>
             <h1 class="font-display font-bold text-3xl leading-[1.15] tracking-tight">
-                {{.Player.Username}}
+                {{.Player.DisplayName}}
                 {{if .Player.IsAdmin}}<span class="ml-2 inline-flex items-center rounded-sm border border-accent bg-accent/10 px-2 py-1 align-middle text-sm text-text">admin</span>{{else if .Player.IsHost}}<span class="ml-2 inline-flex items-center rounded-sm border border-accent bg-accent/10 px-2 py-1 align-middle text-sm text-text">host</span>{{end}}
             </h1>
             <p class="mt-1.5 text-text-dim text-[0.95rem]">State: <span class="text-text">{{.Player.OnboardingState}}</span></p>
@@ -94,7 +94,7 @@
                     <form method="POST" action="/admin/players/{{.Player.ID}}/username" class="flex flex-col gap-2">
                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                         <label for="display-name-input" class="text-text-dim text-xs uppercase tracking-[0.14em]">Name</label>
-                        <input id="display-name-input" type="text" name="display_name" required value="{{.Player.Username}}"
+                        <input id="display-name-input" type="text" name="display_name" required value="{{.Player.DisplayName}}"
                                class="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text">
                         <button type="submit" class="btn-ghost">Save display name</button>
                     </form>
@@ -138,7 +138,7 @@
                             <span class="text-text">{{.ActionLabel}}{{if .Detail}}: <span class="text-text-dim">{{.Detail}}</span>{{end}}</span>
                             <time class="text-text-dim" title="{{.CreatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .CreatedAt}}</time>
                         </div>
-                        <div class="mt-1 text-xs text-text-dim">by {{if .ActorUsername}}{{.ActorUsername}}{{else}}(deleted){{end}}</div>
+                        <div class="mt-1 text-xs text-text-dim">by {{if .ActorDisplayName}}{{.ActorDisplayName}}{{else}}(deleted){{end}}</div>
                     </li>
                 {{end}}
             </ul>

--- a/internal/web/tmpl/admin/pages/playerdetail.gohtml
+++ b/internal/web/tmpl/admin/pages/playerdetail.gohtml
@@ -91,7 +91,7 @@
                         </select>
                         <button type="submit" class="btn-primary">Save role</button>
                     </form>
-                    <form method="POST" action="/admin/players/{{.Player.ID}}/username" class="flex flex-col gap-2">
+                    <form method="POST" action="/admin/players/{{.Player.ID}}/display-name" class="flex flex-col gap-2">
                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                         <label for="display-name-input" class="text-text-dim text-xs uppercase tracking-[0.14em]">Name</label>
                         <input id="display-name-input" type="text" name="display_name" required value="{{.Player.DisplayName}}"

--- a/internal/web/tmpl/admin/pages/playernew.gohtml
+++ b/internal/web/tmpl/admin/pages/playernew.gohtml
@@ -26,7 +26,7 @@
 
         <label class="flex flex-col gap-1 text-sm">
             <span class="text-text-dim text-xs uppercase tracking-[0.14em]">Name (optional)</span>
-            <input type="text" name="display_name" value="{{.Username}}" autocomplete="off"
+            <input type="text" name="display_name" value="{{.DisplayName}}" autocomplete="off"
                    class="rounded-md border border-border bg-surface px-3 py-2 text-text" placeholder="Auto-generated if left blank">
         </label>
 

--- a/internal/web/tmpl/admin/pages/playerslist.gohtml
+++ b/internal/web/tmpl/admin/pages/playerslist.gohtml
@@ -43,7 +43,7 @@
             <table class="w-full text-sm">
                 <thead class="bg-surface text-text-dim text-[0.7rem] uppercase tracking-[0.14em]">
                     <tr>
-                        <th scope="col" class="px-4 py-3 text-left">Username</th>
+                        <th scope="col" class="px-4 py-3 text-left">DisplayName</th>
                         <th scope="col" class="px-4 py-3 text-left">State</th>
                         <th scope="col" class="px-4 py-3 text-left">Account type</th>
                         <th scope="col" class="px-4 py-3 text-left">Email</th>

--- a/internal/web/tmpl/admin/pages/playerslist.gohtml
+++ b/internal/web/tmpl/admin/pages/playerslist.gohtml
@@ -56,7 +56,7 @@
                     {{range .Players}}
                         <tr class="border-t border-border-soft" data-state="{{.OnboardingState}}">
                             <td class="px-4 py-3">
-                                <a href="/admin/players/{{.ID}}" class="text-text hover:text-accent">{{.Username}}</a>
+                                <a href="/admin/players/{{.ID}}" class="text-text hover:text-accent">{{.DisplayName}}</a>
                                 {{if .IsAdmin}}<span class="ml-2 inline-flex items-center rounded-sm border border-accent bg-accent/10 px-1.5 py-0.5 text-xs text-text">admin</span>{{end}}
                             </td>
                             <td class="px-4 py-3 text-text-dim">{{.OnboardingState}}</td>

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -72,8 +72,8 @@
                                     <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
                                 </button>
                             </div>
-                        {{else if .CreatedByUsername}}
-                            <span class="text-[0.7rem] uppercase tracking-[0.12em] text-text-mute">Created by {{.CreatedByUsername}}</span>
+                        {{else if .CreatedByDisplayName}}
+                            <span class="text-[0.7rem] uppercase tracking-[0.12em] text-text-mute">Created by {{.CreatedByDisplayName}}</span>
                         {{end}}
                     </footer>
                 </article>

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -17,8 +17,8 @@
                      so the structure is in place for #103. */}}
                 <span class="pill pill-public">Public</span>
                 <span class="m-0 text-text-dim text-[0.7rem] font-semibold uppercase tracking-[0.18em]">Quiz #{{.Quiz.ID}}</span>
-                {{if .Quiz.CreatedByUsername}}
-                    <span class="m-0 text-text-dim text-[0.7rem] font-semibold uppercase tracking-[0.18em]">Created by {{.Quiz.CreatedByUsername}}</span>
+                {{if .Quiz.CreatedByDisplayName}}
+                    <span class="m-0 text-text-dim text-[0.7rem] font-semibold uppercase tracking-[0.18em]">Created by {{.Quiz.CreatedByDisplayName}}</span>
                 {{end}}
             </div>
 
@@ -244,12 +244,12 @@
                 <div class="player-list">
                     {{range .Players}}
                         <div class="player-row">
-                            <div class="player-name">{{.Username}}</div>
+                            <div class="player-name">{{.DisplayName}}</div>
                             <div class="player-score tabular-nums">{{.Score}}</div>
                             <button type="button"
                                     onclick="openModal('modal-reset-player-{{.PlayerID}}')"
                                     class="player-reset"
-                                    aria-label="Reset {{.Username}}">
+                                    aria-label="Reset {{.DisplayName}}">
                                 Reset
                             </button>
                         </div>
@@ -267,7 +267,7 @@
                                         class="w-6 h-6 inline-flex items-center justify-center rounded-full bg-border-soft text-text-dim border-0 hover:bg-border hover:text-text cursor-pointer">&times;</button>
                             </header>
                             <section class="px-6 py-5 text-[0.95rem]">
-                                Are you sure you want to reset <strong class="text-text">&#34;{{.Username}}&#34;</strong>'s attempt? Their game and all answers will be deleted, and they will be able to play this quiz again. This action cannot be undone.
+                                Are you sure you want to reset <strong class="text-text">&#34;{{.DisplayName}}&#34;</strong>'s attempt? Their game and all answers will be deleted, and they will be able to play this quiz again. This action cannot be undone.
                             </section>
                             <footer class="flex justify-end gap-2 px-6 py-4 border-t border-border-soft">
                                 <button type="button"

--- a/internal/web/tmpl/admin/pages/settings.gohtml
+++ b/internal/web/tmpl/admin/pages/settings.gohtml
@@ -29,7 +29,7 @@
                 <table class="w-full text-sm">
                     <thead>
                         <tr class="text-left text-text-dim uppercase text-xs tracking-[0.14em] border-b border-border-soft">
-                            <th class="px-4 py-3 font-semibold">Username</th>
+                            <th class="px-4 py-3 font-semibold">DisplayName</th>
                             <th class="px-4 py-3 font-semibold">Email</th>
                             <th class="px-4 py-3 font-semibold">Promoted</th>
                             <th class="px-4 py-3 font-semibold text-right">Action</th>

--- a/internal/web/tmpl/admin/pages/settings.gohtml
+++ b/internal/web/tmpl/admin/pages/settings.gohtml
@@ -38,7 +38,7 @@
                     <tbody>
                         {{range .Admins}}
                             <tr class="border-b border-border-soft last:border-0">
-                                <td class="px-4 py-3 text-text">{{.Username}}</td>
+                                <td class="px-4 py-3 text-text">{{.DisplayName}}</td>
                                 <td class="px-4 py-3 text-text-dim">{{if .Email}}{{.Email}}{{else}}&mdash;{{end}}</td>
                                 <td class="px-4 py-3 text-text-dim">
                                     {{if .PromotedAt}}
@@ -49,7 +49,7 @@
                                 </td>
                                 <td class="px-4 py-3 text-right">
                                     <form method="POST" action="/admin/players/{{.ID}}/role" class="inline-flex"
-                                          onsubmit="return confirm('Remove Admin from {{.Username}}?');">
+                                          onsubmit="return confirm('Remove Admin from {{.DisplayName}}?');">
                                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                                         <input type="hidden" name="role" value="host">
                                         <button type="submit" class="btn-ghost">Demote</button>

--- a/internal/web/tmpl/auth/pages/accept_invite.gohtml
+++ b/internal/web/tmpl/auth/pages/accept_invite.gohtml
@@ -21,7 +21,7 @@
             <input type="hidden" name="token" value="{{.Token}}">
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Name</span>
-                <input type="text" name="display_name" value="{{.Username}}" autocomplete="nickname" required class="form-input">
+                <input type="text" name="display_name" value="{{.DisplayName}}" autocomplete="nickname" required class="form-input">
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Password</span>

--- a/internal/web/tmpl/auth/pages/access_denied.gohtml
+++ b/internal/web/tmpl/auth/pages/access_denied.gohtml
@@ -12,7 +12,7 @@
         <p class="mt-3 mb-6 text-text-dim text-[0.95rem]">This area requires an admin account.</p>
 
         <p class="mb-8 text-[0.95rem]">
-            You are signed in as <strong class="text-text font-semibold">{{.Username}}</strong>, but the page you tried to open is
+            You are signed in as <strong class="text-text font-semibold">{{.DisplayName}}</strong>, but the page you tried to open is
             only available to admins.
         </p>
 

--- a/internal/web/tmpl/auth/pages/profile.gohtml
+++ b/internal/web/tmpl/auth/pages/profile.gohtml
@@ -22,7 +22,7 @@
             <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
         {{end}}
 
-        <form action="/profile/username" method="POST" class="bg-surface border border-border-soft rounded-lg p-6">
+        <form action="/profile/display-name" method="POST" class="bg-surface border border-border-soft rounded-lg p-6">
             <input type="hidden" name="csrf_token" value="{{csrfToken}}">
 
             <div class="form-field">

--- a/internal/web/tmpl/auth/pages/profile.gohtml
+++ b/internal/web/tmpl/auth/pages/profile.gohtml
@@ -29,7 +29,7 @@
                 <label for="display_name" class="label-eyebrow">Name</label>
                 <input id="display_name" name="display_name" type="text" required
                        autocomplete="nickname"
-                       value="{{.Username}}" class="form-input">
+                       value="{{.DisplayName}}" class="form-input">
                 <p class="mt-2 text-xs text-text-mute">
                     This is the name your leaderboard rows are shown under.
                 </p>

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -34,7 +34,7 @@
                 <label for="display_name" class="label-eyebrow">Name</label>
                 <input id="display_name" name="display_name" type="text"
                        autocomplete="nickname"
-                       value="{{.Username}}" class="form-input">
+                       value="{{.DisplayName}}" class="form-input">
                 <p class="mt-2 text-xs text-text-mute">Leave blank to use a generated name.</p>
             </div>
 

--- a/internal/web/tmpl/home/layouts/base.gohtml
+++ b/internal/web/tmpl/home/layouts/base.gohtml
@@ -51,7 +51,7 @@
      quiz authors are a tiny minority of visitors, so the admin link
      stays low-contrast at the bottom. The auth slot flips between
      two states: an anonymous visitor sees "Log in"; a signed-in
-     visitor sees their username and a Log out button so they have a
+     visitor sees their displayName and a Log out button so they have a
      visible way out of the session without having to know about
      /admin. Log out is a POST to keep the existing CSRF middleware
      happy; the form's inline styling keeps it visually flush with

--- a/internal/web/tmpl/home/layouts/base.gohtml
+++ b/internal/web/tmpl/home/layouts/base.gohtml
@@ -60,7 +60,7 @@
     <span>Top Banana!</span>
     <div class="flex items-center gap-4">
         {{if .Viewer}}
-            <a href="/profile" class="hover:text-text-dim underline-offset-2 hover:underline">Signed in as <span class="text-text-dim">{{.Viewer.Username}}</span></a>
+            <a href="/profile" class="hover:text-text-dim underline-offset-2 hover:underline">Signed in as <span class="text-text-dim">{{.Viewer.DisplayName}}</span></a>
             <form action="/logout" method="POST" class="m-0 p-0 inline">
                 <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <button type="submit" class="m-0 p-0 bg-transparent border-0 cursor-pointer text-text-mute hover:text-text-dim underline-offset-2 hover:underline">Log out</button>

--- a/internal/web/tmpl/home/pages/all-quizzes.gohtml
+++ b/internal/web/tmpl/home/pages/all-quizzes.gohtml
@@ -39,8 +39,8 @@
                         {{end}}
                         <div class="mt-auto flex items-center justify-between gap-3 pt-2 text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-text-mute">
                             <span>{{.QuestionCount}} {{if eq .QuestionCount 1}}question{{else}}questions{{end}}</span>
-                            {{if .CreatedByUsername}}
-                                <span>By {{.CreatedByUsername}}</span>
+                            {{if .CreatedByDisplayName}}
+                                <span>By {{.CreatedByDisplayName}}</span>
                             {{end}}
                         </div>
                     </article>

--- a/internal/web/tmpl/home/pages/index.gohtml
+++ b/internal/web/tmpl/home/pages/index.gohtml
@@ -96,7 +96,7 @@
                         <li class="flex items-center justify-between gap-3 px-4 py-3">
                             <div class="flex items-center gap-3 min-w-0">
                                 <span class="font-mono text-xs text-text-mute w-5 text-right">{{add $index 1}}</span>
-                                <span class="font-medium truncate">{{$p.Username}}</span>
+                                <span class="font-medium truncate">{{$p.DisplayName}}</span>
                             </div>
                             <span class="text-xs text-text-dim shrink-0">
                                 {{$p.FinishedCount}} {{if eq $p.FinishedCount 1}}quiz{{else}}quizzes{{end}}

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -64,10 +64,10 @@ process.env.TOPBANANA_E2E_DATA_DIR = dataDir;
 // which server it lands on. Bootstrap-admin (first registrant gets the
 // admin role) only fires once per fresh DB, so the allowlist is what
 // promotes subsequent registrants on the same DB. The suite's
-// registerAdmin helper auto-builds "<username>@example.test" from the
-// per-browser usernames, so the email list mirrors those usernames with
+// registerAdmin helper auto-builds "<displayName>@example.test" from the
+// per-browser displayNames, so the email list mirrors those displayNames with
 // the same suffix.
-const adminUsernames = [
+const adminDisplayNames = [
   'e2e-admin-chromium', 'e2e-admin-firefox',                          // auth.spec.ts
   'e2e-admin-create-chromium', 'e2e-admin-create-firefox',            // admin.spec.ts
   'e2e-admin-player-chromium', 'e2e-admin-player-firefox',            // player.spec.ts
@@ -100,7 +100,7 @@ const adminUsernames = [
   'e2e-cred-boss-chromium', 'e2e-cred-boss-firefox',                  // admin-player-credentials.spec.ts name/password (#535)
   'e2e-admin-invite-chromium', 'e2e-admin-invite-firefox',            // admin-invites.spec.ts invite management (#318)
 ];
-const ADMIN_EMAILS = adminUsernames.map(u => `${u}@example.test`).join(',');
+const ADMIN_EMAILS = adminDisplayNames.map(u => `${u}@example.test`).join(',');
 
 const workerServer = (workerIndex: number) => {
   const port = WORKER_PORTS[workerIndex];
@@ -151,7 +151,7 @@ export default defineConfig({
   // One retry in CI absorbs the post-registration flakes (e.g. the
   // URL race after question Save tracked in #384, or any slow-runner
   // browser nav). Registration steps are still single-shot: a retry
-  // hits ErrUsernameTaken from the prior attempt and fails again,
+  // hits ErrDisplayNameTaken from the prior attempt and fails again,
   // but the affected specs are a small subset and the upside on the
   // larger pool of timing-sensitive UI assertions is worth the
   // trade. Local runs keep retries=0 so flakes surface loudly during

--- a/test/e2e/tests/admin-invites.spec.ts
+++ b/test/e2e/tests/admin-invites.spec.ts
@@ -7,10 +7,10 @@ import { registerAdmin } from './helpers';
 // revoke actions on the pending list. Accept-via-link is exercised in the
 // integration suite, where the token is mintable directly.
 test('admin creates, resends, and revokes an invite from the management page', async ({ page, browserName }) => {
-  const adminUsername = `e2e-admin-invite-${browserName}`;
+  const adminDisplayName = `e2e-admin-invite-${browserName}`;
   const inviteEmail = `e2e-invitee-${browserName}@example.test`;
 
-  await registerAdmin(page, adminUsername);
+  await registerAdmin(page, adminDisplayName);
 
   // From the dashboard, the Invite tile leads to the management page.
   await page.goto('/admin');

--- a/test/e2e/tests/admin-nav.spec.ts
+++ b/test/e2e/tests/admin-nav.spec.ts
@@ -7,9 +7,9 @@ import { registerAdmin } from './helpers';
 // linked only by typing the URL or the dashboard card), so the nav links
 // are the load-bearing additions this spec guards.
 test('admin top nav reaches all sections', async ({ page, browserName }) => {
-  const username = `e2e-admin-nav-${browserName}`;
+  const displayName = `e2e-admin-nav-${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
 
   // Scope to the primary nav so the links resolve to the navbar entries,
   // not in-page cards/buttons that happen to share a name.
@@ -33,9 +33,9 @@ test('admin top nav reaches all sections', async ({ page, browserName }) => {
 });
 
 test('admin nav marks the active section', async ({ page, browserName }) => {
-  const username = `e2e-admin-nav-active-${browserName}`;
+  const displayName = `e2e-admin-nav-active-${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
 
   const nav = page.getByRole('navigation', { name: 'Primary' });
 

--- a/test/e2e/tests/admin-player-credentials.spec.ts
+++ b/test/e2e/tests/admin-player-credentials.spec.ts
@@ -7,14 +7,14 @@ import { registerAdmin, markAdmin, PASSWORD } from './helpers';
 // admin session on the main page is left untouched.
 async function registerPlayer(
   context: BrowserContext,
-  username: string,
+  displayName: string,
 ): Promise<void> {
   const playerContext = await context.browser()!.newContext();
   try {
     const playerPage = await playerContext.newPage();
     await playerPage.goto('/register');
-    await playerPage.locator('input[name=email]').fill(`${username}@example.test`);
-    await playerPage.locator('input[name=display_name]').fill(username);
+    await playerPage.locator('input[name=email]').fill(`${displayName}@example.test`);
+    await playerPage.locator('input[name=display_name]').fill(displayName);
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();
@@ -32,30 +32,30 @@ async function registerPlayer(
 // player detail page. Both forms live inside the Admin gate in the
 // Actions card.
 test('admin sets a player display name and password from the detail page', async ({ page, context, browserName }) => {
-  const adminUsername = `e2e-cred-boss-${browserName}`;
-  const targetUsername = `e2e-cred-target-${browserName}`;
-  const renamedUsername = `e2e-cred-renamed-${browserName}`;
+  const adminDisplayName = `e2e-cred-boss-${browserName}`;
+  const targetDisplayName = `e2e-cred-target-${browserName}`;
+  const renamedDisplayName = `e2e-cred-renamed-${browserName}`;
   const newPassword = 'freshpassword13plus';
 
-  await registerAdmin(page, adminUsername);
-  markAdmin(adminUsername);
-  await registerPlayer(context, targetUsername);
+  await registerAdmin(page, adminDisplayName);
+  markAdmin(adminDisplayName);
+  await registerPlayer(context, targetDisplayName);
 
   // Open the target's detail view from the players list.
   await page.goto('/admin/players');
-  await page.getByRole('link', { name: targetUsername }).click();
+  await page.getByRole('link', { name: targetDisplayName }).click();
   await expect(page).toHaveURL(/\/admin\/players\/\d+$/);
-  await expect(page.getByRole('heading', { name: targetUsername })).toBeVisible();
+  await expect(page.getByRole('heading', { name: targetDisplayName })).toBeVisible();
 
   // Rename via the new display-name form; PRG returns with a flash and
   // the persisted name shows in the page heading.
   const nameInput = page.getByLabel('Name', { exact: true });
-  await expect(nameInput).toHaveValue(targetUsername);
-  await nameInput.fill(renamedUsername);
+  await expect(nameInput).toHaveValue(targetDisplayName);
+  await nameInput.fill(renamedDisplayName);
   await page.getByRole('button', { name: 'Save display name' }).click();
   await expect(page).toHaveURL(/\/admin\/players\/\d+$/);
   await expect(page.getByText('Display name updated.')).toBeVisible();
-  await expect(page.getByRole('heading', { name: renamedUsername })).toBeVisible();
+  await expect(page.getByRole('heading', { name: renamedDisplayName })).toBeVisible();
 
   // Set a new password; the confirm dialog warns about signing out other
   // sessions. The success flash confirms the reset ran.

--- a/test/e2e/tests/admin-players.spec.ts
+++ b/test/e2e/tests/admin-players.spec.ts
@@ -11,13 +11,13 @@ import { registerAdmin, PASSWORD } from './helpers';
 // is the bypass the admin-action UI is supposed to replace; using it
 // here would defeat the test).
 test('admin marks an unverified player verified via the detail view', async ({ page, context, browserName }) => {
-  const adminUsername = `e2e-mgmt-admin-${browserName}`;
-  const targetUsername = `e2e-mgmt-target-${browserName}`;
+  const adminDisplayName = `e2e-mgmt-admin-${browserName}`;
+  const targetDisplayName = `e2e-mgmt-target-${browserName}`;
 
   // Register the admin via the helper (which stamps email_verified_at
   // for the admin so /admin/* loads); the helper finishes on
   // /admin/quizzes.
-  await registerAdmin(page, adminUsername);
+  await registerAdmin(page, adminDisplayName);
 
   // Register the second player from a fresh context so the admin
   // session is preserved on the main page. The unverified player is
@@ -26,8 +26,8 @@ test('admin marks an unverified player verified via the detail view', async ({ p
   try {
     const targetPage = await targetContext.newPage();
     await targetPage.goto('/register');
-    await targetPage.locator('input[name=email]').fill(`${targetUsername}@example.test`);
-    await targetPage.locator('input[name=display_name]').fill(targetUsername);
+    await targetPage.locator('input[name=email]').fill(`${targetDisplayName}@example.test`);
+    await targetPage.locator('input[name=display_name]').fill(targetDisplayName);
     await targetPage.locator('input[name=password]').fill(PASSWORD);
     await targetPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await targetPage.locator('button[type=submit]').click();
@@ -47,17 +47,17 @@ test('admin marks an unverified player verified via the detail view', async ({ p
   await expect(page.getByRole('heading', { name: 'Players' })).toBeVisible();
   // Match the target's link in the row rather than getByText, which
   // would also match the substring inside the email cell.
-  await expect(page.getByRole('link', { name: targetUsername })).toBeVisible();
+  await expect(page.getByRole('link', { name: targetDisplayName })).toBeVisible();
 
   // Filter to the unverified tab. The target appears; the admin row does not.
   await page.getByRole('link', { name: /^Unverified/i }).click();
   await expect(page).toHaveURL(/\/admin\/players\?state=unverified/);
-  await expect(page.getByRole('link', { name: targetUsername })).toBeVisible();
+  await expect(page.getByRole('link', { name: targetDisplayName })).toBeVisible();
 
   // Open the target's detail view.
-  await page.getByRole('link', { name: targetUsername }).click();
+  await page.getByRole('link', { name: targetDisplayName }).click();
   await expect(page).toHaveURL(/\/admin\/players\/\d+$/);
-  await expect(page.getByRole('heading', { name: targetUsername })).toBeVisible();
+  await expect(page.getByRole('heading', { name: targetDisplayName })).toBeVisible();
 
   // Confirm before the click because the form's onsubmit handler asks.
   page.once('dialog', async (dialog) => {
@@ -77,5 +77,5 @@ test('admin marks an unverified player verified via the detail view', async ({ p
 
   // Walk back to the unverified tab and confirm the target row is gone.
   await page.goto('/admin/players?state=unverified');
-  await expect(page.getByRole('link', { name: targetUsername })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: targetDisplayName })).toHaveCount(0);
 });

--- a/test/e2e/tests/admin-settings.spec.ts
+++ b/test/e2e/tests/admin-settings.spec.ts
@@ -8,14 +8,14 @@ import { registerAdmin, markAdmin, markHost, PASSWORD } from './helpers';
 // row simply needs to exist for the admin to act on.
 async function registerPlayer(
   context: BrowserContext,
-  username: string,
+  displayName: string,
 ): Promise<void> {
   const playerContext = await context.browser()!.newContext();
   try {
     const playerPage = await playerContext.newPage();
     await playerPage.goto('/register');
-    await playerPage.locator('input[name=email]').fill(`${username}@example.test`);
-    await playerPage.locator('input[name=display_name]').fill(username);
+    await playerPage.locator('input[name=email]').fill(`${displayName}@example.test`);
+    await playerPage.locator('input[name=display_name]').fill(displayName);
     await playerPage.locator('input[name=password]').fill(PASSWORD);
     await playerPage.locator('input[name=password_confirm]').fill(PASSWORD);
     await playerPage.locator('button[type=submit]').click();
@@ -32,21 +32,21 @@ async function registerPlayer(
 // #527/#538 — role management lives on the player detail page. An Admin
 // opens a player's detail view, sets their role with the selector, and the
 // change sticks. The Settings page lists Admins and demotes them back to
-// Host via the repointed /role endpoint; it no longer carries a username
+// Host via the repointed /role endpoint; it no longer carries a displayName
 // promote form.
 test('admin promotes a player to admin from the detail page', async ({ page, context, browserName }) => {
-  const adminUsername = `e2e-admin-boss-${browserName}`;
-  const targetUsername = `e2e-admin-target-${browserName}`;
+  const adminDisplayName = `e2e-admin-boss-${browserName}`;
+  const targetDisplayName = `e2e-admin-target-${browserName}`;
 
-  await registerAdmin(page, adminUsername);
-  markAdmin(adminUsername);
-  await registerPlayer(context, targetUsername);
+  await registerAdmin(page, adminDisplayName);
+  markAdmin(adminDisplayName);
+  await registerPlayer(context, targetDisplayName);
 
   // Open the target's detail view from the players list.
   await page.goto('/admin/players');
-  await page.getByRole('link', { name: targetUsername }).click();
+  await page.getByRole('link', { name: targetDisplayName }).click();
   await expect(page).toHaveURL(/\/admin\/players\/\d+$/);
-  await expect(page.getByRole('heading', { name: targetUsername })).toBeVisible();
+  await expect(page.getByRole('heading', { name: targetDisplayName })).toBeVisible();
 
   // The role selector starts at 'player' for a fresh registration.
   const roleSelect = page.getByLabel('Role');
@@ -67,23 +67,23 @@ test('admin promotes a player to admin from the detail page', async ({ page, con
   await page.goto('/admin/settings');
   await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
   const admins = page.getByRole('region', { name: 'Admins' });
-  await expect(admins.getByRole('cell', { name: targetUsername, exact: true })).toBeVisible();
+  await expect(admins.getByRole('cell', { name: targetDisplayName, exact: true })).toBeVisible();
 
-  // The username promote form is gone.
+  // The displayName promote form is gone.
   await expect(page.getByRole('textbox', { name: 'Promote a player' })).toHaveCount(0);
 });
 
 // The role selector can set every tier, ending on Host.
 test('admin sets a player to host from the detail page', async ({ page, context, browserName }) => {
-  const adminUsername = `e2e-host-boss-${browserName}`;
-  const targetUsername = `e2e-host-target-${browserName}`;
+  const adminDisplayName = `e2e-host-boss-${browserName}`;
+  const targetDisplayName = `e2e-host-target-${browserName}`;
 
-  await registerAdmin(page, adminUsername);
-  markAdmin(adminUsername);
-  await registerPlayer(context, targetUsername);
+  await registerAdmin(page, adminDisplayName);
+  markAdmin(adminDisplayName);
+  await registerPlayer(context, targetDisplayName);
 
   await page.goto('/admin/players');
-  await page.getByRole('link', { name: targetUsername }).click();
+  await page.getByRole('link', { name: targetDisplayName }).click();
   await expect(page).toHaveURL(/\/admin\/players\/\d+$/);
 
   const roleSelect = page.getByLabel('Role');
@@ -99,22 +99,22 @@ test('admin sets a player to host from the detail page', async ({ page, context,
 });
 
 test('admin demotes an admin from the settings table', async ({ page, context, browserName }) => {
-  const adminUsername = `e2e-demote-boss-${browserName}`;
-  const targetUsername = `e2e-demote-target-${browserName}`;
+  const adminDisplayName = `e2e-demote-boss-${browserName}`;
+  const targetDisplayName = `e2e-demote-target-${browserName}`;
 
-  await registerAdmin(page, adminUsername);
-  markAdmin(adminUsername);
+  await registerAdmin(page, adminDisplayName);
+  markAdmin(adminDisplayName);
   // Bootstrap the target straight to Admin so the table has a row to
   // demote that is not the last Admin.
-  await registerPlayer(context, targetUsername);
-  markAdmin(targetUsername);
+  await registerPlayer(context, targetDisplayName);
+  markAdmin(targetDisplayName);
 
   await page.goto('/admin/settings');
   const admins = page.getByRole('region', { name: 'Admins' });
-  await expect(admins.getByRole('cell', { name: targetUsername, exact: true })).toBeVisible();
+  await expect(admins.getByRole('cell', { name: targetDisplayName, exact: true })).toBeVisible();
 
   // The target's row Demote button posts to /role with role=host.
-  const targetRow = admins.getByRole('row', { name: new RegExp(`^${targetUsername}\\b`) });
+  const targetRow = admins.getByRole('row', { name: new RegExp(`^${targetDisplayName}\\b`) });
   page.once('dialog', (dialog) => dialog.accept());
   await targetRow.getByRole('button', { name: 'Demote' }).click();
 
@@ -124,14 +124,14 @@ test('admin demotes an admin from the settings table', async ({ page, context, b
 
   // Back on settings the demoted player no longer appears in the table.
   await page.goto('/admin/settings');
-  await expect(admins.getByRole('cell', { name: targetUsername, exact: true })).toHaveCount(0);
+  await expect(admins.getByRole('cell', { name: targetDisplayName, exact: true })).toHaveCount(0);
 });
 
 test('host does not see Settings and gets 404 at /admin/settings', async ({ page, browserName }) => {
-  const username = `e2e-host-plain-${browserName}`;
+  const displayName = `e2e-host-plain-${browserName}`;
 
-  await registerAdmin(page, username);
-  markHost(username);
+  await registerAdmin(page, displayName);
+  markHost(displayName);
   await page.goto('/admin/quizzes');
 
   // No Settings nav link for a Host.
@@ -146,10 +146,10 @@ test('host does not see Settings and gets 404 at /admin/settings', async ({ page
 // A Host gets the dashboard and Quizzes but never the Admin-only Players
 // or Email links (they 404 for a Host).
 test('host does not see Players or Email nav links and 404s on them', async ({ page, browserName }) => {
-  const username = `e2e-host-gating-${browserName}`;
+  const displayName = `e2e-host-gating-${browserName}`;
 
-  await registerAdmin(page, username);
-  markHost(username);
+  await registerAdmin(page, displayName);
+  markHost(displayName);
   await page.goto('/admin/quizzes');
 
   const nav = page.getByRole('navigation', { name: 'Primary' });

--- a/test/e2e/tests/admin.spec.ts
+++ b/test/e2e/tests/admin.spec.ts
@@ -5,10 +5,10 @@ import { registerAdmin, createQuizWithQuestions, QUIZ_QUESTIONS } from './helper
 // default so the admin can present the quiz on screen without exposing
 // answers; the summary toggles per question, independent of siblings.
 test('admin quiz view hides answer options behind a per-question spoiler toggle', async ({ page, browserName }) => {
-  const username = `e2e-admin-spoiler-${browserName}`;
+  const displayName = `e2e-admin-spoiler-${browserName}`;
   const quizTitle = `E2E Spoiler Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
 
   // Spoiler is collapsed by default — option text in the DOM is hidden by
@@ -43,10 +43,10 @@ test('admin can add, edit, and delete a round on a quiz', async ({ page, browser
   // rounds; every quiz starts with a default 'Round 1', so the created
   // round is a second section. Selectors scope to its .round-section to
   // stay unambiguous against the default round.
-  const username = `e2e-admin-rounds-${browserName}`;
+  const displayName = `e2e-admin-rounds-${browserName}`;
   const quizTitle = `E2E Rounds Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
 
@@ -90,10 +90,10 @@ test('register, create a quiz with varied questions, and see them on the quiz vi
   // Each browser project runs against the same shared server, so use unique
   // names per project. ADMIN_EMAILS (in playwright.config.ts) whitelists
   // these emails so registration promotes them to admin.
-  const username = `e2e-admin-create-${browserName}`;
+  const displayName = `e2e-admin-create-${browserName}`;
   const quizTitle = `E2E Admin Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
 
   // After the last addQuestion the quiz view is loaded. The redesign

--- a/test/e2e/tests/auth.spec.ts
+++ b/test/e2e/tests/auth.spec.ts
@@ -5,14 +5,14 @@ const password = 'correctbatterystaple';
 
 test('register, log out, log back in, and reach the admin dashboard', async ({ page, browserName }) => {
   // Each browser project runs against the same shared server, so use a unique
-  // username per project and rely on ADMIN_EMAILS (set in playwright.config.ts)
+  // displayName per project and rely on ADMIN_EMAILS (set in playwright.config.ts)
   // to promote every project's registrant to admin.
-  const username = `e2e-admin-${browserName}`;
+  const displayName = `e2e-admin-${browserName}`;
 
   // registerAdmin handles the register POST, satisfies the #111 PR3
   // verified-email gate by stamping email_verified_at via sqlite3, and
   // leaves the browser at /admin/quizzes ready for the assertions.
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await expect(page.getByRole('heading', { name: 'Quizzes', level: 1 })).toBeVisible();
 
   // Log out via the navbar button. The form posts to /logout, the server
@@ -29,7 +29,7 @@ test('register, log out, log back in, and reach the admin dashboard', async ({ p
   await expect(page.getByRole('heading', { name: 'Log in', level: 1 })).toBeVisible();
 
   // Log back in with the same credentials. Email is the credential after #446.
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
+  await page.locator('input[name=email]').fill(`${displayName}@example.test`);
   await page.locator('input[name=password]').fill(password);
   await page.locator('button[type=submit]').click();
 
@@ -51,12 +51,12 @@ test('deep link while logged out lands at the deep link after login', async ({ p
   // (NOT the role landing at /admin/quizzes). Without the next
   // round-trip the admin would land on /admin/quizzes and have to
   // re-navigate by hand.
-  const username = `e2e-admin-next-${browserName}`;
+  const displayName = `e2e-admin-next-${browserName}`;
   const password = 'correctbatterystaple';
 
   // Register fresh (and clear the verified-email gate) so the session
   // is set up for the logout + deep-link flow.
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
 
   await page.getByRole('button', { name: 'Log out' }).click();
   await expect(page).toHaveURL(/\/login$/);
@@ -65,7 +65,7 @@ test('deep link while logged out lands at the deep link after login', async ({ p
   await page.goto('/admin/email');
   await expect(page).toHaveURL(/\/login\?next=%2Fadmin%2Femail$/);
 
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
+  await page.locator('input[name=email]').fill(`${displayName}@example.test`);
   await page.locator('input[name=password]').fill(password);
   await page.locator('button[type=submit]').click();
 

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -10,7 +10,7 @@ const PETNAME_PATTERN = /^[A-Z][a-z]+-[A-Z][a-z]+-[A-Z][a-z]+$/;
 test('start screen shows a Playing as card with an auto-generated petname for a fresh anonymous visitor', async ({ page }) => {
   // Playwright's default per-test context has fresh cookies, so navigating
   // to /client/ triggers EnsurePlayer to mint a new anonymous row whose
-  // username is the generated petname.
+  // displayName is the generated petname.
   await page.goto('/client/');
 
   // Two `.claim-cta` blocks live in the DOM at once — start-screen and
@@ -166,19 +166,19 @@ test('Change your name modal pre-fills the input with the current display name',
 });
 
 // Test 5 — authenticated players never see the claim CTA (#409). Their
-// username is stable and changes go through the future profile page
+// displayName is stable and changes go through the future profile page
 // (#410), so the in-game prompt would be noise. Registers as a plain
 // player rather than relying on registerAdmin so the test is robust
 // to ordering — other tests in the same e2e worker may have already
 // claimed the "first registrant becomes admin" slot.
 test('signed-in player does not see the claim-name CTA on the player client', async ({ page, browserName }) => {
-  const username = `e2e-claim-authn-${browserName}-${Date.now()}`;
+  const displayName = `e2e-claim-authn-${browserName}-${Date.now()}`;
   // The hard gate (#574) means register no longer signs the player in.
   // Verify the row directly, then log in so the client sees an
   // authenticated player.
-  await registerForPending(page, username);
-  markEmailVerified(username);
-  await login(page, username);
+  await registerForPending(page, displayName);
+  markEmailVerified(displayName);
+  await login(page, displayName);
 
   await page.goto('/client/');
 

--- a/test/e2e/tests/email-admin.spec.ts
+++ b/test/e2e/tests/email-admin.spec.ts
@@ -7,9 +7,9 @@ import { registerAdmin } from './helpers';
 // hop is what keeps Firefox from prompting "resend this form?" on
 // refresh, so the URL assertion below is load-bearing.
 test('admin can open the email diagnostics page and see status + log', async ({ page, browserName }) => {
-  const username = `e2e-admin-email-${browserName}`;
+  const displayName = `e2e-admin-email-${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
 
   await page.goto('/admin/email');
   await expect(page).toHaveURL(/\/admin\/email$/);

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -22,15 +22,15 @@ export const QUIZ_QUESTIONS: readonly QuestionSpec[] = [
   { text: 'Which are prime?',      options: ['2', '3', '5', '9'],               correctIndices: [0, 1, 2] },
 ];
 
-export async function registerAdmin(page: Page, username: string): Promise<void> {
-  await registerForPending(page, username);
+export async function registerAdmin(page: Page, displayName: string): Promise<void> {
+  await registerForPending(page, displayName);
   // The hard email-verification gate (#574) means register no longer
   // hands out a session: SMTP isn't wired in e2e so we cannot complete
   // the user-facing verify flow, so stamp email_verified_at directly
   // (same trick home.spec.ts uses to wipe games), then log in to obtain
   // a session and land on the admin dashboard.
-  markEmailVerified(username);
-  await login(page, username);
+  markEmailVerified(displayName);
+  await login(page, displayName);
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
 }
 
@@ -38,11 +38,11 @@ export async function registerAdmin(page: Page, username: string): Promise<void>
 // the post-#574 hard-gate outcome: register renders the "verify your
 // email" confirmation at /register with no session (no redirect). The
 // row now exists but the visitor is not signed in. Email is the
-// credential after #446; username is the optional display name.
-export async function registerForPending(page: Page, username: string): Promise<void> {
+// credential after #446; displayName is the optional display name.
+export async function registerForPending(page: Page, displayName: string): Promise<void> {
   await page.goto('/register');
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
-  await page.locator('input[name=display_name]').fill(username);
+  await page.locator('input[name=email]').fill(`${displayName}@example.test`);
+  await page.locator('input[name=display_name]').fill(displayName);
   await page.locator('input[name=password]').fill(PASSWORD);
   await page.locator('input[name=password_confirm]').fill(PASSWORD);
   await page.locator('button[type=submit]').click();
@@ -54,14 +54,14 @@ export async function registerForPending(page: Page, username: string): Promise<
 // the post-login landing URL (it varies by role). LOGIN_COOLDOWN is set
 // to 0s in playwright.config.ts, so back-to-back logins in a worker do
 // not trip the per-IP rate limiter.
-export async function login(page: Page, username: string): Promise<void> {
+export async function login(page: Page, displayName: string): Promise<void> {
   await page.goto('/login');
-  await page.locator('input[name=email]').fill(`${username}@example.test`);
+  await page.locator('input[name=email]').fill(`${displayName}@example.test`);
   await page.locator('input[name=password]').fill(PASSWORD);
   await page.locator('button[type=submit]').click();
 }
 
-export function markEmailVerified(username: string): void {
+export function markEmailVerified(displayName: string): void {
   const dataDir = process.env.TOPBANANA_E2E_DATA_DIR;
   if (!dataDir) {
     throw new Error('TOPBANANA_E2E_DATA_DIR is not set; helpers cannot stamp email_verified_at');
@@ -71,14 +71,14 @@ export function markEmailVerified(username: string): void {
   // doesn't actually neutralise an injection payload on its own. Escape
   // the single quote here instead -- standard SQL literal escaping, one
   // line, no extra round-trip through the CLI's parameter parser.
-  const escapedUsername = username.replace(/'/g, "''");
+  const escapedDisplayName = displayName.replace(/'/g, "''");
   const output = execFileSync('sqlite3', [
     dbFile,
-    `UPDATE players SET email_verified_at = CURRENT_TIMESTAMP WHERE display_name = '${escapedUsername}'; SELECT changes();`,
+    `UPDATE players SET email_verified_at = CURRENT_TIMESTAMP WHERE display_name = '${escapedDisplayName}'; SELECT changes();`,
   ], { encoding: 'utf8' });
   const changed = Number.parseInt(output.trim(), 10);
   if (changed !== 1) {
-    throw new Error(`markEmailVerified(${username}): expected 1 row updated, got ${changed}`);
+    throw new Error(`markEmailVerified(${displayName}): expected 1 row updated, got ${changed}`);
   }
 }
 
@@ -86,29 +86,29 @@ export function markEmailVerified(username: string): void {
 // shelling out to the sqlite3 CLI, mirroring how the production promote
 // path mutates the row. The e2e suite has no Admin out of the box, so
 // this is the bootstrap the settings/role specs use.
-export function markAdmin(username: string): void {
-  setRole(username, 'admin');
+export function markAdmin(displayName: string): void {
+  setRole(displayName, 'admin');
 }
 
 // markHost sets role='host' (the middle tier) for the named player.
-export function markHost(username: string): void {
-  setRole(username, 'host');
+export function markHost(displayName: string): void {
+  setRole(displayName, 'host');
 }
 
-function setRole(username: string, role: 'player' | 'host' | 'admin'): void {
+function setRole(displayName: string, role: 'player' | 'host' | 'admin'): void {
   const dataDir = process.env.TOPBANANA_E2E_DATA_DIR;
   if (!dataDir) {
     throw new Error('TOPBANANA_E2E_DATA_DIR is not set; helpers cannot stamp role');
   }
   const dbFile = join(dataDir, `e2e-${test.info().parallelIndex}.db`);
-  const escapedUsername = username.replace(/'/g, "''");
+  const escapedDisplayName = displayName.replace(/'/g, "''");
   const output = execFileSync('sqlite3', [
     dbFile,
-    `UPDATE players SET role = '${role}' WHERE display_name = '${escapedUsername}'; SELECT changes();`,
+    `UPDATE players SET role = '${role}' WHERE display_name = '${escapedDisplayName}'; SELECT changes();`,
   ], { encoding: 'utf8' });
   const changed = Number.parseInt(output.trim(), 10);
   if (changed !== 1) {
-    throw new Error(`setRole(${username}, ${role}): expected 1 row updated, got ${changed}`);
+    throw new Error(`setRole(${displayName}, ${role}): expected 1 row updated, got ${changed}`);
   }
 }
 

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -74,7 +74,7 @@ export function markEmailVerified(username: string): void {
   const escapedUsername = username.replace(/'/g, "''");
   const output = execFileSync('sqlite3', [
     dbFile,
-    `UPDATE players SET email_verified_at = CURRENT_TIMESTAMP WHERE username = '${escapedUsername}'; SELECT changes();`,
+    `UPDATE players SET email_verified_at = CURRENT_TIMESTAMP WHERE display_name = '${escapedUsername}'; SELECT changes();`,
   ], { encoding: 'utf8' });
   const changed = Number.parseInt(output.trim(), 10);
   if (changed !== 1) {
@@ -104,7 +104,7 @@ function setRole(username: string, role: 'player' | 'host' | 'admin'): void {
   const escapedUsername = username.replace(/'/g, "''");
   const output = execFileSync('sqlite3', [
     dbFile,
-    `UPDATE players SET role = '${role}' WHERE username = '${escapedUsername}'; SELECT changes();`,
+    `UPDATE players SET role = '${role}' WHERE display_name = '${escapedUsername}'; SELECT changes();`,
   ], { encoding: 'utf8' });
   const changed = Number.parseInt(output.trim(), 10);
   if (changed !== 1) {

--- a/test/e2e/tests/pregame-nav.spec.ts
+++ b/test/e2e/tests/pregame-nav.spec.ts
@@ -11,22 +11,22 @@ import { registerAdmin, registerForPending, login, createQuizWithQuestions, mark
 // becomes admin" slot may already be taken by another spec in the same
 // worker), mirroring claim.spec.ts's authenticated-player test.
 test('signed-in player can reach /profile via the account link on the play SPA', async ({ page, browserName }) => {
-  const username = `e2e-pregame-authn-${browserName}-${Date.now()}`;
+  const displayName = `e2e-pregame-authn-${browserName}-${Date.now()}`;
   // The hard gate (#574) means register no longer signs the player in.
   // Verify the row directly, then log in so the SPA sees an
   // authenticated, verified player.
-  await registerForPending(page, username);
-  markEmailVerified(username);
-  await login(page, username);
+  await registerForPending(page, displayName);
+  markEmailVerified(displayName);
+  await login(page, displayName);
 
   await page.goto('/client/');
 
-  // The account link shows the player's username and links to /profile.
+  // The account link shows the player's displayName and links to /profile.
   // It is gated on isAuthenticated() so an anonymous visitor never sees
   // it; the claim CTA covers that case instead.
   const accountLink = page.getByTestId('account-profile-link');
   await expect(accountLink).toBeVisible();
-  await expect(accountLink).toHaveText(username);
+  await expect(accountLink).toHaveText(displayName);
 
   // The claim CTA must stay hidden for this signed-in player — the two
   // affordances are mutually exclusive.

--- a/test/e2e/tests/profile.spec.ts
+++ b/test/e2e/tests/profile.spec.ts
@@ -5,15 +5,15 @@ import { registerForPending, login, markEmailVerified } from './helpers';
 // ADMIN_EMAILS promotion slot) and clears the verified-email gate so
 // /profile — which requires a verified email — is reachable.
 test('profile page links to change-email and change-password', async ({ page, browserName }) => {
-  const username = `e2e-profile-${browserName}-${Date.now()}`;
+  const displayName = `e2e-profile-${browserName}-${Date.now()}`;
 
   // The hard gate (#574) means register no longer signs the player in:
   // it renders the confirmation page with no session. Verify the row
   // directly, then log in to clear the verified-email gate /profile
   // enforces and obtain a session.
-  await registerForPending(page, username);
-  markEmailVerified(username);
-  await login(page, username);
+  await registerForPending(page, displayName);
+  markEmailVerified(displayName);
+  await login(page, displayName);
 
   await page.goto('/profile');
 

--- a/test/e2e/tests/share.spec.ts
+++ b/test/e2e/tests/share.spec.ts
@@ -15,10 +15,10 @@ test('player client start screen has a share button that opens the dialog with i
   // quiz authoring runs well past the default 30s budget on a loaded
   // firefox CI worker (#585); match the playthrough specs' budget.
   test.setTimeout(90_000);
-  const username = `e2e-admin-share-start-${browserName}`;
+  const displayName = `e2e-admin-share-start-${browserName}`;
   const quizTitle = `E2E Share Start Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
 
   // Drop the admin session and navigate via the public list (#284)
@@ -54,10 +54,10 @@ test('player client start screen has a share button that opens the dialog with i
 test('player client finish screen has a share button that includes the score', async ({ page, browserName }) => {
   // Heavy register + quiz authoring + full playthrough; see #585.
   test.setTimeout(90_000);
-  const username = `e2e-admin-share-finish-${browserName}`;
+  const displayName = `e2e-admin-share-finish-${browserName}`;
   const quizTitle = `E2E Share Finish Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
 
   // Play the quiz through as anonymous so the finish screen
@@ -98,10 +98,10 @@ test('player client finish screen has a share button that includes the score', a
 test('share-result reads score from the leaderboard so a revisit still brags the real number', async ({ page, browserName }) => {
   // Heavy register + quiz authoring + full playthrough; see #585.
   test.setTimeout(90_000);
-  const username = `e2e-admin-share-revisit-${browserName}`;
+  const displayName = `e2e-admin-share-revisit-${browserName}`;
   const quizTitle = `E2E Share Revisit Quiz ${browserName}`;
 
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
 
   // First play-through as anonymous so the score lands on the
@@ -157,13 +157,13 @@ test('share-result reads score from the leaderboard so a revisit still brags the
 test('home page popular-card share button opens the dialog with invitation text', async ({ page, browserName }) => {
   // Heavy register + quiz authoring + full playthrough; see #585.
   test.setTimeout(90_000);
-  const username = `e2e-admin-share-home-${browserName}`;
+  const displayName = `e2e-admin-share-home-${browserName}`;
   const quizTitle = `E2E Share Home Quiz ${browserName}`;
 
   // The home page only surfaces quizzes that have at least one
   // finished play in the last 30 days, so we need to author the
   // quiz AND play it through anonymously before the card appears.
-  await registerAdmin(page, username);
+  await registerAdmin(page, displayName);
   await createQuizWithQuestions(page, quizTitle);
   await page.context().clearCookies();
   await startQuizAsAnonymous(page, quizTitle);

--- a/test/integration/admin_htmx_test.go
+++ b/test/integration/admin_htmx_test.go
@@ -65,9 +65,9 @@ func TestAdminHTMX_QuestionReorder(t *testing.T) {
 	}
 	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
-	adminPlayer, err := stores.Players.GetPlayerByUsername(ctx, "htmx-admin")
+	adminPlayer, err := stores.Players.GetPlayerByDisplayName(ctx, "htmx-admin")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	const (
@@ -248,9 +248,9 @@ func TestAdminHTMX_RoundMove(t *testing.T) {
 	}
 	registerVerifyAndSignIn(ctx, t, client, srv.BaseURL, srv.DBURI, "htmx-admin", "htmx-admin-pass-123")
 
-	adminPlayer, err := stores.Players.GetPlayerByUsername(ctx, "htmx-admin")
+	adminPlayer, err := stores.Players.GetPlayerByDisplayName(ctx, "htmx-admin")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	const (
@@ -414,9 +414,9 @@ func verifyPlayerEmail(ctx context.Context, t *testing.T, dbURI, username string
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("verifyPlayerEmail GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("verifyPlayerEmail GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if err := stores.OAuth.MarkPlayerEmailVerifiedIfNew(ctx, player.ID); err != nil {
 		t.Fatalf("verifyPlayerEmail MarkPlayerEmailVerifiedIfNew err = %v, want nil", err)

--- a/test/integration/admin_htmx_test.go
+++ b/test/integration/admin_htmx_test.go
@@ -408,13 +408,13 @@ func postHXRoundMove(
 // follow-up requests can pass the #111 PR3 verified-email gate. Used
 // by integration tests that drive /admin/* after registering through
 // the HTTP register flow.
-func verifyPlayerEmail(ctx context.Context, t *testing.T, dbURI, username string) {
+func verifyPlayerEmail(ctx context.Context, t *testing.T, dbURI, displayName string) {
 	t.Helper()
 
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("verifyPlayerEmail GetPlayerByDisplayName err = %v, want nil", err)
 	}

--- a/test/integration/admin_player_mgmt_test.go
+++ b/test/integration/admin_player_mgmt_test.go
@@ -602,7 +602,7 @@ func lookupPlayerID(ctx context.Context, t *testing.T, dbURI, username string) i
 	t.Helper()
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
 		t.Fatalf("lookupPlayerID err = %v, want nil", err)
 	}

--- a/test/integration/admin_player_mgmt_test.go
+++ b/test/integration/admin_player_mgmt_test.go
@@ -212,7 +212,7 @@ func TestAdminPlayerMgmt_SetEmailClearsVerification(t *testing.T) {
 	verifyPlayerEmail(ctx, t, srv.DBURI, "reverify-target")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "reverify-target")
-	// Match on the role-scoped detail link rather than an email/username
+	// Match on the role-scoped detail link rather than an email/display-name
 	// substring so a flash/banner echoing the value elsewhere on the page
 	// cannot satisfy the assertion (same hazard documented in
 	// TestAdminPlayerMgmt_FilterTabsAndCounts).
@@ -469,7 +469,7 @@ func TestAdminPlayerMgmt_SetUsername(t *testing.T) {
 	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "setname-target", "setname-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setname-target")
-	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/username"
+	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
 
 	res := postAdminAction(
 		ctx,
@@ -561,13 +561,13 @@ func TestAdminPlayerMgmt_SetCredentialsRequireAdmin(t *testing.T) {
 	makeHost(ctx, t, srv.DBURI, "creds-host")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "creds-admin-boss")
-	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/username"
+	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
 	passwordURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/password"
 
 	if got, want := postCSRFForm(
 		ctx, t, hostClient, usernameURL,
 	), http.StatusNotFound; got != want {
-		t.Errorf("POST /username status = %d, want %d", got, want)
+		t.Errorf("POST /display-name status = %d, want %d", got, want)
 	}
 	if got, want := postCSRFForm(
 		ctx, t, hostClient, passwordURL,
@@ -671,7 +671,7 @@ func csrfPageForPostURL(baseURL, postURL string) string {
 		return baseURL + "/admin/players/new"
 	}
 	for _, suffix := range []string{
-		"/verify", "/resend-verification", "/email", "/role", "/username", "/password",
+		"/verify", "/resend-verification", "/email", "/role", "/display-name", "/password",
 	} {
 		if before, ok := strings.CutSuffix(postURL, suffix); ok {
 			return before

--- a/test/integration/admin_player_mgmt_test.go
+++ b/test/integration/admin_player_mgmt_test.go
@@ -453,10 +453,10 @@ func TestAdminPlayerMgmt_SetRolePromotesToAdmin(t *testing.T) {
 	}
 }
 
-// TestAdminPlayerMgmt_SetUsername drives the #535 username endpoint from a
+// TestAdminPlayerMgmt_SetDisplayName drives the #535 displayName endpoint from a
 // super admin: the target's display name is rewritten, the new name shows on
 // the detail page, and the audit trail records the "Display name set" action.
-func TestAdminPlayerMgmt_SetUsername(t *testing.T) {
+func TestAdminPlayerMgmt_SetDisplayName(t *testing.T) {
 	t.Parallel()
 
 	ctx, srv := startServer(t, map[string]string{
@@ -469,18 +469,18 @@ func TestAdminPlayerMgmt_SetUsername(t *testing.T) {
 	registerForPending(ctx, t, newAdminMgmtClient(t), srv.BaseURL, "setname-target", "setname-target-pass-123")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "setname-target")
-	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
+	displayNameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
 
 	res := postAdminAction(
 		ctx,
 		t,
 		adminClient,
 		srv.BaseURL,
-		usernameURL,
+		displayNameURL,
 		url.Values{"display_name": {"renamed-target"}},
 	)
 	if got, want := res.StatusCode, http.StatusSeeOther; got != want {
-		t.Fatalf("set-username status = %d, want %d", got, want)
+		t.Fatalf("set-displayName status = %d, want %d", got, want)
 	}
 
 	detail := getOK(
@@ -541,7 +541,7 @@ func TestAdminPlayerMgmt_SetPassword(t *testing.T) {
 	}
 }
 
-// TestAdminPlayerMgmt_SetCredentialsRequireAdmin pins that the #535 username +
+// TestAdminPlayerMgmt_SetCredentialsRequireAdmin pins that the #535 displayName +
 // password endpoints are Admin-only (#538): a Host gets a 404 (not a 403) on
 // both POSTs so the routes' existence stays hidden. The first registrant is
 // auto-promoted to Admin, so the Host under test is a later registrant demoted
@@ -561,11 +561,11 @@ func TestAdminPlayerMgmt_SetCredentialsRequireAdmin(t *testing.T) {
 	makeHost(ctx, t, srv.DBURI, "creds-host")
 
 	target := lookupPlayerID(ctx, t, srv.DBURI, "creds-admin-boss")
-	usernameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
+	displayNameURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/display-name"
 	passwordURL := srv.BaseURL + "/admin/players/" + intToString(target) + "/password"
 
 	if got, want := postCSRFForm(
-		ctx, t, hostClient, usernameURL,
+		ctx, t, hostClient, displayNameURL,
 	), http.StatusNotFound; got != want {
 		t.Errorf("POST /display-name status = %d, want %d", got, want)
 	}
@@ -595,14 +595,14 @@ func newAdminMgmtClient(t *testing.T) *http.Client {
 	}
 }
 
-// lookupPlayerID resolves the players.id for the given username via a
+// lookupPlayerID resolves the players.id for the given displayName via a
 // direct DB read. Used so the per-player URL can be built without
 // scraping the admin list page.
-func lookupPlayerID(ctx context.Context, t *testing.T, dbURI, username string) int64 {
+func lookupPlayerID(ctx context.Context, t *testing.T, dbURI, displayName string) int64 {
 	t.Helper()
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("lookupPlayerID err = %v, want nil", err)
 	}

--- a/test/integration/admin_settings_test.go
+++ b/test/integration/admin_settings_test.go
@@ -57,13 +57,13 @@ func TestAdminSettings_Integration(t *testing.T) {
 		}
 
 		// Promote the target to admin via the id-based role endpoint.
-		targetID := playerIDByUsername(ctx, t, srv.DBURI, "settings-target")
+		targetID := playerIDByDisplayName(ctx, t, srv.DBURI, "settings-target")
 		if got, want := postCSRFRoleForm(ctx, t, boss,
 			baseURL+fmt.Sprintf("/admin/players/%d/role", targetID), auth.RoleAdmin,
 		), http.StatusSeeOther; got != want {
 			t.Fatalf("promote status = %d, want %d", got, want)
 		}
-		if got, want := roleByUsername(ctx, t, srv.DBURI, "settings-target"), auth.RoleAdmin; got != want {
+		if got, want := roleByDisplayName(ctx, t, srv.DBURI, "settings-target"), auth.RoleAdmin; got != want {
 			t.Fatalf("after promote role = %q, want %q", got, want)
 		}
 
@@ -79,7 +79,7 @@ func TestAdminSettings_Integration(t *testing.T) {
 		), http.StatusSeeOther; got != want {
 			t.Fatalf("demote status = %d, want %d", got, want)
 		}
-		if got, want := roleByUsername(ctx, t, srv.DBURI, "settings-target"), auth.RoleHost; got != want {
+		if got, want := roleByDisplayName(ctx, t, srv.DBURI, "settings-target"), auth.RoleHost; got != want {
 			t.Fatalf("after demote role = %q, want %q", got, want)
 		}
 	})

--- a/test/integration/anon_migration_test.go
+++ b/test/integration/anon_migration_test.go
@@ -100,7 +100,7 @@ func lookupAnonPlayer(ctx context.Context, t *testing.T, players auth.PlayerStor
 	// The seed admin is always id=1 and the destination is id=2 in
 	// this test's narrow universe; the anonymous row is therefore
 	// id=3 (or higher if the test grows). Probe by ascending id
-	// until we hit a row whose username is not in the excluded set.
+	// until we hit a row whose displayName is not in the excluded set.
 	for id := int64(2); id <= 20; id++ {
 		p, err := players.GetPlayerByID(ctx, id)
 		if err != nil {
@@ -119,17 +119,17 @@ func lookupAnonPlayer(ctx context.Context, t *testing.T, players auth.PlayerStor
 // loginAnonAsDest POSTs the credentials with the anonymous client's
 // jar carrying the EnsurePlayer session cookie, so the login handler
 // sees a prior anonymous session and triggers the migration. The
-// username argument is converted to "<username>@example.test" - the
+// displayName argument is converted to "<displayName>@example.test" - the
 // integration suite's convention for the email auto-assigned during
 // registration, and the post-#446 login credential.
-func loginAnonAsDest(ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string) {
+func loginAnonAsDest(ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, password string) {
 	t.Helper()
 
 	csrfToken := primeLoginCSRF(ctx, t, client, baseURL)
 
 	form := url.Values{
 		"csrf_token": {csrfToken},
-		"email":      {username + "@example.test"},
+		"email":      {displayName + "@example.test"},
 		"password":   {password},
 	}
 	req, err := http.NewRequestWithContext(

--- a/test/integration/anon_migration_test.go
+++ b/test/integration/anon_migration_test.go
@@ -48,7 +48,7 @@ func TestAnonMigration_Integration(t *testing.T) {
 	// register hands out no session, and the migration is driven by the
 	// anonymous client logging in below, not by this jar.
 	registerForPending(ctx, t, authClient(t), baseURL, "migration-dest", "correct-battery-13")
-	destPlayer, err := stores.Players.GetPlayerByUsername(ctx, "migration-dest")
+	destPlayer, err := stores.Players.GetPlayerByDisplayName(ctx, "migration-dest")
 	if err != nil {
 		t.Fatalf("lookup destination player err = %v, want nil", err)
 	}
@@ -106,7 +106,7 @@ func lookupAnonPlayer(ctx context.Context, t *testing.T, players auth.PlayerStor
 		if err != nil {
 			continue
 		}
-		known := slices.Contains(excluded, p.Username)
+		known := slices.Contains(excluded, p.DisplayName)
 		if !known {
 			return p
 		}

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -90,11 +90,11 @@ func TestAnonymous_Integration(t *testing.T) {
 	}
 
 	// Scenario 1b: the newly-minted anonymous player should carry a
-	// petname-style username (Adjective-Adjective-Noun) rather than the
+	// petname-style displayName (Adjective-Adjective-Noun) rather than the
 	// legacy "anon-<xid>" format. The petname path is the default; the
 	// xid fallback only runs when the petname pool collides several times
 	// in a row, which is astronomically unlikely in a single-call test.
-	if got, want := countLegacyAnonUsernames(ctx, t, dbConn), 0; got != want {
+	if got, want := countLegacyAnonDisplayNames(ctx, t, dbConn), 0; got != want {
 		t.Errorf("[scenario 1b] rows matching anon-%% = %d, want %d (petname path should win)", got, want)
 	}
 
@@ -140,18 +140,18 @@ func TestAnonymous_Integration(t *testing.T) {
 
 	// Scenario 4: an anonymous player can PATCH /api/players/me to set
 	// their own display name. The row stays the same (still anonymous,
-	// session cookie unchanged); only the username changes.
-	if got, want := patchPlayerUsername(ctx, t, client1, baseURL, "named-one"), http.StatusOK; got != want {
+	// session cookie unchanged); only the displayName changes.
+	if got, want := patchPlayerDisplayName(ctx, t, client1, baseURL, "named-one"), http.StatusOK; got != want {
 		t.Errorf("[scenario 4] PATCH /api/players/me status = %d, want %d", got, want)
 	}
 
-	// Scenario 4b: GET /api/players/me reflects the new username and the
+	// Scenario 4b: GET /api/players/me reflects the new displayName and the
 	// row is still anonymous (no password_hash) — the front-end relies
 	// on this so the claim affordances disappear after a successful
 	// PATCH but the flow keeps working without forcing a login.
 	gotMe := fetchPlayerMe(ctx, t, client1, baseURL)
-	if got, want := gotMe.Username, "named-one"; got != want {
-		t.Errorf("[scenario 4b] /me username = %q, want %q", got, want)
+	if got, want := gotMe.DisplayName, "named-one"; got != want {
+		t.Errorf("[scenario 4b] /me displayName = %q, want %q", got, want)
 	}
 	if got, want := gotMe.IsAnonymous, true; got != want {
 		t.Errorf("[scenario 4b] /me isAnonymous = %v, want %v", got, want)
@@ -174,15 +174,15 @@ func TestAnonymous_Integration(t *testing.T) {
 	}
 
 	// Scenario 5: a second anonymous player trying to claim the same
-	// username gets 409. The first player keeps "named-one".
-	if got, want := patchPlayerUsername(ctx, t, clientA, baseURL, "named-one"), http.StatusConflict; got != want {
+	// displayName gets 409. The first player keeps "named-one".
+	if got, want := patchPlayerDisplayName(ctx, t, clientA, baseURL, "named-one"), http.StatusConflict; got != want {
 		t.Errorf("[scenario 5] colliding PATCH status = %d, want %d", got, want)
 	}
 
-	// Scenario 6: whitespace-only username is rejected as 400 by the
+	// Scenario 6: whitespace-only displayName is rejected as 400 by the
 	// server-side trim — the front-end trims too, but the contract is
 	// what the integration test pins down.
-	if got, want := patchPlayerUsername(ctx, t, clientA, baseURL, "   "), http.StatusBadRequest; got != want {
+	if got, want := patchPlayerDisplayName(ctx, t, clientA, baseURL, "   "), http.StatusBadRequest; got != want {
 		t.Errorf("[scenario 6] whitespace PATCH status = %d, want %d", got, want)
 	}
 }
@@ -262,7 +262,7 @@ func fetchAPIQuizzes(ctx context.Context, t *testing.T, client *http.Client, bas
 // double-pins the wire contract the front-end consumes.
 type meResponse struct {
 	ID              int64  `json:"id"`
-	Username        string `json:"displayName"`
+	DisplayName     string `json:"displayName"`
 	IsAnonymous     bool   `json:"isAnonymous"`
 	HasCustomName   bool   `json:"hasCustomName"`
 	IsAuthenticated bool   `json:"isAuthenticated"`
@@ -298,15 +298,15 @@ func fetchPlayerMe(ctx context.Context, t *testing.T, client *http.Client, baseU
 	return out
 }
 
-// patchPlayerUsername issues PATCH /api/players/me with the given username
+// patchPlayerDisplayName issues PATCH /api/players/me with the given displayName
 // on the supplied client and returns the response status code. Body close
 // errors are reported but don't fail the test.
-func patchPlayerUsername(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username string,
+func patchPlayerDisplayName(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName string,
 ) int {
 	t.Helper()
 
-	body := fmt.Sprintf(`{"displayName": %q}`, username)
+	body := fmt.Sprintf(`{"displayName": %q}`, displayName)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPatch, baseURL+"/api/players/me", strings.NewReader(body),
 	)
@@ -344,11 +344,11 @@ func countAnonymousPlayers(ctx context.Context, t *testing.T, dbConn *sql.DB) in
 	return n
 }
 
-// countLegacyAnonUsernames returns the number of anonymous rows whose
-// username still uses the legacy "anon-<xid>" prefix. After #165, fresh
+// countLegacyAnonDisplayNames returns the number of anonymous rows whose
+// displayName still uses the legacy "anon-<xid>" prefix. After #165, fresh
 // anonymous players get a petname-style name; a non-zero count here
 // indicates the xid fallback path ran (or the migration did not flow).
-func countLegacyAnonUsernames(ctx context.Context, t *testing.T, dbConn *sql.DB) int {
+func countLegacyAnonDisplayNames(ctx context.Context, t *testing.T, dbConn *sql.DB) int {
 	t.Helper()
 
 	var n int

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -354,7 +354,7 @@ func countLegacyAnonUsernames(ctx context.Context, t *testing.T, dbConn *sql.DB)
 	var n int
 	err := dbConn.QueryRowContext(
 		ctx,
-		`SELECT COUNT(*) FROM players WHERE password_hash IS NULL AND username LIKE 'anon-%'`,
+		`SELECT COUNT(*) FROM players WHERE password_hash IS NULL AND display_name LIKE 'anon-%'`,
 	).Scan(&n)
 	if err != nil {
 		t.Fatalf("QueryRow err = %v, want nil", err)

--- a/test/integration/anonymous_test.go
+++ b/test/integration/anonymous_test.go
@@ -262,7 +262,7 @@ func fetchAPIQuizzes(ctx context.Context, t *testing.T, client *http.Client, bas
 // double-pins the wire contract the front-end consumes.
 type meResponse struct {
 	ID              int64  `json:"id"`
-	Username        string `json:"username"`
+	Username        string `json:"displayName"`
 	IsAnonymous     bool   `json:"isAnonymous"`
 	HasCustomName   bool   `json:"hasCustomName"`
 	IsAuthenticated bool   `json:"isAuthenticated"`
@@ -306,7 +306,7 @@ func patchPlayerUsername(
 ) int {
 	t.Helper()
 
-	body := fmt.Sprintf(`{"username": %q}`, username)
+	body := fmt.Sprintf(`{"displayName": %q}`, username)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPatch, baseURL+"/api/players/me", strings.NewReader(body),
 	)

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -99,9 +99,9 @@ func mintSessionCookie(ctx context.Context, t *testing.T, client *http.Client, b
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("mintSessionCookie GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("mintSessionCookie GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	rec := httptest.NewRecorder()

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -93,13 +93,13 @@ const testSessionKey = "integration-test-session-key-0123456789abcdef"
 // the signed-in state without going through login. startServer signs
 // cookies with testSessionKey by default, so the minted cookie verifies
 // unless the test overrode SESSION_KEY.
-func mintSessionCookie(ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username string) {
+func mintSessionCookie(ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName string) {
 	t.Helper()
 
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("mintSessionCookie GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -138,12 +138,12 @@ func authClient(t *testing.T) *http.Client {
 // nothing - the registered row exists in the DB but the visitor is not
 // signed in until they verify and log in (see registerVerifyAndSignIn).
 func registerForPending(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, password string,
 ) {
 	t.Helper()
 
 	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
-	resp := postRegister(ctx, t, client, baseURL, token, username, password)
+	resp := postRegister(ctx, t, client, baseURL, token, displayName, password)
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
 
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
@@ -156,7 +156,7 @@ func registerForPending(
 	if got, want := string(body), "Verify your email"; !strings.Contains(got, want) {
 		t.Errorf("register body missing confirmation headline %q; body=%.300q", want, got)
 	}
-	if got, want := string(body), username+"@example.test"; !strings.Contains(got, want) {
+	if got, want := string(body), displayName+"@example.test"; !strings.Contains(got, want) {
 		t.Errorf("register body missing recipient address %q; body=%.300q", want, got)
 	}
 	assertNoLiveSession(t, resp)
@@ -175,76 +175,76 @@ func assertNoLiveSession(t *testing.T, resp *http.Response) {
 	}
 }
 
-// registerVerifyAndSignIn registers username through /register, stamps
+// registerVerifyAndSignIn registers displayName through /register, stamps
 // email_verified_at directly in the DB (bypassing the email channel),
 // then logs in so client's cookie jar carries a live session. This is
 // the post-#574 replacement for the old "register => signed in"
 // behaviour that many tests relied on: the hard gate means a session is
 // only obtained after verification + login.
 func registerVerifyAndSignIn(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName, password string,
 ) {
 	t.Helper()
 
-	registerForPending(ctx, t, client, baseURL, username, password)
-	verifyPlayerEmail(ctx, t, dbURI, username)
-	loginForRedirect(ctx, t, client, baseURL, username, password)
+	registerForPending(ctx, t, client, baseURL, displayName, password)
+	verifyPlayerEmail(ctx, t, dbURI, displayName)
+	loginForRedirect(ctx, t, client, baseURL, displayName, password)
 }
 
-// registerVerifyAndMint registers username, stamps email_verified_at in
+// registerVerifyAndMint registers displayName, stamps email_verified_at in
 // the DB, and mints a session cookie onto client's jar without going
 // through /login. Use this instead of registerVerifyAndSignIn when a
 // single test signs in several accounts against one server: minting
 // sidesteps the per-IP login cooldown (#494) that back-to-back logins
 // would trip. Relies on startServer's default SESSION_KEY.
 func registerVerifyAndMint(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName, password string,
 ) {
 	t.Helper()
 
-	registerForPending(ctx, t, client, baseURL, username, password)
-	verifyPlayerEmail(ctx, t, dbURI, username)
-	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
+	registerForPending(ctx, t, client, baseURL, displayName, password)
+	verifyPlayerEmail(ctx, t, dbURI, displayName)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 }
 
-// registerAndMint registers username and mints a session cookie onto
+// registerAndMint registers displayName and mints a session cookie onto
 // client's jar WITHOUT stamping email_verified_at, leaving the player
 // signed in but unverified. Use it when a test needs a signed-in row
 // that must stay in the unverified bucket. Relies on startServer's
 // default SESSION_KEY.
 func registerAndMint(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName, password string,
 ) {
 	t.Helper()
 
-	registerForPending(ctx, t, client, baseURL, username, password)
-	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
+	registerForPending(ctx, t, client, baseURL, displayName, password)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 }
 
 // loginForRedirect POSTs /login and returns the Location header from
 // the 303 response.
 func loginForRedirect(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, password string,
 ) string {
 	t.Helper()
 
-	return submitAuthForm(ctx, t, client, baseURL, "/login", username, password)
+	return submitAuthForm(ctx, t, client, baseURL, "/login", displayName, password)
 }
 
 // submitAuthForm runs the GET-CSRF + POST-form dance for the /login
 // redirect probe and asserts the response is 303 (anything else means
 // the auth flow itself failed, not the redirect rule). The email
-// credential is derived from username so a row registered as
-// username@example.test logs in cleanly.
+// credential is derived from displayName so a row registered as
+// displayName@example.test logs in cleanly.
 func submitAuthForm(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, path, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, path, displayName, password string,
 ) string {
 	t.Helper()
 
 	token := fetchCSRFToken(ctx, t, client, baseURL+path)
 
 	form := url.Values{}
-	form.Add("email", username+"@example.test")
+	form.Add("email", displayName+"@example.test")
 	form.Add("password", password)
 	form.Add("csrf_token", token)
 

--- a/test/integration/claim_name_test.go
+++ b/test/integration/claim_name_test.go
@@ -39,12 +39,12 @@ func TestClaimName_NonAnonymousReturnsAlreadyClaimed(t *testing.T) {
 	}
 
 	// Register a password-bearing player and sign them in. The /register
-	// handler sets password_hash + username_claimed=1, so this row is
+	// handler sets password_hash + displayName_claimed=1, so this row is
 	// the "non-anonymous" case the PATCH must reject. The hard gate
 	// (#574) means a session only arrives after verify + login.
 	registerVerifyAndSignIn(ctx, t, client, baseURL, srv.DBURI, "claim-resident", "claim-resident-pass-123")
 
-	body, status := patchPlayerUsernameWithBody(ctx, t, client, baseURL, "different-name")
+	body, status := patchPlayerDisplayNameWithBody(ctx, t, client, baseURL, "different-name")
 	if got, want := status, http.StatusConflict; got != want {
 		t.Fatalf("PATCH status = %d, want %d (body=%q)", got, want, body)
 	}
@@ -64,15 +64,15 @@ func TestClaimName_NonAnonymousReturnsAlreadyClaimed(t *testing.T) {
 	}
 }
 
-// patchPlayerUsernameWithBody is patchPlayerUsername (in anonymous_test.go)
+// patchPlayerDisplayNameWithBody is patchPlayerDisplayName (in anonymous_test.go)
 // but also returns the response body so the caller can assert on the
 // structured error JSON introduced for #289.
-func patchPlayerUsernameWithBody(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username string,
+func patchPlayerDisplayNameWithBody(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName string,
 ) ([]byte, int) {
 	t.Helper()
 
-	body := fmt.Sprintf(`{"displayName": %q}`, username)
+	body := fmt.Sprintf(`{"displayName": %q}`, displayName)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPatch, baseURL+"/api/players/me", strings.NewReader(body),
 	)

--- a/test/integration/claim_name_test.go
+++ b/test/integration/claim_name_test.go
@@ -72,7 +72,7 @@ func patchPlayerUsernameWithBody(
 ) ([]byte, int) {
 	t.Helper()
 
-	body := fmt.Sprintf(`{"username": %q}`, username)
+	body := fmt.Sprintf(`{"displayName": %q}`, username)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPatch, baseURL+"/api/players/me", strings.NewReader(body),
 	)

--- a/test/integration/forgot_password_test.go
+++ b/test/integration/forgot_password_test.go
@@ -39,7 +39,7 @@ func TestForgotPassword_GETRendersForm(t *testing.T) {
 
 // TestForgotPassword_POSTAlwaysFlashesGenericSuccess pins the
 // account-existence-opaque contract: identical response for an
-// unknown identifier, a real username, and a real email. Each
+// unknown identifier, a real displayName, and a real email. Each
 // subtest gets its own server (and so its own per-IP rate-limit
 // bucket) - sharing one server would have the first POST stamp the
 // limiter and the next two POSTs see the "slow down" flash instead

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -124,9 +124,9 @@ func seedGameplayAdmin(
 	}
 	registerGameplayAdmin(ctx, t, client, baseURL)
 
-	p, err := stores.Players.GetPlayerByUsername(ctx, gameplayAdminUsername)
+	p, err := stores.Players.GetPlayerByDisplayName(ctx, gameplayAdminUsername)
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if err := stores.OAuth.MarkPlayerEmailVerifiedIfNew(ctx, p.ID); err != nil {
 		t.Fatalf("MarkPlayerEmailVerifiedIfNew err = %v, want nil", err)

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -87,7 +87,7 @@ type resultsRes struct {
 // out of the parent struct to keep nested-structs-friendly types.
 type leaderboardEntryRes struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"username"`
+	Username        string `json:"displayName"`
 	Score           int    `json:"score"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
 }

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -87,7 +87,7 @@ type resultsRes struct {
 // out of the parent struct to keep nested-structs-friendly types.
 type leaderboardEntryRes struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"displayName"`
+	DisplayName     string `json:"displayName"`
 	Score           int    `json:"score"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`
 }
@@ -99,8 +99,8 @@ type leaderboardRes struct {
 }
 
 const (
-	gameplayAdminUsername = "gameplay-admin"
-	gameplayAdminPassword = "gameplay-admin-pass-123"
+	gameplayAdminDisplayName = "gameplay-admin"
+	gameplayAdminPassword    = "gameplay-admin-pass-123"
 )
 
 // seedGameplayAdmin registers the gameplay-admin via a throwaway jar
@@ -124,7 +124,7 @@ func seedGameplayAdmin(
 	}
 	registerGameplayAdmin(ctx, t, client, baseURL)
 
-	p, err := stores.Players.GetPlayerByDisplayName(ctx, gameplayAdminUsername)
+	p, err := stores.Players.GetPlayerByDisplayName(ctx, gameplayAdminDisplayName)
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -149,7 +149,7 @@ func loginAdminAndResetPlayer(
 	loginToken := fetchCSRFToken(ctx, t, client, baseURL+"/login")
 
 	loginForm := url.Values{}
-	loginForm.Add("email", gameplayAdminUsername+"@example.test")
+	loginForm.Add("email", gameplayAdminDisplayName+"@example.test")
 	loginForm.Add("password", gameplayAdminPassword)
 	loginForm.Add("csrf_token", loginToken)
 
@@ -214,7 +214,7 @@ func loginAdminAndResetPlayer(
 func registerGameplayAdmin(ctx context.Context, t *testing.T, client *http.Client, baseURL string) {
 	t.Helper()
 
-	registerForPending(ctx, t, client, baseURL, gameplayAdminUsername, gameplayAdminPassword)
+	registerForPending(ctx, t, client, baseURL, gameplayAdminDisplayName, gameplayAdminPassword)
 }
 
 // integrationSetup bundles the artefacts a gameplay-style integration test

--- a/test/integration/google_login_test.go
+++ b/test/integration/google_login_test.go
@@ -268,7 +268,7 @@ func TestGoogleLogin_CallbackRejectsEmptySubject(t *testing.T) {
 // continuity-across-sign-in rule: a visitor who has been playing
 // anonymously (session cookie pointing at an auto-petname row) and
 // then signs in with Google for the first time keeps that same
-// player_id and username. No new row is created; the existing row
+// player_id and displayName. No new row is created; the existing row
 // just gains the verified email and an identity link.
 func TestGoogleLogin_CallbackClaimsAnonymousSession(t *testing.T) {
 	t.Parallel()
@@ -512,10 +512,10 @@ func lookupPlayerIDByEmail(t *testing.T, dbURI, email string) int64 {
 	return id
 }
 
-// seedPlayerWithEmail inserts a row with the given username + email
+// seedPlayerWithEmail inserts a row with the given displayName + email
 // directly through SQL so the linking test has an existing player to
 // attach to without going through the register form.
-func seedPlayerWithEmail(t *testing.T, dbURI, username, email string) {
+func seedPlayerWithEmail(t *testing.T, dbURI, displayName, email string) {
 	t.Helper()
 
 	db, err := sql.Open("sqlite", dbURI)
@@ -530,7 +530,7 @@ func seedPlayerWithEmail(t *testing.T, dbURI, username, email string) {
 
 	if _, err := db.ExecContext(t.Context(),
 		`INSERT INTO players (display_name, email, role, display_name_claimed) VALUES (?, ?, 'player', 1)`,
-		username, email,
+		displayName, email,
 	); err != nil {
 		t.Fatalf("seed insert err = %v, want nil", err)
 	}

--- a/test/integration/google_login_test.go
+++ b/test/integration/google_login_test.go
@@ -529,7 +529,7 @@ func seedPlayerWithEmail(t *testing.T, dbURI, username, email string) {
 	})
 
 	if _, err := db.ExecContext(t.Context(),
-		`INSERT INTO players (username, email, role, username_claimed) VALUES (?, ?, 'player', 1)`,
+		`INSERT INTO players (display_name, email, role, display_name_claimed) VALUES (?, ?, 'player', 1)`,
 		username, email,
 	); err != nil {
 		t.Fatalf("seed insert err = %v, want nil", err)

--- a/test/integration/home_test.go
+++ b/test/integration/home_test.go
@@ -270,7 +270,7 @@ func TestHome_Integration_FooterAffordance(t *testing.T) {
 		}
 	})
 
-	t.Run("authenticated request renders username and log-out form", func(t *testing.T) {
+	t.Run("authenticated request renders displayName and log-out form", func(t *testing.T) {
 		snap := fetchWithClient(ctx, t, regClient, srv.BaseURL+"/")
 		if got, want := snap.StatusCode, http.StatusOK; got != want {
 			t.Fatalf("status = %d, want %d", got, want)
@@ -279,7 +279,7 @@ func TestHome_Integration_FooterAffordance(t *testing.T) {
 			t.Error("body missing signed-in affordance")
 		}
 		if !strings.Contains(snap.Body, "homefooter-admin") {
-			t.Error("body missing signed-in username")
+			t.Error("body missing signed-in displayName")
 		}
 		if !strings.Contains(snap.Body, `action="/logout"`) {
 			t.Error("body missing log-out form")

--- a/test/integration/invite_flow_test.go
+++ b/test/integration/invite_flow_test.go
@@ -152,8 +152,8 @@ func TestAcceptInvite_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByEmail err = %v, want nil", err)
 	}
-	if got, want := player.Username, "Accepted Player"; got != want {
-		t.Errorf("username = %q, want %q", got, want)
+	if got, want := player.DisplayName, "Accepted Player"; got != want {
+		t.Errorf("display name = %q, want %q", got, want)
 	}
 	if !player.IsEmailVerified() {
 		t.Error("new player must land email-verified")

--- a/test/integration/invite_flow_test.go
+++ b/test/integration/invite_flow_test.go
@@ -20,7 +20,7 @@ import (
 
 // invitePassword is the password every accept-invite test submits; it
 // clears MinPasswordLength, so the only variable under test is the
-// username and the token state.
+// displayName and the token state.
 const invitePassword = "invite-pass-12345"
 
 // TestAdminInvite_CreatesPendingInvite drives the admin POST /admin/invites
@@ -211,10 +211,10 @@ func TestAcceptInvite_RejectsDeadTokens(t *testing.T) {
 	}
 }
 
-// TestAcceptInvite_TakenUsernameKeepsInviteLive pins the ordering choice:
-// a username collision fails the create and leaves the invite pending, so
+// TestAcceptInvite_TakenDisplayNameKeepsInviteLive pins the ordering choice:
+// a displayName collision fails the create and leaves the invite pending, so
 // the recipient can retry on the same link with a different name.
-func TestAcceptInvite_TakenUsernameKeepsInviteLive(t *testing.T) {
+func TestAcceptInvite_TakenDisplayNameKeepsInviteLive(t *testing.T) {
 	t.Parallel()
 
 	ctx, srv := startServer(t, nil)
@@ -240,7 +240,7 @@ func TestAcceptInvite_TakenUsernameKeepsInviteLive(t *testing.T) {
 
 	// The invite must still be live: a retry with a free name succeeds.
 	if _, err := stores.Invites.GetLiveInvite(ctx, auth.HashInviteToken(raw)); err != nil {
-		t.Errorf("invite must stay live after username collision: err = %v", err)
+		t.Errorf("invite must stay live after displayName collision: err = %v", err)
 	}
 	retry := postAcceptInvite(ctx, t, authClient(t), srv.BaseURL, raw, "Free Name")
 	defer retry.Body.Close() //nolint:errcheck // cleanup.
@@ -412,14 +412,14 @@ func postAcceptInvite(
 	ctx context.Context,
 	t *testing.T,
 	client *http.Client,
-	baseURL, rawToken, username string,
+	baseURL, rawToken, displayName string,
 ) *http.Response {
 	t.Helper()
 	csrfToken := fetchCSRFToken(ctx, t, client, baseURL+"/login")
 	form := url.Values{
 		"csrf_token":   {csrfToken},
 		"token":        {rawToken},
-		"display_name": {username},
+		"display_name": {displayName},
 		"password":     {invitePassword},
 		"confirm":      {invitePassword},
 	}

--- a/test/integration/invite_store_test.go
+++ b/test/integration/invite_store_test.go
@@ -93,7 +93,7 @@ func TestInviteStore_ExpiredRejected(t *testing.T) {
 }
 
 // TestInviteStore_ListPendingInvites covers the management list query
-// (#318): a pending invite appears with its inviter username resolved via
+// (#318): a pending invite appears with its inviter displayName resolved via
 // the LEFT JOIN, while accepted and revoked invites are excluded.
 func TestInviteStore_ListPendingInvites(t *testing.T) {
 	t.Parallel()
@@ -108,7 +108,7 @@ func TestInviteStore_ListPendingInvites(t *testing.T) {
 	}
 
 	mintInvite(ctx, t, stores.Invites, "list-pending@example.test", time.Now().Add(time.Hour))
-	// Attribute one invite to the admin so the inviter username resolves.
+	// Attribute one invite to the admin so the inviter displayName resolves.
 	_, attrHash, err := auth.GenerateInviteToken()
 	if err != nil {
 		t.Fatalf("GenerateInviteToken err = %v, want nil", err)

--- a/test/integration/invite_store_test.go
+++ b/test/integration/invite_store_test.go
@@ -144,8 +144,8 @@ func TestInviteStore_ListPendingInvites(t *testing.T) {
 	if !ok {
 		t.Fatal("attributed invite missing from list")
 	}
-	if got, want := attr.InviterUsername, "list-admin"; got != want {
-		t.Errorf("attr.InviterUsername = %q, want %q", got, want)
+	if got, want := attr.InviterDisplayName, "list-admin"; got != want {
+		t.Errorf("attr.InviterDisplayName = %q, want %q", got, want)
 	}
 }
 

--- a/test/integration/leaderboard_stream_test.go
+++ b/test/integration/leaderboard_stream_test.go
@@ -474,12 +474,12 @@ func TestQuizLeaderboard_ShowsParticipantBeforeAnyAnswer(t *testing.T) {
 //
 //  1. Seed a single-question quiz.
 //  2. Client B plays it to completion so they land on the leaderboard
-//     with an auto-petname username.
+//     with an auto-petname displayName.
 //  3. Client A subscribes to the leaderboard stream and drains the
 //     initial snapshot (which already shows client B's row).
 //  4. Client B PATCHes /api/players/me with a chosen display name.
 //  5. Client A must receive a fresh event whose entry for client B
-//     carries the new username.
+//     carries the new displayName.
 //
 // Without the fan-out wired into PATCH /api/players/me, the third step
 // would never repaint subscribed clients and this test would time out
@@ -525,9 +525,9 @@ func TestLeaderboardStream_NameUpdate_RepaintsSubscribers(t *testing.T) {
 	clientB := newCookieJarClient(t)
 	playSingleQuestionQuizToCompletion(ctx, t, srv.BaseURL, clientB, qz)
 
-	// Capture client B's auto-assigned username from /api/players/me so
+	// Capture client B's auto-assigned displayName from /api/players/me so
 	// we know what to compare against in the post-PATCH event.
-	originalName := getMyUsername(ctx, t, srv.BaseURL, clientB)
+	originalName := getMyDisplayName(ctx, t, srv.BaseURL, clientB)
 
 	// Client A subscribes and drains the initial snapshot. It should
 	// already see client B's row.
@@ -554,8 +554,8 @@ func TestLeaderboardStream_NameUpdate_RepaintsSubscribers(t *testing.T) {
 	if got, want := len(initial.Entries), 1; got != want {
 		t.Fatalf("initial event entries len = %d, want %d (client B should be on the board)", got, want)
 	}
-	if got, want := initial.Entries[0].Username, originalName; got != want {
-		t.Errorf("initial event username = %q, want %q (auto-petname)", got, want)
+	if got, want := initial.Entries[0].DisplayName, originalName; got != want {
+		t.Errorf("initial event displayName = %q, want %q (auto-petname)", got, want)
 	}
 
 	// Client B claims a custom display name.
@@ -580,13 +580,13 @@ func TestLeaderboardStream_NameUpdate_RepaintsSubscribers(t *testing.T) {
 	}
 
 	// Client A should receive a second event whose row carries the new
-	// username.
+	// displayName.
 	second := readSSEEvent(t, scanner)
 	if got, want := len(second.Entries), 1; got != want {
 		t.Fatalf("post-rename entries len = %d, want %d", got, want)
 	}
-	if got, want := second.Entries[0].Username, claimedName; got != want {
-		t.Errorf("post-rename username = %q, want %q (claim should propagate via SSE)", got, want)
+	if got, want := second.Entries[0].DisplayName, claimedName; got != want {
+		t.Errorf("post-rename displayName = %q, want %q (claim should propagate via SSE)", got, want)
 	}
 }
 
@@ -659,15 +659,15 @@ func playSingleQuestionQuizToCompletion(
 
 // playerMeResponse is the JSON shape of GET /api/players/me.
 type playerMeResponse struct {
-	ID       int64  `json:"id"`
-	Username string `json:"displayName"`
+	ID          int64  `json:"id"`
+	DisplayName string `json:"displayName"`
 }
 
-// getMyUsername hits GET /api/players/me with the given cookie-jar
-// client and returns the username on file. The EnsurePlayer middleware
+// getMyDisplayName hits GET /api/players/me with the given cookie-jar
+// client and returns the displayName on file. The EnsurePlayer middleware
 // mints a row on first contact, so this also doubles as the "create a
 // player session" probe.
-func getMyUsername(ctx context.Context, t *testing.T, baseURL string, client *http.Client) string {
+func getMyDisplayName(ctx context.Context, t *testing.T, baseURL string, client *http.Client) string {
 	t.Helper()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/players/me", nil)
@@ -691,18 +691,18 @@ func getMyUsername(ctx context.Context, t *testing.T, baseURL string, client *ht
 	if derr := json.NewDecoder(resp.Body).Decode(&out); derr != nil {
 		t.Fatalf("/me decode err = %v, want nil", derr)
 	}
-	if out.Username == "" {
-		t.Fatal("/me returned empty username")
+	if out.DisplayName == "" {
+		t.Fatal("/me returned empty displayName")
 	}
 
-	return out.Username
+	return out.DisplayName
 }
 
 // leaderboardEventEntry mirrors one row in the SSE leaderboard payload.
 // Lifted to package scope so revive's nested-structs rule is happy.
 type leaderboardEventEntry struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"displayName"`
+	DisplayName     string `json:"displayName"`
 	Score           int    `json:"score"`
 	Rank            int    `json:"rank"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`

--- a/test/integration/leaderboard_stream_test.go
+++ b/test/integration/leaderboard_stream_test.go
@@ -562,7 +562,7 @@ func TestLeaderboardStream_NameUpdate_RepaintsSubscribers(t *testing.T) {
 	const claimedName = "renamed-player"
 	patchReq, err := http.NewRequestWithContext(
 		ctx, http.MethodPatch, srv.BaseURL+"/api/players/me",
-		strings.NewReader(fmt.Sprintf(`{"username": %q}`, claimedName)),
+		strings.NewReader(fmt.Sprintf(`{"displayName": %q}`, claimedName)),
 	)
 	if err != nil {
 		t.Fatalf("NewRequest patch err = %v, want nil", err)
@@ -660,7 +660,7 @@ func playSingleQuestionQuizToCompletion(
 // playerMeResponse is the JSON shape of GET /api/players/me.
 type playerMeResponse struct {
 	ID       int64  `json:"id"`
-	Username string `json:"username"`
+	Username string `json:"displayName"`
 }
 
 // getMyUsername hits GET /api/players/me with the given cookie-jar
@@ -702,7 +702,7 @@ func getMyUsername(ctx context.Context, t *testing.T, baseURL string, client *ht
 // Lifted to package scope so revive's nested-structs rule is happy.
 type leaderboardEventEntry struct {
 	PlayerID        int64  `json:"playerId"`
-	Username        string `json:"username"`
+	Username        string `json:"displayName"`
 	Score           int    `json:"score"`
 	Rank            int    `json:"rank"`
 	IsCurrentPlayer bool   `json:"isCurrentPlayer"`

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -55,9 +55,9 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 		t.Fatalf("register status = %d, want %d", got, want)
 	}
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if player.EmailVerifiedAt != nil {
 		t.Fatalf("EmailVerifiedAt = %v, want nil before login", player.EmailVerifiedAt)

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -40,8 +40,8 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
 	const (
-		username = "login-unverified"
-		password = "correctbattery-unv-13"
+		displayName = "login-unverified"
+		password    = "correctbattery-unv-13"
 	)
 
 	// Register through the real /register handler so the resulting row
@@ -49,13 +49,13 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	// email_verified_at stamp and one verify-token row.
 	regClient := authClient(t)
 	regCSRF := fetchCSRFToken(ctx, t, regClient, srv.BaseURL+"/register")
-	registerResp := postRegister(ctx, t, regClient, srv.BaseURL, regCSRF, username, password)
+	registerResp := postRegister(ctx, t, regClient, srv.BaseURL, regCSRF, displayName, password)
 	registerResp.Body.Close() //nolint:errcheck // cleanup.
 	if got, want := registerResp.StatusCode, http.StatusOK; got != want {
 		t.Fatalf("register status = %d, want %d", got, want)
 	}
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -72,7 +72,7 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	// cookie is unambiguous.
 	loginClient := authClient(t)
 	loginCSRF := fetchCSRFToken(ctx, t, loginClient, srv.BaseURL+"/login")
-	resp := postLoginFormFull(ctx, t, loginClient, srv.BaseURL, loginCSRF, username+"@example.test", password)
+	resp := postLoginFormFull(ctx, t, loginClient, srv.BaseURL, loginCSRF, displayName+"@example.test", password)
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
 
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
@@ -85,7 +85,7 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	if got, want := string(body), "verify your email"; !strings.Contains(got, want) {
 		t.Errorf("body missing verify banner; body=%.300q", got)
 	}
-	if got, want := string(body), username+"@example.test"; !strings.Contains(got, want) {
+	if got, want := string(body), displayName+"@example.test"; !strings.Contains(got, want) {
 		t.Errorf("body missing recipient address; body=%.300q", got)
 	}
 	for _, c := range resp.Cookies() {
@@ -120,13 +120,13 @@ func waitForVerifyTokenCount(ctx context.Context, t *testing.T, dbConn *sql.DB, 
 // body, and cookies themselves. After #574 a successful register
 // renders the confirmation page with 200 and no session cookie.
 func postRegister(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, csrfToken, username, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, csrfToken, displayName, password string,
 ) *http.Response {
 	t.Helper()
 
 	form := url.Values{}
-	form.Add("display_name", username)
-	form.Add("email", username+"@example.test")
+	form.Add("display_name", displayName)
+	form.Add("email", displayName+"@example.test")
 	form.Add("password", password)
 	form.Add("password_confirm", password)
 	form.Add("csrf_token", csrfToken)

--- a/test/integration/profile_email_test.go
+++ b/test/integration/profile_email_test.go
@@ -56,9 +56,9 @@ func TestProfileEmail_HappyPathSwapsAndStaysSignedIn(t *testing.T) {
 	// the consume path end-to-end we mint another token directly via
 	// the store: dispatchEmailChangeIfFree's send is best-effort and
 	// asynchronous, so we cannot read the raw token off the email.
-	player, err := stores.Players.GetPlayerByUsername(ctx, "email-change-happy")
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, "email-change-happy")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	raw, hash, err := auth.GenerateVerifyToken()
 	if err != nil {
@@ -254,9 +254,9 @@ func TestProfileEmail_OldSessionInvalidatedAfterSwap(t *testing.T) {
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, "email-rotate")
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, "email-rotate")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	raw, hash, err := auth.GenerateVerifyToken()
 	if err != nil {

--- a/test/integration/profile_email_test.go
+++ b/test/integration/profile_email_test.go
@@ -333,7 +333,7 @@ type profileEmailSnapshot struct {
 }
 
 // profileEmailGET returns the rendered /profile/email page plus the
-// CSRF token, both extracted the same way the username form helpers
+// CSRF token, both extracted the same way the displayName form helpers
 // do upstream.
 func profileEmailGET(ctx context.Context, t *testing.T, client *http.Client, baseURL string) profileEmailSnapshot {
 	t.Helper()

--- a/test/integration/profile_password_test.go
+++ b/test/integration/profile_password_test.go
@@ -28,12 +28,12 @@ func TestProfilePassword_Integration(t *testing.T) {
 		"REGISTRATION_ENABLED": "true",
 	})
 
-	username := "pw-change-admin"
+	displayName := "pw-change-admin"
 	originalPassword := "correct-battery-13"
 	updatedPassword := "fresh-passphrase-99"
 
 	authn := authClient(t)
-	registerVerifyAndMint(ctx, t, authn, srv.BaseURL, srv.DBURI, username, originalPassword)
+	registerVerifyAndMint(ctx, t, authn, srv.BaseURL, srv.DBURI, displayName, originalPassword)
 
 	t.Run("anonymous visitor redirected to login", func(t *testing.T) {
 		client := authClient(t)
@@ -83,7 +83,7 @@ func TestProfilePassword_Integration(t *testing.T) {
 
 		// Old password must still work: login flow against the same credentials.
 		probe := authClient(t)
-		loc := loginForRedirect(ctx, t, probe, srv.BaseURL, username, originalPassword)
+		loc := loginForRedirect(ctx, t, probe, srv.BaseURL, displayName, originalPassword)
 		if got, want := loc, "/admin/quizzes"; got != want {
 			t.Errorf("post-reject login Location = %q, want %q (old password must still work)", got, want)
 		}
@@ -132,7 +132,7 @@ func TestProfilePassword_Integration(t *testing.T) {
 		// bucket hot; let the 3s cooldown (#494) elapse before the
 		// next /login POST or this one gets served as 429.
 		time.Sleep(auth.LoginCooldown() + 100*time.Millisecond)
-		loc := loginForRedirect(ctx, t, other, srv.BaseURL, username, originalPassword)
+		loc := loginForRedirect(ctx, t, other, srv.BaseURL, displayName, originalPassword)
 		if got, want := loc, "/admin/quizzes"; got != want {
 			t.Fatalf("second client pre-rotation login Location = %q, want %q", got, want)
 		}
@@ -177,7 +177,7 @@ func TestProfilePassword_Integration(t *testing.T) {
 		time.Sleep(auth.LoginCooldown() + 100*time.Millisecond)
 		probeOld := authClient(t)
 		token := fetchCSRFToken(ctx, t, probeOld, srv.BaseURL+"/login")
-		oldStatus := postLoginRaw(ctx, t, probeOld, srv.BaseURL, username, originalPassword, token)
+		oldStatus := postLoginRaw(ctx, t, probeOld, srv.BaseURL, displayName, originalPassword, token)
 		if got, want := oldStatus, http.StatusUnauthorized; got != want {
 			t.Errorf("old-password login status = %d, want %d", got, want)
 		}
@@ -185,7 +185,7 @@ func TestProfilePassword_Integration(t *testing.T) {
 		// New password must work.
 		time.Sleep(auth.LoginCooldown() + 100*time.Millisecond)
 		probeNew := authClient(t)
-		loc = loginForRedirect(ctx, t, probeNew, srv.BaseURL, username, updatedPassword)
+		loc = loginForRedirect(ctx, t, probeNew, srv.BaseURL, displayName, updatedPassword)
 		if got, want := loc, "/admin/quizzes"; got != want {
 			t.Errorf("new-password login Location = %q, want %q", got, want)
 		}
@@ -278,13 +278,13 @@ func extractPasswordCSRFToken(t *testing.T, body string) string {
 // asserting on the Location header (a failed login renders the form
 // in place with a 401, not a 303).
 func postLoginRaw(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, password, csrfToken string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, password, csrfToken string,
 ) int {
 	t.Helper()
 
 	form := url.Values{}
-	form.Add("username", username)
-	form.Add("email", username+"@example.test")
+	form.Add("displayName", displayName)
+	form.Add("email", displayName+"@example.test")
 	form.Add("password", password)
 	form.Add("csrf_token", csrfToken)
 

--- a/test/integration/profile_test.go
+++ b/test/integration/profile_test.go
@@ -69,7 +69,7 @@ func TestProfile_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("POST /profile/username with empty value returns 400", func(t *testing.T) {
+	t.Run("POST /profile/display-name with empty value returns 400", func(t *testing.T) {
 		snap := profilePOST(ctx, t, authn, srv.BaseURL, "   ")
 		if got, want := snap.status, http.StatusBadRequest; got != want {
 			t.Errorf("status = %d, want %d", got, want)
@@ -79,7 +79,7 @@ func TestProfile_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("POST /profile/username with a taken value returns 409", func(t *testing.T) {
+	t.Run("POST /profile/display-name with a taken value returns 409", func(t *testing.T) {
 		// Register a second player so the admin can collide with them.
 		registerForPending(ctx, t, authClient(t), srv.BaseURL, "rival-name", "correct-battery-13")
 
@@ -97,7 +97,7 @@ func TestProfile_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("POST /profile/username with a fresh value renames the player", func(t *testing.T) {
+	t.Run("POST /profile/display-name with a fresh value renames the player", func(t *testing.T) {
 		snap := profilePOST(ctx, t, authn, srv.BaseURL, "renamed-admin")
 		if got, want := snap.status, http.StatusOK; got != want {
 			t.Fatalf("status = %d, want %d (body=%q)", got, want, snap.body)
@@ -157,7 +157,7 @@ func profilePOST(ctx context.Context, t *testing.T, client *http.Client, baseURL
 		"display_name": {username},
 	}
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, baseURL+"/profile/username", strings.NewReader(form.Encode()),
+		ctx, http.MethodPost, baseURL+"/profile/display-name", strings.NewReader(form.Encode()),
 	)
 	if err != nil {
 		t.Fatalf("NewRequest err = %v, want nil", err)

--- a/test/integration/profile_test.go
+++ b/test/integration/profile_test.go
@@ -54,7 +54,7 @@ func TestProfile_Integration(t *testing.T) {
 	authn := authClient(t)
 	registerVerifyAndMint(ctx, t, authn, srv.BaseURL, srv.DBURI, "profile-admin", "correct-battery-13")
 
-	t.Run("GET /profile renders form with the current username", func(t *testing.T) {
+	t.Run("GET /profile renders form with the current displayName", func(t *testing.T) {
 		snap := profileGET(ctx, t, authn, srv.BaseURL)
 		if got, want := snap.status, http.StatusOK; got != want {
 			t.Fatalf("status = %d, want %d", got, want)
@@ -65,7 +65,7 @@ func TestProfile_Integration(t *testing.T) {
 		// The value attribute must contain the signed-in admin's name
 		// so the input arrives pre-filled.
 		if !strings.Contains(snap.body, `value="profile-admin"`) {
-			t.Error(`body missing value="profile-admin" on the username input`)
+			t.Error(`body missing value="profile-admin" on the displayName input`)
 		}
 	})
 
@@ -88,12 +88,12 @@ func TestProfile_Integration(t *testing.T) {
 			t.Errorf("status = %d, want %d", got, want)
 		}
 		if !strings.Contains(snap.body, "already taken") {
-			t.Error("body missing taken-username error message")
+			t.Error("body missing taken-displayName error message")
 		}
 		// The attempted value sticks in the input so the user can edit
 		// it instead of retyping.
 		if !strings.Contains(snap.body, `value="rival-name"`) {
-			t.Error(`body missing value="rival-name" on the username input after a collision`)
+			t.Error(`body missing value="rival-name" on the displayName input after a collision`)
 		}
 	})
 
@@ -106,7 +106,7 @@ func TestProfile_Integration(t *testing.T) {
 			t.Error("body missing success banner")
 		}
 		if !strings.Contains(snap.body, `value="renamed-admin"`) {
-			t.Error(`body missing value="renamed-admin" on the username input after a successful rename`)
+			t.Error(`body missing value="renamed-admin" on the displayName input after a successful rename`)
 		}
 	})
 }
@@ -146,7 +146,12 @@ func profileGET(ctx context.Context, t *testing.T, client *http.Client, baseURL 
 	}
 }
 
-func profilePOST(ctx context.Context, t *testing.T, client *http.Client, baseURL, username string) profilePageSnapshot {
+func profilePOST(
+	ctx context.Context,
+	t *testing.T,
+	client *http.Client,
+	baseURL, displayName string,
+) profilePageSnapshot {
 	t.Helper()
 
 	// Re-fetch the page each time so the CSRF token paired with the
@@ -154,7 +159,7 @@ func profilePOST(ctx context.Context, t *testing.T, client *http.Client, baseURL
 	priming := profileGET(ctx, t, client, baseURL)
 	form := url.Values{
 		"csrf_token":   {priming.csrf},
-		"display_name": {username},
+		"display_name": {displayName},
 	}
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodPost, baseURL+"/profile/display-name", strings.NewReader(form.Encode()),

--- a/test/integration/question_idor_test.go
+++ b/test/integration/question_idor_test.go
@@ -48,13 +48,13 @@ func TestQuestionIDOR_Integration(t *testing.T) {
 	})
 	stores := store.New(db, slog.Default())
 
-	playerA, err := stores.Players.GetPlayerByUsername(ctx, "idor-admin-a")
+	playerA, err := stores.Players.GetPlayerByDisplayName(ctx, "idor-admin-a")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername(a) err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName(a) err = %v, want nil", err)
 	}
-	playerB, err := stores.Players.GetPlayerByUsername(ctx, "idor-admin-b")
+	playerB, err := stores.Players.GetPlayerByDisplayName(ctx, "idor-admin-b")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername(b) err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName(b) err = %v, want nil", err)
 	}
 
 	quizA := &quiz.Quiz{

--- a/test/integration/quiz_ownership_test.go
+++ b/test/integration/quiz_ownership_test.go
@@ -133,7 +133,7 @@ func TestQuizOwnership_Integration(t *testing.T) {
 }
 
 // registerAdminClient builds a cookie-jar HTTP client, registers the
-// supplied username through the public /register form (which promotes
+// supplied displayName through the public /register form (which promotes
 // to admin via ADMIN_EMAILS), stamps email_verified_at, and mints a
 // session cookie onto the jar so follow-up admin requests pass both the
 // auth middleware and the #111 PR3 verified-email gate. After the #574
@@ -141,7 +141,7 @@ func TestQuizOwnership_Integration(t *testing.T) {
 // minted directly (startServer signs with the default testSessionKey).
 // Minting also sidesteps the per-IP login cooldown that several
 // back-to-back logins would trip.
-func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, username string) *http.Client {
+func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, displayName string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -154,9 +154,9 @@ func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, user
 		},
 	}
 
-	registerForPending(ctx, t, client, baseURL, username, "integration-pass-123")
-	verifyPlayerEmail(ctx, t, dbURI, username)
-	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
+	registerForPending(ctx, t, client, baseURL, displayName, "integration-pass-123")
+	verifyPlayerEmail(ctx, t, dbURI, displayName)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 
 	return client
 }

--- a/test/integration/register_enumeration_test.go
+++ b/test/integration/register_enumeration_test.go
@@ -60,17 +60,17 @@ func TestRegister_EmailCollisionOpaque(t *testing.T) {
 }
 
 // registerRaw POSTs /register with an explicit email (decoupled from the
-// username, unlike postRegister) and returns the status and body. Used by
-// the opacity test which needs two distinct usernames sharing one email.
+// displayName, unlike postRegister) and returns the status and body. Used by
+// the opacity test which needs two distinct displayNames sharing one email.
 func registerRaw(
-	ctx context.Context, t *testing.T, client *http.Client, baseURL, username, email, password string,
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, email, password string,
 ) (int, string) {
 	t.Helper()
 
 	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
 
 	form := url.Values{}
-	form.Add("display_name", username)
+	form.Add("display_name", displayName)
 	form.Add("email", email)
 	form.Add("password", password)
 	form.Add("password_confirm", password)

--- a/test/integration/register_verify_gate_test.go
+++ b/test/integration/register_verify_gate_test.go
@@ -29,13 +29,13 @@ func TestRegister_HardGate_NoSessionUntilVerified(t *testing.T) {
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
 	const (
-		username = "hardgate"
-		password = "hard-gate-pass-123"
+		displayName = "hardgate"
+		password    = "hard-gate-pass-123"
 	)
 
 	client := authClient(t)
 	csrf := fetchCSRFToken(ctx, t, client, srv.BaseURL+"/register")
-	resp := postRegister(ctx, t, client, srv.BaseURL, csrf, username, password)
+	resp := postRegister(ctx, t, client, srv.BaseURL, csrf, displayName, password)
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close() //nolint:errcheck // cleanup.
 	if err != nil {
@@ -58,7 +58,7 @@ func TestRegister_HardGate_NoSessionUntilVerified(t *testing.T) {
 	}
 
 	// 3. A verify-token row was committed for the new account.
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -81,9 +81,9 @@ func TestRegister_HardGate_NoSessionUntilVerified(t *testing.T) {
 
 	// 5. Verify the email, log in, and confirm the account now reaches the
 	// authenticated route.
-	verifyPlayerEmail(ctx, t, srv.DBURI, username)
+	verifyPlayerEmail(ctx, t, srv.DBURI, displayName)
 	loginClient := authClient(t)
-	loc := loginForRedirect(ctx, t, loginClient, srv.BaseURL, username, password)
+	loc := loginForRedirect(ctx, t, loginClient, srv.BaseURL, displayName, password)
 	if got, want := loc, "/admin/quizzes"; got != want {
 		t.Errorf("post-verify login Location = %q, want %q (first registrant is admin)", got, want)
 	}

--- a/test/integration/register_verify_gate_test.go
+++ b/test/integration/register_verify_gate_test.go
@@ -58,9 +58,9 @@ func TestRegister_HardGate_NoSessionUntilVerified(t *testing.T) {
 	}
 
 	// 3. A verify-token row was committed for the new account.
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if player.EmailVerifiedAt != nil {
 		t.Fatalf("EmailVerifiedAt = %v, want nil right after register", player.EmailVerifiedAt)

--- a/test/integration/reset_password_test.go
+++ b/test/integration/reset_password_test.go
@@ -37,9 +37,9 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, "reset-happy")
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, "reset-happy")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	startingVersion := player.SessionVersion
 

--- a/test/integration/roles_test.go
+++ b/test/integration/roles_test.go
@@ -36,7 +36,7 @@ func TestRoles_HostGating(t *testing.T) {
 	// roles-player keeps the default Player tier.
 
 	ownerQuiz := createQuizAs(ctx, t, owner, baseURL, "Owner Host Quiz")
-	hostID := playerIDByUsername(ctx, t, srv.DBURI, "roles-host")
+	hostID := playerIDByDisplayName(ctx, t, srv.DBURI, "roles-host")
 
 	t.Run("host reaches the dashboard", func(t *testing.T) {
 		t.Parallel()
@@ -135,8 +135,8 @@ func TestRoles_RoleChange(t *testing.T) {
 	target := registerAdminClient(ctx, t, baseURL, srv.DBURI, "rc-target")
 
 	makeHost(ctx, t, srv.DBURI, "rc-owner")
-	bossID := playerIDByUsername(ctx, t, srv.DBURI, "rc-boss")
-	targetID := playerIDByUsername(ctx, t, srv.DBURI, "rc-target")
+	bossID := playerIDByDisplayName(ctx, t, srv.DBURI, "rc-boss")
+	targetID := playerIDByDisplayName(ctx, t, srv.DBURI, "rc-target")
 
 	// boss promotes target player -> admin.
 	if got, want := postCSRFRoleForm(ctx, t, boss,
@@ -144,7 +144,7 @@ func TestRoles_RoleChange(t *testing.T) {
 	), http.StatusSeeOther; got != want {
 		t.Fatalf("promote-to-admin status = %d, want %d", got, want)
 	}
-	if got, want := roleByUsername(ctx, t, srv.DBURI, "rc-target"), auth.RoleAdmin; got != want {
+	if got, want := roleByDisplayName(ctx, t, srv.DBURI, "rc-target"), auth.RoleAdmin; got != want {
 		t.Fatalf("after promote role = %q, want %q", got, want)
 	}
 	assertAuditRow(ctx, t, srv.DBURI, targetID, bossID, auth.AdminActionRoleChanged)
@@ -163,7 +163,7 @@ func TestRoles_RoleChange(t *testing.T) {
 	), http.StatusSeeOther; got != want {
 		t.Fatalf("demote-to-host status = %d, want %d", got, want)
 	}
-	if got, want := roleByUsername(ctx, t, srv.DBURI, "rc-target"), auth.RoleHost; got != want {
+	if got, want := roleByDisplayName(ctx, t, srv.DBURI, "rc-target"), auth.RoleHost; got != want {
 		t.Fatalf("after demote role = %q, want %q", got, want)
 	}
 
@@ -191,8 +191,8 @@ func TestRoles_LastAdminGuard(t *testing.T) {
 	solo := registerAdminClient(ctx, t, baseURL, srv.DBURI, "guard-solo")
 	registerAdminClient(ctx, t, baseURL, srv.DBURI, "guard-second")
 
-	soloID := playerIDByUsername(ctx, t, srv.DBURI, "guard-solo")
-	secondID := playerIDByUsername(ctx, t, srv.DBURI, "guard-second")
+	soloID := playerIDByDisplayName(ctx, t, srv.DBURI, "guard-solo")
+	secondID := playerIDByDisplayName(ctx, t, srv.DBURI, "guard-second")
 
 	// The sole Admin cannot demote themselves: refused (303 back with a
 	// flash) and the row stays Admin.
@@ -201,7 +201,7 @@ func TestRoles_LastAdminGuard(t *testing.T) {
 	), http.StatusSeeOther; got != want {
 		t.Fatalf("self-demote status = %d, want %d", got, want)
 	}
-	if got, want := roleByUsername(ctx, t, srv.DBURI, "guard-solo"), auth.RoleAdmin; got != want {
+	if got, want := roleByDisplayName(ctx, t, srv.DBURI, "guard-solo"), auth.RoleAdmin; got != want {
 		t.Fatalf("after refused self-demote role = %q, want %q", got, want)
 	}
 
@@ -211,7 +211,7 @@ func TestRoles_LastAdminGuard(t *testing.T) {
 	), http.StatusSeeOther; got != want {
 		t.Fatalf("promote second status = %d, want %d", got, want)
 	}
-	if got, want := roleByUsername(ctx, t, srv.DBURI, "guard-second"), auth.RoleAdmin; got != want {
+	if got, want := roleByDisplayName(ctx, t, srv.DBURI, "guard-second"), auth.RoleAdmin; got != want {
 		t.Fatalf("after promote second role = %q, want %q", got, want)
 	}
 	if got, want := postCSRFRoleForm(ctx, t, solo,
@@ -219,7 +219,7 @@ func TestRoles_LastAdminGuard(t *testing.T) {
 	), http.StatusSeeOther; got != want {
 		t.Fatalf("demote second status = %d, want %d", got, want)
 	}
-	if got, want := roleByUsername(ctx, t, srv.DBURI, "guard-second"), auth.RoleHost; got != want {
+	if got, want := roleByDisplayName(ctx, t, srv.DBURI, "guard-second"), auth.RoleHost; got != want {
 		t.Errorf("after demote second role = %q, want %q", got, want)
 	}
 }
@@ -250,12 +250,12 @@ func assertAuditRow(ctx context.Context, t *testing.T, dbURI string, target, act
 // the production role endpoint mutates the row. Used to set up Host fixtures
 // (the only non-default tier the integration suite seeds directly; Admin comes
 // from ADMIN_EMAILS / first-registrant promotion).
-func makeHost(ctx context.Context, t *testing.T, dbURI, username string) {
+func makeHost(ctx context.Context, t *testing.T, dbURI, displayName string) {
 	t.Helper()
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
 		t.Fatalf("makeHost GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -264,30 +264,30 @@ func makeHost(ctx context.Context, t *testing.T, dbURI, username string) {
 	}
 }
 
-// roleByUsername reads the current role for the named player through the
+// roleByDisplayName reads the current role for the named player through the
 // auth.Player mapping so the test pins the persisted state.
-func roleByUsername(ctx context.Context, t *testing.T, dbURI, username string) string {
+func roleByDisplayName(ctx context.Context, t *testing.T, dbURI, displayName string) string {
 	t.Helper()
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
-		t.Fatalf("roleByUsername GetPlayerByDisplayName err = %v, want nil", err)
+		t.Fatalf("roleByDisplayName GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	return player.Role
 }
 
-// playerIDByUsername returns the players.id for the named player.
-func playerIDByUsername(ctx context.Context, t *testing.T, dbURI, username string) int64 {
+// playerIDByDisplayName returns the players.id for the named player.
+func playerIDByDisplayName(ctx context.Context, t *testing.T, dbURI, displayName string) int64 {
 	t.Helper()
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
 	if err != nil {
-		t.Fatalf("playerIDByUsername GetPlayerByDisplayName err = %v, want nil", err)
+		t.Fatalf("playerIDByDisplayName GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	return player.ID

--- a/test/integration/roles_test.go
+++ b/test/integration/roles_test.go
@@ -255,9 +255,9 @@ func makeHost(ctx context.Context, t *testing.T, dbURI, username string) {
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("makeHost GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("makeHost GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	if err := stores.AdminPlayers.SetPlayerRole(ctx, player.ID, auth.RoleHost); err != nil {
 		t.Fatalf("makeHost SetPlayerRole err = %v, want nil", err)
@@ -271,9 +271,9 @@ func roleByUsername(ctx context.Context, t *testing.T, dbURI, username string) s
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("roleByUsername GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("roleByUsername GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	return player.Role
@@ -285,9 +285,9 @@ func playerIDByUsername(ctx context.Context, t *testing.T, dbURI, username strin
 	dbConn, stores := openStores(t, dbURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, username)
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, username)
 	if err != nil {
-		t.Fatalf("playerIDByUsername GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("playerIDByUsername GetPlayerByDisplayName err = %v, want nil", err)
 	}
 
 	return player.ID

--- a/test/integration/verify_email_visibility_test.go
+++ b/test/integration/verify_email_visibility_test.go
@@ -36,8 +36,8 @@ func TestVerifyEmail_SeparateConnectionStampVisibleToNextRequest(t *testing.T) {
 	// First registrant is promoted to Admin via ADMIN_EMAILS but left
 	// UNVERIFIED on purpose: we want RequireVerifiedEmail to bounce them
 	// until the separate-connection stamp lands.
-	const username = "verify-race"
-	client := registerClientUnverified(ctx, t, baseURL, srv.DBURI, username)
+	const displayName = "verify-race"
+	client := registerClientUnverified(ctx, t, baseURL, srv.DBURI, displayName)
 
 	gated := baseURL + "/admin/quizzes"
 
@@ -46,7 +46,7 @@ func TestVerifyEmail_SeparateConnectionStampVisibleToNextRequest(t *testing.T) {
 	assertBouncedToPending(ctx, t, client, gated)
 
 	// Stamp email_verified_at over a SEPARATE connection.
-	verifyPlayerEmail(ctx, t, srv.DBURI, username)
+	verifyPlayerEmail(ctx, t, srv.DBURI, displayName)
 
 	// IMMEDIATELY hit the same gated endpoint. No sleep: this is the
 	// visibility window #555 worried about. The stamp must be visible to
@@ -78,13 +78,13 @@ func assertBouncedToPending(ctx context.Context, t *testing.T, client *http.Clie
 	}
 }
 
-// registerClientUnverified registers username through /register and
+// registerClientUnverified registers displayName through /register and
 // mints a session cookie onto its jar WITHOUT stamping
 // email_verified_at, leaving the player in the signed-in-but-unverified
 // state the caller needs to drive RequireVerifiedEmail. The #574 hard
 // gate means register no longer hands out a session, so the cookie is
 // minted directly (startServer signs with the default testSessionKey).
-func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, dbURI, username string) *http.Client {
+func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, dbURI, displayName string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -97,8 +97,8 @@ func registerClientUnverified(ctx context.Context, t *testing.T, baseURL, dbURI,
 		},
 	}
 
-	registerForPending(ctx, t, client, baseURL, username, "integration-pass-123")
-	mintSessionCookie(ctx, t, client, baseURL, dbURI, username)
+	registerForPending(ctx, t, client, baseURL, displayName, "integration-pass-123")
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 
 	return client
 }

--- a/test/integration/verify_gate_test.go
+++ b/test/integration/verify_gate_test.go
@@ -111,9 +111,9 @@ func TestVerifyGate_AfterVerifyAdminReachesDashboard(t *testing.T) {
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
-	player, err := stores.Players.GetPlayerByUsername(ctx, "gate-after")
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, "gate-after")
 	if err != nil {
-		t.Fatalf("GetPlayerByUsername err = %v, want nil", err)
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
 	raw, hash, err := auth.GenerateVerifyToken()
 	if err != nil {


### PR DESCRIPTION
Closes #581

Login is by email (since #446), so `players.username` was never a login credential - it holds a public display handle, and the UI labels it "Name" (#580). This renames the column and aligns the vocabulary **everywhere** - DB, Go, API, routes, error codes/messages, audit action, and docs.

**DB / Go**
- Migration `20260601000000`: `RENAME COLUMN username -> display_name` and `username_claimed -> display_name_claimed`. No table rebuild (child FKs point at players.id); UNIQUE index carries across. `lint-migrations` clean.
- Regenerated sqlc; renamed store/service methods (`GetPlayerByDisplayName`, `UpdatePlayerDisplayName`), structs, handlers (`HandleProfileDisplayName`, `HandlePlayerSetDisplayName`), the `AdminActionDisplayNameSet` audit constant (+ its `display_name_set` value), and ~hundred identifier references.

**API + routes**
- JSON key `username` -> `displayName` (camelCase) on the leaderboard/player/claim payloads + SSE stream; the player client reads `player.displayName`/`entry.displayName` and sends `{ displayName }`.
- Error codes `username_taken`/`username_required` -> `display_name_*` and their messages -> "display name ..."; the SPA does not switch on the codes.
- Routes `POST /profile/username` -> `/profile/display-name` and `/admin/players/{id}/username` -> `.../display-name`.

**Docs**
- `docs/Vision.md` schema + `CLAUDE.md` example updated.

**Intentionally left as-is**: the migration files (history), `SMTP_USERNAME`/mailer `Username` (SMTP auth, unrelated), one pre-rename column reference in `roles_migration_test.go` (it seeds before the rename migration runs - commented), and historical `RELEASE_NOTES.md` / throwaway `mockups/`.

Out of scope (per the ticket): renaming `email` -> `username`.