### PR TITLE
Raise store and helper coverage and lift the CI floor to 80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,9 @@ jobs:
         # Enforced total-coverage floor. The action's threshold-total input
         # defaults to -1 (gate off) and overrides any value in the config
         # file, so the threshold has to live here to take effect. Set just
-        # below current coverage as a regression floor; ratchet up toward
-        # 80 as coverage rises (#667).
-        threshold-total: 79
+        # below current coverage as a regression floor; ratchet up as
+        # coverage rises (#667).
+        threshold-total: 80
 
         ## when token is not specified (value '') this feature is turned off
         ## in this example badge is created and committed only for main branch

--- a/internal/admin/export_test.go
+++ b/internal/admin/export_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/starquake/topbanana/internal/quiz"
 )
@@ -114,3 +115,27 @@ func ValidateQuestionForm(ctx context.Context, q *quiz.Question) map[string]stri
 // MaxOptions exposes the per-question option cap so tests can build a
 // payload one over the limit without hard-coding the value.
 const MaxOptions = maxOptions
+
+// ParseOptionalTimeLimit exposes the unexported per-question
+// time_limit_seconds parser so the external admin_test package can pin
+// the blank / valid / garbage mapping without driving the form handler.
+var ParseOptionalTimeLimit = parseOptionalTimeLimit
+
+// NewPlayerInputResult is the test-visible projection of the unexported
+// newPlayerCreateInput: the resolved display name and the first
+// validation error message. Returned by [NewPlayerInputResultFor] so the
+// external admin_test package can pin newPlayerInput's branches without
+// reaching the unexported errMsg field.
+type NewPlayerInputResult struct {
+	DisplayName string
+	ErrMsg      string
+}
+
+// NewPlayerInputResultFor runs the unexported newPlayerInput against r and
+// projects the result so the external admin_test package can assert the
+// petname fallback and the per-field validation messages.
+func NewPlayerInputResultFor(r *http.Request) NewPlayerInputResult {
+	in := newPlayerInput(r)
+
+	return NewPlayerInputResult{DisplayName: in.DisplayName, ErrMsg: in.errMsg}
+}

--- a/internal/admin/forms_test.go
+++ b/internal/admin/forms_test.go
@@ -292,3 +292,51 @@ func TestQuestionForm_Valid_OptionRules(t *testing.T) {
 		})
 	}
 }
