### PR TITLE
Fix login redirect loop for a stale session_version cookie

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -420,9 +420,16 @@ func HandleLoginForm(
 // a [SafeNextPath]-validated value so a deep link visitor with a live
 // session lands on their intended page; falls back to the role
 // landing otherwise. Returns true if it wrote a response - the caller
-// must skip its own render in that case. Errors during the
-// session/player lookup fall through to a normal render so a
-// transient DB hiccup doesn't lock the visitor out of the auth pages.
+// must skip its own render in that case.
+//
+// Resolves the session through loadSessionPlayer (not a bare
+// GetPlayerByID) so the "signed in" test here matches the one the
+// gating middleware applies, session_version included. Without that
+// agreement a cookie left version-stale by a password reset reads as
+// signed-in here but signed-out at the gate, so /login 303s the
+// visitor onto a page that 303s them straight back - an unbreakable
+// loop the visitor cannot even log out of (#615). A missing/dead/stale
+// cookie or a transient lookup error falls through to a normal render.
 func redirectIfSignedIn(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -430,11 +437,7 @@ func redirectIfSignedIn(
 	sessions *session.Manager,
 	next string,
 ) bool {
-	playerID, ok := sessions.PlayerID(r)
-	if !ok {
-		return false
-	}
-	player, err := players.GetPlayerByID(r.Context(), playerID)
+	player, err := loadSessionPlayer(r, players, sessions)
 	if err != nil || !player.IsAuthenticated() {
 		return false
 	}

--- a/test/integration/login_stale_session_test.go
+++ b/test/integration/login_stale_session_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/session"
+)
+
+// TestLogin_StaleSessionVersionRendersForm pins #615: a validly-signed
+// session cookie whose session_version is behind the row's (the state a
+// password reset / "sign out other sessions" leaves on a still-open
+// browser) must render the login form, not 303 away.
+//
+// The gating middleware already treats such a cookie as logged-out and
+// bounces gated pages to /login?next=...; if GET /login also saw it as
+// signed in it would 303 straight back, forming the gate->login->gate
+// loop the visitor cannot escape by logging in. So the load-bearing
+// assertion is that GET /login returns 200 (the form), not a redirect.
+func TestLogin_StaleSessionVersionRendersForm(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	const (
+		displayName = "stale-version"
+		password    = "correct-battery-stale-13"
+	)
+	client := authClient(t)
+	registerForPending(ctx, t, client, srv.BaseURL, displayName, password)
+	verifyPlayerEmail(ctx, t, srv.DBURI, displayName)
+	mintStaleSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, displayName)
+
+	resp := doRequest(ctx, t, client, http.MethodGet, srv.BaseURL+"/login", nil)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("GET /login with a stale-session_version cookie status = %d, want %d "+
+			"(the login form, not a redirect that loops with the gate)", got, want)
+	}
+}
+
+// mintStaleSessionCookie installs a validly-signed session cookie for
+// displayName whose session_version is one ahead of the stored row, so
+// loadSessionPlayer sees the version mismatch a post-reset cookie would.
+// Relies on startServer's default SESSION_KEY (testSessionKey).
+func mintStaleSessionCookie(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName string,
+) {
+	t.Helper()
+
+	dbConn, stores := openStores(t, dbURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
+	if err != nil {
+		t.Fatalf("mintStaleSessionCookie GetPlayerByDisplayName err = %v, want nil", err)
+	}
+
+	rec := httptest.NewRecorder()
+	session.New([]byte(testSessionKey), false).Set(rec, player.ID, player.SessionVersion+1)
+	cookie := rec.Result().Cookies()[0]
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("url.Parse err = %v, want nil", err)
+	}
+	client.Jar.SetCookies(parsed, []*http.Cookie{cookie})
+}


### PR DESCRIPTION
Closes #615

`GET /login` resolved the session with `sessions.PlayerID` + `GetPlayerByID`, which ignores `session_version`, while the gating middleware resolves it with `loadSessionPlayer`, which checks `session_version`. A cookie left version-stale by a password reset / "sign out other sessions" therefore read as signed-in at `/login` but signed-out at the gate: the gate 303'd to `/login?next=<page>` and `/login` 303'd straight back, an infinite loop the visitor could not escape by logging in (the form never rendered) - only by clearing cookies.

Fix: route `redirectIfSignedIn` through the same `loadSessionPlayer` the middleware uses, so `/login` and the gates agree on what "signed in" means. A version-stale (or deleted, or missing) cookie now reads as logged-out at `/login`, the form renders, and the loop cannot form. Valid sessions still redirect to their landing as before.

Added an integration test that installs a validly-signed cookie one `session_version` ahead of the row and asserts `GET /login` returns the form (200), not a redirect. Verified it fails against the pre-fix code and passes after.