### PR TITLE
Align CSRF cookie lifetime with the session lifetime

### DIFF
--- a/internal/csrf/csrf.go
+++ b/internal/csrf/csrf.go
@@ -40,8 +40,14 @@ const CookieName = "tb_csrf_nonce"
 // FormField is the name of the hidden form field carrying the CSRF token.
 const FormField = "csrf_token"
 
-// MaxAge is the lifetime of the CSRF nonce cookie in seconds (24h).
-const MaxAge = 24 * 60 * 60
+// MaxAge is the lifetime of the CSRF nonce cookie in seconds (30 days).
+// It must be at least the session cookie lifetime (internal/session.MaxAge):
+// a nonce backs the csrf_token rendered into every form, so if it expires
+// while the session is still valid, a still-signed-in user submitting a
+// form rendered earlier (e.g. a logout button on a tab open past the old
+// 24h) gets a spurious 403 (#614). Invariant pinned by
+// TestCSRFCookieOutlivesSession.
+const MaxAge = 30 * 24 * 60 * 60
 
 // nonceByteLength is the length of the random nonce written to the cookie.
 const nonceByteLength = 16

--- a/internal/csrf/csrf_test.go
+++ b/internal/csrf/csrf_test.go
@@ -9,7 +9,24 @@ import (
 	"testing"
 
 	. "github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/session"
 )
+
+// TestCSRFCookieOutlivesSession pins #614: the CSRF nonce cookie must
+// live at least as long as the session cookie. If the nonce expires
+// first, a still-signed-in user submitting a form rendered earlier (e.g.
+// a logout button on a tab open past the nonce's lifetime) fails the
+// double-submit check with a spurious 403.
+func TestCSRFCookieOutlivesSession(t *testing.T) {
+	t.Parallel()
+	if got, want := MaxAge, session.MaxAge; got < want {
+		t.Errorf(
+			"csrf.MaxAge = %d, want >= session.MaxAge (%d) so a CSRF token cannot expire before the session that accepts it",
+			got,
+			want,
+		)
+	}
+}
 
 // newGetRequest builds a GET request with the test context attached so
 // httptest plays nicely with t.Cleanup.


### PR DESCRIPTION
Closes #614

The CSRF nonce cookie (`tb_csrf_nonce`) lived 24h while the session cookie lives 30 days. Since the nonce backs the `csrf_token` rendered into every form, a still-signed-in user submitting a form rendered earlier - the classic case being a logout button on a tab left open past 24h - hit a spurious 403 once the nonce expired but the session had not.

Fix: raise the CSRF cookie lifetime to 30 days so it is at least the session lifetime. A form rendered any time within the session now stays submittable. A longer-lived random nonce does not weaken the signed double-submit (the cookie is HttpOnly + SameSite=Lax and the token is HMAC-bound to it); the security property is same-origin, not rotation frequency.

Added `TestCSRFCookieOutlivesSession` asserting `csrf.MaxAge >= session.MaxAge`, and the constant's comment names it, so the two lifetimes cannot silently desync again.

Aligning the lifetimes removes the spurious-403 case entirely (both cookies now expire together), so the raw 403 only remains for genuinely missing/cleared cookies or cross-site attempts - where it is the correct response. A friendlier expired-form page is therefore not needed here.