### PR TITLE
Add coverage for admin round and resend handlers

### DIFF
--- a/internal/admin/export_test.go
+++ b/internal/admin/export_test.go
@@ -75,6 +75,21 @@ func EmailRateLimiterEntryCount(l *EmailRateLimiter) int {
 	return len(l.last)
 }
 
+// NewPerTargetLimiterWithClock exposes the internal clock-injected
+// per-target rate-limiter constructor so the external admin_test package
+// can pin the per-player-id cool-down without sleeping.
+var NewPerTargetLimiterWithClock = newPerTargetLimiterWithClock
+
+// PerTargetLimiterEntryCount returns how many targets the limiter is
+// tracking right now. Lets the unit test pin the prune-stale-entries
+// behaviour without exporting the internal map.
+func PerTargetLimiterEntryCount(l *PerTargetLimiter) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return len(l.last)
+}
+
 // RoleChangeNotice exposes the unexported plain success flash builder so
 // the role-change opt-out test can assert the no-email wording without
 // hard-coding it.

--- a/internal/admin/pertargetlimiter_test.go
+++ b/internal/admin/pertargetlimiter_test.go
@@ -1,0 +1,115 @@
+package admin_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/admin"
+)
+
+// mutableClock is a test clock whose now value the test advances by hand,
+// so the limiter's window math is exercised without sleeping.
+type mutableClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *mutableClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.now
+}
+
+func (c *mutableClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func TestPerTargetLimiter_Allow(t *testing.T) {
+	t.Parallel()
+
+	const window = time.Minute
+	const target int64 = 42
+
+	t.Run("first call on a target admits", func(t *testing.T) {
+		t.Parallel()
+
+		clock := &mutableClock{now: time.Unix(0, 0)}
+		limiter := NewPerTargetLimiterWithClock(window, clock.Now)
+
+		wait, ok := limiter.Allow(target)
+		if !ok {
+			t.Error("Allow = false, want true on the first call")
+		}
+		if got, want := wait, time.Duration(0); got != want {
+			t.Errorf("wait = %v, want %v on an admit", got, want)
+		}
+	})
+
+	t.Run("second call within the window blocks", func(t *testing.T) {
+		t.Parallel()
+
+		clock := &mutableClock{now: time.Unix(0, 0)}
+		limiter := NewPerTargetLimiterWithClock(window, clock.Now)
+
+		if _, ok := limiter.Allow(target); !ok {
+			t.Fatal("first Allow = false, want true")
+		}
+
+		clock.Advance(window / 2)
+		wait, ok := limiter.Allow(target)
+		if ok {
+			t.Error("Allow = true, want false within the window")
+		}
+		if wait <= 0 {
+			t.Errorf("wait = %v, want a positive remaining duration", wait)
+		}
+	})
+
+	t.Run("call after the window admits again", func(t *testing.T) {
+		t.Parallel()
+
+		clock := &mutableClock{now: time.Unix(0, 0)}
+		limiter := NewPerTargetLimiterWithClock(window, clock.Now)
+
+		if _, ok := limiter.Allow(target); !ok {
+			t.Fatal("first Allow = false, want true")
+		}
+
+		clock.Advance(window)
+		wait, ok := limiter.Allow(target)
+		if !ok {
+			t.Error("Allow = false, want true once the window has elapsed")
+		}
+		if got, want := wait, time.Duration(0); got != want {
+			t.Errorf("wait = %v, want %v on a re-admit", got, want)
+		}
+	})
+
+	t.Run("stale entries are evicted past twice the window", func(t *testing.T) {
+		t.Parallel()
+
+		clock := &mutableClock{now: time.Unix(0, 0)}
+		limiter := NewPerTargetLimiterWithClock(window, clock.Now)
+
+		if _, ok := limiter.Allow(target); !ok {
+			t.Fatal("first Allow = false, want true")
+		}
+		if got, want := PerTargetLimiterEntryCount(limiter), 1; got != want {
+			t.Errorf("entry count = %d, want %d after one admit", got, want)
+		}
+
+		// Advance past 2*window and touch a different target so the sweep
+		// runs and prunes the stale entry for the original target.
+		clock.Advance(2*window + time.Second)
+		if _, ok := limiter.Allow(target + 1); !ok {
+			t.Fatal("Allow(other) = false, want true")
+		}
+		if got, want := PerTargetLimiterEntryCount(limiter), 1; got != want {
+			t.Errorf("entry count = %d, want %d (stale target pruned, only the new one remains)", got, want)
+		}
+	})
+}

--- a/internal/admin/playeractions_resend_test.go
+++ b/internal/admin/playeractions_resend_test.go
@@ -1,0 +1,150 @@
+package admin_test
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/admin"
+	"github.com/starquake/topbanana/internal/auth"
+)
+
+// postResend drives HandlePlayerResendVerification against the target with
+// the supplied dependencies, returning the recorder. The limiter is shared
+// across calls within a test so the rate-limited branch can be exercised by
+// calling twice.
+func postResend(
+	t *testing.T, env *adminEnv, targetID, baseURL string, limiter *PerTargetLimiter,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := HandlePlayerResendVerification(
+		slog.New(slog.DiscardHandler), env.admin, env.tokens, stubVerifyEmailSender{},
+		baseURL, limiter, newCredFlash(t),
+	)
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/admin/players/"+targetID+"/resend-verification", nil,
+	)
+	req.SetPathValue("playerID", targetID)
+	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHandlePlayerResendVerification(t *testing.T) {
+	t.Parallel()
+
+	const baseURL = "https://x.test"
+
+	t.Run("unparseable playerID is a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		limiter := NewPerTargetLimiter(time.Minute)
+
+		rec := postResend(t, env, "abc", baseURL, limiter)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("missing target is a 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		limiter := NewPerTargetLimiter(time.Minute)
+
+		rec := postResend(t, env, "999999", baseURL, limiter)
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("happy dispatch issues a token and redirects", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		target := env.seedCredentialledPlayer(t, "unverified", "unverified@example.test", auth.RolePlayer)
+		limiter := NewPerTargetLimiter(time.Minute)
+
+		rec := postResend(
+			t, env, strconv.FormatInt(target, 10), baseURL, limiter,
+		)
+		if got, want := rec.Code, http.StatusSeeOther; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+		// A real CreateVerifyToken ran on the detached goroutine; the
+		// audit row is written synchronously before the redirect.
+		entries := env.auditEntries(t, target)
+		if got, want := len(entries), 1; got != want {
+			t.Fatalf("audit entries = %d, want %d", got, want)
+		}
+		if got, want := entries[0].Action, auth.AdminActionResendVerification; got != want {
+			t.Errorf("audit action = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("email not configured flashes and writes no audit", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		target := env.seedCredentialledPlayer(t, "unverified", "unverified@example.test", auth.RolePlayer)
+		limiter := NewPerTargetLimiter(time.Minute)
+
+		// Empty baseURL makes dispatchAdminResendVerification report
+		// "not configured" so the handler skips the audit + success notice.
+		rec := postResend(t, env, strconv.FormatInt(target, 10), "", limiter)
+		if got, want := rec.Code, http.StatusSeeOther; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+		if got, want := len(env.auditEntries(t, target)), 0; got != want {
+			t.Errorf("audit entries = %d, want %d when email is unconfigured", got, want)
+		}
+	})
+
+	t.Run("second resend within the window is rate limited", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		target := env.seedCredentialledPlayer(t, "unverified", "unverified@example.test", auth.RolePlayer)
+		limiter := NewPerTargetLimiter(time.Minute)
+		id := strconv.FormatInt(target, 10)
+
+		if got, want := postResend(t, env, id, baseURL, limiter).Code,
+			http.StatusSeeOther; got != want {
+			t.Fatalf("first resend status = %d, want %d", got, want)
+		}
+
+		rec := postResend(t, env, id, baseURL, limiter)
+		if got, want := rec.Code, http.StatusSeeOther; got != want {
+			t.Errorf("second resend status = %d, want %d", got, want)
+		}
+		if got, want := rec.Header().Get("Retry-After"), ""; got == want {
+			t.Errorf("Retry-After = %q, want a non-empty value on the rate-limited path", got)
+		}
+		// The blocked second call writes no second audit row.
+		if got, want := len(env.auditEntries(t, target)), 1; got != want {
+			t.Errorf("audit entries = %d, want %d (only the first dispatch audits)", got, want)
+		}
+	})
+
+	t.Run("store error renders a 500", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		env.seedCredentialledPlayer(t, "unverified", "unverified@example.test", auth.RolePlayer)
+		limiter := NewPerTargetLimiter(time.Minute)
+		env.closeStore(t)
+
+		rec := postResend(t, env, "1", baseURL, limiter)
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+}

--- a/internal/admin/rounds_test.go
+++ b/internal/admin/rounds_test.go
@@ -1,0 +1,408 @@
+package admin_test
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/admin"
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// nonOwnerID is a player id distinct from testAdminID; an actor carrying
+// it with a non-admin role fails requireQuizOwner on a quiz owned by the
+// seeded admin.
+const nonOwnerID int64 = 4242
+
+func newRoundsCSRF() *csrf.Manager {
+	return csrf.New([]byte("test-key-test-key-test-key-32byt"), false)
+}
+
+// roundsFixture bundles the seeded quiz with the ids the round handler
+// tests target, so the seed helper stays under revive's
+// function-result-limit.
+type roundsFixture struct {
+	quiz        *quiz.Quiz
+	secondRound int64
+	questionID  int64
+}
+
+// seedRoundsQuiz persists a single-question quiz owned by the admin and
+// returns it alongside the question's id and a freshly created second
+// round so the move/delete handlers have real targets. The store stamps a
+// default round on CreateQuiz; the seeded question lands in it.
+func seedRoundsQuiz(t *testing.T, env *adminEnv) roundsFixture {
+	t.Helper()
+
+	qz := ownedQuiz("Rounds Quiz", "rounds-quiz")
+	qz.Questions = []*quiz.Question{
+		{
+			Text:     "What is the capital of France?",
+			Position: 1,
+			Options: []*quiz.Option{
+				{Text: "Paris", Correct: true},
+				{Text: "London"},
+			},
+		},
+	}
+	env.seedQuiz(t, qz)
+
+	second := &quiz.Round{QuizID: qz.ID, Position: 1, Title: "Round 2"}
+	if err := env.quizzes.CreateRound(t.Context(), second); err != nil {
+		t.Fatalf("CreateRound err = %v, want nil", err)
+	}
+
+	return roundsFixture{quiz: qz, secondRound: second.ID, questionID: qz.Questions[0].ID}
+}
+
+// adminActor returns the request with the seeded admin attached, passing
+// the owner gate for an admin-owned quiz.
+func adminActor(req *http.Request) *http.Request {
+	return req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}))
+}
+
+// nonOwnerActor returns the request with a non-admin player whose id is
+// not the quiz creator's, so requireQuizOwner renders a 403.
+func nonOwnerActor(req *http.Request) *http.Request {
+	return req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: nonOwnerID, Role: auth.RolePlayer}))
+}
+
+func postMoveToRound(
+	t *testing.T, env *adminEnv, quizID, questionID string, form url.Values,
+	actor func(*http.Request) *http.Request,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := HandleQuestionMoveToRound(slog.New(slog.DiscardHandler), newRoundsCSRF(), env.quizzes)
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		"/admin/quizzes/"+quizID+"/questions/"+questionID+"/round",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("quizID", quizID)
+	req.SetPathValue("questionID", questionID)
+	req = actor(req)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHandleQuestionMoveToRound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("moves the question to the target round", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.questionID, 10),
+			url.Values{"round_id": {strconv.FormatInt(f.secondRound, 10)}}, adminActor,
+		)
+
+		if got, want := rec.Code, http.StatusSeeOther; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+		moved, err := env.quizzes.GetQuestion(t.Context(), f.questionID)
+		if err != nil {
+			t.Fatalf("GetQuestion err = %v, want nil", err)
+		}
+		if got, want := moved.RoundID, f.secondRound; got != want {
+			t.Errorf("moved.RoundID = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unparseable quizID is a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+
+		rec := postMoveToRound(
+			t, env, "abc", "1", url.Values{"round_id": {"1"}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unparseable questionID is a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), "abc",
+			url.Values{"round_id": {strconv.FormatInt(f.secondRound, 10)}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unparseable round_id is a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.questionID, 10),
+			url.Values{"round_id": {"not-a-number"}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("non-owner is forbidden", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.questionID, 10),
+			url.Values{"round_id": {strconv.FormatInt(f.secondRound, 10)}}, nonOwnerActor,
+		)
+		if got, want := rec.Code, http.StatusForbidden; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unknown question is a 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), "999999",
+			url.Values{"round_id": {strconv.FormatInt(f.secondRound, 10)}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("unknown round is a 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.questionID, 10),
+			url.Values{"round_id": {"999999"}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("store error renders a 500", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+		env.closeStore(t)
+
+		rec := postMoveToRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.questionID, 10),
+			url.Values{"round_id": {strconv.FormatInt(f.secondRound, 10)}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+}
+
+func deleteRound(
+	t *testing.T, env *adminEnv, quizID, roundID string,
+	actor func(*http.Request) *http.Request,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := HandleRoundDelete(slog.New(slog.DiscardHandler), newRoundsCSRF(), env.quizzes)
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		"/admin/quizzes/"+quizID+"/rounds/"+roundID+"/delete", nil,
+	)
+	req.SetPathValue("quizID", quizID)
+	req.SetPathValue("roundID", roundID)
+	req = actor(req)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHandleRoundDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes the round", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := deleteRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.secondRound, 10), adminActor,
+		)
+		if got, want := rec.Code, http.StatusSeeOther; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+		_, err := env.quizzes.GetRound(t.Context(), f.secondRound)
+		if got, want := err, quiz.ErrRoundNotFound; !errors.Is(got, want) {
+			t.Errorf("GetRound err = %v, want %v (round should be gone)", got, want)
+		}
+	})
+
+	t.Run("unparseable roundID is a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := deleteRound(t, env, strconv.FormatInt(f.quiz.ID, 10), "abc", adminActor)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("non-owner is forbidden", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := deleteRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.secondRound, 10), nonOwnerActor,
+		)
+		if got, want := rec.Code, http.StatusForbidden; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("round not found is a 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := deleteRound(t, env, strconv.FormatInt(f.quiz.ID, 10), "999999", adminActor)
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("a round on another quiz is a 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		// A second owned quiz whose round id is real but foreign. Mounting
+		// it on the first quiz's URL must surface as 404 (the IDOR gate in
+		// roundByID), not delete the foreign round.
+		other := ownedQuiz("Other Quiz", "other-quiz")
+		env.seedQuiz(t, other)
+		otherRounds, err := env.quizzes.ListRoundsByQuiz(t.Context(), other.ID)
+		if err != nil {
+			t.Fatalf("ListRoundsByQuiz err = %v, want nil", err)
+		}
+		foreignRound := otherRounds[0].ID
+
+		rec := deleteRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(foreignRound, 10), adminActor,
+		)
+		if got, want := rec.Code, http.StatusNotFound; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+		// The foreign round must still exist.
+		if _, err := env.quizzes.GetRound(t.Context(), foreignRound); err != nil {
+			t.Errorf("GetRound(foreign) err = %v, want nil (must not be deleted)", err)
+		}
+	})
+
+	t.Run("store error renders a 500", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+		env.closeStore(t)
+
+		rec := deleteRound(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), strconv.FormatInt(f.secondRound, 10), adminActor,
+		)
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+}
+
+func postRoundSave(
+	t *testing.T, env *adminEnv, quizID string, form url.Values,
+	actor func(*http.Request) *http.Request,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := HandleRoundSave(slog.New(slog.DiscardHandler), newRoundsCSRF(), env.quizzes)
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		"/admin/quizzes/"+quizID+"/rounds", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("quizID", quizID)
+	req = actor(req)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHandleRoundSave(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blank title re-renders the form as a 400", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+
+		rec := postRoundSave(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), url.Values{"title": {""}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("store error renders a 500", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		f := seedRoundsQuiz(t, env)
+		env.closeStore(t)
+
+		rec := postRoundSave(
+			t, env, strconv.FormatInt(f.quiz.ID, 10), url.Values{"title": {"New Round"}}, adminActor,
+		)
+		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status = %d, want %d", got, want)
+		}
+	})
+}

