### PR TITLE
Tag the retention store test as an integration test

### DIFF
--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package store_test
 
 import (


### PR DESCRIPTION
The retention store test added in #633 touches the real database via dbtest, so per the testing rule it must carry `//go:build integration` and run in the integration suite, not the fast unit suite. It followed the untagged store-test tech-debt pattern by mistake; this adds the tag to match `rounds_migration_test.go`. No behavior change.