### PR TITLE
Show inline feedback under the password field when it is too short

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -356,13 +356,14 @@ func optionDataFromOptions(options []*quiz.Option) []*OptionData {
 // its real implementation here - no per-request override needed.
 func parseTemplate(path string) *template.Template {
 	funcs := template.FuncMap{
-		"currentUser":  func() string { return "" },
-		"csrfToken":    func() string { return "" },
-		"ogImage":      func() string { return "" },
-		"navSection":   func() string { return "" },
-		"isAdmin":      func() bool { return false },
-		"envTitleTag":  envtag.Get,
-		"humanizeTime": humanizeTime,
+		"currentUser":       func() string { return "" },
+		"csrfToken":         func() string { return "" },
+		"ogImage":           func() string { return "" },
+		"navSection":        func() string { return "" },
+		"isAdmin":           func() bool { return false },
+		"envTitleTag":       envtag.Get,
+		"humanizeTime":      humanizeTime,
+		"passwordMinLength": func() int { return auth.MinPasswordLength },
 	}
 	base := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "admin/layouts/*.gohtml"),

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -866,6 +866,7 @@ func newTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, page string
 		"passwordHelp": func() string {
 			return fmt.Sprintf("Must be %d-%d characters.", MinPasswordLength, MaxPasswordLength)
 		},
+		"passwordMinLength": func() int { return MinPasswordLength },
 	}
 	layouts := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "auth/layouts/*.gohtml"),

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -184,6 +184,7 @@ func newTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, page string
 		"passwordHelp": func() string {
 			return fmt.Sprintf("Must be %d-%d characters.", auth.MinPasswordLength, auth.MaxPasswordLength)
 		},
+		"passwordMinLength": func() int { return auth.MinPasswordLength },
 	}
 	layouts := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "auth/layouts/*.gohtml"),

--- a/internal/web/static/js/password-length.js
+++ b/internal/web/static/js/password-length.js
@@ -1,12 +1,9 @@
-// password-length.js shows a live "too short" hint under a new-password
-// input as the visitor types, so they learn the minimum before submitting
-// rather than after a server round-trip. Server-side validation stays the
-// source of truth; this is a hint only.
-//
-// The threshold comes from the input's DOM minLength property (rendered from
-// auth.MinPasswordLength), so there is no second copy of the number here. The
-// paired message element is named in data-password-length; an unset/0
-// minLength or a missing message element is a no-op.
+// password-length.js shows a live "too short" hint under a new-password input
+// as the visitor types, so they learn the minimum before submitting; the
+// server stays the source of truth (this is a hint only). The threshold comes
+// from the input's DOM minLength (rendered from auth.MinPasswordLength), so
+// there is no second copy of the number here; a missing message element (named
+// in data-password-length) or minLength <= 0 is a no-op.
 
 function wire(input) {
     const messageId = input.dataset.passwordLength;

--- a/internal/web/static/js/password-length.js
+++ b/internal/web/static/js/password-length.js
@@ -1,0 +1,35 @@
+// password-length.js shows a live "too short" hint under a new-password
+// input as the visitor types, so they learn the minimum before submitting
+// rather than after a server round-trip. Server-side validation stays the
+// source of truth; this is a hint only.
+//
+// The threshold comes from the input's DOM minLength property (rendered from
+// auth.MinPasswordLength), so there is no second copy of the number here. The
+// paired message element is named in data-password-length; an unset/0
+// minLength or a missing message element is a no-op.
+
+function wire(input) {
+    const messageId = input.dataset.passwordLength;
+    const message = messageId ? document.getElementById(messageId) : null;
+    if (!message) return;
+
+    const update = () => {
+        const min = input.minLength;
+        if (min > 0 && input.value.length > 0 && input.value.length < min) {
+            message.textContent = `Must be at least ${min} characters.`;
+        } else {
+            message.textContent = '';
+        }
+    };
+
+    input.addEventListener('input', update);
+}
+
+if (typeof document !== 'undefined') {
+    const run = () => document.querySelectorAll('[data-password-length]').forEach(wire);
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', run);
+    } else {
+        run();
+    }
+}

