### PR TITLE
Harden the cooldown e2e test against firefox CI timing

### DIFF
--- a/test/e2e/tests/cooldown.spec.ts
+++ b/test/e2e/tests/cooldown.spec.ts
@@ -34,12 +34,18 @@ test('forgot-password cooldown button counts down and re-enables', async ({ page
   // countdown.
   await page.locator('input[name=identifier]').fill('nobody@example.test');
   await submit.click();
+  // Wait for the PRG redirect to land before asserting, and give the
+  // disabled-state checks a generous timeout: under firefox on a loaded CI
+  // runner the redirect + render can exceed the default 5s, which flaked the
+  // button-disabled assertion -- and once the first attempt failed, the armed
+  // 60s per-IP limiter then doomed the retry. See #643.
+  await page.waitForURL(/\/forgot-password$/);
 
   // The stable locator always resolves, so these state assertions auto-wait
   // through the redirect and cooldown.js's relabel. Tolerate any countdown
   // value rather than the exact "Wait 60s" frame, which is racy under load.
-  await expect(submit).toBeDisabled();
-  await expect(submit).toHaveText(/^Wait \d+s$/);
+  await expect(submit).toBeDisabled({ timeout: 15_000 });
+  await expect(submit).toHaveText(/^Wait \d+s$/, { timeout: 15_000 });
 
   // Advance past the full 60s cooldown without real waiting. runFor
   // (not fastForward) fires every intermediate 1s tick of cooldown.js's


### PR DESCRIPTION
Follow-up to #643, which reduced but did not eliminate the flake. It recurred on firefox CI (blocking #652's run).

#643 fixed the *locator* (the name-based locator returned "element not found"). This run's failure was different: the stable `button[type=submit]` locator resolved fine, but `expect(submit).toBeDisabled()` **timed out at the default 5s** -- the button *does* reach the disabled "Wait Ns" state (the retry log showed "Wait 49s"), the redirect + render just took longer than 5s under firefox on a loaded runner. And once that first attempt failed, the armed 60s per-IP limiter doomed the retry (the second submit then clicked a disabled button -> 30s timeout).

The forgot-password cooldown is a hardcoded 60s (not env-configurable), so a short-cooldown e2e tweak isn't available without a production change + a second-submit-window race. The proportionate fix targets the actual failure:
- `await page.waitForURL(/forgot-password$/)` after the second submit, so assertions run after the redirect lands;
- `toBeDisabled` / `toHaveText` get a 15s timeout to absorb firefox-under-load.

A reliable first attempt means no doomed retry. Validated locally on chromium + firefox.