### PR TITLE
Automate auth manual test plan cases with integration tests and mailpit e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
         run: npx playwright install-deps ${{ matrix.browser }}
         working-directory: test/e2e
 
-      # The e2e suite runs the verify / reset / invite email round-trips
+      # The e2e suite runs the verify and invite email round-trips
       # against a local mailpit SMTP catch-all. The pinned binary is
       # downloaded into build/bin by the Makefile; playwright.config.ts
       # starts it as a webServer and points it at build/bin/mailpit.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,6 +63,13 @@ jobs:
         run: npx playwright install-deps ${{ matrix.browser }}
         working-directory: test/e2e
 
+      # The e2e suite runs the verify / reset / invite email round-trips
+      # against a local mailpit SMTP catch-all. The pinned binary is
+      # downloaded into build/bin by the Makefile; playwright.config.ts
+      # starts it as a webServer and points it at build/bin/mailpit.
+      - name: Download mailpit
+        run: make build/bin/mailpit
+
       - name: Run Playwright tests
         run: npx playwright test --project=${{ matrix.browser }}
         working-directory: test/e2e

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ GOLANGCI_BIN     := $(BIN_DIR)/golangci-lint
 SQLC_VERSION := v1.31.1
 SQLC_BIN     := $(BIN_DIR)/sqlc
 
+# mailpit version + binary path. Used by the e2e suite as a local SMTP
+# catch-all so the browser tests can drive the real verify / reset /
+# invite email round-trip (the app sends to mailpit; the specs read the
+# message back over mailpit's HTTP API). Pinned like the Tailwind binary:
+# mailpit is not a Go module tool, so dependabot does not track it - bump
+# the version here manually.
+MAILPIT_VERSION := v1.30.1
+MAILPIT_BIN     := $(BIN_DIR)/mailpit
+
 # Developer check before committing. Includes smoke (#349) so the
 # migration-against-existing-data class of bug — which test-coverage's
 # fresh DB can't catch — fails locally before CI does.
@@ -204,9 +213,9 @@ test-coverage-html: test-coverage
 # `cd test/e2e || exit 1;` instead so the cd lands in the parent
 # shell and both backgrounded playwright runs inherit it.
 .PHONY: test-e2e
-test-e2e:
+test-e2e: $(MAILPIT_BIN)
 	cd test/e2e && npm ci && npx playwright install chromium firefox
-	cd test/e2e && npx playwright test
+	cd test/e2e && TOPBANANA_MAILPIT_BIN=$(abspath $(MAILPIT_BIN)) npx playwright test
 
 # Smoke-test the binary against the existing dev DB: parses config, opens
 # the DB, runs migrations, and exits 0. Catches startup / migration / config
@@ -383,6 +392,41 @@ $(SQLC_BIN):
 	        https://github.com/sqlc-dev/sqlc/releases/download/$(SQLC_VERSION)/$(SQLC_TARBALL) && \
 	    tar -xzf $$tmp/sqlc.tar.gz -C $$tmp && \
 	    mv $$tmp/sqlc $@ && \
+	    rm -rf $$tmp
+	@chmod +x $@
+
+# --- mailpit -----------------------------------------------------------------
+#
+# Release assets are mailpit-<os>-<arch>.tar.gz with the binary at the
+# tarball root, so the download mirrors the sqlc target. The asset arch
+# tokens are amd64/arm64 (like golangci-lint), not sqlc's underscore form.
+
+ifeq ($(UNAME_S),Linux)
+    ifeq ($(UNAME_M),aarch64)
+        MAILPIT_ASSET := mailpit-linux-arm64
+    else
+        MAILPIT_ASSET := mailpit-linux-amd64
+    endif
+else ifeq ($(UNAME_S),Darwin)
+    ifeq ($(UNAME_M),arm64)
+        MAILPIT_ASSET := mailpit-darwin-arm64
+    else
+        MAILPIT_ASSET := mailpit-darwin-amd64
+    endif
+else
+    MAILPIT_ASSET := mailpit-linux-amd64
+endif
+
+MAILPIT_TARBALL := $(MAILPIT_ASSET).tar.gz
+
+$(MAILPIT_BIN):
+	@mkdir -p $(BIN_DIR)
+	@echo "Downloading mailpit $(MAILPIT_VERSION) ($(MAILPIT_ASSET))..."
+	@tmp=$$(mktemp -d) && \
+	    curl -sSfL -o $$tmp/mailpit.tar.gz \
+	        https://github.com/axllent/mailpit/releases/download/$(MAILPIT_VERSION)/$(MAILPIT_TARBALL) && \
+	    tar -xzf $$tmp/mailpit.tar.gz -C $$tmp && \
+	    mv $$tmp/mailpit $@ && \
 	    rm -rf $$tmp
 	@chmod +x $@
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ SQLC_VERSION := v1.31.1
 SQLC_BIN     := $(BIN_DIR)/sqlc
 
 # mailpit version + binary path. Used by the e2e suite as a local SMTP