+
+func TestParseOptionalTimeLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		raw     string
+		wantNil bool
+		want    int
+	}{
+		"blank yields nil (inherit quiz default)": {
+			raw:     "",
+			wantNil: true,
+		},
+		"whitespace-only yields nil": {
+			raw:     "   ",
+			wantNil: true,
+		},
+		"valid number yields a pointer to it": {
+			raw:  "45",
+			want: 45,
+		},
+		"non-numeric yields a pointer to 0": {
+			raw:  "abc",
+			want: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseOptionalTimeLimit(tc.raw)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("ParseOptionalTimeLimit(%q) = %v, want nil", tc.raw, *got)
+				}
+
+				return
+			}
+			if got == nil {
+				t.Fatalf("ParseOptionalTimeLimit(%q) = nil, want %d", tc.raw, tc.want)
+			}
+			if *got != tc.want {
+				t.Errorf("ParseOptionalTimeLimit(%q) = %d, want %d", tc.raw, *got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/admin/playeractions_credentials_test.go
+++ b/internal/admin/playeractions_credentials_test.go
@@ -211,3 +211,84 @@ func TestHandlePlayerSetPassword_TooShortRejectedNoMutation(t *testing.T) {
 		t.Errorf("audit entries = %d, want %d on a rejected password", got, want)
 	}
 }
+
+// newPlayerInputRequest builds a POST request carrying the create-player
+// form fields as a urlencoded body. httptest.NewRequest is banned by the
+// noctx linter, so the request is built with a context.
+func newPlayerInputRequest(t *testing.T, displayName, email, password string) *http.Request {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("display_name", displayName)
+	form.Set("email", email)
+	form.Set("password", password)
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/admin/players", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+func TestNewPlayerInput(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validEmail = "new@example.test"
+		// MinPasswordLength is 13, MaxPasswordLength is 72.
+		validPassword = "correct-horse-battery"
+	)
+
+	t.Run("blank display name falls back to a generated petname", func(t *testing.T) {
+		t.Parallel()
+
+		got := NewPlayerInputResultFor(newPlayerInputRequest(t, "", validEmail, validPassword))
+		if got.DisplayName == "" {
+			t.Error("DisplayName = empty, want a generated petname")
+		}
+		if got.ErrMsg != "" {
+			t.Errorf("ErrMsg = %q, want empty", got.ErrMsg)
+		}
+	})
+
+	t.Run("invalid email is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		got := NewPlayerInputResultFor(newPlayerInputRequest(t, "Alice", "not-an-email", validPassword))
+		if want := "Enter a valid email address."; got.ErrMsg != want {
+			t.Errorf("ErrMsg = %q, want %q", got.ErrMsg, want)
+		}
+	})
+
+	t.Run("too-short password is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		got := NewPlayerInputResultFor(newPlayerInputRequest(t, "Alice", validEmail, "short"))
+		if want := "at least"; !strings.Contains(got.ErrMsg, want) {
+			t.Errorf("ErrMsg = %q, should contain %q", got.ErrMsg, want)
+		}
+	})
+
+	t.Run("too-long password is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		got := NewPlayerInputResultFor(
+			newPlayerInputRequest(t, "Alice", validEmail, strings.Repeat("x", 73)),
+		)
+		if want := "at most"; !strings.Contains(got.ErrMsg, want) {
+			t.Errorf("ErrMsg = %q, should contain %q", got.ErrMsg, want)
+		}
+	})
+
+	t.Run("valid input has no error message", func(t *testing.T) {
+		t.Parallel()
+
+		got := NewPlayerInputResultFor(newPlayerInputRequest(t, "Alice", validEmail, validPassword))
+		if got.ErrMsg != "" {
+			t.Errorf("ErrMsg = %q, want empty", got.ErrMsg)
+		}
+		if got.DisplayName != "Alice" {
+			t.Errorf("DisplayName = %q, want %q", got.DisplayName, "Alice")
+		}
+	})
+}

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -1,0 +1,6 @@
+package store
+
+// ParseSQLiteTimestamp exposes the unexported parseSQLiteTimestamp helper
+// so the external store_test package can pin its two accepted formats and
+// the nil-on-unparseable fall-through without exporting it from the package.
+var ParseSQLiteTimestamp = parseSQLiteTimestamp

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -179,6 +179,65 @@ func TestGameStore_CreateParticipant(t *testing.T) {
 			t.Error("p.JoinedAt is zero, want non-zero time")
 		}
 	})
+
+	t.Run("returns ErrGameAlreadyExists on the (player, quiz) UNIQUE collision", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-participant-dup")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		first := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), first); err != nil {
+			t.Fatalf("failed to create first game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: first.ID, PlayerID: player.ID, QuizID: testQuiz.ID},
+		); err != nil {
+			t.Fatalf("failed to create first participant: %v", err)
+		}
+
+		// A second participant for the same (player, quiz) trips the
+		// UNIQUE INDEX from 20260520180000.
+		second := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), second); err != nil {
+			t.Fatalf("failed to create second game: %v", err)
+		}
+		err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: second.ID, PlayerID: player.ID, QuizID: testQuiz.ID},
+		)
+		if got, want := err, game.ErrGameAlreadyExists; !errors.Is(got, want) {
+			t.Errorf("CreateParticipant err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("wraps the underlying error on a closed DB", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		gameStore := NewGameStore(db, slog.Default())
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close db: %v", err)
+		}
+
+		err := gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: "g", PlayerID: 1, QuizID: 1},
+		)
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to create participant"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
 }
 
 func TestGameStore_CreateQuestion(t *testing.T) {
@@ -265,6 +324,81 @@ func TestGameStore_CreateAnswer(t *testing.T) {
 		}
 		if got, want := a.AnsweredAt, tappedAt; !got.Equal(want) {
 			t.Errorf("a.AnsweredAt = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns ErrAnswerAlreadyRecorded on a duplicate answer", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err := gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+
+		now := time.Now()
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err := gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+
+		a := &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   1,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+			AnsweredAt: now,
+		}
+		if err := gameStore.CreateAnswer(t.Context(), a); err != nil {
+			t.Fatalf("first CreateAnswer err = %v, want nil", err)
+		}
+
+		// A second answer for the same (game, player, game_question) trips
+		// the UNIQUE constraint and maps to the sentinel (#353).
+		dup := &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   1,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[1].ID,
+			AnsweredAt: now,
+		}
+		err := gameStore.CreateAnswer(t.Context(), dup)
+		if got, want := err, game.ErrAnswerAlreadyRecorded; !errors.Is(got, want) {
+			t.Errorf("CreateAnswer err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("wraps the underlying error on a closed DB", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		gameStore := NewGameStore(db, slog.Default())
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close db: %v", err)
+		}
+
+		err := gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     "g",
+			PlayerID:   1,
+			QuestionID: 1,
+			OptionID:   1,
+			AnsweredAt: time.Now(),
+		})
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to create answer"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
 		}
 	})
 }