--- a/internal/web/tmpl/admin/layouts/base.gohtml
+++ b/internal/web/tmpl/admin/layouts/base.gohtml
@@ -33,6 +33,10 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap">
     <link rel="stylesheet" href="/assets/css/app.css">
     <script src="/assets/js/htmx.min.js" defer></script>
+    {{/* password-length.js shows a live "too short" hint under the
+         set-password input. Self-noops where there is no
+         [data-password-length]. */}}
+    <script type="module" src="/assets/js/password-length.js" defer></script>
     <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/sw.js');</script>
 </head>
 <body class="bg-bg text-text font-sans antialiased min-h-screen leading-relaxed">

--- a/internal/web/tmpl/admin/pages/playerdetail.gohtml
+++ b/internal/web/tmpl/admin/pages/playerdetail.gohtml
@@ -102,9 +102,11 @@
                           onsubmit="return confirm('Set a new password? This signs the player out of their other sessions.');">
                         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                         <label for="password-input" class="text-text-dim text-xs uppercase tracking-[0.14em]">Set password</label>
-                        <input id="password-input" type="password" name="password" required minlength="13" autocomplete="new-password"
+                        <input id="password-input" type="password" name="password" required minlength="{{passwordMinLength}}" autocomplete="new-password"
+                               data-password-length="password-length-hint"
                                class="rounded-md border border-border bg-surface px-3 py-2 text-sm text-text">
                         <p class="text-text-dim text-xs">Hand the password over out-of-band. Setting it signs the player out of their other sessions.</p>
+                        <p id="password-length-hint" class="text-danger text-xs" role="alert" aria-live="polite"></p>
                         <button type="submit" class="btn-primary">Save password</button>
                     </form>
                 {{end}}

--- a/internal/web/tmpl/auth/layouts/base.gohtml
+++ b/internal/web/tmpl/auth/layouts/base.gohtml
@@ -39,6 +39,9 @@
          [data-cooldown] element, so loading it on every auth page is
          fine. */}}
     <script type="module" src="/assets/js/cooldown.js" defer></script>
+    {{/* password-length.js shows a live "too short" hint under new-password
+         inputs. Self-noops where there is no [data-password-length]. */}}
+    <script type="module" src="/assets/js/password-length.js" defer></script>
     <script>if('serviceWorker' in navigator)navigator.serviceWorker.register('/sw.js');</script>
 </head>
 <body class="bg-bg text-text font-sans antialiased min-h-screen leading-relaxed">

--- a/internal/web/tmpl/auth/pages/accept_invite.gohtml
+++ b/internal/web/tmpl/auth/pages/accept_invite.gohtml
@@ -25,7 +25,10 @@
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Password</span>
-                <input type="password" name="password" autocomplete="new-password" required class="form-input">
+                <input type="password" name="password" autocomplete="new-password" required
+                       minlength="{{passwordMinLength}}" data-password-length="password-length-hint"
+                       class="form-input">
+                <span id="password-length-hint" class="text-xs text-danger" role="alert" aria-live="polite"></span>
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Confirm password</span>

--- a/internal/web/tmpl/auth/pages/profile_password.gohtml
+++ b/internal/web/tmpl/auth/pages/profile_password.gohtml
@@ -31,8 +31,10 @@
             <div class="form-field">
                 <label for="new_password" class="label-eyebrow">New password</label>
                 <input id="new_password" name="new_password" type="password" required
-                       autocomplete="new-password" class="form-input">
+                       autocomplete="new-password" minlength="{{passwordMinLength}}"
+                       data-password-length="new-password-length-hint" class="form-input">
                 <p class="mt-2 text-xs text-text-mute">{{passwordHelp}}</p>
+                <p id="new-password-length-hint" class="mt-2 text-xs text-danger" role="alert" aria-live="polite"></p>
             </div>
 
             <div class="form-field">

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -41,9 +41,11 @@
             <div class="form-field">
                 <label for="password" class="label-eyebrow">Password</label>
                 <input id="password" name="password" type="password" required
