### PR TITLE
Carry an anonymous game onto the account when accepting an invite

### DIFF
--- a/internal/auth/invite_handler.go
+++ b/internal/auth/invite_handler.go
@@ -93,6 +93,10 @@ type AcceptInviteDeps struct {
 	Invites  InviteStore
 	Players  InvitePlayerStore
 	Sessions *session.Manager
+	// Games carries an anonymous visitor's game history onto the new
+	// account when they accept an invite from a guest session, matching
+	// the login / Google paths (#617). Nil disables the migration.
+	Games AnonymousGameMigrator
 }
 
 // HandleAcceptInviteSubmit handles POST /accept-invite. It re-validates
@@ -217,7 +221,15 @@ func acceptInvite(
 
 		return
 	}
+	// Capture the prior session (a guest who played before accepting)
+	// before Set overwrites the cookie, then carry their games onto the
+	// new account - same reattribution the login / Google paths do (#617).
+	var priorSessionPlayerID *int64
+	if id, ok := deps.Sessions.PlayerID(r); ok {
+		priorSessionPlayerID = &id
+	}
 	deps.Sessions.Set(w, refreshed.ID, refreshed.SessionVersion)
+	migrateGamesAfterSignIn(r.Context(), logger, deps.Players, deps.Games, priorSessionPlayerID, refreshed.ID)
 	http.Redirect(w, r, landingPathFor(refreshed.Role), http.StatusSeeOther)
 }
 

--- a/internal/auth/migrate.go
+++ b/internal/auth/migrate.go
@@ -6,6 +6,15 @@ import (
 	"log/slog"
 )
 
+// playerByIDLookup is the slice of PlayerStore that
+// migrateGamesAfterSignIn needs: just the prior-session player lookup.
+// Narrowed so a caller whose store interface is smaller than the full
+// PlayerStore (the invite-accept flow's InvitePlayerStore) can reuse
+// the migration without widening its dependency.
+type playerByIDLookup interface {
+	GetPlayerByID(ctx context.Context, id int64) (*Player, error)
+}
+
 // migrateGamesAfterSignIn moves an anonymous visitor's game history
 // onto the account they just signed into (#406). Refuses the move
 // when the prior row is credentialled - that would be data corruption,
@@ -13,7 +22,7 @@ import (
 func migrateGamesAfterSignIn(
 	ctx context.Context,
 	logger *slog.Logger,
-	players PlayerStore,
+	players playerByIDLookup,
 	games AnonymousGameMigrator,
 	priorSessionPlayerID *int64,
 	signedInPlayerID int64,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -171,6 +171,7 @@ func addEmailFlowRoutes(
 			Invites:  stores.Invites,
 			Players:  stores.InvitePlayers,
 			Sessions: sessions,
+			Games:    stores.GameMigrator,
 		}),
 	)))
 }

--- a/test/integration/invite_claims_anon_game_test.go
+++ b/test/integration/invite_claims_anon_game_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// TestAcceptInvite_PreservesAnonymousGame pins #617: a guest who plays a
+// game and then accepts an invite in the same browser keeps that game.
+// Invite-accept creates a fresh credentialled row (unlike register's
+// in-place upgrade), so the anonymous row's games are reattributed onto
+// the new account, matching the login / Google paths.
+func TestAcceptInvite_PreservesAnonymousGame(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegration(t)
+	stores := setup.Stores
+
+	quizRow := &quiz.Quiz{
+		Title: "Invite Claim Quiz", Slug: "invite-claim-quiz",
+		Description:       "Played as a guest, then accepted an invite.",
+		CreatedByPlayerID: seededAdminID,
+		Questions: []*quiz.Question{
+			{Text: "Q1", Position: 1, Options: []*quiz.Option{{Text: "a", Correct: true}, {Text: "b"}}},
+		},
+	}
+	if err := stores.Quizzes.CreateQuiz(ctx, quizRow); err != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", err)
+	}
+
+	// Play a game anonymously through one client.
+	client := authClient(t)
+	primeAnonymousPlayer(ctx, t, client, setup.BaseURL)
+	anonPlayer := lookupAnonPlayer(ctx, t, stores.Players, "admin")
+	finishGameInt(t, stores.Games, anonPlayer.ID, quizRow)
+	requirePlayerGameCount(t, setup.DBURI, anonPlayer.ID, 1)
+
+	// Accept an invite through the SAME client so the guest session rides
+	// along; the new account should inherit the just-played game.
+	raw := mintInvite(ctx, t, stores.Invites, "invite-anon@example.test", time.Now().Add(time.Hour))
+	resp := postAcceptInvite(ctx, t, client, setup.BaseURL, raw, "Invited Player")
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("accept-invite status = %d, want %d", got, want)
+	}
+
+	invited, err := stores.Players.GetPlayerByDisplayName(ctx, "Invited Player")
+	if err != nil {
+		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
+	}
+	if invited.ID == anonPlayer.ID {
+		t.Fatalf("invited player id = %d, want a fresh row distinct from the anonymous row", invited.ID)
+	}
+
+	// The just-played game moved off the anonymous row onto the new account.
+	requirePlayerGameCount(t, setup.DBURI, anonPlayer.ID, 0)
+	requirePlayerGameCount(t, setup.DBURI, invited.ID, 1)
+}


### PR DESCRIPTION
Closes #617

Accepting an invite created a fresh credentialled row and signed in, but never touched the anonymous session, so a guest who played a game and then accepted an invite in the same browser lost it - unlike the login / Google paths (which reattribute) and register (which upgrades the anonymous row in place).

Fix: after the invite account is created and signed in, reattribute the prior anonymous session's games onto it via the same `migrateGamesAfterSignIn` the login / Google paths use. The migration already no-ops unless the prior session is genuinely anonymous, so a cookieless accept or one made while logged in as someone else is unaffected.

`migrateGamesAfterSignIn` only needs `GetPlayerByID`, so its `players` parameter is narrowed to a small `playerByIDLookup` interface - satisfied by both the full `PlayerStore` (login / Google) and the invite flow's narrower `InvitePlayerStore` - rather than widening the invite handler's dependency.

Added an integration test: play a game anonymously, accept an invite through the same client, assert the game moves off the anonymous row onto the new account. Verified it fails against the pre-fix code and passes after.