### PR TITLE
Widen integration server readiness budget under coverage runs

### DIFF
--- a/test/integration/testmain_test.go
+++ b/test/integration/testmain_test.go
@@ -90,8 +90,18 @@ func startServer(t *testing.T, extraEnv map[string]string) (context.Context, tes
 		errCh <- app.Run(ctx, getenv, stdout, ln)
 	}()
 
+	// Coverage instrumentation (make test-coverage, the CI build job) plus
+	// -race slows server startup enough that a batch of parallel boots -
+	// each running every migration on a fresh DB - can blow past a tight
+	// readiness budget all at once (#608). Widen the budget only under
+	// coverage; a plain `make test-integration` keeps the short budget so
+	// a genuine startup hang still fails fast.
+	readyTimeout := 10 * time.Second
+	if testing.CoverMode() != "" {
+		readyTimeout = 60 * time.Second
+	}
 	baseURL := "http://" + ln.Addr().String()
-	if werr := testutil.WaitForReady(ctx, t, 10*time.Second, baseURL+"/healthz"); werr != nil {
+	if werr := testutil.WaitForReady(ctx, t, readyTimeout, baseURL+"/healthz"); werr != nil {
 		t.Fatalf("error waiting for server to be ready: %v", werr)
 	}
 


### PR DESCRIPTION
Closes #608

`startServer` waited for `/healthz` with a hard 10s budget. Under `make test-coverage` (the CI `build` job: `-race` + coverage instrumentation across all packages), many `t.Parallel()` tests boot a full server at once - each running every migration on a fresh DB - and a whole batch exceeds 10s together, failing with "error waiting for server to be ready". Plain `make test-integration` (no coverage) never reproduced it.

Fix: widen the readiness budget to 60s only when coverage is active (`testing.CoverMode() != ""`). A plain `make test-integration` keeps the tight 10s budget so a genuine startup hang still fails fast; the happy path completes in well under a second regardless.

Verification: looping the coverage command reproduced the failure on the first iteration before the change; after it, 7 consecutive coverage runs passed.