### PR TITLE
Make the auth login and middleware handler tests real integration tests

### DIFF
--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1,298 +1,23 @@
+//go:build integration
+
 package auth_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/mailer"
 	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
 )
-
-// stubPlayerStore is an in-memory PlayerStore for tests.
-type stubPlayerStore struct {
-	mu      sync.Mutex
-	byID    map[int64]*Player
-	byName  map[string]*Player
-	nextID  int64
-	failGet bool
-	// forceAnonCollisions, when > 0, makes the next N CreateAnonymousPlayer
-	// calls return ErrDisplayNameTaken without inserting. Each call decrements
-	// the counter, so once it reaches zero the stub returns to its normal
-	// insert-or-conflict behaviour. Used by the petname retry-loop tests
-	// to drive the middleware down the collision path a deterministic
-	// number of times.
-	forceAnonCollisions int
-	// forceAnonErr, when set, is returned by the NEXT CreateAnonymousPlayer
-	// call and then automatically cleared. The single-shot semantics keep
-	// each test scenario self-contained: setting the error and then
-	// triggering a single request exercises one error branch without
-	// leaking the failure into any follow-up call inside the same test.
-	// Used to exercise the non-collision error branch of EnsurePlayer.
-	forceAnonErr error
-}
-
-func newStubPlayerStore() *stubPlayerStore {
-	return &stubPlayerStore{
-		byID:   map[int64]*Player{},
-		byName: map[string]*Player{},
-		nextID: 1,
-	}
-}
-
-func (s *stubPlayerStore) GetPlayerByDisplayName(_ context.Context, displayName string) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	p, ok := s.byName[displayName]
-	if !ok {
-		return nil, ErrPlayerNotFound
-	}
-
-	return p, nil
-}
-
-func (s *stubPlayerStore) GetPlayerByEmail(_ context.Context, email string) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for _, p := range s.byID {
-		if p.Email == email {
-			return p, nil
-		}
-	}
-
-	return nil, ErrPlayerNotFound
-}
-
-func (s *stubPlayerStore) GetPlayerByID(_ context.Context, id int64) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.failGet {
-		return nil, errors.New("boom")
-	}
-	p, ok := s.byID[id]
-	if !ok {
-		return nil, ErrPlayerNotFound
-	}
-
-	return p, nil
-}
-
-// CreatePlayer mirrors the SQL semantics of internal/queries/players.sql:
-// honour an explicit "admin" request, otherwise promote the very first
-// password-bearing player to admin so the "first registrant becomes admin"
-// rule is observed atomically.
-func (s *stubPlayerStore) CreatePlayer(
-	_ context.Context,
-	displayName, email, passwordHash, requestedRole string,
-) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, exists := s.byName[displayName]; exists {
-		return nil, ErrDisplayNameTaken
-	}
-	if email != "" {
-		for _, p := range s.byID {
-			if p.Email == email {
-				return nil, ErrEmailTaken
-			}
-		}
-	}
-
-	role := s.resolveRoleLocked(requestedRole)
-
-	p := &Player{
-		ID:           s.nextID,
-		DisplayName:  displayName,
-		Email:        email,
-		PasswordHash: passwordHash,
-		Role:         role,
-	}
-	s.nextID++
-	s.byID[p.ID] = p
-	s.byName[displayName] = p
-
-	return p, nil
-}
-
-// CreateAnonymousPlayer mirrors store.CreateAnonymousPlayer: insert a row
-// with the given displayName, no password_hash, role = "player".
-func (s *stubPlayerStore) CreateAnonymousPlayer(_ context.Context, displayName string) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.forceAnonErr != nil {
-		err := s.forceAnonErr
-		s.forceAnonErr = nil
-
-		return nil, err
-	}
-	if s.forceAnonCollisions > 0 {
-		s.forceAnonCollisions--
-
-		return nil, ErrDisplayNameTaken
-	}
-
-	if _, exists := s.byName[displayName]; exists {
-		return nil, ErrDisplayNameTaken
-	}
-
-	p := &Player{
-		ID:          s.nextID,
-		DisplayName: displayName,
-		Role:        RolePlayer,
-	}
-	s.nextID++
-	s.byID[p.ID] = p
-	s.byName[displayName] = p
-
-	return p, nil
-}
-
-// ClaimPlayer mirrors store.ClaimPlayer: upgrades an anonymous row in place
-// or fails with ErrPlayerAlreadyClaimed / ErrPlayerNotFound /
-// ErrDisplayNameTaken.
-func (s *stubPlayerStore) ClaimPlayer(
-	_ context.Context,
-	playerID int64,
-	displayName, email, passwordHash, requestedRole string,
-) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	existing, ok := s.byID[playerID]
-	if !ok {
-		return nil, ErrPlayerNotFound
-	}
-	if existing.PasswordHash != "" {
-		return nil, ErrPlayerAlreadyClaimed
-	}
-	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
-		return nil, ErrDisplayNameTaken
-	}
-	if email != "" {
-		for _, p := range s.byID {
-			if p.ID != playerID && p.Email == email {
-				return nil, ErrEmailTaken
-			}
-		}
-	}
-
-	delete(s.byName, existing.DisplayName)
-	existing.Email = email
-	existing.DisplayName = displayName
-	existing.PasswordHash = passwordHash
-	existing.Role = s.resolveRoleLocked(requestedRole)
-	s.byName[displayName] = existing
-
-	return existing, nil
-}
-
-func (s *stubPlayerStore) UpdatePlayerDisplayName(
-	_ context.Context, playerID int64, displayName string,
-) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	existing, ok := s.byID[playerID]
-	if !ok {
-		return nil, ErrPlayerNotFound
-	}
-	if existing.PasswordHash != "" {
-		return nil, ErrPlayerNotAnonymous
-	}
-	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
-		return nil, ErrDisplayNameTaken
-	}
-
-	delete(s.byName, existing.DisplayName)
-	existing.DisplayName = displayName
-	s.byName[displayName] = existing
-
-	return existing, nil
-}
-
-func (s *stubPlayerStore) RenamePlayer(
-	_ context.Context, playerID int64, displayName string,
-) (*Player, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if strings.TrimSpace(displayName) == "" {
-		return nil, ErrDisplayNameEmpty
-	}
-	existing, ok := s.byID[playerID]
-	if !ok {
-		return nil, ErrPlayerNotFound
-	}
-	if other, exists := s.byName[displayName]; exists && other.ID != playerID {
-		return nil, ErrDisplayNameTaken
-	}
-
-	delete(s.byName, existing.DisplayName)
-	existing.DisplayName = displayName
-	s.byName[displayName] = existing
-
-	return existing, nil
-}
-
-func (s *stubPlayerStore) SetPlayerPasswordHash(_ context.Context, displayName, passwordHash string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	p, ok := s.byName[displayName]
-	if !ok {
-		return ErrPlayerNotFound
-	}
-	p.PasswordHash = passwordHash
-
-	return nil
-}
-
-func (s *stubPlayerStore) ChangePlayerPassword(_ context.Context, playerID int64, passwordHash string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	p, ok := s.byID[playerID]
-	if !ok {
-		return ErrPlayerNotFound
-	}
-	p.PasswordHash = passwordHash
-	p.SessionVersion++
-
-	return nil
-}
-
-// resolveRoleLocked applies the same "first password-bearing registrant
-// becomes admin" rule as the production SQL. Caller must hold s.mu.
-func (s *stubPlayerStore) resolveRoleLocked(requestedRole string) string {
-	if requestedRole == RoleAdmin {
-		return RoleAdmin
-	}
-	for _, existing := range s.byID {
-		if existing.PasswordHash != "" {
-			return RolePlayer
-		}
-	}
-
-	return RoleAdmin
-}
-
-func discardLogger() *slog.Logger {
-	return slog.New(slog.DiscardHandler)
-}
 
 func postForm(t *testing.T, handler http.Handler, path string, values url.Values) *httptest.ResponseRecorder {
 	t.Helper()
@@ -311,7 +36,7 @@ func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 	handler := HandleRegisterForm(
 		discardLogger(),
 		nil,
-		newStubPlayerStore(),
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
 		session.New([]byte("k"), true),
 		false,
 	)
@@ -340,8 +65,8 @@ func TestHandleRegisterForm_GET_RendersForm(t *testing.T) {
 func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
@@ -352,7 +77,7 @@ func TestHandleRegisterSubmit_FirstUser_BecomesAdmin(t *testing.T) {
 
 	assertRegisterPending(t, rec, "alice@example.test")
 
-	p, err := store.GetPlayerByDisplayName(t.Context(), "alice")
+	p, err := players.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -408,13 +133,21 @@ func assertSessionCleared(t *testing.T, rec *httptest.ResponseRecorder) {
 func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	// Pre-seed first admin.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "hash", RoleAdmin); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	// Pre-seed a credentialled admin so bob is not auto-promoted by the
+	// first-credentialled-registrant rule. (The migration-seeded admin row
+	// has no password_hash, so it does not count for that rule.)
+	if _, err := players.CreatePlayer(
+		t.Context(),
+		"seed-admin",
+		"seed-admin@example.test",
+		"hash",
+		RoleAdmin,
+	); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"bob"},
 		"email":            {"bob@example.test"},
@@ -424,7 +157,7 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 
 	assertRegisterPending(t, rec, "bob@example.test")
 
-	p, err := store.GetPlayerByDisplayName(t.Context(), "bob")
+	p, err := players.GetPlayerByDisplayName(t.Context(), "bob")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -436,16 +169,16 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	// Pre-seed first user so the count > 0 and the env var path is exercised.
-	if _, err := store.CreatePlayer(t.Context(), "first", "first@example.test", "h", RolePlayer); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "first", "first@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleRegisterSubmit(
 		discardLogger(),
 		nil,
-		store,
+		players,
 		session.New([]byte("k"), true),
 		RegisterDeps{AdminEmails: []string{"alice@example.test", "carol@example.test"}},
 	)
@@ -458,7 +191,7 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 
 	assertRegisterPending(t, rec, "carol@example.test")
 
-	p, err := store.GetPlayerByDisplayName(t.Context(), "carol")
+	p, err := players.GetPlayerByDisplayName(t.Context(), "carol")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -470,8 +203,8 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
@@ -487,7 +220,7 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, GetPlayerByDisplayName err = %v", err)
 	}
 }