@@ -463,6 +597,95 @@ func TestGameStore_DeleteGamesForPlayerOnQuiz(t *testing.T) {
 		// Bystander's game must still exist.
 		if _, err = gameStore.GetGame(t.Context(), bystanderGame.ID); err != nil {
 			t.Errorf("bystander game lookup err = %v, want nil", err)
+		}
+	})
+
+	t.Run("wraps the underlying error on a closed DB", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		gameStore := NewGameStore(db, slog.Default())
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close db: %v", err)
+		}
+
+		err := gameStore.DeleteGamesForPlayerOnQuiz(t.Context(), 1, 1)
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to begin transaction"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+
+	t.Run("rolls back and surfaces the error when a dependent delete fails", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		playerStore := NewPlayerStore(db, slog.Default())
+		player, err := playerStore.CreateAnonymousPlayer(t.Context(), "anon-reset-rollback")
+		if err != nil {
+			t.Fatalf("failed to create player: %v", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err = gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+		if err = gameStore.CreateParticipant(
+			t.Context(), &game.Participant{GameID: g.ID, PlayerID: player.ID, QuizID: testQuiz.ID},
+		); err != nil {
+			t.Fatalf("failed to create participant: %v", err)
+		}
+		now := time.Now().UTC().Truncate(time.Second)
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			t.Fatalf("failed to create game question: %v", err)
+		}
+		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
+			GameID:     g.ID,
+			PlayerID:   player.ID,
+			QuestionID: gq.ID,
+			OptionID:   testQuiz.Questions[0].Options[0].ID,
+			AnsweredAt: now,
+		}); err != nil {
+			t.Fatalf("failed to create answer: %v", err)
+		}
+
+		// Abort the answers delete so the transaction body fails and the
+		// method takes its rollback path.
+		if _, err = db.ExecContext(t.Context(), `
+			CREATE TRIGGER game_answers_no_delete_reset
+			BEFORE DELETE ON game_answers
+			BEGIN
+				SELECT RAISE(ABORT, 'no deletes');
+			END;
+		`); err != nil {
+			t.Fatalf("failed to create trigger: %v", err)
+		}
+
+		err = gameStore.DeleteGamesForPlayerOnQuiz(t.Context(), player.ID, testQuiz.ID)
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to delete answers"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+
+		// Rollback must leave the game intact.
+		if _, err = gameStore.GetGame(t.Context(), g.ID); err != nil {
+			t.Errorf("game lookup after rollback err = %v, want nil", err)
 		}
 	})
 }

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -1251,3 +1251,106 @@ func TestResetTokenStore_InvalidHashRejected(t *testing.T) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
 }
