### PR TITLE
Resolve all signed-in checks through one version-aware helper

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -422,14 +422,14 @@ func HandleLoginForm(
 // landing otherwise. Returns true if it wrote a response - the caller
 // must skip its own render in that case.
 //
-// Resolves the session through loadSessionPlayer (not a bare
+// Resolves the session through AuthenticatedSessionPlayer (not a bare
 // GetPlayerByID) so the "signed in" test here matches the one the
 // gating middleware applies, session_version included. Without that
 // agreement a cookie left version-stale by a password reset reads as
 // signed-in here but signed-out at the gate, so /login 303s the
 // visitor onto a page that 303s them straight back - an unbreakable
 // loop the visitor cannot even log out of (#615). A missing/dead/stale
-// cookie or a transient lookup error falls through to a normal render.
+// cookie or an anonymous session falls through to a normal render.
 func redirectIfSignedIn(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -437,8 +437,8 @@ func redirectIfSignedIn(
 	sessions *session.Manager,
 	next string,
 ) bool {
-	player, err := loadSessionPlayer(r, players, sessions)
-	if err != nil || !player.IsAuthenticated() {
+	player, ok := AuthenticatedSessionPlayer(r, players, sessions)
+	if !ok {
 		return false
 	}
 	target := next

--- a/internal/auth/verify_gate.go
+++ b/internal/auth/verify_gate.go
@@ -92,7 +92,7 @@ func HandleVerifyPending(
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/verify_email_pending.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p, ok := loadAuthenticatedPlayer(r, players, sessions)
+		p, ok := AuthenticatedSessionPlayer(r, players, sessions)
 		if !ok {
 			redirectToLoginWithNext(w, r)
 
@@ -138,7 +138,7 @@ func HandleVerifyResend(
 	flash *SignedFlash,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p, ok := loadAuthenticatedPlayer(r, players, sessions)
+		p, ok := AuthenticatedSessionPlayer(r, players, sessions)
 		if !ok {
 			redirectToLoginWithNext(w, r)
 
@@ -194,19 +194,16 @@ func HandleVerifyResend(
 	})
 }
 
-// loadAuthenticatedPlayer pulls the session player and reports false
-// when the cookie is missing, invalid, points at a deleted row, or
-// resolves to an anonymous-only row. Centralised so the interstitial
-// and resend handlers agree on what "signed in" means without
-// re-implementing the lookup. Distinct from middleware.go's
-// loadSessionPlayer (which returns the sentinel ErrPlayerNotFound) so
-// callers that only need a bool stay simple.
-func loadAuthenticatedPlayer(r *http.Request, players PlayerStore, sessions *session.Manager) (*Player, bool) {
-	id, ok := sessions.PlayerID(r)
-	if !ok {
-		return nil, false
-	}
-	p, err := players.GetPlayerByID(r.Context(), id)
+// AuthenticatedSessionPlayer returns the credentialled player the
+// request's session points at, reporting false when the cookie is
+// missing, invalid, version-stale, points at a deleted row, or resolves
+// to an anonymous-only row. It builds on loadSessionPlayer so the
+// session_version check - the single definition of a live session -
+// lives in one place (#620); this layer only adds the "must be
+// credentialled" rule its callers share: the interstitial + resend
+// handlers, the /login redirect, and the home-page footer.
+func AuthenticatedSessionPlayer(r *http.Request, players PlayerStore, sessions *session.Manager) (*Player, bool) {
+	p, err := loadSessionPlayer(r, players, sessions)
 	if err != nil || !p.IsAuthenticated() {
 		return nil, false
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -182,12 +182,8 @@ func addEmailFlowRoutes(
 // "Log in" link path.
 func homeViewerFunc(players auth.PlayerStore, sessions *session.Manager) home.ViewerFunc {
 	return func(r *http.Request) *home.Viewer {
-		id, ok := sessions.PlayerID(r)
+		p, ok := auth.AuthenticatedSessionPlayer(r, players, sessions)
 		if !ok {
-			return nil
-		}
-		p, err := players.GetPlayerByID(r.Context(), id)
-		if err != nil || !p.IsAuthenticated() {
 			return nil
 		}
 

--- a/test/integration/home_footer_stale_session_test.go
+++ b/test/integration/home_footer_stale_session_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestHomeFooter_StaleSessionVersionShowsLoggedOut pins #620: the home
+// footer's "signed in" check resolves the session through the same
+// version-aware path as the gates, so a cookie left version-stale by a
+// password reset does not render "Signed in as ..." while every gated
+// page treats it as logged out.
+func TestHomeFooter_StaleSessionVersionShowsLoggedOut(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{"REGISTRATION_ENABLED": "true"})
+
+	const (
+		displayName = "footer-stale"
+		password    = "correct-battery-footer-13"
+	)
+	client := authClient(t)
+	registerForPending(ctx, t, client, srv.BaseURL, displayName, password)
+	verifyPlayerEmail(ctx, t, srv.DBURI, displayName)
+	mintStaleSessionCookie(ctx, t, client, srv.BaseURL, srv.DBURI, displayName)
+
+	resp := doRequest(ctx, t, client, http.MethodGet, srv.BaseURL+"/", nil)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("GET / status = %d, want %d", got, want)
+	}
+	if strings.Contains(string(body), "Signed in as") {
+		t.Error(`home footer rendered "Signed in as" for a version-stale cookie; want the logged-out state`)
+	}
+}


### PR DESCRIPTION
Closes #620

"Is this cookie a valid signed-in session?" was hand-rolled in several places that did not all apply the session_version check `loadSessionPlayer` does - the divergence behind the #615 redirect loop. The home footer (`homeViewerFunc`) and the verify-flow helper still used a bare `PlayerID` + `GetPlayerByID`, so a version-stale cookie (post password reset) read as signed in there while every gated page treated it as logged out.

Consolidates onto two layers:

- `loadSessionPlayer` stays the single version-aware lookup (any player, including anonymous).
- `AuthenticatedSessionPlayer` (was `loadAuthenticatedPlayer`, now exported) builds on it and adds the "must be credentialled" rule. Used by the verify-pending + resend handlers, the `/login` redirect (`redirectIfSignedIn`), and the home footer.

So "signed in" is defined exactly once and cannot drift again. Behaviour is unchanged for valid / anonymous / missing cookies; a version-stale cookie now reads as logged-out everywhere (the home footer no longer shows "Signed in as ..." for one).

Added an integration test asserting the home footer does not render "Signed in as ..." for a version-stale cookie; verified it fails against the old footer logic and passes after.