### PR TITLE
Extract Google icon and auth flash banners into shared partials

### DIFF
--- a/internal/web/tmpl/auth/layouts/components.gohtml
+++ b/internal/web/tmpl/auth/layouts/components.gohtml
@@ -1,0 +1,11 @@
+{{/* Shared auth-page fragments. The flash banners take their message as
+     the pipeline so the (drift-prone) styling lives in one place:
+     {{template "authError" .Message}}. The Google icon takes no data. */}}
+{{define "authNotice"}}<div class="mb-6 px-4 py-3 rounded-sm bg-success/10 border border-success/40 text-success text-sm" role="status">{{.}}</div>{{end}}
+{{define "authError"}}<div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.}}</div>{{end}}
+{{define "googleIcon"}}<svg aria-hidden="true" focusable="false" viewBox="0 0 18 18" class="w-5 h-5">
+    <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
+    <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.183l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.583-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
+    <path fill="#FBBC05" d="M3.964 10.708A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.708V4.96H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.04l3.007-2.332z"/>
+    <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.96L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
+</svg>{{end}}

--- a/internal/web/tmpl/auth/pages/login.gohtml
+++ b/internal/web/tmpl/auth/pages/login.gohtml
@@ -8,7 +8,7 @@
         </header>
 
         {{if .Message}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
+            {{template "authError" .Message}}
         {{end}}
 
         <form action="/login" method="POST" class="bg-surface border border-border-soft rounded-lg p-6">
@@ -55,12 +55,7 @@
                 <span class="h-px flex-1 bg-border-soft"></span>
             </div>
             <a href="/login/google{{if .Next}}?next={{.Next | urlquery}}{{end}}" class="flex items-center justify-center gap-3 w-full px-4 py-3 rounded-sm bg-surface border border-border-soft text-text hover:bg-surface-alt no-underline">
-                <svg aria-hidden="true" focusable="false" viewBox="0 0 18 18" class="w-5 h-5">
-                    <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
-                    <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.183l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.583-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
-                    <path fill="#FBBC05" d="M3.964 10.708A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.708V4.96H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.04l3.007-2.332z"/>
-                    <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.96L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
-                </svg>
+                {{template "googleIcon"}}
                 <span class="text-sm font-medium">Sign in with Google</span>
             </a>
         {{end}}

--- a/internal/web/tmpl/auth/pages/profile.gohtml
+++ b/internal/web/tmpl/auth/pages/profile.gohtml
@@ -8,10 +8,10 @@
         </header>
 
         {{if .Saved}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-success/10 border border-success/40 text-success text-sm" role="status">Display name updated.</div>
+            {{template "authNotice" "Display name updated."}}
         {{end}}
         {{if .Message}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
+            {{template "authError" .Message}}
         {{end}}
 
         <form action="/profile/display-name" method="POST" class="bg-surface border border-border-soft rounded-lg p-6">

--- a/internal/web/tmpl/auth/pages/profile_email.gohtml
+++ b/internal/web/tmpl/auth/pages/profile_email.gohtml
@@ -8,10 +8,10 @@
         </header>
 
         {{if .Notice}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-success/10 border border-success/40 text-success text-sm" role="status">{{.Notice}}</div>
+            {{template "authNotice" .Notice}}
         {{end}}
         {{if .Message}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
+            {{template "authError" .Message}}
         {{end}}
 
         {{if .HasPassword}}

--- a/internal/web/tmpl/auth/pages/profile_password.gohtml
+++ b/internal/web/tmpl/auth/pages/profile_password.gohtml
@@ -8,10 +8,10 @@
         </header>
 
         {{if .Saved}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-success/10 border border-success/40 text-success text-sm" role="status">Password updated.</div>
+            {{template "authNotice" "Password updated."}}
         {{end}}
         {{if .Message}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
+            {{template "authError" .Message}}
         {{end}}
 
         <form action="/profile/password" method="POST" class="bg-surface border border-border-soft rounded-lg p-6 flex flex-col gap-4">

--- a/internal/web/tmpl/auth/pages/register.gohtml
+++ b/internal/web/tmpl/auth/pages/register.gohtml
@@ -8,7 +8,7 @@
         </header>
 
         {{if .Message}}
-            <div class="mb-6 px-4 py-3 rounded-sm bg-danger/10 border border-danger/40 text-danger text-sm" role="alert">{{.Message}}</div>
+            {{template "authError" .Message}}
         {{end}}
 
         <form action="/register" method="POST" class="bg-surface border border-border-soft rounded-lg p-6">
@@ -70,12 +70,7 @@
                 <span class="h-px flex-1 bg-border-soft"></span>
             </div>
             <a href="/login/google" class="flex items-center justify-center gap-3 w-full px-4 py-3 rounded-sm bg-surface border border-border-soft text-text hover:bg-surface-alt no-underline">
-                <svg aria-hidden="true" focusable="false" viewBox="0 0 18 18" class="w-5 h-5">
-                    <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
-                    <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.183l-2.908-2.258c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.583-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
-                    <path fill="#FBBC05" d="M3.964 10.708A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.708V4.96H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.04l3.007-2.332z"/>
-                    <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.96L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
-                </svg>
+                {{template "googleIcon"}}
                 <span class="text-sm font-medium">Sign up with Google</span>
             </a>
         {{end}}


### PR DESCRIPTION
Closes #612

Follows the auth logo partial (#609) by sharing the remaining identical fragments across the auth pages, so the styling can't drift between copies:

- `googleIcon` - the Google sign-in SVG, byte-identical in login.gohtml and register.gohtml.
- `authError` - the danger flash banner (role="alert"), identical across login, register, profile, profile_email, profile_password. Takes the message as its pipeline: `{{template "authError" .Message}}`.
- `authNotice` - the success flash banner (role="status"), across the 3 profile pages.

All three live in a new `auth/layouts/components.gohtml` (the renderer already globs `auth/layouts/*.gohtml`, so no Go change). The message banners pass the text as the pipeline, so `{{.}}` keeps the same HTML auto-escaping the inline `{{.Message}}` had.

Scope is auth only - the admin error banners are a different shape (`text-[0.9rem]`, `{{.Error}}`) and stay as-is.

Validation: `make smoke` (templates parse), `make tailwind-check` (no new classes), the login error-banner integration test still passes (it renders through the new `authError` partial), and the full chromium e2e suite passes.