-                       autocomplete="new-password"
+                       autocomplete="new-password" minlength="{{passwordMinLength}}"
+                       data-password-length="password-length-hint"
                        class="form-input">
                 <p class="mt-2 text-xs text-text-mute">{{passwordHelp}}</p>
+                <p id="password-length-hint" class="mt-2 text-xs text-danger" role="alert" aria-live="polite"></p>
             </div>
 
             <div class="form-field">

--- a/internal/web/tmpl/auth/pages/reset_password.gohtml
+++ b/internal/web/tmpl/auth/pages/reset_password.gohtml
@@ -21,7 +21,10 @@
             <input type="hidden" name="token" value="{{.Token}}">
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">New password</span>
-                <input type="password" name="password" autocomplete="new-password" required class="form-input">
+                <input type="password" name="password" autocomplete="new-password" required
+                       minlength="{{passwordMinLength}}" data-password-length="password-length-hint"
+                       class="form-input">
+                <span id="password-length-hint" class="text-xs text-danger" role="alert" aria-live="polite"></span>
             </label>
             <label class="flex flex-col gap-1 text-sm">
                 <span class="text-text-dim">Confirm new password</span>

--- a/test/e2e/tests/password-length.spec.ts
+++ b/test/e2e/tests/password-length.spec.ts
@@ -10,14 +10,11 @@ test('register password field shows then clears the too-short hint', async ({ pa
   const password = page.locator('input[name=password]');
   const hint = page.locator('#password-length-hint');
 
-  // Empty value: no hint.
   await expect(hint).toHaveText('');
 
-  // Non-empty but under the minimum: the hint names the threshold.
   await password.fill('short');
   await expect(hint).toHaveText('Must be at least 13 characters.');
 
-  // Long enough: the hint clears.
   await password.fill('correctbatterystaple');
   await expect(hint).toHaveText('');
 });

--- a/test/e2e/tests/password-length.spec.ts
+++ b/test/e2e/tests/password-length.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures';
+
+// password-length.js shows a live "too short" hint under the register
+// page's new-password input. The threshold is auth.MinPasswordLength (13),
+// rendered into the input's minlength and read back by the JS, so the hint
+// stays in sync with the server-side rule.
+test('register password field shows then clears the too-short hint', async ({ page }) => {
+  await page.goto('/register');
+
+  const password = page.locator('input[name=password]');
+  const hint = page.locator('#password-length-hint');
+
+  // Empty value: no hint.
+  await expect(hint).toHaveText('');
+
+  // Non-empty but under the minimum: the hint names the threshold.
+  await password.fill('short');
+  await expect(hint).toHaveText('Must be at least 13 characters.');
+
+  // Long enough: the hint clears.
+  await password.fill('correctbatterystaple');
+  await expect(hint).toHaveText('');
+});


### PR DESCRIPTION
Closes #572

New-password fields gave no signal that a password was too short (min 13, `auth.MinPasswordLength`) until submit. This adds a live hint under the field as the visitor types, clearing once long enough. Server-side validation stays the source of truth - this is a client hint only.

- New `internal/web/static/js/password-length.js`: a vanilla ES module (mirrors `cooldown.js`; the auth pages don't load Alpine) that wires `[data-password-length]` inputs and, on input, shows "Must be at least N characters." while the value is non-empty and shorter than the minimum, else clears it. The threshold is read from the input's DOM `minLength` - no duplicated copy of 13 in JS.
- New `passwordMinLength` template func (returns `auth.MinPasswordLength`) registered in the auth, profile, and admin func maps, rendered as `minlength="{{passwordMinLength}}"` so the value comes from the Go constant. playerdetail's hardcoded `minlength="13"` now uses it too.
- Wired on every new-password field: register, reset-password, accept-invite, profile/password, and the admin set-password form. Loaded via the auth + admin base layouts (self-noops where there's no `[data-password-length]`).
- e2e `password-length.spec.ts`: on /register, a too-short value shows the hint and a long-enough value clears it.