--- a/internal/game/service_test.go
+++ b/internal/game/service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -165,6 +166,64 @@ func TestService_GetGameForPlayerOnQuiz(t *testing.T) {
 		_, err := svc.GetGameForPlayerOnQuiz(t.Context(), 1, 999)
 		if got, want := err, quiz.ErrQuizNotFound; !errors.Is(got, want) {
 			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestService_GetQuiz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the seeded quiz", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		got, err := svc.GetQuiz(ctx, testQuiz.ID)
+		if err != nil {
+			t.Fatalf("GetQuiz err = %v, want nil", err)
+		}
+		if got == nil {
+			t.Fatal("GetQuiz returned nil quiz, want the seeded quiz")
+		}
+		if want := testQuiz.ID; got.ID != want {
+			t.Errorf("quiz ID = %d, want %d", got.ID, want)
+		}
+		if want := testQuiz.Title; got.Title != want {
+			t.Errorf("quiz Title = %q, want %q", got.Title, want)
+		}
+	})
+
+	t.Run("wraps the store error with a get-quiz prefix", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+		svc := NewService(gameStore, quizStore, slog.Default())
+
+		if err := db.Close(); err != nil {
+			t.Fatalf("closing test DB err = %v, want nil", err)
+		}
+
+		_, err := svc.GetQuiz(ctx, 1)
+		if err == nil {
+			t.Fatal("GetQuiz err = nil, want a wrapped store error")
+		}
+		if got, want := err.Error(), "get quiz"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
 		}
 	})
 }


