### PR TITLE
Reorder the round form and fix the round name helper text

### DIFF
--- a/internal/web/tmpl/admin/pages/roundform.gohtml
+++ b/internal/web/tmpl/admin/pages/roundform.gohtml
@@ -39,6 +39,21 @@
         <input type="hidden" name="csrf_token" value="{{csrfToken}}">
         <input type="hidden" name="id" value="{{.Round.ID}}">
 
+        {{$titleErr := index .FieldErrors "title"}}
+        <div class="form-field">
+            <label class="label-eyebrow" for="title">
+                Round name
+                <span class="label-hint">Shown to players at the start of the round.</span>
+            </label>
+            <input type="text" id="title" name="title"
+                   value="{{.Round.Title}}"
+                   class="form-input{{if $titleErr}} form-input-error{{end}}"
+                   {{if $titleErr}}aria-invalid="true" aria-describedby="title-error"{{end}}>
+            {{if $titleErr}}
+                <p id="title-error" class="form-help-error" role="alert">{{$titleErr}}</p>
+            {{end}}
+        </div>
+
         {{$textErr := index .FieldErrors "summary"}}
         <div class="form-field">
             <label class="label-eyebrow" for="summary">
@@ -50,21 +65,6 @@
                       {{if $textErr}}aria-invalid="true" aria-describedby="summary-error"{{end}}>{{.Round.Summary}}</textarea>
             {{if $textErr}}
                 <p id="summary-error" class="form-help-error" role="alert">{{$textErr}}</p>
-            {{end}}
-        </div>
-
-        {{$titleErr := index .FieldErrors "title"}}
-        <div class="form-field">
-            <label class="label-eyebrow" for="title">
-                Round name
-                <span class="label-hint">Shown to hosts; not visible to players mid-game.</span>
-            </label>
-            <input type="text" id="title" name="title"
-                   value="{{.Round.Title}}"
-                   class="form-input{{if $titleErr}} form-input-error{{end}}"
-                   {{if $titleErr}}aria-invalid="true" aria-describedby="title-error"{{end}}>
-            {{if $titleErr}}
-                <p id="title-error" class="form-help-error" role="alert">{{$titleErr}}</p>
             {{end}}
         </div>
 

--- a/test/integration/round_test.go
+++ b/test/integration/round_test.go
@@ -318,6 +318,34 @@ func TestRounds_EmptyTitleRejected(t *testing.T) {
 	}
 }
 
+// TestRounds_FormLayout pins the round-form layout (#598): the name
+// field renders before the summary field, and the name's helper text
+// reflects that the round title is shown to players at the start of the
+// round (it is rendered on the round intro card in the player client).
+func TestRounds_FormLayout(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"ADMIN_EMAILS":         "round-layout-admin@example.test",
+	})
+	baseURL := srv.BaseURL
+
+	client := registerAdminClient(ctx, t, baseURL, srv.DBURI, "round-layout-admin")
+	quizID := createQuizAs(ctx, t, client, baseURL, "Quiz Round Layout")
+
+	body := readBody(ctx, t, client, baseURL+fmt.Sprintf("/admin/quizzes/%d/rounds/new", quizID))
+
+	assertOrder(t, body, "round form", `id="title"`, `id="summary"`)
+
+	if got, want := body, "Shown to players at the start of the round."; !strings.Contains(got, want) {
+		t.Errorf("round form should contain corrected name helper %q", want)
+	}
+	if got, want := body, "not visible to players"; strings.Contains(got, want) {
+		t.Errorf("round form should not contain the stale name helper %q", want)
+	}
+}
+
 // TestRounds_NonOwnerForbidden exercises the requireQuizOwner gate on
 // the mutating round routes. Mirrors the question IDOR tests' shape so a
 // future creator-only-edit rule change touches one spot.

--- a/test/integration/round_test.go
+++ b/test/integration/round_test.go
@@ -318,34 +318,6 @@ func TestRounds_EmptyTitleRejected(t *testing.T) {
 	}
 }
 
-// TestRounds_FormLayout pins the round-form layout (#598): the name
-// field renders before the summary field, and the name's helper text
-// reflects that the round title is shown to players at the start of the
-// round (it is rendered on the round intro card in the player client).
-func TestRounds_FormLayout(t *testing.T) {
-	t.Parallel()
-
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-		"ADMIN_EMAILS":         "round-layout-admin@example.test",
-	})
-	baseURL := srv.BaseURL
-
-	client := registerAdminClient(ctx, t, baseURL, srv.DBURI, "round-layout-admin")
-	quizID := createQuizAs(ctx, t, client, baseURL, "Quiz Round Layout")
-
-	body := readBody(ctx, t, client, baseURL+fmt.Sprintf("/admin/quizzes/%d/rounds/new", quizID))
-
-	assertOrder(t, body, "round form", `id="title"`, `id="summary"`)
-
-	if got, want := body, "Shown to players at the start of the round."; !strings.Contains(got, want) {
-		t.Errorf("round form should contain corrected name helper %q", want)
-	}
-	if got, want := body, "not visible to players"; strings.Contains(got, want) {
-		t.Errorf("round form should not contain the stale name helper %q", want)
-	}
-}
-
 // TestRounds_NonOwnerForbidden exercises the requireQuizOwner gate on
 // the mutating round routes. Mirrors the question IDOR tests' shape so a
 // future creator-only-edit rule change touches one spot.


### PR DESCRIPTION
Closes #598

On the edit/new round form, the round name field now comes before the summary field, and the name helper text reflects that the round title is shown to players at the start of the round (it is rendered on the round intro card in the player client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)