### PR TITLE
Make the health handler test a real integration test

### DIFF
--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,235 +1,81 @@
+//go:build integration
+
 package health_test
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/starquake/topbanana/internal/game"
+	"github.com/starquake/topbanana/internal/dbtest"
 	. "github.com/starquake/topbanana/internal/health"
-	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
 )
 
-// stubQuizStore satisfies quiz.Store for the /healthz handler tests.
-// Only Ping is exercised by the handler, so every other method returns
-// errors.ErrUnsupported to surface accidental use.
-type stubQuizStore struct {
-	pingErr error
+// healthzResponse mirrors the JSON the /healthz handler emits.
+type healthzResponse struct {
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks"`
 }
 
-func (s *stubQuizStore) Ping(_ context.Context) error { return s.pingErr }
-func (*stubQuizStore) ListQuizzes(_ context.Context) ([]*quiz.Quiz, error) {
-	return nil, errors.ErrUnsupported
+// serveHealthz drives the real HandleHealthz handler against the given stores
+// and decodes the response body.
+func serveHealthz(t *testing.T, stores *store.Stores) (*httptest.ResponseRecorder, healthzResponse) {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	HandleHealthz(slog.New(slog.DiscardHandler), stores)(w, req)
+
+	var res healthzResponse
+	if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+		t.Fatalf("decode response err = %v, want nil", err)
+	}
+
+	return w, res
 }
 
-func (*stubQuizStore) ListPublicQuizzes(_ context.Context) ([]*quiz.Quiz, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) QuestionCountsByQuiz(_ context.Context) (map[int64]int, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetQuiz(_ context.Context, _ int64) (*quiz.Quiz, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) QuizExists(_ context.Context, _ int64) (bool, error) {
-	return false, errors.ErrUnsupported
-}
-func (*stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error { return errors.ErrUnsupported }
-func (*stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error { return errors.ErrUnsupported }
-func (*stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error      { return errors.ErrUnsupported }
-func (*stubQuizStore) ListQuestions(_ context.Context, _ int64) ([]*quiz.Question, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetQuestion(_ context.Context, _ int64) (*quiz.Question, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) CreateQuestionAtNextPosition(_ context.Context, _ *quiz.Question) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) UpdateQuestion(_ context.Context, _ *quiz.Question) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) SwapQuestionPositions(_ context.Context, _, _ int64, _ string) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) DeleteQuestion(_ context.Context, _ int64) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetOption(_ context.Context, _ int64) (*quiz.Option, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetOptionsByIDs(_ context.Context, _ []int64) ([]*quiz.Option, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) ListRoundsByQuiz(_ context.Context, _ int64) ([]*quiz.Round, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetRound(_ context.Context, _ int64) (*quiz.Round, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) GetDefaultRound(_ context.Context, _ int64) (*quiz.Round, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubQuizStore) CreateRound(_ context.Context, _ *quiz.Round) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) UpdateRound(_ context.Context, _ *quiz.Round) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) DeleteRound(_ context.Context, _ int64) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) MoveRound(_ context.Context, _, _ int64, _ string) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubQuizStore) MoveQuestionToRound(_ context.Context, _, _, _ int64) error {
-	return errors.ErrUnsupported
-}
-
-// stubGameStore satisfies game.Store for the /healthz handler tests.
-// Only Ping is exercised by the handler, so every other method returns
-// errors.ErrUnsupported to surface accidental use.
-type stubGameStore struct{}
-
-func (*stubGameStore) Ping(_ context.Context) error { return nil }
-func (*stubGameStore) GetGame(_ context.Context, _ string) (*game.Game, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubGameStore) GetGameByPlayerAndQuiz(_ context.Context, _, _ int64) (*game.Game, error) {
-	return nil, errors.ErrUnsupported
-}
-func (*stubGameStore) CreateGame(_ context.Context, _ *game.Game) error { return errors.ErrUnsupported }
-func (*stubGameStore) StartGame(_ context.Context, _ string) error      { return errors.ErrUnsupported }
-func (*stubGameStore) CreateParticipant(_ context.Context, _ *game.Participant) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) CreateGameAndParticipant(_ context.Context, _ *game.Game, _ *game.Participant) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) CreateQuestion(_ context.Context, _ *game.Question) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) CreateAnswer(_ context.Context, _ *game.Answer) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) ListAnswersForQuizLeaderboard(
-	_ context.Context, _ int64,
-) ([]*game.LeaderboardAnswer, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubGameStore) ListParticipantsForQuizLeaderboard(
-	_ context.Context, _ int64, _ time.Time,
-) ([]*game.LeaderboardParticipant, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubGameStore) DeleteGamesForPlayerOnQuiz(_ context.Context, _, _ int64) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) ListQuizIDsForPlayer(_ context.Context, _ int64) ([]int64, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func (*stubGameStore) MarkRoundSeen(_ context.Context, _ string, _ int64, _ game.RoundPhase) error {
-	return errors.ErrUnsupported
-}
-
-func (*stubGameStore) ListSeenRoundPhasesByGame(_ context.Context, _ string) ([]game.SeenRoundPhase, error) {
-	return nil, errors.ErrUnsupported
-}
-
-func TestHandleHealthz(t *testing.T) {
+func TestHandleHealthz_OKWhenDatabaseHealthy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns ok when database is healthy", func(t *testing.T) {
-		t.Parallel()
-		stores := &store.Stores{
-			Quizzes: &stubQuizStore{},
-			Games:   &stubGameStore{},
-		}
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		HandleHealthz(slog.Default(), stores)(w, req)
+	stores := store.New(dbtest.Open(t), slog.New(slog.DiscardHandler))
 
-		if got, want := w.Code, http.StatusOK; got != want {
-			t.Errorf("status = %d, want %d", got, want)
-		}
-		var res struct {
-			Status string            `json:"status"`
-			Checks map[string]string `json:"checks"`
-		}
-		if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
-			t.Fatalf("failed to decode response: %v", err)
-		}
-		if got, want := res.Status, "ok"; got != want {
-			t.Errorf("status = %q, want %q", got, want)
-		}
-		if got, want := res.Checks["database"], "healthy"; got != want {
-			t.Errorf("checks.database = %q, want %q", got, want)
-		}
-	})
+	w, res := serveHealthz(t, stores)
 
