### PR TITLE
Add coverage for OAuth linking, invite, and password rotation

### DIFF
--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -47,6 +47,18 @@ func ExportClaimAnonymousSessionPlayer(
 	return claimAnonymousSessionPlayer(ctx, identities, sessionPlayerID, subject, email)
 }
 
+// ExportLinkExistingPlayerByEmail exposes linkExistingPlayerByEmail so
+// the silent link-by-email branches (lookup error, link-race refetch,
+// mark-verified error) can be unit-tested with a fault-injection store
+// without staging the whole linkOrCreateGooglePlayer flow.
+func ExportLinkExistingPlayerByEmail(
+	ctx context.Context,
+	identities OAuthIdentityStore,
+	subject, email string,
+) (*Player, error) {
+	return linkExistingPlayerByEmail(ctx, identities, subject, email)
+}
+
 // ExportCreateGooglePlayer exposes createGooglePlayer so the
 // race-recovery branch (LinkProviderIdentity returns
 // ErrIdentityAlreadyLinked because another callback won) can be
@@ -92,3 +104,13 @@ var (
 // rate-limiter constructor so the external auth_test package can pin
 // the per-IP cool-down without sleeping (#494).
 var NewLoginRateLimiterWithClock = newLoginRateLimiterWithClock
+
+// ValidateAcceptInviteInput exposes validateAcceptInviteInput so the
+// external test package can pin the display-name + password rule table
+// from input strings without staging an HTTP request.
+var ValidateAcceptInviteInput = validateAcceptInviteInput
+
+// AcceptInviteCollisionMessage exposes acceptInviteCollisionMessage so
+// the external test package can pin the create-conflict sentinel
+// mapping without staging the whole accept-invite flow.
+var AcceptInviteCollisionMessage = acceptInviteCollisionMessage

--- a/internal/auth/google_branches_test.go
+++ b/internal/auth/google_branches_test.go
@@ -1,0 +1,274 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/auth"
+)
+
+// identityStubStore is a fault-injection OAuthIdentityStore: each method
+// returns a per-field configured value/error. The race-recovery branches
+// in linkExistingPlayerByEmail and claimAnonymousSessionPlayer fire only
+// when two concurrent OAuth callbacks interleave, which a single-threaded
+// real DB cannot reproduce on demand, so the result of each call is
+// injected here. CreatePlayerFromOAuth is never reached by either helper
+// under test, so it stays hard-wired to ErrUnsupported to surface an
+// unexpected call loudly.
+type identityStubStore struct {
+	byEmailPlayer   *Player
+	byEmailErr      error
+	bySubjectPlayer *Player
+	bySubjectErr    error
+	linkErr         error
+	markVerifiedErr error
+	claimPlayer     *Player
+	claimErr        error
+}
+
+func (s *identityStubStore) GetPlayerByEmail(_ context.Context, _ string) (*Player, error) {
+	return s.byEmailPlayer, s.byEmailErr
+}
+
+func (s *identityStubStore) GetPlayerByProviderSubject(_ context.Context, _, _ string) (*Player, error) {
+	return s.bySubjectPlayer, s.bySubjectErr
+}
+
+func (s *identityStubStore) LinkProviderIdentity(_ context.Context, _ int64, _, _ string) error {
+	return s.linkErr
+}
+
+func (s *identityStubStore) MarkPlayerEmailVerifiedIfNew(_ context.Context, _ int64) error {
+	return s.markVerifiedErr
+}
+
+func (s *identityStubStore) ClaimPlayerForOAuth(_ context.Context, _ int64, _ string) (*Player, error) {
+	return s.claimPlayer, s.claimErr
+}
+
+func (*identityStubStore) CreatePlayerFromOAuth(_ context.Context, _, _ string) (*Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+// TestLinkExistingPlayerByEmail_GetPlayerByEmailErrorWraps pins branch
+// (a): a GetPlayerByEmail failure that is not ErrPlayerNotFound wraps as
+// "get player by email" rather than being swallowed as a no-match.
+func TestLinkExistingPlayerByEmail_GetPlayerByEmailErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{byEmailErr: errors.New("db down")}
+
+	_, err := ExportLinkExistingPlayerByEmail(t.Context(), store, "sub", "x@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "get player by email"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}
+
+// TestLinkExistingPlayerByEmail_RecoversFromConcurrentLink pins branch
+// (b): GetPlayerByEmail finds a row, LinkProviderIdentity loses the race
+// with ErrIdentityAlreadyLinked, and the refetch by subject returns the
+// winning row.
+func TestLinkExistingPlayerByEmail_RecoversFromConcurrentLink(t *testing.T) {
+	t.Parallel()
+
+	winner := &Player{ID: 42, DisplayName: "alice", Email: "alice@example.test"}
+	store := &identityStubStore{
+		byEmailPlayer:   &Player{ID: 7, DisplayName: "alice", Email: "alice@example.test"},
+		linkErr:         ErrIdentityAlreadyLinked,
+		bySubjectPlayer: winner,
+	}
+
+	got, err := ExportLinkExistingPlayerByEmail(t.Context(), store, "sub", "alice@example.test")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got == nil || got.ID != winner.ID {
+		t.Errorf("recovered player = %v, want id %d (the winner's row)", got, winner.ID)
+	}
+}
+
+// TestLinkExistingPlayerByEmail_RefetchAfterLinkRaceErrorWraps pins
+// branch (c): the link race fires but the refetch by subject errors, so
+// the failure wraps as "refetch after link race".
+func TestLinkExistingPlayerByEmail_RefetchAfterLinkRaceErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{
+		byEmailPlayer: &Player{ID: 7, Email: "alice@example.test"},
+		linkErr:       ErrIdentityAlreadyLinked,
+		bySubjectErr:  errors.New("refetch failed"),
+	}
+
+	_, err := ExportLinkExistingPlayerByEmail(t.Context(), store, "sub", "alice@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "refetch after link race"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}
+
+// TestLinkExistingPlayerByEmail_MarkVerifiedErrorWraps pins branch (d):
+// the link succeeds but MarkPlayerEmailVerifiedIfNew errors, so the
+// failure wraps as "mark email verified after link".
+func TestLinkExistingPlayerByEmail_MarkVerifiedErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{
+		byEmailPlayer:   &Player{ID: 7, Email: "alice@example.test"},
+		markVerifiedErr: errors.New("stamp failed"),
+	}
+
+	_, err := ExportLinkExistingPlayerByEmail(t.Context(), store, "sub", "alice@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "mark email verified after link"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}
+
+// TestLinkExistingPlayerByEmail_StampsVerifiedWhenNil pins branch (e):
+// the happy path links the identity and stamps EmailVerifiedAt on a row
+// whose column was still nil. The non-nil EmailVerifiedAt confirms the
+// helper ran past the MarkPlayerEmailVerifiedIfNew call to the stamp.
+func TestLinkExistingPlayerByEmail_StampsVerifiedWhenNil(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{byEmailPlayer: &Player{ID: 7, Email: "alice@example.test"}}
+
+	got, err := ExportLinkExistingPlayerByEmail(t.Context(), store, "sub", "alice@example.test")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got.EmailVerifiedAt == nil {
+		t.Error("EmailVerifiedAt = nil, want non-nil (stamped when previously nil)")
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_LookupAfterClaimFindsRow pins branch
+// (a): the claim reports ErrPlayerNotFound, but a concurrent callback
+// already linked the (provider, subject), so the lookup by subject
+// returns that existing row.
+func TestClaimAnonymousSessionPlayer_LookupAfterClaimFindsRow(t *testing.T) {
+	t.Parallel()
+
+	winner := &Player{ID: 99, Email: "winner@example.test"}
+	store := &identityStubStore{
+		claimErr:        ErrPlayerNotFound,
+		bySubjectPlayer: winner,
+	}
+
+	got, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "x@example.test")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got == nil || got.ID != winner.ID {
+		t.Errorf("recovered player = %v, want id %d (the winner's row)", got, winner.ID)
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_LookupAfterClaimErrorWraps pins branch
+// (b): the claim reports ErrPlayerNotFound and the recovery lookup
+// errors with something other than ErrPlayerNotFound, so the failure
+// wraps as "lookup after claim race".
+func TestClaimAnonymousSessionPlayer_LookupAfterClaimErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{
+		claimErr:     ErrPlayerNotFound,
+		bySubjectErr: errors.New("lookup blew up"),
+	}
+
+	_, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "x@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "lookup after claim race"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_NoConcurrentLinkReturnsNotFound pins
+// branch (c): the claim reports ErrPlayerNotFound and no concurrent
+// callback linked the subject, so the helper returns ErrPlayerNotFound
+// for the caller to fall through to createGooglePlayer.
+func TestClaimAnonymousSessionPlayer_NoConcurrentLinkReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{
+		claimErr:     ErrPlayerNotFound,
+		bySubjectErr: ErrPlayerNotFound,
+	}
+
+	_, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "x@example.test")
+	if got, want := err, ErrPlayerNotFound; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_LinkRaceRefetchesRow pins branch (d):
+// the claim succeeds but LinkProviderIdentity loses the race with
+// ErrIdentityAlreadyLinked, so the refetch by subject returns the
+// canonical OAuth-linked row.
+func TestClaimAnonymousSessionPlayer_LinkRaceRefetchesRow(t *testing.T) {
+	t.Parallel()
+
+	winner := &Player{ID: 99, Email: "winner@example.test"}
+	store := &identityStubStore{
+		claimPlayer:     &Player{ID: 7, Email: "claimed@example.test"},
+		linkErr:         ErrIdentityAlreadyLinked,
+		bySubjectPlayer: winner,
+	}
+
+	got, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "claimed@example.test")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got == nil || got.ID != winner.ID {
+		t.Errorf("recovered player = %v, want id %d (the winner's row)", got, winner.ID)
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_LinkRaceRefetchErrorWraps pins branch
+// (e): the claim succeeds, the link race fires, but the refetch by
+// subject errors, so the failure wraps as "refetch after link race".
+func TestClaimAnonymousSessionPlayer_LinkRaceRefetchErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{
+		claimPlayer:  &Player{ID: 7, Email: "claimed@example.test"},
+		linkErr:      ErrIdentityAlreadyLinked,
+		bySubjectErr: errors.New("refetch failed"),
+	}
+
+	_, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "claimed@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "refetch after link race"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}
+
+// TestClaimAnonymousSessionPlayer_GenericClaimErrorWraps pins branch
+// (f): a claim error that is not ErrPlayerNotFound wraps as "claim
+// anonymous player for oauth".
+func TestClaimAnonymousSessionPlayer_GenericClaimErrorWraps(t *testing.T) {
+	t.Parallel()
+
+	store := &identityStubStore{claimErr: errors.New("claim blew up")}
+
+	_, err := ExportClaimAnonymousSessionPlayer(t.Context(), store, 7, "sub", "x@example.test")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if got, want := err.Error(), "claim anonymous player for oauth"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}

--- a/internal/auth/invite_handler_test.go
+++ b/internal/auth/invite_handler_test.go
@@ -1,0 +1,126 @@
+package auth_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/auth"
+)
+
+func TestValidateAcceptInviteInput(t *testing.T) {
+	t.Parallel()
+
+	validPassword := strings.Repeat("a", MinPasswordLength)
+	tooShort := strings.Repeat("a", MinPasswordLength-1)
+	tooLong := strings.Repeat("a", MaxPasswordLength+1)
+
+	tests := []struct {
+		name        string
+		displayName string
+		password    string
+		confirm     string
+		wantMsg     string
+		wantOK      bool
+	}{
+		{
+			name:        "empty display name",
+			displayName: "",
+			password:    validPassword,
+			confirm:     validPassword,
+			wantMsg:     "Pick a display name.",
+			wantOK:      false,
+		},
+		{
+			name:        "password too short",
+			displayName: "alice",
+			password:    tooShort,
+			confirm:     tooShort,
+			wantMsg:     fmt.Sprintf("Password must be at least %d characters.", MinPasswordLength),
+			wantOK:      false,
+		},
+		{
+			name:        "password too long",
+			displayName: "alice",
+			password:    tooLong,
+			confirm:     tooLong,
+			wantMsg:     fmt.Sprintf("Password must be at most %d characters.", MaxPasswordLength),
+			wantOK:      false,
+		},
+		{
+			name:        "confirm mismatch",
+			displayName: "alice",
+			password:    validPassword,
+			confirm:     validPassword + "x",
+			wantMsg:     "Passwords do not match.",
+			wantOK:      false,
+		},
+		{
+			name:        "valid",
+			displayName: "alice",
+			password:    validPassword,
+			confirm:     validPassword,
+			wantMsg:     "",
+			wantOK:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg, ok := ValidateAcceptInviteInput(tc.displayName, tc.password, tc.confirm)
+			if got, want := ok, tc.wantOK; got != want {
+				t.Errorf("ValidateAcceptInviteInput ok = %t, want %t", got, want)
+			}
+			if got, want := msg, tc.wantMsg; got != want {
+				t.Errorf("ValidateAcceptInviteInput msg = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestAcceptInviteCollisionMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+		wantOK  bool
+	}{
+		{
+			name:    "display name taken",
+			err:     ErrDisplayNameTaken,
+			wantMsg: "That display name is already taken. Pick another.",
+			wantOK:  true,
+		},
+		{
+			name:    "email taken",
+			err:     ErrEmailTaken,
+			wantMsg: "An account already exists for this email - sign in instead.",
+			wantOK:  true,
+		},
+		{
+			name:    "other error",
+			err:     errors.New("db down"),
+			wantMsg: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg, ok := AcceptInviteCollisionMessage(tc.err)
+			if got, want := ok, tc.wantOK; got != want {
+				t.Errorf("AcceptInviteCollisionMessage ok = %t, want %t", got, want)
+			}
+			if got, want := msg, tc.wantMsg; got != want {
+				t.Errorf("AcceptInviteCollisionMessage msg = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/profile/password_handler_test.go
+++ b/internal/profile/password_handler_test.go
@@ -1,0 +1,196 @@
+package profile_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/dbtest"
+	. "github.com/starquake/topbanana/internal/profile"
+	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// passwordChangeCurrent is the current password the in-context player is
+// seeded with; the form submits it so the current-password gate passes
+// and the rotation branches under test are reached.
+const passwordChangeCurrent = "correct-battery-13"
+
+// passwordChangeResult bundles what postPasswordChange surfaces.
+type passwordChangeResult struct {
+	logs string
+	rec  *httptest.ResponseRecorder
+}
+
+// postPasswordChange drives HandleProfilePasswordChange with the given
+// store. The in-context player carries id 7 and a hash of
+// passwordChangeCurrent, and the form submits a fresh, well-formed new
+// password so validation and the current-password check both pass,
+// isolating the rotation / reload error branches.
+func postPasswordChange(t *testing.T, players auth.PlayerStore) passwordChangeResult {
+	t.Helper()
+
+	hash, err := auth.HashPassword(passwordChangeCurrent)
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+
+	var logs strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	csrfMgr := csrf.New([]byte("test-key-32-bytes-test-key-32byt"), false)
+	sessions := session.New([]byte("test-key-32-bytes-test-key-32byt"), false)
+	handler := HandleProfilePasswordChange(logger, csrfMgr, players, sessions)
+
+	newPassword := strings.Repeat("z", auth.MinPasswordLength)
+	form := url.Values{
+		"current_password":     {passwordChangeCurrent},
+		"new_password":         {newPassword},
+		"new_password_confirm": {newPassword},
+	}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/profile/password", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: 7, PasswordHash: hash}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return passwordChangeResult{logs: logs.String(), rec: rec}
+}
+
+// sessionRefreshed reports whether the response set a non-clearing
+// session cookie, which Manager.Set does only when the rotation +
+// reload both succeed.
+func sessionRefreshed(rec *httptest.ResponseRecorder) bool {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == session.CookieName && c.Value != "" && c.MaxAge >= 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestHandleProfilePasswordChange_PlayerVanishedDuringRotate drives a real
+// PlayerStore whose row for the in-context player id never existed, so
+// ChangePlayerPassword reports ErrPlayerNotFound (the "player vanished
+// mid-request" branch) -- the real rows==0 path, not an injected sentinel.
+func TestHandleProfilePasswordChange_PlayerVanishedDuringRotate(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), slog.Default())
+
+	res := postPasswordChange(t, players)
+
+	if got, want := res.rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := res.logs, "change password: player vanished mid-request"; !strings.Contains(got, want) {
+		t.Errorf("log = %q, should contain %q", got, want)
+	}
+	if sessionRefreshed(res.rec) {
+		t.Error("session cookie was refreshed, want it left untouched on rotation failure")
+	}
+}
+
+// TestHandleProfilePasswordChange_GenericRotateError drives a real
+// PlayerStore over a closed DB so ChangePlayerPassword fails with a
+// wrapped driver error (the generic rotate-error branch), per the
+// project rule to prefer a closed DB over a double for an ordinary
+// store-errored branch.
+func TestHandleProfilePasswordChange_GenericRotateError(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	players := store.NewPlayerStore(db, slog.Default())
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	res := postPasswordChange(t, players)
+
+	if got, want := res.rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := res.logs, "error rotating password"; !strings.Contains(got, want) {
+		t.Errorf("log = %q, should contain %q", got, want)
+	}
+	if sessionRefreshed(res.rec) {
+		t.Error("session cookie was refreshed, want it left untouched on rotation failure")
+	}
+}
+
+// reloadFailStore is a PlayerStore whose rotate succeeds but whose
+// post-rotate reload fails. A real store cannot reproduce this: the row
+// ChangePlayerPassword just updated is still present for GetPlayerByID to
+// read back, so the reload failure has to be injected. Every other method
+// returns a sentinel so an accidental call surfaces loudly.
+type reloadFailStore struct{ getErr error }
+
+func (*reloadFailStore) ChangePlayerPassword(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+
+func (s *reloadFailStore) GetPlayerByID(_ context.Context, _ int64) (*auth.Player, error) {
+	return nil, s.getErr
+}
+
+func (*reloadFailStore) GetPlayerByDisplayName(_ context.Context, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) GetPlayerByEmail(_ context.Context, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) CreatePlayer(_ context.Context, _, _, _, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) CreateAnonymousPlayer(_ context.Context, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) ClaimPlayer(_ context.Context, _ int64, _, _, _, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) RenamePlayer(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+func (*reloadFailStore) SetPlayerPasswordHash(_ context.Context, _, _ string) error {
+	return errors.ErrUnsupported
+}
+
+func (*reloadFailStore) UpdatePlayerDisplayName(_ context.Context, _ int64, _ string) (*auth.Player, error) {
+	return nil, errors.ErrUnsupported
+}
+
+// TestHandleProfilePasswordChange_ReloadAfterRotateFails pins the one
+// branch a real store cannot reproduce: the rotation commits but the
+// reload that follows it errors, so the handler 500s without refreshing
+// the session.
+func TestHandleProfilePasswordChange_ReloadAfterRotateFails(t *testing.T) {
+	t.Parallel()
+
+	res := postPasswordChange(t, &reloadFailStore{getErr: errors.New("reload failed")})
+
+	if got, want := res.rec.Code, http.StatusInternalServerError; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := res.logs, "error reloading player after password change"; !strings.Contains(got, want) {
+		t.Errorf("log = %q, should contain %q", got, want)
+	}
+	if sessionRefreshed(res.rec) {
+		t.Error("session cookie was refreshed, want it left untouched on reload failure")
+	}
+}

--- a/internal/profile/testmain_test.go
+++ b/internal/profile/testmain_test.go
@@ -1,0 +1,15 @@
+package profile_test
+
+import (
+	"testing"
+
+	"github.com/starquake/topbanana/internal/database"
+)
+
+func TestMain(m *testing.M) {
+	// Configure goose global state once so dbtest.Open can apply
+	// migrations for the real-store password-rotation tests.
+	database.SetupGoose()
+
+	m.Run()
+}

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -1354,3 +1354,70 @@ func TestPlayerStore_SetPlayerEmail(t *testing.T) {
 		}
 	})
 }
+
+// TestPlayerStore_CreatePlayerFromOAuth_HappyPath pins the create path:
+// the display name is trimmed, the email is lower-cased, and a player
+// with a player role is returned.
+func TestPlayerStore_CreatePlayerFromOAuth_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	player, err := ps.CreatePlayerFromOAuth(t.Context(), "  Oauthy  ", "  Fresh@Example.Test ")
+	if err != nil {
+		t.Fatalf("CreatePlayerFromOAuth err = %v, want nil", err)
+	}
+	if got, want := player.DisplayName, "Oauthy"; got != want {
+		t.Errorf("DisplayName = %q, want %q (trimmed)", got, want)
+	}
+	if got, want := player.Email, "fresh@example.test"; got != want {
+		t.Errorf("Email = %q, want %q (lower-cased)", got, want)
+	}
+	// The role CASE in the query promotes the first OAuth-only registrant
+	// to admin, so the exact role depends on DB state; only assert it is
+	// populated.
+	if player.Role == "" {
+		t.Error("Role = empty, want non-empty")
+	}
+}
+
+// TestPlayerStore_CreatePlayerFromOAuth_DuplicateDisplayName pins that a
+// UNIQUE display-name collision maps to auth.ErrDisplayNameTaken, the
+// sentinel the OAuth handler retries on with a fresh petname.
+func TestPlayerStore_CreatePlayerFromOAuth_DuplicateDisplayName(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+
+	if _, err := ps.CreatePlayerFromOAuth(t.Context(), "samename", "first@example.test"); err != nil {
+		t.Fatalf("first CreatePlayerFromOAuth err = %v, want nil", err)
+	}
+
+	_, err := ps.CreatePlayerFromOAuth(t.Context(), "samename", "second@example.test")
+	if got, want := err, auth.ErrDisplayNameTaken; !errors.Is(got, want) {
+		t.Errorf("CreatePlayerFromOAuth err = %v, want %v", got, want)
+	}
+}
+
+// TestPlayerStore_CreatePlayerFromOAuth_ClosedDBWraps pins the
+// store-error branch: a closed DB surfaces a wrapped "failed to create
+// player from oauth" rather than a bare driver error.
+func TestPlayerStore_CreatePlayerFromOAuth_ClosedDBWraps(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	ps := NewPlayerStore(db, slog.Default())
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	_, err := ps.CreatePlayerFromOAuth(t.Context(), "anyone", "anyone@example.test")
+	if err == nil {
+		t.Fatal("CreatePlayerFromOAuth err = nil, want non-nil on closed DB")
+	}
+	if got, want := err.Error(), "failed to create player from oauth"; !strings.Contains(got, want) {
+		t.Errorf("err.Error() = %q, should contain %q", got, want)
+	}
+}


### PR DESCRIPTION
Covers the auth / account-security flows from #667 (categories 1-3), the follow-up to the store/helper slice in #671.

Total coverage: 80.4% -> 80.9%.

Tests added (test-only; no production code, `internal/db/`, SQL, or CI/gate config touched):
- `auth.claimAnonymousSessionPlayer` 52.9% -> 94.1% and `auth.linkExistingPlayerByEmail` 55.6% -> 94.4% -- the concurrent-callback race-recovery branches (lost-link refetch, lookup-after-claim, generic-error wraps), driven by a configurable fault-injection `OAuthIdentityStore` (a single-threaded real DB can't reproduce these races).
- `store.CreatePlayerFromOAuth` 42.9% -> 100% (happy path with trim/lowercase, duplicate-name -> `ErrDisplayNameTaken`, closed-DB wrap).
- `auth.validateAcceptInviteInput` 55.6% -> 100% and `auth.acceptInviteCollisionMessage` 50% -> 100% (pure table tests).
- `profile.rotateAndRefresh` 38.9% -> 83.3% via the password-change handler with a fault-injection `PlayerStore`: player-vanished-mid-rotate, generic rotate error, reload-after-rotate failure -- each asserts 500 and that the session is not refreshed. The remaining uncovered line is the `HashPassword` error branch, unreachable through the handler (validation rejects >72-byte input before rotation).

Partially addresses #667 -- category 6 (admin handler error branches in playeractions.go / rounds.go) is the remaining slice. No `Closes` keyword for that reason.