@@ -499,8 +232,8 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	longPassword := strings.Repeat("a", MaxPasswordLength+1)
 	rec := postForm(t, handler, "/register", url.Values{
@@ -517,7 +250,7 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 	if got := rec.Body.String(); !strings.Contains(got, want) {
 		t.Errorf("body = %q, want substring %q", got, want)
 	}
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, GetPlayerByDisplayName err = %v", err)
 	}
 }
@@ -525,12 +258,12 @@ func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
 func TestHandleRegisterSubmit_DuplicateDisplayName(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RolePlayer); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
 		"email":            {"alice@example.test"},
@@ -554,14 +287,14 @@ func TestHandleRegisterSubmit_DuplicateDisplayName(t *testing.T) {
 func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "alice", "shared@example.test", "h", RolePlayer); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(t.Context(), "alice", "shared@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
 
 	sender := &recordingSender{}
 	handler := HandleRegisterSubmit(
-		discardLogger(), nil, store, session.New([]byte("k"), true),
+		discardLogger(), nil, players, session.New([]byte("k"), true),
 		RegisterDeps{Mailer: sender},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
@@ -601,8 +334,8 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
 		"email":            {"not-an-email"},
@@ -621,8 +354,8 @@ func TestHandleRegisterSubmit_RejectsInvalidEmail(t *testing.T) {
 func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
@@ -632,7 +365,7 @@ func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}
 }
@@ -640,8 +373,8 @@ func TestHandleRegisterSubmit_MatchingPasswords_CreatesPlayer(t *testing.T) {
 func TestHandleRegisterSubmit_MismatchedPasswords_Rejects(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	password := "correctbattery"
 	rec := postForm(t, handler, "/register", url.Values{
@@ -673,7 +406,7 @@ func TestHandleRegisterSubmit_MismatchedPasswords_Rejects(t *testing.T) {
 	if strings.Contains(body, "correctbatterydifferent") {
 		t.Errorf("body must not leak the submitted password_confirm, got %q", body)
 	}
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "alice"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("player should not have been created, err = %v", err)
 	}
 }
@@ -681,8 +414,8 @@ func TestHandleRegisterSubmit_MismatchedPasswords_Rejects(t *testing.T) {
 func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"alice"},
 		"email":            {"  ALICE@Example.Test "},
@@ -691,7 +424,7 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	p, err := store.GetPlayerByDisplayName(t.Context(), "alice")
+	p, err := players.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -708,14 +441,14 @@ func TestHandleRegisterSubmit_LowercasesAndTrimsEmail(t *testing.T) {
 func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-existing")
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	anon, err := players.CreateAnonymousPlayer(t.Context(), "anon-existing")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, sessions, RegisterDeps{})
 
 	// Build a request that already carries the anonymous session cookie.
 	rec := httptest.NewRecorder()
@@ -741,7 +474,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 
 	// The same row was upgraded - no new row should appear, and the
 	// anonymous displayName should be gone.
-	upgraded, err := store.GetPlayerByDisplayName(t.Context(), "alice")
+	upgraded, err := players.GetPlayerByDisplayName(t.Context(), "alice")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -751,7 +484,7 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 	if upgraded.PasswordHash == "" {
 		t.Error("upgraded.PasswordHash is empty, want bcrypt hash from claim")
 	}
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "anon-existing"); !errors.Is(err, ErrPlayerNotFound) {
 		t.Errorf("anonymous row still resolvable by old displayName; err = %v, want ErrPlayerNotFound", err)
 	}
 }
@@ -763,8 +496,8 @@ func TestHandleRegisterSubmit_ClaimsAnonymousSession(t *testing.T) {
 func TestHandleRegisterSubmit_ClaimWithTakenDisplayName(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(
 		t.Context(),
 		"alice",
 		"alice@example.test",
@@ -773,13 +506,13 @@ func TestHandleRegisterSubmit_ClaimWithTakenDisplayName(t *testing.T) {
 	); err != nil {
 		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
 	}
-	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-claimer")
+	anon, err := players.CreateAnonymousPlayer(t.Context(), "anon-claimer")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID, 0)
@@ -803,7 +536,7 @@ func TestHandleRegisterSubmit_ClaimWithTakenDisplayName(t *testing.T) {
 		t.Errorf("status = %d, want %d", got, want)
 	}
 	// Anonymous row was not mutated.
-	stillAnon, err := store.GetPlayerByID(t.Context(), anon.ID)
+	stillAnon, err := players.GetPlayerByID(t.Context(), anon.ID)
 	if err != nil {
 		t.Fatalf("GetPlayerByID err = %v, want nil", err)
 	}
@@ -823,13 +556,13 @@ func TestHandleRegisterSubmit_ClaimWithTakenDisplayName(t *testing.T) {
 func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-racer")
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	anon, err := players.CreateAnonymousPlayer(t.Context(), "anon-racer")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 	// Simulate another tab claiming the row first.
-	if _, claimErr := store.ClaimPlayer(
+	if _, claimErr := players.ClaimPlayer(
 		t.Context(),
 		anon.ID,
 		"winner",
@@ -841,7 +574,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, sessions, RegisterDeps{})
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, sessions, RegisterDeps{})
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID, 0) // cookie still points at the now-claimed row
@@ -864,7 +597,7 @@ func TestHandleRegisterSubmit_ClaimAlreadyClaimed_FallsBackToCreate(t *testing.T
 	assertRegisterPending(t, rec, "latecomer@example.test")
 	assertSessionCleared(t, rec)
 	// A fresh row was created instead of clobbering the already-claimed one.
-	latecomer, err := store.GetPlayerByDisplayName(t.Context(), "latecomer")
+	latecomer, err := players.GetPlayerByDisplayName(t.Context(), "latecomer")
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
@@ -879,7 +612,7 @@ func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
-		newStubPlayerStore(),
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
 		session.New([]byte("k"), true),
 		false,
 		false,
@@ -903,7 +636,7 @@ func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
-		newStubPlayerStore(),
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
 		session.New([]byte("k"), true),
 		false,
 		false,
@@ -927,7 +660,7 @@ func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 	handler := HandleLoginForm(
 		discardLogger(),
 		nil,
-		newStubPlayerStore(),
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
 		session.New([]byte("k"), true),
 		true,
 		false,
@@ -952,7 +685,7 @@ func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
@@ -961,7 +694,7 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	// registrant becomes admin" rule (mirroring the production SQL)
 	// promotes that row, not carol. Carol then stays as a plain
 	// player and the redirect lands on / instead of /admin/quizzes.
-	if _, seedErr := store.CreatePlayer(
+	if _, seedErr := players.CreatePlayer(
 		t.Context(),
 		"first-admin",
 		"first-admin@example.test",
@@ -970,13 +703,13 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	); seedErr != nil {
 		t.Fatalf("seed admin err = %v, want nil", seedErr)
 	}
-	player, err := store.CreatePlayer(t.Context(), "carol", "carol@example.test", hash, RolePlayer)
+	player, err := players.CreatePlayer(t.Context(), "carol", "carol@example.test", hash, RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID, 0)
@@ -1001,14 +734,14 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 func TestHandleLoginForm_AnonymousSession_RendersForm(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	anon, err := store.CreateAnonymousPlayer(t.Context(), "anon-fancy")
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	anon, err := players.CreateAnonymousPlayer(t.Context(), "anon-fancy")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleLoginForm(discardLogger(), nil, store, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID, 0)
@@ -1027,54 +760,53 @@ func TestHandleLoginForm_AnonymousSession_RendersForm(t *testing.T) {
 	}
 }
 
-// loginDeps returns a LoginDeps with the supplied store + session
+// loginDeps returns a LoginDeps with the supplied players + session
 // manager + limiter and the rest of the fields zero-valued. Mailer /
 // Tokens / ResendLimiter staying nil keeps the verify-resend branch
 // dormant for tests that don't exercise it; the verified-email
 // helper [markVerified] is what flips the gate off for happy-path
 // tests.
 func loginDeps(
-	store PlayerStore, sessions *session.Manager, limiter *LoginRateLimiter,
+	players PlayerStore, sessions *session.Manager, limiter *LoginRateLimiter,
 ) LoginDeps {
 	return LoginDeps{
-		Players:  store,
+		Players:  players,
 		Sessions: sessions,
 		Limiter:  limiter,
 	}
 }
 
-// markVerified stamps email_verified_at on the named stub player so
-// the post-#492 login gate lets them through. Production rows get
-// stamped via SendVerifyEmail's ConsumeVerifyToken path; in tests we
-// just toggle the column directly because the verify dance is not
-// what these cases pin.
-func markVerified(t *testing.T, store *stubPlayerStore, displayName string) {
+// markVerified stamps email_verified_at on the named player so the
+// post-#492 login gate lets them through. Production rows get stamped
+// via SendVerifyEmail's ConsumeVerifyToken path; in tests we set the
+// column directly through SetPlayerEmailVerifiedNow because the verify
+// dance is not what these cases pin.
+func markVerified(t *testing.T, players *store.PlayerStore, displayName string) {
 	t.Helper()
-	store.mu.Lock()
-	defer store.mu.Unlock()
-	p, ok := store.byName[displayName]
-	if !ok {
-		t.Fatalf("markVerified: no stub player named %q", displayName)
+	p, err := players.GetPlayerByDisplayName(t.Context(), displayName)
+	if err != nil {
+		t.Fatalf("markVerified: GetPlayerByDisplayName(%q) err = %v, want nil", displayName, err)
 	}
-	now := time.Now().UTC()
-	p.EmailVerifiedAt = &now
+	if err := players.SetPlayerEmailVerifiedNow(t.Context(), p.ID); err != nil {
+		t.Fatalf("markVerified: SetPlayerEmailVerifiedNow err = %v, want nil", err)
+	}
 }
 
 func TestHandleLoginSubmit_Success(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "alice")
+	markVerified(t, players, "alice")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
@@ -1094,18 +826,18 @@ func TestHandleLoginSubmit_Success(t *testing.T) {
 func TestHandleLoginSubmit_HonoursNext(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "alice")
+	markVerified(t, players, "alice")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
@@ -1126,18 +858,18 @@ func TestHandleLoginSubmit_HonoursNext(t *testing.T) {
 func TestHandleLoginSubmit_RejectsUnsafeNext(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "alice")
+	markVerified(t, players, "alice")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"alice@example.test"},
 		"password": {"correctbattery"},
@@ -1158,10 +890,10 @@ func TestHandleLoginSubmit_RejectsUnsafeNext(t *testing.T) {
 func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	// Pre-seed an admin so the "first password-bearing registrant
 	// becomes admin" rule doesn't accidentally promote bob.
-	if _, err := store.CreatePlayer(
+	if _, err := players.CreatePlayer(
 		t.Context(),
 		"first-admin",
 		"first-admin@example.test",
@@ -1174,13 +906,13 @@ func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "bob", "bob@example.test", hash, RolePlayer); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "bob", "bob@example.test", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "bob")
+	markVerified(t, players, "bob")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"bob@example.test"},
 		"password": {"correctbattery"},
@@ -1197,9 +929,9 @@ func TestHandleLoginSubmit_Success_Player(t *testing.T) {
 func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"ghost@example.test"},
@@ -1217,18 +949,18 @@ func TestHandleLoginSubmit_BadCredentials_UnknownUser(t *testing.T) {
 func TestHandleLoginSubmit_BadCredentials_WrongPassword(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("right-password-yes")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RolePlayer); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "alice")
+	markVerified(t, players, "alice")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"alice@example.test"},
 		"password": {"wrong-password-no"},
@@ -1246,13 +978,13 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 	t.Parallel()
 
 	// Seed a player with no password hash (legacy admin from migration).
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "legacy", "legacy@example.test", "", RoleAdmin); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(t.Context(), "legacy", "legacy@example.test", "", RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"legacy@example.test"},
 		"password": {"anything-goes-here-13"},
@@ -1270,18 +1002,18 @@ func TestHandleLoginSubmit_RejectsEmptyHash(t *testing.T) {
 func TestHandleLoginSubmit_EmailMixedCaseAndWhitespace(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "alice")
+	markVerified(t, players, "alice")
 
 	handler := HandleLoginSubmit(discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
 	rec := postForm(t, handler, "/login", url.Values{
 		"email":    {"  ALICE@Example.Test "},
 		"password": {"correctbattery"},
@@ -1302,8 +1034,8 @@ func TestHandleLoginSubmit_EmailMixedCaseAndWhitespace(t *testing.T) {
 func TestHandleRegisterSubmit_BlankDisplayName_GeneratesPetname(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"   "},
@@ -1316,7 +1048,7 @@ func TestHandleRegisterSubmit_BlankDisplayName_GeneratesPetname(t *testing.T) {
 	// The whitespace-only displayName path falls into GeneratePetname, so
 	// no row should be created under the empty key. The row exists under
 	// the petname; we look it up by email instead.
-	p, err := store.GetPlayerByEmail(t.Context(), "petname@example.test")
+	p, err := players.GetPlayerByEmail(t.Context(), "petname@example.test")
 	if err != nil {
 		t.Fatalf("GetPlayerByEmail err = %v, want nil", err)
 	}
@@ -1328,8 +1060,8 @@ func TestHandleRegisterSubmit_BlankDisplayName_GeneratesPetname(t *testing.T) {
 func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	handler := HandleRegisterSubmit(discardLogger(), nil, store, session.New([]byte("k"), true), RegisterDeps{})
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	handler := HandleRegisterSubmit(discardLogger(), nil, players, session.New([]byte("k"), true), RegisterDeps{})
 
 	password := strings.Repeat("a", MinPasswordLength) // exactly 13 characters
 	rec := postForm(t, handler, "/register", url.Values{
@@ -1340,7 +1072,7 @@ func TestHandleRegisterSubmit_PasswordExactlyMinLength(t *testing.T) {
 	})
 
 	assertRegisterPending(t, rec, "alice@example.test")
-	if _, err := store.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
+	if _, err := players.GetPlayerByDisplayName(t.Context(), "alice"); err != nil {
 		t.Errorf("player should have been created, err = %v", err)
 	}
 }
@@ -1399,12 +1131,12 @@ func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "unv", "unv@example.test", hash, RolePlayer); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "unv", "unv@example.test", hash, RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
 
@@ -1412,7 +1144,7 @@ func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 	sender := &recordingSender{}
 	sessions := session.New([]byte("k"), true)
 	handler := HandleLoginSubmit(discardLogger(), nil, LoginDeps{
-		Players:       store,
+		Players:       players,
 		Sessions:      sessions,
 		Limiter:       NewLoginRateLimiter(time.Minute, nil),
 		Mailer:        sender,
@@ -1474,20 +1206,20 @@ func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 func TestHandleLoginSubmit_VerifiedEmail_SignsIn(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	hash, err := HashPassword("correctbattery")
 	if err != nil {
 		t.Fatalf("HashPassword err = %v, want nil", err)
 	}
-	if _, err := store.CreatePlayer(t.Context(), "ver", "ver@example.test", hash, RoleAdmin); err != nil {
+	if _, err := players.CreatePlayer(t.Context(), "ver", "ver@example.test", hash, RoleAdmin); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	markVerified(t, store, "ver")
+	markVerified(t, players, "ver")
 
 	tokens := &recordingVerifyTokenStore{}
 	sender := &recordingSender{}
 	handler := HandleLoginSubmit(discardLogger(), nil, LoginDeps{
-		Players:       store,
+		Players:       players,
 		Sessions:      session.New([]byte("k"), true),
 		Limiter:       NewLoginRateLimiter(time.Minute, nil),
 		Mailer:        sender,

--- a/internal/auth/login_limiter_login_test.go
+++ b/internal/auth/login_limiter_login_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// TestHandleLoginSubmit_RateLimited pins the #494 contract: a second
+// POST inside the cool-down renders the 429 banner regardless of
+// credential validity, with Retry-After set. Uses the same fake
+// httptest peer IP so both requests share the limiter bucket.
+func TestHandleLoginSubmit_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	limiter := NewLoginRateLimiter(time.Minute, nil)
+	handler := HandleLoginSubmit(
+		discardLogger(), nil,
+		loginDeps(players, session.New([]byte("k"), true), limiter),
+	)
+
+	first := postLogin(t, handler, "alice", "wrong-password")
+	if got, want := first.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("first POST status = %d, want %d", got, want)
+	}
+
+	second := postLogin(t, handler, "alice", "wrong-password")
+	if got, want := second.Code, http.StatusTooManyRequests; got != want {
+		t.Errorf("second POST status = %d, want %d", got, want)
+	}
+	if got := second.Header().Get("Retry-After"); got == "" {
+		t.Error("Retry-After header empty on rate-limited second POST")
+	}
+	if got, want := second.Body.String(), "Too many attempts"; !strings.Contains(got, want) {
+		t.Errorf("body should contain %q, got %q", want, got)
+	}
+}
+
+// TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser pins the
+// "always trip regardless of displayName existence" design constraint:
+// the limiter check runs BEFORE the credential lookup, so two POSTs
+// against a non-existent displayName also trip the second response.
+func TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	limiter := NewLoginRateLimiter(time.Minute, nil)
+	handler := HandleLoginSubmit(
+		discardLogger(), nil,
+		loginDeps(players, session.New([]byte("k"), true), limiter),
+	)
+
+	first := postLogin(t, handler, "ghost", "whatever-password")
+	if got, want := first.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("first POST status = %d, want %d", got, want)
+	}
+
+	second := postLogin(t, handler, "ghost", "whatever-password")
+	if got, want := second.Code, http.StatusTooManyRequests; got != want {
+		t.Errorf("second POST status = %d, want %d (limiter must fire on unknown users too)", got, want)
+	}
+}
+
+// TestHandleLoginSubmit_RateLimitedRefusesCorrectCredentials pins the
+// invariant that the limiter check runs BEFORE the credential check,
+// so a hot bucket blocks a valid login attempt too. Without this, an
+// attacker who burned the window with garbage attempts could still
+// race a legitimate user's correct submission through.
+func TestHandleLoginSubmit_RateLimitedRefusesCorrectCredentials(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	hash, err := HashPassword("correctbattery")
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	markVerified(t, players, "alice")
+
+	limiter := NewLoginRateLimiter(time.Minute, nil)
+	handler := HandleLoginSubmit(
+		discardLogger(), nil,
+		loginDeps(players, session.New([]byte("k"), true), limiter),
+	)
+
+	first := postLogin(t, handler, "alice", "wrong-password")
+	if got, want := first.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("first POST status = %d, want %d", got, want)
+	}
+
+	second := postLogin(t, handler, "alice", "correctbattery")
+	if got, want := second.Code, http.StatusTooManyRequests; got != want {
+		t.Errorf(
+			"second POST status = %d, want %d (limiter must gate even valid creds)",
+			got, want,
+		)
+	}
+}
+
+func postLogin(t *testing.T, handler http.Handler, displayName, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"displayName": {displayName}, "password": {password}}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/login", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}

--- a/internal/auth/login_limiter_test.go
+++ b/internal/auth/login_limiter_test.go
@@ -1,15 +1,10 @@
 package auth_test
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strings"
 	"testing"
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
-	"github.com/starquake/topbanana/internal/session"
 )
 
 func TestLoginRateLimiter_AllowsFirstThenBlocks(t *testing.T) {
@@ -62,111 +57,4 @@ func TestLoginRateLimiter_AdmitsAfterWindow(t *testing.T) {
 	if _, ok := limiter.Allow("1.2.3.4"); !ok {
 		t.Error("Allow after window = false, want true")
 	}
-}
-
-// TestHandleLoginSubmit_RateLimited pins the #494 contract: a second
-// POST inside the cool-down renders the 429 banner regardless of
-// credential validity, with Retry-After set. Uses the same fake
-// httptest peer IP so both requests share the limiter bucket.
-func TestHandleLoginSubmit_RateLimited(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	limiter := NewLoginRateLimiter(time.Minute, nil)
-	handler := HandleLoginSubmit(
-		discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), limiter),
-	)
-
-	first := postLogin(t, handler, "alice", "wrong-password")
-	if got, want := first.Code, http.StatusUnauthorized; got != want {
-		t.Fatalf("first POST status = %d, want %d", got, want)
-	}
-
-	second := postLogin(t, handler, "alice", "wrong-password")
-	if got, want := second.Code, http.StatusTooManyRequests; got != want {
-		t.Errorf("second POST status = %d, want %d", got, want)
-	}
-	if got := second.Header().Get("Retry-After"); got == "" {
-		t.Error("Retry-After header empty on rate-limited second POST")
-	}
-	if got, want := second.Body.String(), "Too many attempts"; !strings.Contains(got, want) {
-		t.Errorf("body should contain %q, got %q", want, got)
-	}
-}
-
-// TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser pins the
-// "always trip regardless of displayName existence" design constraint:
-// the limiter check runs BEFORE the credential lookup, so two POSTs
-// against a non-existent displayName also trip the second response.
-func TestHandleLoginSubmit_RateLimitedFiresOnUnknownUser(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	limiter := NewLoginRateLimiter(time.Minute, nil)
-	handler := HandleLoginSubmit(
-		discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), limiter),
-	)
-
-	first := postLogin(t, handler, "ghost", "whatever-password")
-	if got, want := first.Code, http.StatusUnauthorized; got != want {
-		t.Fatalf("first POST status = %d, want %d", got, want)
-	}
-
-	second := postLogin(t, handler, "ghost", "whatever-password")
-	if got, want := second.Code, http.StatusTooManyRequests; got != want {
-		t.Errorf("second POST status = %d, want %d (limiter must fire on unknown users too)", got, want)
-	}
-}
-
-// TestHandleLoginSubmit_RateLimitedRefusesCorrectCredentials pins the
-// invariant that the limiter check runs BEFORE the credential check,
-// so a hot bucket blocks a valid login attempt too. Without this, an
-// attacker who burned the window with garbage attempts could still
-// race a legitimate user's correct submission through.
-func TestHandleLoginSubmit_RateLimitedRefusesCorrectCredentials(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	hash, err := HashPassword("correctbattery")
-	if err != nil {
-		t.Fatalf("HashPassword err = %v, want nil", err)
-	}
-	if _, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
-		t.Fatalf("CreatePlayer err = %v, want nil", err)
-	}
-	markVerified(t, store, "alice")
-
-	limiter := NewLoginRateLimiter(time.Minute, nil)
-	handler := HandleLoginSubmit(
-		discardLogger(), nil,
-		loginDeps(store, session.New([]byte("k"), true), limiter),
-	)
-
-	first := postLogin(t, handler, "alice", "wrong-password")
-	if got, want := first.Code, http.StatusUnauthorized; got != want {
-		t.Fatalf("first POST status = %d, want %d", got, want)
-	}
-
-	second := postLogin(t, handler, "alice", "correctbattery")
-	if got, want := second.Code, http.StatusTooManyRequests; got != want {
-		t.Errorf(
-			"second POST status = %d, want %d (limiter must gate even valid creds)",
-			got, want,
-		)
-	}
-}
-
-func postLogin(t *testing.T, handler http.Handler, displayName, password string) *httptest.ResponseRecorder {
-	t.Helper()
-	form := url.Values{"displayName": {displayName}, "password": {password}}
-	req := httptest.NewRequestWithContext(
-		t.Context(), http.MethodPost, "/login", strings.NewReader(form.Encode()),
-	)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	return rec
 }

--- a/internal/auth/middleware_faults_test.go
+++ b/internal/auth/middleware_faults_test.go
@@ -1,0 +1,160 @@
+package auth_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/session"
+)
+
+func TestRequireGameHost_StoreError_500(t *testing.T) {
+	t.Parallel()
+
+	store := newFakePlayerStore()
+	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	store.failGet = true
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("next should not be called when store errors")
+	})
+
+	sessions := session.New([]byte("k"), true)
+	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, admin.ID, 0)
+	cookie := rec.Result().Cookies()[0]
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
+	t.Parallel()
+
+	store := newFakePlayerStore()
+	// Force the first three CreateAnonymousPlayer calls to return
+	// ErrDisplayNameTaken; the fourth attempt should succeed and produce a
+	// regular petname row.
+	store.forceAnonCollisions = 3
+	sessions := session.New([]byte("k"), true)
+
+	var seenPlayer *Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = PlayerFromContext(r.Context())
+	})
+
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; middleware should have retried past the collisions")
+	}
+	if got := seenPlayer.DisplayName; strings.HasPrefix(got, "anon-") {
+		t.Errorf("seenPlayer.DisplayName = %q, want a petname-style name (no anon- fallback)", got)
+	}
+	if got, want := strings.Count(seenPlayer.DisplayName, "-"), 2; got != want {
+		t.Errorf("seenPlayer.DisplayName = %q, want %d hyphens", seenPlayer.DisplayName, want)
+	}
+}
+
+func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
+	t.Parallel()
+
+	store := newFakePlayerStore()
+	// Force every petname attempt (5) to collide so the fallback xid path
+	// has to run.
+	store.forceAnonCollisions = 5
+	sessions := session.New([]byte("k"), true)
+
+	var seenPlayer *Player
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seenPlayer, _ = PlayerFromContext(r.Context())
+	})
+
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if seenPlayer == nil {
+		t.Fatal("PlayerFromContext returned nil player; fallback should have produced one")
+	}
+	if got, want := seenPlayer.DisplayName[:5], "anon-"; got != want {
+		t.Errorf("seenPlayer.DisplayName prefix = %q, want %q (xid fallback after exhausted retries)", got, want)
+	}
+}
+
+func TestEnsurePlayer_CreateAnonymousNonCollisionError_500(t *testing.T) {
+	t.Parallel()
+
+	store := newFakePlayerStore()
+	store.forceAnonErr = errors.New("boom")
+	sessions := session.New([]byte("k"), true)
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("next should not be called when CreateAnonymousPlayer returns a non-collision error")
+	})
+
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
+	t.Parallel()
+
+	store := newFakePlayerStore()
+	existing, err := store.CreateAnonymousPlayer(t.Context(), "anon-x")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	store.failGet = true
+
+	sessions := session.New([]byte("k"), true)
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("next should not be called on store error")
+	})
+
+	mw := EnsurePlayer(next, store, sessions, discardLogger())
+
+	rec := httptest.NewRecorder()
+	sessions.Set(rec, existing.ID, 0)
+	cookie := rec.Result().Cookies()[0]
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), "internal error"; !strings.Contains(got, want) {
+		t.Errorf("body = %q, should contain %q", got, want)
+	}
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,34 +1,24 @@
+//go:build integration
+
 package auth_test
 
 import (
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
 )
