### PR TITLE
Enforce a total test-coverage floor in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
       with:
         config: .testcoverage.yml
 
+        # Enforced total-coverage floor. The action's threshold-total input
+        # defaults to -1 (gate off) and overrides any value in the config
+        # file, so the threshold has to live here to take effect. Set just
+        # below current coverage as a regression floor; ratchet up toward
+        # 80 as coverage rises (#667).
+        threshold-total: 79
+
         ## when token is not specified (value '') this feature is turned off
         ## in this example badge is created and committed only for main branch
         git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,7 +1,8 @@
 # Test coverage configuration
 
-# Threshold for total coverage (percentage)
-threshold-total: 80
+# Total-coverage threshold is enforced in .github/workflows/ci.yml: the
+# action's threshold-total input defaults to -1 and overrides any value
+# set here, so a threshold in this file has no effect. See #667.
 
 # List of packages to exclude from coverage report
 exclude:


### PR DESCRIPTION
The `vladopajic/go-test-coverage` step ran with `threshold-total: -1` (the action's input default), which overrides the value in `.testcoverage.yml`, so the coverage check was advisory only -- it computed the number and pushed the badge but never failed a build. main sits at 79.5%.

This sets `threshold-total: 79` in the workflow `with:` block (the only place the action honors) as a regression floor: a PR that drops total coverage below 79% now fails the required `build` check. The floor is set just under current coverage so it locks in the level without breaking existing PRs; ratchet it toward 80 as coverage rises.

The dead `threshold-total` in `.testcoverage.yml` is replaced with a comment pointing at the workflow, so the two can't drift.

Part of #667.