### PR DESCRIPTION
Covers the category-6 admin handler error branches from #667 plus two 0%-covered helpers, following the merged #671/#672 slices. Drives the real `adminEnv` harness (migrated `dbtest` stores, `closeStore` for store-error branches) -- no new stubs.

Total coverage: 82.0% -> 82.1%.

Per-function (before -> after):
- `admin/rounds.go HandleQuestionMoveToRound` 4.2% -> 83.3% (move + bad path ids / non-owner / question+round not found / closed-store 500)
- `admin/rounds.go HandleRoundDelete` 47.4% -> 63.2% (delete + bad path / non-owner / not-found / cross-quiz IDOR / closed-store; the no-rows 404 is unreachable through a real store after the ownership gate)
- `admin/rounds.go roundByID` 28.6% -> 78.6%; `HandleRoundSave` invalid-form + store-error added
- `admin/playeractions.go HandlePlayerResendVerification` 3.7% -> 85.2% (bad path / not-found / happy dispatch+audit / not-configured / rate-limited / closed-store)
- `admin/playeractions.go loadActionTarget` 33.3% -> 100%
- `admin/playeractions.go PerTargetLimiter.Allow` 0% -> 100% (clock-injected: admit / block-in-window / re-admit / stale-eviction)
- `game/game.go Service.GetQuiz` 0% -> 100%

Partially addresses #667. Remaining low-coverage clusters (admin `invites.go`, assorted store third-branches) are lower-value; #667 can close with a summary once you're happy with the level.