-	t.Run("returns degraded when database ping fails", func(t *testing.T) {
-		t.Parallel()
-		stores := &store.Stores{
-			Quizzes: &stubQuizStore{pingErr: errors.New("connection refused")},
-			Games:   &stubGameStore{},
-		}
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
-		w := httptest.NewRecorder()
-		HandleHealthz(slog.Default(), stores)(w, req)
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := res.Status, "ok"; got != want {
+		t.Errorf("status = %q, want %q", got, want)
+	}
+	if got, want := res.Checks["database"], "healthy"; got != want {
+		t.Errorf("checks.database = %q, want %q", got, want)
+	}
+}
 
-		if got, want := w.Code, http.StatusServiceUnavailable; got != want {
-			t.Errorf("status = %d, want %d", got, want)
-		}
-		var res struct {
-			Status string            `json:"status"`
-			Checks map[string]string `json:"checks"`
-		}
-		if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
-			t.Fatalf("failed to decode response: %v", err)
-		}
-		if got, want := res.Status, "degraded"; got != want {
-			t.Errorf("status = %q, want %q", got, want)
-		}
-		if got, want := res.Checks["database"], "unhealthy"; !strings.Contains(got, want) {
-			t.Errorf("checks.database = %q, should contain %q", got, want)
-		}
-	})
+func TestHandleHealthz_DegradedWhenDatabasePingFails(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	stores := store.New(db, slog.New(slog.DiscardHandler))
+	// Real fault injection: closing the connection makes the store's Ping
+	// fail, exercising the degraded-health path without a test double.
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close err = %v, want nil", err)
+	}
+
+	w, res := serveHealthz(t, stores)
+
+	if got, want := w.Code, http.StatusServiceUnavailable; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := res.Status, "degraded"; got != want {
+		t.Errorf("status = %q, want %q", got, want)
+	}
+	if got, want := res.Checks["database"], "unhealthy"; !strings.Contains(got, want) {
+		t.Errorf("checks.database = %q, should contain %q", got, want)
+	}
 }

--- a/internal/health/testmain_test.go
+++ b/internal/health/testmain_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package health_test
+
+import (
+	"testing"
+
+	"github.com/starquake/topbanana/internal/database"
+)
+
+func TestMain(m *testing.M) {
+	// Configure goose global state once so dbtest.Open can run migrations.
+	database.SetupGoose()
+
+	m.Run()
+}


### PR DESCRIPTION
Another slice of #638: convert the stub-driven /healthz handler test to a real integration test.

`internal/health/health_test.go` drove `HandleHealthz` against a hand-written `stubQuizStore` (which implemented the entire `quiz.Store` interface as no-ops just to supply `Ping`) plus a `stubGameStore`. Replaced with the real `store.HomeStore`/`store.Stores` on a migrated `dbtest` DB:
- healthy case: open DB -> `Ping` succeeds -> 200 `ok` / `healthy`.
- degraded case: `db.Close()` before serving -> `Ping` fails -> 503 `degraded` / `unhealthy` (real fault injection, no stub).

Deletes ~150 lines of interface-satisfying stub boilerplate. Tagged `//go:build integration`, file stays `health_test.go`; added `testmain_test.go` for goose setup (mirrors the home slice #640).

Partial for #638; remaining stub-driven packages (clientapi, admin, auth, server) are separate slices.

Verified: `go vet` both flavors; `make test` no longer runs these; `make check` passes; lint clean; both tests pass under `-race`.