-# catch-all so the browser tests can drive the real verify / reset /
-# invite email round-trip (the app sends to mailpit; the specs read the
+# catch-all so the browser tests can drive the real verify and invite
+# email round-trips (the app sends to mailpit; the specs read the
 # message back over mailpit's HTTP API). Pinned like the Tailwind binary:
 # mailpit is not a Go module tool, so dependabot does not track it - bump
 # the version here manually.

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -24,19 +24,44 @@ const WORKER_COUNT = 4;
 // override for debugging a single worker on a known port: when set,
 // worker i listens on TOPBANANA_E2E_PORT + i (the old fixed-base
 // behaviour). It is no longer the default.
-const WORKER_PORTS = resolveWorkerPorts(WORKER_COUNT);
+// Mailpit (the e2e SMTP catch-all) needs its own SMTP + HTTP port pair
+// alongside the worker ports. Both are discovered together (see
+// resolvePorts) and shared with the re-loaded worker configs and the
+// fixtures via TOPBANANA_E2E_PORTS / TOPBANANA_E2E_MAILPIT. The mailpit
+// SMTP port goes into each worker server's SMTP_PORT; the HTTP port is
+// where the specs read sent mail back (tests/mailpit.ts reads the same
+// env).
+const { workerPorts: WORKER_PORTS, mailpit: MAILPIT } = resolvePorts(WORKER_COUNT);
 
