### PR TITLE
Animate the round intro and round results cards

### DIFF
--- a/internal/client/static/index.html
+++ b/internal/client/static/index.html
@@ -443,7 +443,8 @@
                      boundary that fires before Q1. -->
                 <template x-if="roundItem && roundItem.phase === 'intro'">
                     <div class="flex flex-col min-h-[calc(100svh-5rem)] sm:min-h-[calc(100svh-8rem)]"
-                         data-testid="round-intro-card">
+                         data-testid="round-intro-card"
+                         x-init="$nextTick(() => animateRoundIntro($el))">
                         <div class="flex justify-end gap-2 mb-4">
                             <template x-if="lastQuestionPosition > 0">
                                 <span class="hud-chip">
@@ -521,7 +522,8 @@
                      intro and question views. -->
                 <template x-if="roundItem && roundItem.phase === 'results'">
                     <div class="flex flex-col min-h-[calc(100svh-5rem)] sm:min-h-[calc(100svh-8rem)]"
-                         data-testid="round-recap-card">
+                         data-testid="round-recap-card"
+                         x-init="$nextTick(() => animateRoundResults($el))">
                         <div class="flex justify-end gap-2 mb-4">
                             <template x-if="lastQuestionPosition > 0">
                                 <span class="hud-chip">
@@ -555,20 +557,23 @@
                              for THIS round. -->
                         <p class="mb-2 text-center font-display font-semibold text-accent
                                   text-[clamp(1.6rem,4vw,2.6rem)]"
-                           data-testid="round-recap-score">
+                           data-testid="round-recap-score"
+                           data-recap-figure>
                             You scored <span x-text="roundItem.roundScore"></span> this round
                         </p>
                         <p class="mb-8 font-display leading-snug text-text text-center
                                   text-[clamp(1rem,3vw,1.5rem)]
                                   lg:text-[clamp(1.25rem,2.5vw,2rem)]"
-                           data-testid="round-recap-correct">
+                           data-testid="round-recap-correct"
+                           data-recap-figure>
                             <span x-text="roundItem.roundCorrect"></span> of <span x-text="roundItem.roundQuestions"></span> correct
                         </p>
 
                         <!-- Running game total beneath the round result. -->
                         <p class="mb-8 text-center font-display font-semibold text-text
                                   text-[clamp(1.2rem,3vw,1.8rem)]"
-                           data-testid="round-score">
+                           data-testid="round-score"
+                           data-recap-figure>
                             Your score: <span x-text="roundItem.score"></span>
                         </p>
 

--- a/internal/client/static/js/components/GameApp.js
+++ b/internal/client/static/js/components/GameApp.js
@@ -828,6 +828,48 @@ export class GameApp {
         });
     }
 
+    // animateRoundIntro plays the round intro card's entrance: a brief
+    // fade + rise. The from-state (opacity 0, translateY) is supplied by
+    // anime via the [from, to] array form, NOT by a CSS class — runAnim
+    // no-ops under reduced motion or a missing global, and in that case
+    // the card must already be at its visible resting state rather than
+    // stuck at opacity 0. Triggered from x-init with $el as the card.
+    animateRoundIntro(el) {
+        requestAnimationFrame(() => {
+            runAnim(el, {
+                opacity: [0, 1],
+                translateY: [12, 0],
+                duration: 380,
+                easing: 'easeOutQuad',
+            });
+        });
+    }
+
+    // animateRoundResults plays the recap card's entrance, then staggers
+    // the recap figures (score, correct/total, running total) so the
+    // numbers land one after another. As with animateRoundIntro the
+    // from-state is anime-driven, so a reduced-motion user or a missing
+    // anime global sees the fully visible card and figures immediately.
+    animateRoundResults(el) {
+        requestAnimationFrame(() => {
+            runAnim(el, {
+                opacity: [0, 1],
+                translateY: [12, 0],
+                duration: 380,
+                easing: 'easeOutQuad',
+            });
+            const a = typeof window !== 'undefined' ? window.anime : null;
+            const figures = el.querySelectorAll('[data-recap-figure]');
+            runAnim(figures, {
+                opacity: [0, 1],
+                translateY: [10, 0],
+                duration: 420,
+                delay: a && typeof a.stagger === 'function' ? a.stagger(120, { start: 120 }) : 120,
+                easing: 'easeOutBack',
+            });
+        });
+    }
+
     startCountdown() {
         const start = new Date(this.question.startedAt).getTime();
         const end = new Date(this.question.expiredAt).getTime();

--- a/test/e2e/tests/round.spec.ts
+++ b/test/e2e/tests/round.spec.ts
@@ -158,3 +158,58 @@ test('round boundary cards auto-advance on their countdown and skip on Continue'
   await expect(autoIntro.getByTestId('round-countdown')).toBeVisible();
   await expect(autoIntro).toBeHidden({ timeout: 10_000 });
 });
