### PR TITLE
Fix data race in GoogleAuthenticator provider init retry

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -88,8 +88,8 @@ type GoogleAuthenticator struct {
 	cfg      GoogleConfig
 	stateKey []byte
 
-	initOnce sync.Once
-	initErr  error
+	mu       sync.Mutex
+	ready    bool
 	provider *oidc.Provider
 	verifier *oidc.IDTokenVerifier
 	oauth2   *oauth2.Config
@@ -579,45 +579,44 @@ func createGooglePlayer(
 // ensureProvider lazily initialises the OIDC provider, verifier, and
 // oauth2.Config the first time a request arrives. Deferring this past
 // startup keeps the process bootable when Google (or the test mock) is
-// briefly unreachable, and the [sync.Once] means concurrent requests
-// share a single discovery fetch.
+// briefly unreachable.
+//
+// Guarded by a.mu rather than a [sync.Once] because a transient
+// discovery failure must be retryable: a.ready stays false on error so
+// the next request tries again, instead of pinning the server in a
+// failed state. The mutex (held across the discovery fetch) both
+// serialises concurrent first-requests onto a single fetch and provides
+// the happens-before that lets the callback path read a.oauth2 /
+// a.verifier unlocked after ensureProvider returns nil. The previous
+// reset-the-Once-on-error retry raced on its unexported init fields and
+// could deadlock under contention (#622).
 func (a *GoogleAuthenticator) ensureProvider(ctx context.Context) error {
-	a.initOnce.Do(func() {
-		issuer := a.cfg.IssuerURL
-		if issuer == "" {
-			issuer = googleDefaultIssuer
-		}
-
-		provider, err := oidc.NewProvider(ctx, issuer)
-		if err != nil {
-			a.initErr = fmt.Errorf("oidc new provider: %w", err)
-
-			return
-		}
-
-		a.provider = provider
-		a.verifier = provider.Verifier(&oidc.Config{ClientID: a.cfg.ClientID})
-		a.oauth2 = &oauth2.Config{
-			ClientID:     a.cfg.ClientID,
-			ClientSecret: a.cfg.ClientSecret,
-			RedirectURL:  a.cfg.RedirectURL,
-			Endpoint:     provider.Endpoint(),
-			Scopes:       []string{oidc.ScopeOpenID, "email", "profile"},
-		}
-	})
-
-	if a.initErr != nil {
-		// Allow a retry on the next request after a transient failure
-		// (e.g. discovery endpoint flaky during deploy) by resetting
-		// the sync.Once on error. Without this an unlucky first
-		// request would pin the server in a permanent "init failed"
-		// state until restart.
-		err := a.initErr
-		a.initOnce = sync.Once{}
-		a.initErr = nil
-
-		return err
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.ready {
+		return nil
 	}
+
+	issuer := a.cfg.IssuerURL
+	if issuer == "" {
+		issuer = googleDefaultIssuer
+	}
+
+	provider, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return fmt.Errorf("oidc new provider: %w", err)
+	}
+
+	a.provider = provider
+	a.verifier = provider.Verifier(&oidc.Config{ClientID: a.cfg.ClientID})
+	a.oauth2 = &oauth2.Config{
+		ClientID:     a.cfg.ClientID,
+		ClientSecret: a.cfg.ClientSecret,
+		RedirectURL:  a.cfg.RedirectURL,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       []string{oidc.ScopeOpenID, "email", "profile"},
+	}
+	a.ready = true
 
 	return nil
 }

--- a/internal/auth/google_race_test.go
+++ b/internal/auth/google_race_test.go
@@ -1,0 +1,45 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+// TestGoogleAuthenticator_ConcurrentInitRetry pins #622: when OIDC
+// discovery keeps failing, concurrent requests retry initialisation
+// without a data race. Driven through the exported HandleGoogleLogin
+// (which calls the unexported ensureProvider) against an unreachable
+// issuer so every request takes the discovery-failure retry path. Run
+// under -race this fails against the old sync.Once-reset retry (which
+// reassigned the Once and read/wrote initErr unlocked, and could even
+// deadlock) and passes with the mutex-guarded version.
+func TestGoogleAuthenticator_ConcurrentInitRetry(t *testing.T) {
+	t.Parallel()
+
+	authn := auth.NewGoogleAuthenticator(auth.GoogleConfig{
+		ClientID:  "test-client",
+		IssuerURL: "http://127.0.0.1:1", // connection refused -> fast discovery failure
+	}, []byte("test-session-key-0123456789abcdef"))
+	handler := auth.HandleGoogleLogin(discardLogger(), authn)
+
+	ctx := t.Context()
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/login/google", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if got, want := rec.Code, http.StatusInternalServerError; got != want {
+				t.Errorf("HandleGoogleLogin status = %d, want %d for an unreachable issuer", got, want)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #622

`GoogleAuthenticator.ensureProvider` (called on every Google login/callback) recovered from a failed OIDC discovery by reassigning `a.initOnce = sync.Once{}` and read/writing `a.initErr` with no lock, despite the type being documented "Safe for concurrent use". When the first discovery fetch fails and concurrent requests arrive, goroutines race on `initOnce` / `initErr` (-race-detectable), and overwriting a `sync.Once` mid-`Do` can deadlock under contention.

Fix: guard init with a `sync.Mutex` + `ready bool` instead. Held across the discovery fetch, the mutex serialises concurrent first-requests onto one fetch, leaves `ready` false on error so the next request retries, and gives the happens-before for the unlocked `oauth2`/`verifier` reads on the callback path. Behaviour (lazy init, retry-on-failure, cache-on-success) is unchanged.

Added a `-race` regression test driving concurrent `HandleGoogleLogin` against an unreachable issuer; it passes on the fix and fails (races/hangs) against the old code.

Found during a full-codebase review (/code-review).