-function resolveWorkerPorts(count: number): number[] {
-  const cached = process.env.TOPBANANA_E2E_PORTS;
-  if (cached) {
-    return cached.split(',').map(Number);
+function resolvePorts(count: number): { workerPorts: number[]; mailpit: { smtp: number; http: number } } {
+  const cachedWorkers = process.env.TOPBANANA_E2E_PORTS;
+  const cachedMailpit = process.env.TOPBANANA_E2E_MAILPIT;
+  if (cachedWorkers && cachedMailpit) {
+    const [smtp, http] = cachedMailpit.split(',').map(Number);
+    return { workerPorts: cachedWorkers.split(',').map(Number), mailpit: { smtp, http } };
   }
+
   const override = process.env.TOPBANANA_E2E_PORT;
-  const ports = override
-    ? Array.from({ length: count }, (_, i) => Number(override) + i)
-    : discoverFreePorts(count);
-  process.env.TOPBANANA_E2E_PORTS = ports.join(',');
-  return ports;
+  let workerPorts: number[];
+  let mailpitPorts: number[];
+  if (override) {
+    // Debug path: fixed worker ports from the override base; mailpit
+    // still takes free ports since it has no fixed-base contract.
+    workerPorts = Array.from({ length: count }, (_, i) => Number(override) + i);
+    mailpitPorts = discoverFreePorts(2);
+  } else {
+    // Discover worker + mailpit ports in ONE call so the
+    // simultaneous-listener distinctness guarantee (#476) spans both -
+    // two separate calls could hand the same OS port to a worker and to
+    // mailpit, colliding when the servers bind.
+    const all = discoverFreePorts(count + 2);
+    workerPorts = all.slice(0, count);
+    mailpitPorts = all.slice(count);
+  }
+
+  process.env.TOPBANANA_E2E_PORTS = workerPorts.join(',');
+  process.env.TOPBANANA_E2E_MAILPIT = mailpitPorts.join(',');
+  return { workerPorts, mailpit: { smtp: mailpitPorts[0], http: mailpitPorts[1] } };
 }
 
 // Open `count` ephemeral listeners on :0 in a short-lived Node
@@ -133,6 +158,17 @@ const workerServer = (workerIndex: number) => {
       // falsely trip "Too many attempts" on back-to-back same-IP logins.
       LOGIN_COOLDOWN: '0s',
       ADMIN_EMAILS,
+      // Point the mailer at the shared mailpit catch-all so the email
+      // round-trip specs can read the verify / reset / invite link back
+      // over mailpit's API. SMTP_TLS=false keeps it plain SMTP (mailpit
+      // does not offer STARTTLS on its listener); sends are best-effort
+      // and async in the handler, so a worker booting before mailpit is
+      // ready does not break the non-email specs. The link in each mail
+      // is built from BASE_URL above, so it points back at this worker.
+      SMTP_HOST: '127.0.0.1',
+      SMTP_PORT: String(MAILPIT.smtp),
+      SMTP_FROM: 'topbanana@example.test',
+      SMTP_TLS: 'false',
     },
     reuseExistingServer: false,
     timeout: 120_000,
@@ -140,6 +176,24 @@ const workerServer = (workerIndex: number) => {
     stderr: 'pipe' as const,
   };
 };
+
+// mailpitServer runs the pinned mailpit binary as a single shared SMTP
+// catch-all + HTTP API for the whole run (all workers send into it; the
+// specs read messages back filtered by recipient). The binary path comes
+// from the Makefile via TOPBANANA_MAILPIT_BIN; a direct `npx playwright
+// test` (no make) falls back to the build/bin/mailpit the Makefile
+// downloads, resolved against the repo root via cwd.
+const mailpitServer = () => ({
+  command:
+    `${process.env.TOPBANANA_MAILPIT_BIN ?? 'build/bin/mailpit'}` +
+    ` --smtp 127.0.0.1:${MAILPIT.smtp} --listen 127.0.0.1:${MAILPIT.http}`,
+  cwd: '../..',
+  url: `http://127.0.0.1:${MAILPIT.http}/`,
+  reuseExistingServer: false,
+  timeout: 60_000,
+  stdout: 'pipe' as const,
+  stderr: 'pipe' as const,
+});
 
 export default defineConfig({
   testDir: './tests',
@@ -188,5 +242,8 @@ export default defineConfig({
       dependencies: ['setup'],
     },
   ],
-  webServer: Array.from({ length: WORKER_COUNT }, (_, i) => workerServer(i)),
+  // Mailpit first so it is listening before the worker servers (whose
+  // mailer points at it) start; Playwright waits for every entry's url
+  // health check before running tests.
+  webServer: [mailpitServer(), ...Array.from({ length: WORKER_COUNT }, (_, i) => workerServer(i))],
 });

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -159,7 +159,7 @@ const workerServer = (workerIndex: number) => {
       LOGIN_COOLDOWN: '0s',
       ADMIN_EMAILS,
       // Point the mailer at the shared mailpit catch-all so the email
-      // round-trip specs can read the verify / reset / invite link back
+      // round-trip specs can read the verify and invite link back
       // over mailpit's API. SMTP_TLS=false keeps it plain SMTP (mailpit
       // does not offer STARTTLS on its listener); sends are best-effort
       // and async in the handler, so a worker booting before mailpit is

--- a/test/e2e/tests/admin-invites.spec.ts
+++ b/test/e2e/tests/admin-invites.spec.ts
@@ -5,11 +5,11 @@ import { adminStatePath } from '../e2e-auth';
 // in as an admin to drive the invite-management UI.
 test.use({ storageState: adminStatePath() });
 
-// #318 slice 2 - admin invite management UI. Admin-side only: the e2e
-// harness has no SMTP and the raw invite token is never stored, so this
-// covers the dashboard tile, the create form, and the per-row resend /
-// revoke actions on the pending list. Accept-via-link is exercised in the
-// integration suite, where the token is mintable directly.
+// #318 slice 2 - admin invite management UI. Covers the dashboard tile,
+// the create form, and the per-row resend / revoke actions on the
+// pending list. The accept-via-link round-trip lives in
+// invite-roundtrip.spec.ts (which reads the emailed link from mailpit)
+// and in the integration suite (which mints the token directly).
 test('admin creates, resends, and revokes an invite from the management page', async ({ page, browserName }) => {
   const inviteEmail = `e2e-invitee-${browserName}@example.test`;
 
@@ -19,9 +19,8 @@ test('admin creates, resends, and revokes an invite from the management page', a
   await expect(page).toHaveURL('/admin/invites');
   await expect(page.getByRole('heading', { name: 'Invites', exact: true })).toBeVisible();
 
-  // Submit the create form; SMTP is not configured in e2e, so the banner
-  // says the link exists but no mail went out. The PRG lands back on the
-  // list with the new invite visible.
+  // Submit the create form. The PRG lands back on the list with the new
+  // invite visible (the success banner names the recipient too).
   await page.locator('input[name=email]').fill(inviteEmail);
   await page.locator('input[name=note]').fill('a friend');
   await page.getByRole('button', { name: 'Send invite' }).click();
@@ -34,7 +33,7 @@ test('admin creates, resends, and revokes an invite from the management page', a
   const row = page.getByRole('row').filter({ hasText: inviteEmail });
   await row.getByRole('button', { name: 'Resend' }).click();
   await expect(page).toHaveURL('/admin/invites');
-  await expect(page.getByText('Invite link rotated', { exact: false })).toBeVisible();
+  await expect(page.getByText('Invite resent', { exact: false })).toBeVisible();
   await expect(page.getByRole('cell', { name: inviteEmail })).toBeVisible();
 
   // Revoke drops it from the pending list. The confirm() dialog is auto-

--- a/test/e2e/tests/email-admin.spec.ts
+++ b/test/e2e/tests/email-admin.spec.ts
@@ -15,11 +15,12 @@ test('admin can open the email diagnostics page and see status + log', async ({ 
   await expect(page).toHaveURL(/\/admin\/email$/);
 
   await expect(page.getByRole('heading', { name: /email diagnostics/i })).toBeVisible();
-  // One "disabled (no-op)" badge in e2e: SMTP is unwired. BASE_URL is
-  // configured per-worker (the invite flow needs it, #318), so its badge
-  // does not appear. Pinning the count keeps the test honest if SMTP
-  // becomes configurable later.
-  await expect(page.getByText(/disabled \(no-op\)/i)).toHaveCount(1);
+  // SMTP is now wired to the mailpit catch-all and BASE_URL is set
+  // per-worker, so both status rows read configured and no
+  // "disabled (no-op)" badge appears. Pinning the count keeps the test
+  // honest if either wiring regresses.
+  await expect(page.getByText('enabled', { exact: true })).toBeVisible();
+  await expect(page.getByText(/disabled \(no-op\)/i)).toHaveCount(0);
 
   const recipient = page.locator('input[name=to]');
   await expect(recipient).toBeVisible();
@@ -27,13 +28,14 @@ test('admin can open the email diagnostics page and see status + log', async ({ 
 
   // Submit. With PRG the browser lands on /admin/email (not
   // /admin/email/test); the banner is delivered via the flash cookie
-  // the GET clears.
+  // the GET clears. The send now reaches mailpit, so the notice reports
+  // success rather than the not-configured error.
   await page.getByRole('button', { name: /send test email/i }).click();
   await expect(page).toHaveURL(/\/admin\/email$/);
-  await expect(page.getByRole('alert')).toContainText(/email is not configured/i);
+  await expect(page.getByRole('status')).toContainText(/test email sent to ops@example.test/i);
 
   // Flash is one-shot: navigating away and back must drop the banner.
   await page.goto('/admin');
   await page.goto('/admin/email');
-  await expect(page.getByRole('alert')).toHaveCount(0);
+  await expect(page.getByRole('status')).toHaveCount(0);
 });

--- a/test/e2e/tests/email-roundtrip.spec.ts
+++ b/test/e2e/tests/email-roundtrip.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from './fixtures';
+import { login, registerForPending } from './helpers';
+import { waitForEmailLink } from './mailpit';
+
+// Email round-trip spec. Unlike the rest of the suite (which fakes the
+// verify step by stamping email_verified_at), this drives the real
+// browser flow end to end: the worker server sends mail to the shared
+// mailpit catch-all, and the spec reads the link back over mailpit's API
+// and follows it. A per-browser recipient keeps the shared inbox
+// unambiguous under parallel workers.
+//
+// Only the verify link is exercised here. The reset-link leg is the same
+// mailpit mechanism, and exercising it would need the forgot-password
+// form whose 60s per-IP cooldown cooldown.spec.ts deliberately depends
+// on - the two cannot share one server config. Reset is covered by the
+// integration suite (TestResetPassword_HappyPath) and the invite link
+// round-trip lives in invite-roundtrip.spec.ts.
+
+test('verify-email link signs the account in once followed', async ({ page, browserName }) => {
+  const displayName = `e2e-verify-rt-${browserName}`;
+  const email = `${displayName}@example.test`;
+
+  // Register through the UI; the hard gate leaves the account unverified
+  // with no session, and a verification mail is dispatched.
+  await registerForPending(page, displayName);
+
+  // Read the verification link mailpit caught and follow it in the browser.
+  const link = await waitForEmailLink(email, '/verify-email?token=');
+  await page.goto(link);
+  await expect(page.getByRole('heading', { name: 'Email verified' })).toBeVisible();
+
+  // The account can now sign in and hold a session (the navbar Log out
+  // button is the role-agnostic signed-in marker).
+  await login(page, displayName);
+  await expect(page.getByRole('button', { name: 'Log out' })).toBeVisible();
+});

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -25,10 +25,11 @@ export const QUIZ_QUESTIONS: readonly QuestionSpec[] = [
 export async function registerAdmin(page: Page, displayName: string): Promise<void> {
   await registerForPending(page, displayName);
   // The hard email-verification gate (#574) means register no longer
-  // hands out a session: SMTP isn't wired in e2e so we cannot complete
-  // the user-facing verify flow, so stamp email_verified_at directly
-  // (same trick home.spec.ts uses to wipe games), then log in to obtain
-  // a session and land on the admin dashboard.
+  // hands out a session. Stamp email_verified_at directly (same trick
+  // home.spec.ts uses to wipe games) rather than clicking the emailed
+  // link: this is the setup shortcut for the many specs that just need a
+  // signed-in admin. The real link round-trip is covered on its own in
+  // email-roundtrip.spec.ts. Then log in to land on the admin dashboard.
   markEmailVerified(displayName);
   await login(page, displayName);
   await expect(page).toHaveURL(/\/admin\/quizzes$/);

--- a/test/e2e/tests/invite-roundtrip.spec.ts
+++ b/test/e2e/tests/invite-roundtrip.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from './fixtures';
+import { adminStatePath } from '../e2e-auth';
+import { PASSWORD } from './helpers';
+import { waitForEmailLink } from './mailpit';
+
+// Invite accept-via-link round-trip. The admin-invites spec covers the
+// management UI but stops at the send (it predates SMTP in e2e); this
+// spec completes the loop now that mailpit catches the invite mail: an
+// admin sends an invite, and the invitee accepts it through the emailed
+// link in a separate browser context, landing signed in.
+test.use({ storageState: adminStatePath() });
+
+test('invite accept link creates an account and signs it in', async ({ page, browser, browserName }) => {
+  const inviteEmail = `e2e-invite-rt-${browserName}@example.test`;
+  const inviteeName = `e2e-invitee-rt-${browserName}`;
+
+  // Send the invite as the signed-in admin.
+  await page.goto('/admin/invites');
+  await page.locator('input[name=email]').fill(inviteEmail);
+  await page.getByRole('button', { name: 'Send invite' }).click();
+  await expect(page).toHaveURL('/admin/invites');
+  await expect(page.getByRole('cell', { name: inviteEmail })).toBeVisible();
+
+  // Read the accept link mailpit caught for the invitee.
+  const link = await waitForEmailLink(inviteEmail, '/accept-invite?token=');
+
+  // Accept in a fresh context so the admin session on `page` is left
+  // intact. The emailed link is absolute, so this context needs no
+  // baseURL of its own.
+  const inviteeContext = await browser.newContext();
+  try {
+    const inviteePage = await inviteeContext.newPage();
+    await inviteePage.goto(link);
+    await expect(inviteePage.getByRole('heading', { name: 'Accept your invite' })).toBeVisible();
+    await inviteePage.locator('input[name=display_name]').fill(inviteeName);
+    await inviteePage.locator('input[name=password]').fill(PASSWORD);
+    await inviteePage.locator('input[name=confirm]').fill(PASSWORD);
+    await inviteePage.getByRole('button', { name: 'Create account' }).click();
+
+    // Accept creates an already-verified account and auto-signs in, so
+    // the new session lands without a separate login step.
+    await expect(inviteePage.getByRole('button', { name: 'Log out' })).toBeVisible();
+  } finally {
+    await inviteeContext.close();
+  }
+});

--- a/test/e2e/tests/mailpit.ts
+++ b/test/e2e/tests/mailpit.ts
@@ -1,5 +1,5 @@
 // Mailpit query helpers for the email round-trip specs. The worker
-// servers send verify / reset / invite mail to the shared mailpit
+// servers send their mail (verify, invite, ...) to the shared mailpit
 // catch-all (wired in playwright.config.ts); these helpers read it back
 // over mailpit's HTTP API. The app sends mail asynchronously (a
 // best-effort goroutine), so reads poll until the message lands.
@@ -35,9 +35,9 @@ export async function waitForEmailLink(
 
   while (Date.now() < deadline) {
     // Scan every message addressed to the recipient, not just the
-    // newest: a flow often produces more than one (e.g. the register
-    // verify mail plus a later reset mail to the same address), and only
-    // one of them carries the link this caller wants.
+    // newest: a recipient can accumulate more than one mail (a retried
+    // spec re-registers the same address, future flows may add others),
+    // and not all of them carry the link this caller wants.
     const matches = await messagesTo(base, recipient);
     for (const m of matches) {
       const link = await linkFromMessage(base, m.ID, pathContains);

--- a/test/e2e/tests/mailpit.ts
+++ b/test/e2e/tests/mailpit.ts
@@ -1,0 +1,88 @@
+// Mailpit query helpers for the email round-trip specs. The worker
+// servers send verify / reset / invite mail to the shared mailpit
+// catch-all (wired in playwright.config.ts); these helpers read it back
+// over mailpit's HTTP API. The app sends mail asynchronously (a
+// best-effort goroutine), so reads poll until the message lands.
+
+// mailpitBaseURL derives the API base from TOPBANANA_E2E_MAILPIT, the
+// "smtp,http" port pair playwright.config.ts publishes once per run.
+export function mailpitBaseURL(): string {
+  const cached = process.env.TOPBANANA_E2E_MAILPIT;
+  if (!cached) {
+    throw new Error('TOPBANANA_E2E_MAILPIT is not set; the mailpit helper cannot find the API');
+  }
+  const http = cached.split(',')[1];
+  return `http://127.0.0.1:${http}`;
+}
+
+type MailpitSummary = { ID: string; To: { Address: string }[] };
+type MailpitMessage = { Text?: string; HTML?: string };
+
+// waitForEmailLink polls mailpit for the newest message addressed to
+// `recipient` and returns the first absolute URL whose path contains
+// `pathContains` (e.g. "/verify-email?token="). One shared inbox serves
+// all parallel workers, so filtering by the unique per-test recipient -
+// not "latest message" - is what keeps the round-trip specs from picking
+// up each other's mail.
+export async function waitForEmailLink(
+  recipient: string,
+  pathContains: string,
+  timeoutMs = 10_000,
+): Promise<string> {
+  const base = mailpitBaseURL();
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = 'no matching message arrived';
+
+  while (Date.now() < deadline) {
+    // Scan every message addressed to the recipient, not just the
+    // newest: a flow often produces more than one (e.g. the register
+    // verify mail plus a later reset mail to the same address), and only
+    // one of them carries the link this caller wants.
+    const matches = await messagesTo(base, recipient);
+    for (const m of matches) {
+      const link = await linkFromMessage(base, m.ID, pathContains);
+      if (link) {
+        return link;
+      }
+    }
+    if (matches.length > 0) {
+      lastErr = `${matches.length} message(s) to ${recipient}, none carrying a link containing ${pathContains}`;
+    }
+    await sleep(150);
+  }
+
+  throw new Error(`waitForEmailLink(${recipient}, ${pathContains}) timed out: ${lastErr}`);
+}
+
+async function messagesTo(base: string, recipient: string): Promise<MailpitSummary[]> {
+  const url = `${base}/api/v1/search?query=${encodeURIComponent(`to:${recipient}`)}&limit=20`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    return [];
+  }
+  const data = (await res.json()) as { messages?: MailpitSummary[] };
+  // The search tokenises the address, so confirm an exact To match
+  // before trusting each hit.
+  return (data.messages ?? []).filter((m) =>
+    m.To?.some((t) => t.Address.toLowerCase() === recipient.toLowerCase()),
+  );
+}
+
+async function linkFromMessage(base: string, id: string, pathContains: string): Promise<string | undefined> {
+  const res = await fetch(`${base}/api/v1/message/${id}`);
+  if (!res.ok) {
+    return undefined;
+  }
+  const body = (await res.json()) as MailpitMessage;
+  const text = body.Text ?? body.HTML ?? '';
+  const re = new RegExp(`https?://[^\\s"'<>]*${escapeRegExp(pathContains)}[^\\s"'<>]*`);
+  return re.exec(text)?.[0];
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/integration/auth_gaps_test.go
+++ b/test/integration/auth_gaps_test.go
@@ -1,0 +1,314 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRegister_PasswordMismatchRejected pins the reg-mismatch case from
+// docs/auth-manual-test-plan.md: a register POST whose password and
+// confirmation differ is rejected with the mismatch message and no
+// account is created.
+func TestRegister_PasswordMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	status, body := registerWithConfirm(
+		ctx, t, authClient(t), srv.BaseURL,
+		"reg-mismatch", "reg-mismatch@example.test", "correct-battery-13", "different-battery-13",
+	)
+
+	if got, want := status, http.StatusBadRequest; got != want {
+		t.Errorf("register status = %d, want %d", got, want)
+	}
+	if got, want := body, "Passwords do not match."; !strings.Contains(got, want) {
+		t.Errorf("register body missing mismatch message %q; body=%.300q", want, got)
+	}
+
+	dbConn, stores := openStores(t, srv.DBURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+	if _, err := stores.Players.GetPlayerByDisplayName(ctx, "reg-mismatch"); err == nil {
+		t.Error("GetPlayerByDisplayName err = nil, want not-found (mismatch must not create an account)")
+	}
+}
+
+// TestRegister_DuplicateDisplayNameRejected pins the reg-dupname case: a
+// display name is a public handle, not an enumeration secret, so reusing
+// one reports the collision with a 409 instead of the opaque pending page.
+func TestRegister_DuplicateDisplayNameRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	// Seed the owner so the display name is taken.
+	registerForPending(ctx, t, authClient(t), srv.BaseURL, "dupname-owner", "correct-battery-13")
+
+	// Reuse the display name under a fresh email.
+	status, body := registerRaw(
+		ctx, t, authClient(t), srv.BaseURL, "dupname-owner", "dupname-other@example.test", "correct-battery-13",
+	)
+
+	if got, want := status, http.StatusConflict; got != want {
+		t.Errorf("duplicate-name register status = %d, want %d", got, want)
+	}
+	if got, want := body, "That display name is already taken."; !strings.Contains(got, want) {
+		t.Errorf("register body missing taken-name message %q; body=%.300q", want, got)
+	}
+}
+
+// TestRegister_DisabledReturns404 pins the reg-disabled case: with
+// REGISTRATION_ENABLED unset the /register routes are never registered,
+// so both the form and the submit 404 from the mux.
+func TestRegister_DisabledReturns404(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, nil)
+	client := authClient(t)
+
+	getResp := doRequest(ctx, t, client, http.MethodGet, srv.BaseURL+"/register", nil)
+	getResp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := getResp.StatusCode, http.StatusNotFound; got != want {
+		t.Errorf("GET /register status = %d, want %d (registration disabled)", got, want)
+	}
+
+	form := url.Values{}
+	form.Add("display_name", "reg-disabled")
+	form.Add("email", "reg-disabled@example.test")
+	form.Add("password", "correct-battery-13")
+	form.Add("password_confirm", "correct-battery-13")
+	postResp := doRequest(ctx, t, client, http.MethodPost, srv.BaseURL+"/register", strings.NewReader(form.Encode()))
+	postResp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := postResp.StatusCode, http.StatusNotFound; got != want {
+		t.Errorf("POST /register status = %d, want %d (registration disabled)", got, want)
+	}
+}
+
+// TestLogin_BadPasswordAndUnknownEmailAreIndistinguishable pins the
+// login-badpass / login-unknown enumeration contract: a wrong password
+// on a real account and an unknown email return byte-identical responses
+// (once the echoed email is normalised out), so /login is not an oracle
+// for which addresses have accounts.
+func TestLogin_BadPasswordAndUnknownEmailAreIndistinguishable(t *testing.T) {
+	t.Parallel()
+
+	// LOGIN_COOLDOWN=0s so the two back-to-back same-IP logins below do
+	// not trip the per-IP limiter (#494) and diverge into a 429.
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"LOGIN_COOLDOWN":       "0s",
+	})
+
+	const (
+		realEmail = "login-enum-real@example.test"
+		realPass  = "correct-battery-real-13"
+	)
+	registerForPending(ctx, t, authClient(t), srv.BaseURL, "login-enum-real", realPass)
+	verifyPlayerEmail(ctx, t, srv.DBURI, "login-enum-real")
+
+	// One client for both probes so the rendered login form carries the
+	// same CSRF nonce - otherwise the per-client csrf_token field is the
+	// only byte that differs and the opacity compare gets a false miss.
+	client := authClient(t)
+	badPassStatus, badPassBody := loginStatusBody(ctx, t, client, srv.BaseURL, realEmail, "wrong-battery-13")
+	unknownStatus, unknownBody := loginStatusBody(
+		ctx, t, client, srv.BaseURL, "login-enum-absent@example.test", "wrong-battery-13",
+	)
+
+	if got, want := badPassStatus, http.StatusUnauthorized; got != want {
+		t.Errorf("bad-password status = %d, want %d", got, want)
+	}
+	if got, want := unknownStatus, badPassStatus; got != want {
+		t.Errorf("unknown-email status = %d, want %d (bad-password)", got, want)
+	}
+
+	badNorm := strings.ReplaceAll(badPassBody, realEmail, "EMAIL")
+	unknownNorm := strings.ReplaceAll(unknownBody, "login-enum-absent@example.test", "EMAIL")
+	if badNorm != unknownNorm {
+		t.Errorf("login responses differ after email normalisation:\nbadpass=%.400q\nunknown=%.400q",
+			badNorm, unknownNorm)
+	}
+}
+
+// TestLogin_RejectsOpenRedirectNext pins the next-openredirect case: a
+// crafted off-site next value is dropped, so a successful login lands on
+// the role's safe default landing path rather than the external URL.
+func TestLogin_RejectsOpenRedirectNext(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"LOGIN_COOLDOWN":       "0s",
+	})
+
+	const (
+		displayName = "redir-player"
+		password    = "correct-battery-redir-13"
+	)
+	registerForPending(ctx, t, authClient(t), srv.BaseURL, displayName, password)
+	verifyPlayerEmail(ctx, t, srv.DBURI, displayName)
+
+	// The off-site next must be dropped: a successful login lands on a
+	// same-site path (the role landing), never the external target. The
+	// exact landing depends on the role the registrant is assigned, so
+	// assert the security property - stayed on-site - rather than a fixed
+	// path.
+	for _, next := range []string{"https://evil.example", "//evil.example", "/\\evil.example"} {
+		location := loginWithNext(ctx, t, authClient(t), srv.BaseURL, displayName+"@example.test", password, next)
+		if !strings.HasPrefix(location, "/") || strings.HasPrefix(location, "//") {
+			t.Errorf("login next=%q Location = %q, want a same-site path", next, location)
+		}
+		if strings.Contains(location, "evil.example") {
+			t.Errorf("login next=%q Location = %q leaked the off-site target", next, location)
+		}
+	}
+}
+
+// TestCSRF_RejectsMissingAndBadToken pins the csrf hardening spot check:
+// an unsafe POST without a valid token is rejected with 403 before the
+// handler runs.
+func TestCSRF_RejectsMissingAndBadToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	// No prior GET, so the client carries neither the nonce cookie nor a
+	// token: the double-submit check fails.
+	missing := url.Values{}
+	missing.Add("email", "csrf@example.test")
+	missing.Add("password", "correct-battery-13")
+	missingResp := doRequest(
+		ctx, t, authClient(t), http.MethodPost, srv.BaseURL+"/login", strings.NewReader(missing.Encode()),
+	)
+	missingResp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := missingResp.StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("POST /login without CSRF token status = %d, want %d", got, want)
+	}
+
+	// A client that GETs the form first holds a valid nonce cookie, but a
+	// garbage token still fails the constant-time compare.
+	client := authClient(t)
+	fetchCSRFToken(ctx, t, client, srv.BaseURL+"/register")
+	bad := url.Values{}
+	bad.Add("display_name", "csrf-bad")
+	bad.Add("email", "csrf-bad@example.test")
+	bad.Add("password", "correct-battery-13")
+	bad.Add("password_confirm", "correct-battery-13")
+	bad.Add("csrf_token", "not-a-valid-token")
+	badResp := doRequest(
+		ctx, t, client, http.MethodPost, srv.BaseURL+"/register", strings.NewReader(bad.Encode()),
+	)
+	badResp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := badResp.StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("POST /register with bad CSRF token status = %d, want %d", got, want)
+	}
+}
+
+// registerWithConfirm POSTs /register with an explicit password
+// confirmation field, so a caller can drive the mismatch branch that
+// registerRaw (confirm == password) cannot reach. Returns status + body.
+func registerWithConfirm(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, displayName, email, password, confirm string,
+) (int, string) {
+	t.Helper()
+
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/register")
+
+	form := url.Values{}
+	form.Add("display_name", displayName)
+	form.Add("email", email)
+	form.Add("password", password)
+	form.Add("password_confirm", confirm)
+	form.Add("csrf_token", token)
+
+	resp := doRequest(ctx, t, client, http.MethodPost, baseURL+"/register", strings.NewReader(form.Encode()))
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+
+	return resp.StatusCode, string(body)
+}
+
+// loginStatusBody POSTs /login with a fetched CSRF token and returns the
+// response status and body. Used by the enumeration-equivalence check.
+func loginStatusBody(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, email, password string,
+) (int, string) {
+	t.Helper()
+
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/login")
+
+	form := url.Values{}
+	form.Add("email", email)
+	form.Add("password", password)
+	form.Add("csrf_token", token)
+
+	resp := doRequest(ctx, t, client, http.MethodPost, baseURL+"/login", strings.NewReader(form.Encode()))
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+
+	return resp.StatusCode, string(body)
+}
+
+// loginWithNext POSTs /login carrying a next form field and returns the
+// 303 Location header. Fails the test if the login does not redirect, so
+// the caller can focus on asserting the redirect target.
+func loginWithNext(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, email, password, next string,
+) string {
+	t.Helper()
+
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/login")
+
+	form := url.Values{}
+	form.Add("email", email)
+	form.Add("password", password)
+	form.Add("next", next)
+	form.Add("csrf_token", token)
+
+	resp := doRequest(ctx, t, client, http.MethodPost, baseURL+"/login", strings.NewReader(form.Encode()))
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("login POST status = %d, want %d", got, want)
+	}
+
+	return resp.Header.Get("Location")
+}
+
+// doRequest builds and sends a request with the form content type and
+// returns the raw response. Centralises the NewRequestWithContext +
+// client.Do boilerplate the gap tests repeat.
+func doRequest(
+	ctx context.Context, t *testing.T, client *http.Client, method, target string, body io.Reader,
+) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do err = %v, want nil", err)
+	}
+
+	return resp
+}


### PR DESCRIPTION
Closes #606

Automates the cases from docs/auth-manual-test-plan.md that can run without a human.

## Integration gap-fills (test/integration/auth_gaps_test.go)
- register password mismatch (400, no account), duplicate display name (409), registration-disabled 404
- login bad-password / unknown-email return byte-identical responses (enumeration opacity)
- off-site `?next=` is dropped after login (stays on-site)
- missing / bad CSRF token is rejected with 403

## Mailpit e2e round-trips
- A pinned mailpit binary is downloaded into build/bin the same way as sqlc / tailwind (Makefile), and runs as a local SMTP catch-all webServer in playwright.config.ts. Each worker's mailer points at it.
- tests/mailpit.ts reads sent mail back over mailpit's HTTP API, filtered by the per-test recipient, and extracts the link.
- email-roundtrip.spec.ts follows the real verify-email link in the browser; invite-roundtrip.spec.ts has an admin invite an account and the invitee accept it via the emailed link.

## Adjusted for SMTP now being live in e2e
- email-admin.spec.ts asserts the configured diagnostics state and a successful test-send.
- admin-invites.spec.ts resend banner text; stale comments in helpers.ts.

## Left manual on purpose
- Real Google OAuth consent and real SMTP delivery to a real inbox.
- The reset-password link round-trip: it needs the forgot-password form whose 60s per-IP cooldown cooldown.spec.ts deliberately depends on, so the two cannot share one server config. Reset stays covered by the integration suite (TestResetPassword_HappyPath).

CI needs no new install step: the e2e workflow runs `make build/bin/mailpit` before the Playwright run.