+
+// The intro and recap cards run an anime.js entrance (#575). runAnim
+// no-ops under reduced motion, so the cards' resting CSS must already be
+// fully visible — a regression that starts them hidden in CSS and relies
+// on anime to fade them in would leave reduced-motion players staring at
+// a blank screen. Emulating reduced motion before play and asserting both
+// cards plus their figures are visible pins that the from-state is
+// anime-driven, not CSS.
+test('round boundary cards stay visible under reduced motion', async ({ page, browserName }) => {
+  test.setTimeout(60_000);
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+
+  const quizTitle = `E2E Round Reduced Motion ${browserName}`;
+  await importQuiz(page, {
+    title: quizTitle,
+    description: 'E2E reduced-motion round quiz',
+    rounds: [roundWithSummary('Steady on!')],
+  });
+
+  await page.context().clearCookies();
+  await startQuiz(page, quizTitle);
+
+  // Intro card and its content are visible with motion disabled.
+  const introCard = page.getByTestId('round-intro-card');
+  await expect(introCard).toBeVisible({ timeout: 10_000 });
+  await expect(introCard).toHaveCSS('opacity', '1');
+  await expect(page.getByTestId('round-title')).toContainText('Round 1');
+  await expect(page.getByTestId('round-summary')).toContainText('Steady on!');
+  await expect(introCard.getByTestId('round-countdown')).toBeVisible();
+  await page.getByTestId('round-continue').click();
+
+  const q1Option = page.getByRole('button', { name: '4' });
+  await expect(q1Option).toBeVisible({ timeout: 10_000 });
+  await q1Option.click();
+  await expect(page.locator('.splash-correct')).toBeVisible();
+
+  const q2Option = page.getByRole('button', { name: 'Paris' });
+  await expect(q2Option).toBeVisible({ timeout: 10_000 });
+  await q2Option.click();
+  await expect(page.locator('.splash-correct')).toBeVisible();
+
+  // Recap card and its staggered figures are fully visible with motion
+  // disabled — the score, correct/total, and running total all show.
+  const recapCard = page.getByTestId('round-recap-card');
+  await expect(recapCard).toBeVisible({ timeout: 10_000 });
+  await expect(recapCard).toHaveCSS('opacity', '1');
+  const recapScore = page.getByTestId('round-recap-score');
+  await expect(recapScore).toBeVisible();
+  await expect(recapScore).toHaveCSS('opacity', '1');
+  await expect(page.getByTestId('round-recap-correct')).toContainText('2 of 2 correct');
+  await expect(page.getByTestId('round-recap-correct')).toHaveCSS('opacity', '1');
+  await expect(page.getByTestId('round-score')).toBeVisible();
+  await expect(page.getByTestId('round-score')).toHaveCSS('opacity', '1');
+});


### PR DESCRIPTION
Closes #575

The round-boundary cards appeared without motion. This adds a short fade + rise entrance to both, using the already-vendored anime.js via the existing `runAnim` wrapper (no new dependency).

- `animateRoundIntro` / `animateRoundResults` on `GameApp`, triggered from each card's `x-init`. The results card additionally staggers the recap figures (score, correct/total, running total) so the numbers land one after another.
- **Reduced-motion safe:** `runAnim` no-ops under `prefers-reduced-motion` or a missing anime global, and the from-state (`opacity: [0,1]`, `translateY: [12,0]`) is supplied by anime - NOT by a CSS class - so the cards' resting CSS is fully visible. A reduced-motion user or an anime load failure sees the cards immediately, never stuck hidden.
- e2e: a new `round.spec.ts` test emulates `reducedMotion: 'reduce'`, drives a round to its recap, and asserts both cards + all recap figures are visible AND `opacity: 1` - pinning that the from-state is anime-driven, not CSS. The existing test still covers the animated path.

Tailwind/theme tokens only; anime.js stays vendored.