### PR TITLE
Await the session runner on shutdown to fix the integration race (#608)

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -102,7 +102,14 @@ func Run(
 		tokenSweepInterval,
 	)
 	gameService, leaderboardHub := newGameService(cfg, logger, stores)
-	sessionService, sessionHub := startSessionRunner(signalCtx, cfg, logger, stores, gameService)
+	// Own the runner's context so shutdown waits for its goroutine to exit
+	// before Run returns - else it logs past test teardown under -race (#608).
+	runnerCtx, stopRunner := context.WithCancel(signalCtx)
+	sessionService, sessionHub, runnerDone := startSessionRunner(runnerCtx, cfg, logger, stores, gameService)
+	defer func() {
+		stopRunner()
+		<-runnerDone
+	}()
 
 	mailerTester, mailerStatus, err := buildMailer(signalCtx, cfg, logger)
 	if err != nil {
@@ -149,23 +156,29 @@ func newGameService(cfg *config.Config, logger *slog.Logger, stores *store.Store
 // publish ticks through the hub, the runner advances phases on the server
 // clock, and Start hands a started session to the runner via SetAdvancer. The
 // runner is one goroutine bound to ctx (the shutdown context), so it stops
-// before the DB closes. Returns the service + hub for server wiring (MP-5 /
-// #682).
+// before the DB closes. Returns the service + hub for server wiring plus a
+// done channel that closes when the runner goroutine exits, so the caller
+// can wait for it on shutdown rather than leaking a still-logging goroutine
+// past Run (MP-5 / #682, #608).
 func startSessionRunner(
 	ctx context.Context,
 	cfg *config.Config,
 	logger *slog.Logger,
 	stores *store.Stores,
 	scorer livesession.Scorer,
-) (*livesession.Service, *livesession.Hub) {
+) (*livesession.Service, *livesession.Hub, <-chan struct{}) {
 	service := livesession.NewService(stores.LiveSessions, stores.Quizzes, logger)
 	hub := livesession.NewHub()
 	service.SetPublisher(hub)
 	runner := livesession.NewRunner(stores.LiveSessions, stores.Quizzes, hub, scorer, logger, runnerConfig(cfg))
 	service.SetAdvancer(runner)
-	go runner.Run(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runner.Run(ctx)
+	}()
 
-	return service, hub
+	return service, hub, done
 }
 
 // runnerBeatTickDivisor keeps the runner's per-beat scan tick a fraction of

--- a/test/integration/testmain_test.go
+++ b/test/integration/testmain_test.go
@@ -75,6 +75,14 @@ func startServer(t *testing.T, extraEnv map[string]string) (context.Context, tes
 			// that need a signed-in-but-unverified client forge the cookie
 			// directly. Overridable via extraEnv.
 			"SESSION_KEY": testSessionKey,
+			// Quiet the MP-5 session runner by default. Its 250ms beat
+			// polls the DB (ListLiveSessionIDs) in every test server, and
+			// ~100 parallel servers each polling under -race + coverage adds
+			// enough background load to widen the #608 readiness flake. The
+			// vast majority of integration tests never exercise the runner,
+			// so park its beat; the runner tests opt back in via extraEnv
+			// (SESSION_RUNNER_BEAT=30ms), which maps.Copy layers on top.
+			"SESSION_RUNNER_BEAT": "1h",
 		}
 		maps.Copy(env, extraEnv)
 


### PR DESCRIPTION
Closes #608

The integration suite intermittently aborted under `-race` because the MP-5 session-runner goroutine (started fire-and-forget via `go runner.Run(ctx)`) could still be mid-tick and log through the test harness's TestWriter *after* the owning `*testing.T` had finished — a data race that fails the whole package.

- **Fix (root cause):** `app.Run` now owns the runner's context and **waits for the goroutine to exit on shutdown** (`startSessionRunner` returns a done channel; a deferred `stopRunner()` + `<-runnerDone` runs before `Run` returns), so the test's `errCh` drain guarantees the runner has stopped before teardown.
- **Also:** park the runner's beat by default in the integration harness (the 250ms poll across ~100 parallel servers was needless background load; runner tests override via `SESSION_RUNNER_BEAT`).

Validated: session/host tests pass 5x under `-race`; full `make check` green.