+
+func TestParseSQLiteTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		raw     string
+		wantNil bool
+		want    time.Time
+	}{
+		"sqlite datetime format": {
+			raw:  "2026-06-04 12:34:56",
+			want: time.Date(2026, 6, 4, 12, 34, 56, 0, time.UTC),
+		},
+		"rfc3339 format": {
+			raw:  "2026-06-04T12:34:56Z",
+			want: time.Date(2026, 6, 4, 12, 34, 56, 0, time.UTC),
+		},
+		"unparseable falls through to nil": {
+			raw:     "not a timestamp",
+			wantNil: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseSQLiteTimestamp(tc.raw)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("ParseSQLiteTimestamp(%q) = %v, want nil", tc.raw, got)
+				}
+
+				return
+			}
+			if got == nil {
+				t.Fatalf("ParseSQLiteTimestamp(%q) = nil, want %v", tc.raw, tc.want)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("ParseSQLiteTimestamp(%q) = %v, want %v", tc.raw, *got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlayerStore_SetPlayerEmail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path overwrites the email", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		created, err := ps.CreatePlayerByAdmin(t.Context(), "set-email-happy", "before@example.test", "hashed-secret")
+		if err != nil {
+			t.Fatalf("CreatePlayerByAdmin err = %v, want nil", err)
+		}
+
+		if setErr := ps.SetPlayerEmail(t.Context(), created.ID, "after@example.test"); setErr != nil {
+			t.Fatalf("SetPlayerEmail err = %v, want nil", setErr)
+		}
+
+		got, err := ps.GetPlayerByID(t.Context(), created.ID)
+		if err != nil {
+			t.Fatalf("GetPlayerByID err = %v, want nil", err)
+		}
+		if want := "after@example.test"; got.Email != want {
+			t.Errorf("Email = %q, want %q", got.Email, want)
+		}
+	})
+
+	t.Run("returns ErrEmailTaken on a UNIQUE collision", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		if _, err := ps.CreatePlayerByAdmin(
+			t.Context(), "set-email-owner", "taken@example.test", "hashed-secret",
+		); err != nil {
+			t.Fatalf("CreatePlayerByAdmin (owner) err = %v, want nil", err)
+		}
+		other, err := ps.CreatePlayerByAdmin(t.Context(), "set-email-other", "other@example.test", "hashed-secret")
+		if err != nil {
+			t.Fatalf("CreatePlayerByAdmin (other) err = %v, want nil", err)
+		}
+
+		err = ps.SetPlayerEmail(t.Context(), other.ID, "taken@example.test")
+		if got, want := err, auth.ErrEmailTaken; !errors.Is(got, want) {
+			t.Errorf("SetPlayerEmail err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns ErrPlayerNotFound for an unknown id", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		ps := NewPlayerStore(db, slog.Default())
+
+		err := ps.SetPlayerEmail(t.Context(), 999999, "nobody@example.test")
+		if got, want := err, auth.ErrPlayerNotFound; !errors.Is(got, want) {
+			t.Errorf("SetPlayerEmail err = %v, want %v", got, want)
+		}
+	})
+}

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -2461,3 +2461,114 @@ func TestQuizStore_MoveQuestionToPosition(t *testing.T) {
 		}
 	})
 }
+
+func TestQuizStore_GetOption(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the stored option", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		want := testQuiz.Questions[0].Options[2]
+		got, err := quizStore.GetOption(t.Context(), want.ID)
+		if err != nil {
+			t.Fatalf("GetOption err = %v, want nil", err)
+		}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("option diff (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("returns ErrOptionNotFound for a missing option", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		opt, err := quizStore.GetOption(t.Context(), 999)
+		if got, want := err, quiz.ErrOptionNotFound; !errors.Is(got, want) {
+			t.Errorf("GetOption err = %v, want %v", got, want)
+		}
+		if opt != nil {
+			t.Errorf("option = %v, want nil", opt)
+		}
+	})
+
+	t.Run("wraps the underlying error on a closed DB", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close database: %v", err)
+		}
+
+		_, err := quizStore.GetOption(t.Context(), 1)
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to get option"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+}
+
+func TestQuizStore_CreateQuestionAtNextPosition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("appends after the highest existing position", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		// newTestQuizzes seeds positions 10 and 20, so the next slot is 21.
+		qs := &quiz.Question{
+			QuizID:  testQuiz.ID,
+			Text:    "Appended question",
+			Options: []*quiz.Option{{Text: "A", Correct: true}},
+		}
+		if err := quizStore.CreateQuestionAtNextPosition(t.Context(), qs); err != nil {
+			t.Fatalf("CreateQuestionAtNextPosition err = %v, want nil", err)
+		}
+		if got, want := qs.Position, 21; got != want {
+			t.Errorf("qs.Position = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("wraps the underlying error on a closed DB", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close database: %v", err)
+		}
+
+		qs := &quiz.Question{QuizID: testQuiz.ID, Text: "doomed"}
+		err := quizStore.CreateQuestionAtNextPosition(t.Context(), qs)
+		if err == nil {
+			t.Fatal("got nil, want error")
+		}
+		if got, want := err.Error(), "failed to create question at next position"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+}

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/starquake/topbanana/internal/dbtest"
@@ -68,6 +69,47 @@ func TestRetentionSweep(t *testing.T) {
 	}
 
 	assertRetention(ctx, t, db, seed)