-
-// findCookie returns the first response cookie with the given name and a
-// boolean reporting whether it was found. Used by the EnsurePlayer tests to
-// assert that a fresh session cookie is set on the response.
-func findCookie(rec *httptest.ResponseRecorder, name string) (*http.Cookie, bool) {
-	for _, c := range rec.Result().Cookies() {
-		if c.Name == name {
-			return c, true
-		}
-	}
-
-	return nil, false
-}
 
 func TestRequireGameHost_AllowsAdmin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	admin, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -43,7 +33,7 @@ func TestRequireGameHost_AllowsAdmin(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
+	mw := RequireGameHost(next, players, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID, 0)
@@ -74,13 +64,21 @@ func TestRequireGameHost_AllowsAdmin(t *testing.T) {
 func TestRequireGameHost_DeniesPlayer(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	// Pre-seed an admin so the next CreatePlayer call is not auto-promoted to admin
-	// by the "first password-bearing registrant becomes admin" rule.
-	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "h", RoleAdmin); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	// Pre-seed a credentialled admin so the next CreatePlayer call is not
+	// auto-promoted to admin by the "first password-bearing registrant
+	// becomes admin" rule. (The migration-seeded admin row has no
+	// password_hash, so it does not count for that rule.)
+	if _, err := players.CreatePlayer(
+		t.Context(),
+		"seed-admin",
+		"seed-admin@example.test",
+		"h",
+		RoleAdmin,
+	); err != nil {
 		t.Fatalf("seed admin err = %v, want nil", err)
 	}
-	player, err := store.CreatePlayer(t.Context(), "bob", "bob@example.test", "h", RolePlayer)
+	player, err := players.CreatePlayer(t.Context(), "bob", "bob@example.test", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -90,7 +88,7 @@ func TestRequireGameHost_DeniesPlayer(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
+	mw := RequireGameHost(next, players, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID, 0)
@@ -115,12 +113,12 @@ func TestRequireGameHost_DeniesPlayer(t *testing.T) {
 func TestRequireGameHost_NoCookie_RedirectsToLogin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called without cookie")
 	})
 
-	mw := RequireGameHost(next, store, session.New([]byte("k"), true), nil, discardLogger())
+	mw := RequireGameHost(next, players, session.New([]byte("k"), true), nil, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -144,12 +142,12 @@ func TestRequireGameHost_NoCookie_RedirectsToLogin(t *testing.T) {
 func TestRequireGameHost_PostDropsNext(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called without cookie")
 	})
 
-	mw := RequireGameHost(next, store, session.New([]byte("k"), true), nil, discardLogger())
+	mw := RequireGameHost(next, players, session.New([]byte("k"), true), nil, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -166,13 +164,13 @@ func TestRequireGameHost_PostDropsNext(t *testing.T) {
 func TestRequireGameHost_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called for unknown player")
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
+	mw := RequireGameHost(next, players, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, 9999, 0)
@@ -188,52 +186,29 @@ func TestRequireGameHost_UnknownPlayerID_RedirectsToLogin(t *testing.T) {
 	}
 }
 
-func TestRequireGameHost_StoreError_500(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
-	if err != nil {
-		t.Fatalf("CreatePlayer err = %v, want nil", err)
-	}
-	store.failGet = true
-
-	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Error("next should not be called when store errors")
-	})
-
-	sessions := session.New([]byte("k"), true)
-	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
-
-	rec := httptest.NewRecorder()
-	sessions.Set(rec, admin.ID, 0)
-	cookie := rec.Result().Cookies()[0]
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes", nil)
-	req.AddCookie(cookie)
-	rec = httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if got, want := rec.Code, http.StatusInternalServerError; got != want {
-		t.Errorf("status = %d, want %d", got, want)
-	}
-}
-
 // TestRequireGameHost_AllowsHost pins that a Host (middle tier) reaches the
 // dashboard routes (#538). A pre-seeded admin keeps the new row off the
 // first-registrant promotion; the row is then bumped to Host directly.
 func TestRequireGameHost_AllowsHost(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "h", RoleAdmin); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(
+		t.Context(),
+		"seed-admin",
+		"seed-admin@example.test",
+		"h",
+		RoleAdmin,
+	); err != nil {
 		t.Fatalf("seed admin err = %v, want nil", err)
 	}
-	host, err := store.CreatePlayer(t.Context(), "hank", "hank@example.test", "h", RolePlayer)
+	host, err := players.CreatePlayer(t.Context(), "hank", "hank@example.test", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	host.Role = RoleHost
+	if err = players.SetPlayerRole(t.Context(), host.ID, RoleHost); err != nil {
+		t.Fatalf("SetPlayerRole err = %v, want nil", err)
+	}
 
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -242,7 +217,7 @@ func TestRequireGameHost_AllowsHost(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireGameHost(next, store, sessions, nil, discardLogger())
+	mw := RequireGameHost(next, players, sessions, nil, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, host.ID, 0)
@@ -266,8 +241,8 @@ func TestRequireGameHost_AllowsHost(t *testing.T) {
 func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	admin, err := store.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	admin, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", "h", RoleAdmin)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -279,7 +254,7 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireAdmin(next, store, sessions, discardLogger())
+	mw := RequireAdmin(next, players, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, admin.ID, 0)
@@ -304,22 +279,30 @@ func TestRequireAdmin_AllowsAdmin(t *testing.T) {
 func TestRequireAdmin_DeniesHostWith404(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	if _, err := store.CreatePlayer(t.Context(), "admin", "admin@example.test", "h", RoleAdmin); err != nil {
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(
+		t.Context(),
+		"seed-admin",
+		"seed-admin@example.test",
+		"h",
+		RoleAdmin,
+	); err != nil {
 		t.Fatalf("seed admin err = %v, want nil", err)
 	}
-	host, err := store.CreatePlayer(t.Context(), "hank", "hank@example.test", "h", RolePlayer)
+	host, err := players.CreatePlayer(t.Context(), "hank", "hank@example.test", "h", RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
-	host.Role = RoleHost
+	if err = players.SetPlayerRole(t.Context(), host.ID, RoleHost); err != nil {
+		t.Fatalf("SetPlayerRole err = %v, want nil", err)
+	}
 
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("next should not be called for a host on an admin-only route")
 	})
 
 	sessions := session.New([]byte("k"), true)
-	mw := RequireAdmin(next, store, sessions, discardLogger())
+	mw := RequireAdmin(next, players, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, host.ID, 0)
@@ -338,7 +321,7 @@ func TestRequireAdmin_DeniesHostWith404(t *testing.T) {
 func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *Player
@@ -349,7 +332,7 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	})
 
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, players, sessions, discardLogger())
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
 	rec := httptest.NewRecorder()
@@ -392,8 +375,8 @@ func TestEnsurePlayer_NoCookie_CreatesAnonymousAndSetsCookie(t *testing.T) {
 func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
-	existing, err := store.CreateAnonymousPlayer(t.Context(), "anon-existing")
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	existing, err := players.CreateAnonymousPlayer(t.Context(), "anon-existing")
 	if err != nil {
 		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
 	}
@@ -405,7 +388,7 @@ func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, players, sessions, discardLogger())
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, existing.ID, 0)
@@ -430,7 +413,7 @@ func TestEnsurePlayer_ValidCookie_ReusesExistingRow(t *testing.T) {
 func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	sessions := session.New([]byte("k"), true)
 
 	var seenPlayer *Player
@@ -438,7 +421,7 @@ func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 		seenPlayer, _ = PlayerFromContext(r.Context())
 	})
 
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, players, sessions, discardLogger())
 
 	// Issue a cookie pointing at an ID that does not exist in the store.
 	rec := httptest.NewRecorder()
@@ -467,7 +450,7 @@ func TestEnsurePlayer_DeletedPlayer_MintsNewAnonymous(t *testing.T) {
 func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 	t.Parallel()
 
-	store := newStubPlayerStore()
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
 	sessions := session.New([]byte("k"), true)
 
 	var seenIDs []int64
@@ -476,7 +459,7 @@ func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 		seenIDs = append(seenIDs, p.ID)
 	})
 
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
+	mw := EnsurePlayer(next, players, sessions, discardLogger())
 
 	for range 2 {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
@@ -488,122 +471,5 @@ func TestEnsurePlayer_TwoCookielessRequests_TwoDistinctPlayers(t *testing.T) {
 	}
 	if seenIDs[0] == seenIDs[1] {
 		t.Errorf("two cookieless requests produced the same player ID %d, want distinct", seenIDs[0])
-	}
-}
-
-func TestEnsurePlayer_PetnameCollision_Retries(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	// Force the first three CreateAnonymousPlayer calls to return
-	// ErrDisplayNameTaken; the fourth attempt should succeed and produce a
-	// regular petname row.
-	store.forceAnonCollisions = 3
-	sessions := session.New([]byte("k"), true)
-
-	var seenPlayer *Player
-	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = PlayerFromContext(r.Context())
-	})
-
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
-	rec := httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if seenPlayer == nil {
-		t.Fatal("PlayerFromContext returned nil player; middleware should have retried past the collisions")
-	}
-	if got := seenPlayer.DisplayName; strings.HasPrefix(got, "anon-") {
-		t.Errorf("seenPlayer.DisplayName = %q, want a petname-style name (no anon- fallback)", got)
-	}
-	if got, want := strings.Count(seenPlayer.DisplayName, "-"), 2; got != want {
-		t.Errorf("seenPlayer.DisplayName = %q, want %d hyphens", seenPlayer.DisplayName, want)
-	}
-}
-
-func TestEnsurePlayer_PetnameExhausted_FallsBackToXid(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	// Force every petname attempt (5) to collide so the fallback xid path
-	// has to run.
-	store.forceAnonCollisions = 5
-	sessions := session.New([]byte("k"), true)
-
-	var seenPlayer *Player
-	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		seenPlayer, _ = PlayerFromContext(r.Context())
-	})
-
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
-	rec := httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if seenPlayer == nil {
-		t.Fatal("PlayerFromContext returned nil player; fallback should have produced one")
-	}
-	if got, want := seenPlayer.DisplayName[:5], "anon-"; got != want {
-		t.Errorf("seenPlayer.DisplayName prefix = %q, want %q (xid fallback after exhausted retries)", got, want)
-	}
-}
-
-func TestEnsurePlayer_CreateAnonymousNonCollisionError_500(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	store.forceAnonErr = errors.New("boom")
-	sessions := session.New([]byte("k"), true)
-
-	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Error("next should not be called when CreateAnonymousPlayer returns a non-collision error")
-	})
-
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
-	rec := httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if got, want := rec.Code, http.StatusInternalServerError; got != want {
-		t.Errorf("status = %d, want %d", got, want)
-	}
-}
-
-func TestEnsurePlayer_GetPlayerError_500(t *testing.T) {
-	t.Parallel()
-
-	store := newStubPlayerStore()
-	existing, err := store.CreateAnonymousPlayer(t.Context(), "anon-x")
-	if err != nil {
-		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
-	}
-	store.failGet = true
-
-	sessions := session.New([]byte("k"), true)
-
-	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Error("next should not be called on store error")
-	})
-
-	mw := EnsurePlayer(next, store, sessions, discardLogger())
-
-	rec := httptest.NewRecorder()
-	sessions.Set(rec, existing.ID, 0)
-	cookie := rec.Result().Cookies()[0]
-
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes", nil)
-	req.AddCookie(cookie)
-	rec = httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	if got, want := rec.Code, http.StatusInternalServerError; got != want {
-		t.Errorf("status = %d, want %d", got, want)
-	}
-	if got, want := rec.Body.String(), "internal error"; !strings.Contains(got, want) {
-		t.Errorf("body = %q, should contain %q", got, want)
 	}
 }

