### PR TITLE
Unit-test the version commit-resolution branches

### DIFF
--- a/internal/version/export_test.go
+++ b/internal/version/export_test.go
@@ -1,0 +1,6 @@
+package version
+
+// CommitFromSettings exposes the unexported VCS-settings parser so its
+// revision / dirty / no-revision branches can be unit-tested with
+// synthetic settings, independent of how the test binary was built.
+var CommitFromSettings = commitFromSettings

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -79,8 +79,18 @@ func resolvedCommit() string {
 		return ""
 	}
 
+	return commitFromSettings(info.Settings)
+}
+
+// commitFromSettings derives the short commit from a build's VCS
+// settings: the short vcs.revision, plus a "-dirty" marker when
+// vcs.modified is set. Returns "" when no revision is recorded (e.g. a
+// build by file path, which Go does not VCS-stamp). Split out from
+// resolvedCommit so the revision/dirty branches are unit-testable with
+// synthetic settings, without depending on how the test binary was built.
+func commitFromSettings(settings []debug.BuildSetting) string {
 	var revision, modified string
-	for _, s := range info.Settings {
+	for _, s := range settings {
 		switch s.Key {
 		case "vcs.revision":
 			revision = s.Value

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,10 +1,41 @@
 package version_test
 
 import (
+	"runtime/debug"
 	"testing"
 
 	. "github.com/starquake/topbanana/internal/version"
 )
+
+func TestCommitFromSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		want     string
+	}{
+		{"no revision recorded", []debug.BuildSetting{{Key: "GOARCH", Value: "amd64"}}, ""},
+		{"clean revision", []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+			{Key: "vcs.modified", Value: "false"},
+		}, "0123456"},
+		{"dirty revision", []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "0123456789abcdef"},
+			{Key: "vcs.modified", Value: "true"},
+		}, "0123456-dirty"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := CommitFromSettings(tc.settings), tc.want; got != want {
+				t.Errorf("CommitFromSettings(%v) = %q, want %q", tc.settings, got, want)
+			}
+		})
+	}
+}
 
 // These tests mutate the package-level build-stamp vars and the
 // process-wide env, so they must run serially: t.Parallel would let two


### PR DESCRIPTION
Follow-up to the version-display feature (#665): extract the VCS-settings parsing in `internal/version` into a pure `commitFromSettings` and unit-test its revision / dirty / no-revision branches (previously only reachable via `runtime/debug.ReadBuildInfo`). A small slice of #667.