### PR TITLE
Make the auth email-verification handler tests real integration tests

### DIFF
--- a/internal/auth/testmain_test.go
+++ b/internal/auth/testmain_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/starquake/topbanana/internal/database"
+)
+
+func TestMain(m *testing.M) {
+	// Configure goose global state once so dbtest.Open can run migrations.
+	database.SetupGoose()
+
+	m.Run()
+}

--- a/internal/auth/verify_handler_test.go
+++ b/internal/auth/verify_handler_test.go
@@ -1,7 +1,9 @@
+//go:build integration
+
 package auth_test
 
 import (
-	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,13 +11,16 @@ import (
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
 )
 
 func TestHandleVerifyEmail_MissingToken(t *testing.T) {
 	t.Parallel()
 
-	rec := runVerifyEmail(t, &stubVerifyTokens{}, "")
+	db := dbtest.Open(t)
+	rec := runVerifyEmail(t, db, "")
 	if got, want := rec.Code, http.StatusBadRequest; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
@@ -24,21 +29,42 @@ func TestHandleVerifyEmail_MissingToken(t *testing.T) {
 func TestHandleVerifyEmail_Success(t *testing.T) {
 	t.Parallel()
 
-	store := &stubVerifyTokens{consumePlayerID: 99}
-	rec := runVerifyEmail(t, store, "raw-token")
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	player := createVerifyPlayer(t, stores.Players, "alice", "alice@example.test", RolePlayer)
+	if player.EmailVerifiedAt != nil {
+		t.Fatalf("seed player should start unverified, EmailVerifiedAt = %v", player.EmailVerifiedAt)
+	}
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(time.Hour))
 
+	rec := runVerifyEmail(t, db, raw)
 	if got, want := rec.Code, http.StatusOK; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	if got, want := store.consumedHash, HashVerifyToken("raw-token"); got != want {
-		t.Errorf("consumedHash = %q, want %q", got, want)
+
+	verified, err := stores.Players.GetPlayerByID(t.Context(), player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if verified.EmailVerifiedAt == nil {
+		t.Error("EmailVerifiedAt is nil after successful verify, want stamped")
 	}
 }
 
 func TestHandleVerifyEmail_AlreadyUsed(t *testing.T) {
 	t.Parallel()
 
-	rec := runVerifyEmail(t, &stubVerifyTokens{consumeErr: ErrVerifyTokenAlreadyUsed}, "raw-token")
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	player := createVerifyPlayer(t, stores.Players, "alice", "alice@example.test", RolePlayer)
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(time.Hour))
+
+	// Burn the token once so the second consume reports already-used.
+	if _, err := stores.VerifyTokens.ConsumeVerifyToken(t.Context(), HashVerifyToken(raw)); err != nil {
+		t.Fatalf("first ConsumeVerifyToken err = %v, want nil", err)
+	}
+
+	rec := runVerifyEmail(t, db, raw)
 	if got, want := rec.Code, http.StatusOK; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
@@ -47,7 +73,13 @@ func TestHandleVerifyEmail_AlreadyUsed(t *testing.T) {
 func TestHandleVerifyEmail_Invalid(t *testing.T) {
 	t.Parallel()
 
-	rec := runVerifyEmail(t, &stubVerifyTokens{consumeErr: ErrVerifyTokenInvalid}, "raw-token")
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	player := createVerifyPlayer(t, stores.Players, "alice", "alice@example.test", RolePlayer)
+	// An expired-but-unconsumed token classifies as invalid -> 410 Gone.
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(-time.Hour))
+
+	rec := runVerifyEmail(t, db, raw)
 	if got, want := rec.Code, http.StatusGone; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
@@ -60,22 +92,22 @@ func TestHandleVerifyEmail_Invalid(t *testing.T) {
 func TestHandleVerifyEmail_MismatchedSessionClears(t *testing.T) {
 	t.Parallel()
 
-	players := newStubPlayerStore()
-	sessionPlayer, err := players.CreatePlayer(
-		t.Context(), "session-user", "session@example.test", "h", "admin",
-	)
-	if err != nil {
-		t.Fatalf("CreatePlayer err = %v, want nil", err)
-	}
-	tokens := &stubVerifyTokens{consumePlayerID: sessionPlayer.ID + 1}
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	// First password-bearing registrant is promoted to admin, so seed the
+	// session player first to give it the admin role the fix would otherwise
+	// land on if the session were honoured.
+	sessionPlayer := createVerifyPlayer(t, stores.Players, "session-user", "session@example.test", RoleAdmin)
+	tokenOwner := createVerifyPlayer(t, stores.Players, "token-owner", "token-owner@example.test", RolePlayer)
+	raw := seedVerifyToken(t, stores.VerifyTokens, tokenOwner.ID, time.Now().Add(time.Hour))
 	sessions := session.New([]byte("test-key-32-bytes-test-key-32byt"), false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, sessionPlayer.ID, sessionPlayer.SessionVersion)
 	cookie := rec.Result().Cookies()[0]
 
-	handler := HandleVerifyEmail(discardLogger(), nil, tokens, players, sessions)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token=raw-token", nil)
+	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token="+raw, nil)
 	req.AddCookie(cookie)
 	out := httptest.NewRecorder()
 	handler.ServeHTTP(out, req)
@@ -106,22 +138,18 @@ func TestHandleVerifyEmail_MismatchedSessionClears(t *testing.T) {
 func TestHandleVerifyEmail_MatchingSessionKeepsLanding(t *testing.T) {
 	t.Parallel()
 
-	players := newStubPlayerStore()
-	player, err := players.CreatePlayer(
-		t.Context(), "match-user", "match@example.test", "h", "admin",
-	)
-	if err != nil {
-		t.Fatalf("CreatePlayer err = %v, want nil", err)
-	}
-	tokens := &stubVerifyTokens{consumePlayerID: player.ID}
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	player := createVerifyPlayer(t, stores.Players, "match-user", "match@example.test", RoleAdmin)
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(time.Hour))
 	sessions := session.New([]byte("test-key-32-bytes-test-key-32byt"), false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID, player.SessionVersion)
 	cookie := rec.Result().Cookies()[0]
 
-	handler := HandleVerifyEmail(discardLogger(), nil, tokens, players, sessions)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token=raw-token", nil)
+	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token="+raw, nil)
 	req.AddCookie(cookie)
 	out := httptest.NewRecorder()
 	handler.ServeHTTP(out, req)
@@ -134,12 +162,12 @@ func TestHandleVerifyEmail_MatchingSessionKeepsLanding(t *testing.T) {
 	}
 }
 
-func runVerifyEmail(t *testing.T, tokens *stubVerifyTokens, raw string) *httptest.ResponseRecorder {
+func runVerifyEmail(t *testing.T, db *sql.DB, raw string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	players := newStubPlayerStore()
-	sessions := session.New([]byte("k"), true)
-	handler := HandleVerifyEmail(discardLogger(), nil, tokens, players, sessions)
+	stores := store.New(db, discardLogger())
+	sessions := session.New([]byte("test-key-32-bytes-test-key-32byt"), true)
+	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
 
 	target := "/verify-email"
 	if raw != "" {
@@ -152,27 +180,36 @@ func runVerifyEmail(t *testing.T, tokens *stubVerifyTokens, raw string) *httptes
 	return rec
 }
 
-type stubVerifyTokens struct {
-	consumePlayerID int64
-	consumeErr      error
-	consumedHash    string
-}
+// createVerifyPlayer inserts a credentialled player through the real
+// store and returns it. The verify-handler tests need a real row the
+// token can reference and the session can point at.
+func createVerifyPlayer(
+	t *testing.T, players PlayerStore, displayName, email, role string,
+) *Player {
+	t.Helper()
 
-func (*stubVerifyTokens) CreateVerifyToken(
-	_ context.Context, _ string, _ int64, _ time.Time, _ string,
-) error {
-	return nil
-}
-
-func (s *stubVerifyTokens) ConsumeVerifyToken(_ context.Context, tokenHash string) (int64, error) {
-	s.consumedHash = tokenHash
-	if s.consumeErr != nil {
-		return s.consumePlayerID, s.consumeErr
+	p, err := players.CreatePlayer(t.Context(), displayName, email, "hash", role)
+	if err != nil {
+		t.Fatalf("CreatePlayer %q err = %v, want nil", displayName, err)
 	}
 
-	return s.consumePlayerID, nil
+	return p
 }
 
-func (*stubVerifyTokens) DeleteExpiredVerifyTokens(_ context.Context) error {
-	return nil
+// seedVerifyToken mints a raw token, stores its hash for the given player
+// with the supplied expiry through the real store, and returns the raw
+// token so the caller can drive the handler with it. A past expiry yields
+// the expired-but-unconsumed row the invalid-link branch reads.
+func seedVerifyToken(t *testing.T, tokens VerifyTokenStore, playerID int64, expiresAt time.Time) string {
+	t.Helper()
+
+	raw, hash, err := GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if err := tokens.CreateVerifyToken(t.Context(), hash, playerID, expiresAt, ""); err != nil {
+		t.Fatalf("CreateVerifyToken err = %v, want nil", err)
+	}
+
+	return raw
 }

--- a/internal/auth/verify_request_test.go
+++ b/internal/auth/verify_request_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package auth_test
 
 import (
@@ -10,13 +12,16 @@ import (
 
 	. "github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
 )
 
 func TestHandleVerifyEmailRequestForm_AnonymousRenders(t *testing.T) {
 	t.Parallel()
 
-	rec := runVerifyRequestGET(t, newStubPlayerStore())
+	stores := store.New(dbtest.Open(t), discardLogger())
+	rec := runVerifyRequestGET(t, stores.Players)
 	if got, want := rec.Code, http.StatusOK; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
@@ -28,8 +33,8 @@ func TestHandleVerifyEmailRequestForm_AnonymousRenders(t *testing.T) {
 func TestHandleVerifyEmailRequestForm_SignedInRedirectsToLanding(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	p, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RolePlayer)
+	stores := store.New(dbtest.Open(t), discardLogger())
+	p, err := stores.Players.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -43,7 +48,7 @@ func TestHandleVerifyEmailRequestForm_SignedInRedirectsToLanding(t *testing.T) {
 
 	csrfMgr := csrf.New([]byte("k"), true)
 	flash := NewSignedFlash([]byte("k"), true, VerifyRequestFlashCookieName, VerifyRequestFlashCookiePath)
-	HandleVerifyEmailRequestForm(discardLogger(), csrfMgr, store, sessions, flash).ServeHTTP(rec, req)
+	HandleVerifyEmailRequestForm(discardLogger(), csrfMgr, stores.Players, sessions, flash).ServeHTTP(rec, req)
 
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)
@@ -57,7 +62,6 @@ func TestHandleVerifyEmailRequestForm_SignedInRedirectsToLanding(t *testing.T) {
 func TestHandleVerifyEmailRequestSubmit_AlwaysFlashesGenericSuccess(t *testing.T) {
 	t.Parallel()
 
-	verified := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 	for _, tc := range []struct {
 		name  string
 		email string
@@ -71,24 +75,21 @@ func TestHandleVerifyEmailRequestSubmit_AlwaysFlashesGenericSuccess(t *testing.T
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := newStubPlayerStore()
-			if _, err := store.CreatePlayer(
+			stores := store.New(dbtest.Open(t), discardLogger())
+			verifiedPlayer, err := stores.Players.CreatePlayer(
 				t.Context(), "verified", "verified@example.test", "h", RolePlayer,
-			); err != nil {
+			)
+			if err != nil {
 				t.Fatalf("CreatePlayer verified err = %v, want nil", err)
 			}
-			if p, err := store.GetPlayerByDisplayName(t.Context(), "verified"); err == nil {
-				p.EmailVerifiedAt = &verified
-			} else {
-				t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
-			}
-			if _, err := store.CreatePlayer(
+			markVerifiedViaStore(t, stores.VerifyTokens, verifiedPlayer.ID)
+			if _, err := stores.Players.CreatePlayer(
 				t.Context(), "unverified", "unverified@example.test", "h", RolePlayer,
 			); err != nil {
 				t.Fatalf("CreatePlayer unverified err = %v, want nil", err)
 			}
 
-			rec := runVerifyRequestPOST(t, store, &recordingVerifyTokenStore{}, &recordingSender{},
+			rec := runVerifyRequestPOST(t, stores.Players, &recordingVerifyTokenStore{}, &recordingSender{},
 				NewVerifyResendLimiter(time.Minute, nil), tc.email)
 
 			if got, want := rec.Code, http.StatusSeeOther; got != want {
@@ -104,8 +105,8 @@ func TestHandleVerifyEmailRequestSubmit_AlwaysFlashesGenericSuccess(t *testing.T
 func TestHandleVerifyEmailRequestSubmit_UnverifiedMatchDispatchesEmail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(
+	stores := store.New(dbtest.Open(t), discardLogger())
+	if _, err := stores.Players.CreatePlayer(
 		t.Context(), "alice", "alice@example.test", "h", RolePlayer,
 	); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
@@ -113,7 +114,7 @@ func TestHandleVerifyEmailRequestSubmit_UnverifiedMatchDispatchesEmail(t *testin
 	tokens := &recordingVerifyTokenStore{}
 	sender := &recordingSender{}
 
-	rec := runVerifyRequestPOST(t, store, tokens, sender,
+	rec := runVerifyRequestPOST(t, stores.Players, tokens, sender,
 		NewVerifyResendLimiter(time.Minute, nil), "alice@example.test")
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Fatalf("status = %d, want %d", got, want)
@@ -135,22 +136,18 @@ func TestHandleVerifyEmailRequestSubmit_UnverifiedMatchDispatchesEmail(t *testin
 func TestHandleVerifyEmailRequestSubmit_AlreadyVerifiedSendsNoMail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(
+	stores := store.New(dbtest.Open(t), discardLogger())
+	p, err := stores.Players.CreatePlayer(
 		t.Context(), "alice", "alice@example.test", "h", RolePlayer,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	verified := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
-	if p, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err == nil {
-		p.EmailVerifiedAt = &verified
-	} else {
-		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
-	}
+	markVerifiedViaStore(t, stores.VerifyTokens, p.ID)
 	tokens := &recordingVerifyTokenStore{}
 	sender := &recordingSender{}
 
-	runVerifyRequestPOST(t, store, tokens, sender,
+	runVerifyRequestPOST(t, stores.Players, tokens, sender,
 		NewVerifyResendLimiter(time.Minute, nil), "alice@example.test")
 
 	time.Sleep(50 * time.Millisecond)
@@ -162,11 +159,11 @@ func TestHandleVerifyEmailRequestSubmit_AlreadyVerifiedSendsNoMail(t *testing.T)
 func TestHandleVerifyEmailRequestSubmit_UnknownEmailSendsNoMail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	stores := store.New(dbtest.Open(t), discardLogger())
 	tokens := &recordingVerifyTokenStore{}
 	sender := &recordingSender{}
 
-	runVerifyRequestPOST(t, store, tokens, sender,
+	runVerifyRequestPOST(t, stores.Players, tokens, sender,
 		NewVerifyResendLimiter(time.Minute, nil), "ghost@example.test")
 
 	time.Sleep(50 * time.Millisecond)
@@ -178,8 +175,8 @@ func TestHandleVerifyEmailRequestSubmit_UnknownEmailSendsNoMail(t *testing.T) {
 func TestHandleVerifyEmailRequestSubmit_RateLimitedBlocksDispatch(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(
+	stores := store.New(dbtest.Open(t), discardLogger())
+	if _, err := stores.Players.CreatePlayer(
 		t.Context(), "alice", "alice@example.test", "h", RolePlayer,
 	); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
@@ -188,11 +185,11 @@ func TestHandleVerifyEmailRequestSubmit_RateLimitedBlocksDispatch(t *testing.T) 
 	sender := &recordingSender{}
 	limiter := NewVerifyResendLimiter(time.Minute, nil)
 
-	first := runVerifyRequestPOST(t, store, tokens, sender, limiter, "alice@example.test")
+	first := runVerifyRequestPOST(t, stores.Players, tokens, sender, limiter, "alice@example.test")
 	if got, want := first.Code, http.StatusSeeOther; got != want {
 		t.Fatalf("first status = %d, want %d", got, want)
 	}
-	second := runVerifyRequestPOST(t, store, tokens, sender, limiter, "alice@example.test")
+	second := runVerifyRequestPOST(t, stores.Players, tokens, sender, limiter, "alice@example.test")
 	if got, want := second.Code, http.StatusSeeOther; got != want {
 		t.Errorf("second status = %d, want %d", got, want)
 	}
@@ -201,12 +198,32 @@ func TestHandleVerifyEmailRequestSubmit_RateLimitedBlocksDispatch(t *testing.T) 
 	}
 }
 
-func runVerifyRequestGET(t *testing.T, store PlayerStore) *httptest.ResponseRecorder {
+// markVerifiedViaStore stamps email_verified_at on the player by minting
+// then consuming a verify token through the real store - the same path
+// production uses to flip the column. The PlayerStore interface exposes
+// no direct verify toggle, so the token round-trip is how a test marks a
+// real row verified.
+func markVerifiedViaStore(t *testing.T, tokens VerifyTokenStore, playerID int64) {
+	t.Helper()
+
+	raw, hash, err := GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("GenerateVerifyToken err = %v, want nil", err)
+	}
+	if err := tokens.CreateVerifyToken(t.Context(), hash, playerID, time.Now().Add(time.Hour), ""); err != nil {
+		t.Fatalf("CreateVerifyToken err = %v, want nil", err)
+	}
+	if _, err := tokens.ConsumeVerifyToken(t.Context(), HashVerifyToken(raw)); err != nil {
+		t.Fatalf("ConsumeVerifyToken err = %v, want nil", err)
+	}
+}
+
+func runVerifyRequestGET(t *testing.T, players PlayerStore) *httptest.ResponseRecorder {
 	t.Helper()
 	csrfMgr := csrf.New([]byte("k"), true)
 	flash := NewSignedFlash([]byte("k"), true, VerifyRequestFlashCookieName, VerifyRequestFlashCookiePath)
 	sessions := session.New([]byte("k"), true)
-	handler := HandleVerifyEmailRequestForm(discardLogger(), csrfMgr, store, sessions, flash)
+	handler := HandleVerifyEmailRequestForm(discardLogger(), csrfMgr, players, sessions, flash)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email/request", nil)
 	rec := httptest.NewRecorder()
@@ -217,7 +234,7 @@ func runVerifyRequestGET(t *testing.T, store PlayerStore) *httptest.ResponseReco
 
 func runVerifyRequestPOST(
 	t *testing.T,
-	store PlayerStore,
+	players PlayerStore,
 	tokens VerifyTokenStore,
 	sender VerifyEmailSender,
 	limiter *VerifyResendLimiter,
@@ -227,7 +244,7 @@ func runVerifyRequestPOST(
 	sessions := session.New([]byte("k"), true)
 	flash := NewSignedFlash([]byte("k"), true, VerifyRequestFlashCookieName, VerifyRequestFlashCookiePath)
 	handler := HandleVerifyEmailRequestSubmit(
-		discardLogger(), store, sessions, tokens, sender,
+		discardLogger(), players, sessions, tokens, sender,
 		"https://topbanana.example", limiter, flash,
 	)
 


### PR DESCRIPTION
#638 sub-slice: de-stub the email-verification handler tests in `internal/auth`.

`internal/auth` is large with shared store stubs, so it's being converted in cohesive sub-slices. This one covers the verify-email handlers:
- `verify_handler_test.go` (`HandleVerifyEmail`) -> real handler + real stores via `dbtest`; deleted the verify-only `stubVerifyTokens`.
- `verify_request_test.go` (`HandleVerifyEmailRequestForm`/`Submit`) -> real `stores.Players` for the player-lookup path. The mailer spy and verify-token-create recorder are kept as legitimate **outbound captures** (they assert email/token side effects, not re-state store reads) -- analogous to the closed-DB fault-injection pattern.
- Added `testmain_test.go` for goose.

Left as-is (correctly):
- `verify_gate_test.go` -- `RequireVerifiedEmail` reads the player from the request context, has no store dependency, so it stays a pure-logic **unit** test.
- The shared `stubPlayerStore` (in `handler_test.go`) stays -- still used by the untagged login/register/middleware tests; a later sub-slice removes it.

Partial for #638. Remaining auth sub-slices: forgot/reset handlers, then login/google/middleware (which finally drops `stubPlayerStore`). Then clientapi, admin.

Verified: `go vet` both flavors; `make test` keeps the unit tests, drops the converted ones; `make check` passes (79.7%); lint clean; `-race` stable.