--- a/internal/auth/playerstore_fake_test.go
+++ b/internal/auth/playerstore_fake_test.go
@@ -1,0 +1,155 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	. "github.com/starquake/topbanana/internal/auth"
+)
+
+// fakePlayerStore is a fault-injection PlayerStore for the handful of
+// middleware tests that pin error branches a real store cannot produce
+// on demand. Three knobs drive those branches:
+//
+//   - failGet makes GetPlayerByID return a non-sentinel error, so the
+//     "load existing session player failed" 500 path fires without
+//     having to corrupt a real row.
+//   - forceAnonCollisions makes the next N CreateAnonymousPlayer calls
+//     return ErrDisplayNameTaken, exercising the bounded petname retry
+//     loop and its xid fallback. A real store cannot collide on demand:
+//     petnames are generated randomly, so N consecutive forced
+//     collisions are not reproducible against live UNIQUE indexes.
+//   - forceAnonErr makes the next CreateAnonymousPlayer return a chosen
+//     non-collision error, exercising the EnsurePlayer 500 branch.
+//
+// Every other interface method is minimal (mint an id on create,
+// not-found / unsupported otherwise): these tests only ever reach the
+// three knobbed paths, so an unexpected call on any other method should
+// surface loudly rather than pass silently. Tautological tests that
+// just need a working player store use a real store.New instead.
+type fakePlayerStore struct {
+	mu     sync.Mutex
+	nextID int64
+	// failGet, when true, makes GetPlayerByID return a non-sentinel error.
+	failGet bool
+	// forceAnonCollisions, when > 0, makes the next N CreateAnonymousPlayer
+	// calls return ErrDisplayNameTaken without inserting. Each call
+	// decrements the counter; once it reaches zero the fake returns to its
+	// normal id-minting behaviour.
+	forceAnonCollisions int
+	// forceAnonErr, when set, is returned by the next CreateAnonymousPlayer
+	// call and then cleared, so a single request exercises one error branch
+	// without leaking the failure into a follow-up call.
+	forceAnonErr error
+}
+
+func newFakePlayerStore() *fakePlayerStore {
+	return &fakePlayerStore{nextID: 1}
+}
+
+func (s *fakePlayerStore) GetPlayerByID(_ context.Context, id int64) (*Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.failGet {
+		return nil, errors.New("boom")
+	}
+
+	return &Player{ID: id, Role: RolePlayer}, nil
+}
+
+func (s *fakePlayerStore) CreateAnonymousPlayer(_ context.Context, displayName string) (*Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.forceAnonErr != nil {
+		err := s.forceAnonErr
+		s.forceAnonErr = nil
+
+		return nil, err
+	}
+	if s.forceAnonCollisions > 0 {
+		s.forceAnonCollisions--
+
+		return nil, ErrDisplayNameTaken
+	}
+
+	p := &Player{ID: s.nextID, DisplayName: displayName, Role: RolePlayer}
+	s.nextID++
+
+	return p, nil
+}
+
+// CreatePlayer mints a row so the failGet tests can seed a player and set
+// a session cookie before flipping the knob; role is irrelevant because
+// failGet short-circuits GetPlayerByID before any role check.
+func (s *fakePlayerStore) CreatePlayer(
+	_ context.Context, displayName, email, passwordHash, _ string,
+) (*Player, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p := &Player{
+		ID:           s.nextID,
+		DisplayName:  displayName,
+		Email:        email,
+		PasswordHash: passwordHash,
+		Role:         RolePlayer,
+	}
+	s.nextID++
+
+	return p, nil
+}
+
+func (*fakePlayerStore) GetPlayerByDisplayName(_ context.Context, _ string) (*Player, error) {
+	return nil, ErrPlayerNotFound
+}
+
+func (*fakePlayerStore) GetPlayerByEmail(_ context.Context, _ string) (*Player, error) {
+	return nil, ErrPlayerNotFound
+}
+
+func (*fakePlayerStore) ClaimPlayer(
+	_ context.Context, _ int64, _, _, _, _ string,
+) (*Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*fakePlayerStore) UpdatePlayerDisplayName(
+	_ context.Context, _ int64, _ string,
+) (*Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*fakePlayerStore) RenamePlayer(_ context.Context, _ int64, _ string) (*Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*fakePlayerStore) SetPlayerPasswordHash(_ context.Context, _, _ string) error {
+	return errors.ErrUnsupported
+}
+
+func (*fakePlayerStore) ChangePlayerPassword(_ context.Context, _ int64, _ string) error {
+	return errors.ErrUnsupported
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// findCookie returns the first response cookie with the given name and a
+// boolean reporting whether it was found. Used by the EnsurePlayer tests to
+// assert that a fresh session cookie is set on the response.
+func findCookie(rec *httptest.ResponseRecorder, name string) (*http.Cookie, bool) {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			return c, true
+		}
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
Final auth sub-slice of #638: the `stubPlayerStore` cluster. Completes the auth package de-stub.

The nuance here is the point of the exercise: convert the *tautological* store tests to real stores, but keep a SLIM fault-injection fake for the three branches a real store genuinely can't produce.

- `playerstore_fake_test.go` (new, untagged): the only remaining player-store double -- a slim `fakePlayerStore` keeping exactly the three meaningful knobs: `failGet` (GetPlayerByID error), `forceAnonCollisions` (forced petname collisions), `forceAnonErr` (anon-create error). Everything else minimal. Documented as a fault-injection double.
- `middleware_faults_test.go` (new, untagged): the 5 tests that need those knobs (EnsurePlayer petname retry/exhaustion, anon-create error, GetPlayerByID failure, RequireGameHost store error) -- pure-logic unit tests on the fake.
- `handler_test.go` (now integration): all 34 login/register flow tests on real `store.NewPlayerStore(dbtest.Open(t))`.
- `middleware_test.go` (now integration): the 12 plain-lookup RequireAdmin/RequireGameHost/EnsurePlayer happy-path tests on real stores.
- `login_limiter_login_test.go` (new, integration): the 3 store-driven login-submit rate-limit tests; `login_limiter_test.go` keeps the 3 pure-limiter-logic tests untagged.
- Deleted the full `stubPlayerStore`.

No test dropped: 143 `Test*` functions, identical to main. `rg 'stubPlayerStore'` is now empty; `fakePlayerStore` is the only player-store double.

Verified: `go vet` both flavors; `make test` keeps the fault-injection + pure-logic tests; `make check` passes (79.9%); lint clean (incl. `--build-tags=integration`); `-race` passes both flavors.

#638 remaining after this: `clientapi`, `admin`.