+}
+
+// TestSweepAbandonedGames_DeleteError pins the deleteGamesByIDs error
+// branch: an abandoned game is seeded with a game_answer, then a
+// BEFORE DELETE trigger on game_answers aborts the first dependent
+// delete so the sweep surfaces the wrapped failure instead of swallowing
+// it.
+func TestSweepAbandonedGames_DeleteError(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	db := dbtest.Open(t)
+
+	ownerID := insertSignedInPlayer(ctx, t, db, "abandoned-owner", seedRecent)
+	q := seedQuiz(ctx, t, db, "abandoned-err", seedMidOld, ownerID)
+	gameID := insertGame(ctx, t, db, "g-abandoned-err", q.quizID, seedMidOld)
+	insertParticipant(ctx, t, db, gameID, ownerID, q.quizID, seedMidOld)
+	gq := insertGameQuestion(ctx, t, db, gameID, q.q1, seedMidOld)
+	insertGameAnswer(ctx, t, db, gameID, ownerID, gq, q.opt1, seedMidOld)
+
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER game_answers_no_delete
+		BEFORE DELETE ON game_answers
+		BEGIN
+			SELECT RAISE(ABORT, 'no deletes');
+		END;
+	`); err != nil {
+		t.Fatalf("failed to create trigger: %v", err)
+	}
+
+	retention := NewRetentionStore(db, slog.Default())
+	err := retention.SweepAbandonedGames(ctx, AbandonedGameDays)
+	if err == nil {
+		t.Fatal("got nil, want error")
+	}
+	if got, want := err.Error(), "failed to delete game answers"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+	if got, want := err.Error(), "failed to sweep abandoned games"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
 }
 
 // seededQuiz bundles the quiz, its round, and its two questions (each with

--- a/internal/store/round_test.go
+++ b/internal/store/round_test.go
@@ -691,3 +691,102 @@ func TestQuizStore_MoveRoundToPosition(t *testing.T) {
 		}
 	})
 }
+
+func TestQuizStore_MoveQuestionToRound(t *testing.T) {
+	t.Parallel()
+
+	rounds := []string{"R1", "R2"}
+	layout := map[string][]string{
+		"R1": {"Q1", "Q2"},
+		"R2": {"Q3"},
+	}
+
+	t.Run("reassigns the question to the target round", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		f := seedRoundQuiz(t, quizStore, rounds, layout)
+
+		if err := quizStore.MoveQuestionToRound(
+			t.Context(), f.quiz.ID, f.questionIDs["Q1"], f.roundIDs["R2"],
+		); err != nil {
+			t.Fatalf("MoveQuestionToRound err = %v, want nil", err)
+		}
+
+		moved, err := quizStore.GetQuestion(t.Context(), f.questionIDs["Q1"])
+		if err != nil {
+			t.Fatalf("GetQuestion err = %v, want nil", err)
+		}
+		if got, want := moved.RoundID, f.roundIDs["R2"]; got != want {
+			t.Errorf("moved.RoundID = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unknown question returns ErrQuestionNotFound", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		f := seedRoundQuiz(t, quizStore, rounds, layout)
+
+		err := quizStore.MoveQuestionToRound(t.Context(), f.quiz.ID, 999999, f.roundIDs["R2"])
+		if got, want := err, quiz.ErrQuestionNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("question on a foreign quiz returns ErrQuestionNotFound", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		f := seedRoundQuiz(t, quizStore, rounds, layout)
+
+		err := quizStore.MoveQuestionToRound(t.Context(), f.quiz.ID+1, f.questionIDs["Q1"], f.roundIDs["R2"])
+		if got, want := err, quiz.ErrQuestionNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unknown round returns ErrRoundNotFound", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		f := seedRoundQuiz(t, quizStore, rounds, layout)
+
+		err := quizStore.MoveQuestionToRound(t.Context(), f.quiz.ID, f.questionIDs["Q1"], 999999)
+		if got, want := err, quiz.ErrRoundNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("round on a foreign quiz returns ErrRoundNotFound", func(t *testing.T) {
+		t.Parallel()
+		quizStore := NewQuizStore(dbtest.Open(t), slog.Default())
+		f := seedRoundQuiz(t, quizStore, rounds, layout)
+
+		// Seed a second quiz and target one of its rounds; the cross-quiz
+		// guard must reject it even though the round id is real.
+		other := seedRoundQuiz2(t, quizStore)
+		err := quizStore.MoveQuestionToRound(t.Context(), f.quiz.ID, f.questionIDs["Q1"], other.roundIDs["R1"])
+		if got, want := err, quiz.ErrRoundNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
+// seedRoundQuiz2 seeds a second quiz with a distinct slug so a cross-quiz
+// round-move test has a real but foreign round id to aim at.
+func seedRoundQuiz2(t *testing.T, quizStore *QuizStore) roundQuizFixture {
+	t.Helper()
+
+	qz := &quiz.Quiz{
+		Title:             "Other Round Quiz",
+		Slug:              "other-round-quiz",
+		Description:       "foreign-round fixture",
+		CreatedByPlayerID: seededAdminID,
+	}
+	if err := quizStore.CreateQuiz(t.Context(), qz); err != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", err)
+	}
+	deflt, err := quizStore.GetDefaultRound(t.Context(), qz.ID)
+	if err != nil {
+		t.Fatalf("GetDefaultRound err = %v, want nil", err)
+	}
+
+	return roundQuizFixture{quiz: qz, roundIDs: map[string]int64{"R1": deflt.ID}}
+}


### PR DESCRIPTION
Covers the store error/edge branches and pure helpers from #667 (categories 4 and 5), then lifts the enforced coverage floor now that total clears 80.

Total coverage: 79.6% -> 80.4%.

Tests added (test-only; no production code, `internal/db/`, or SQL touched):
- `store.GetOption` 0% -> 100% (happy / not-found / closed-DB)
- `store.CreateParticipant` 55.6% -> 100%, `CreateAnswer` 55.6% -> 100% (UNIQUE-collision sentinels + closed-DB)
- `store.DeleteGamesForPlayerOnQuiz` 50% -> 80% (closed-DB + trigger-forced rollback that asserts the game survives)
- `store.CreateQuestionAtNextPosition` 56.2% -> 75% (append + closed-DB; the optimistic-retry race is left uncovered)
- `store.moveQuestionToRoundTx` 47.1% -> 82.4% (four sentinel branches incl. cross-quiz)
- `store.deleteGamesByIDs` 54.5% -> 63.6% (trigger-forced delete error)
- `store.parseSQLiteTimestamp` 0% -> 100%, `SetPlayerEmail` 50% -> 90%
- `admin.parseOptionalTimeLimit` 42.9% -> 100%, `newPlayerInput` 50% -> 100%

The enforced floor (`threshold-total` in `.github/workflows/ci.yml`) goes 79 -> 80. Margin is thin (0.4%); a future PR that drops total below 80 now fails the required `build` check, which is the intended ratchet.

Partially addresses #667 -- the auth/account-linking, invite, and password-rotation flows (categories 1-3) and the admin handler error branches (category 6) are a follow-up. No `Closes` keyword for that reason.