### PR TITLE
Return 400 on oversized admin forms and fix timestamp parsing

### DIFF
--- a/internal/admin/playeractions.go
+++ b/internal/admin/playeractions.go
@@ -140,6 +140,9 @@ func HandlePlayerSetEmail(
 		if !ok {
 			return
 		}
+		if !parseActionForm(w, r, logger, "set-email") {
+			return
+		}
 
 		email := strings.ToLower(strings.TrimSpace(r.PostFormValue("email")))
 		if !auth.LooksLikeEmail(email) {
@@ -185,6 +188,9 @@ func HandlePlayerSetDisplayName(
 		if !ok {
 			return
 		}
+		if !parseActionForm(w, r, logger, "set-display-name") {
+			return
+		}
 
 		name := strings.TrimSpace(r.PostFormValue("display_name"))
 
@@ -224,6 +230,9 @@ func HandlePlayerSetPassword(
 		}
 		actor, ok := requireAdminActor(w, r)
 		if !ok {
+			return
+		}
+		if !parseActionForm(w, r, logger, "set-password") {
 			return
 		}
 
@@ -300,6 +309,9 @@ func HandlePlayerSetRole(
 		if !ok {
 			return
 		}
+		if !parseActionForm(w, r, logger, "set-role") {
+			return
+		}
 
 		desired := r.PostFormValue("role")
 		if !roleIsValid(desired) {
@@ -327,16 +339,7 @@ func HandlePlayerSetRole(
 			return
 		}
 
-		if err := store.SetPlayerRole(r.Context(), playerID, desired); err != nil {
-			if errors.Is(err, auth.ErrPlayerNotFound) {
-				http.NotFound(w, r)
-
-				return
-			}
-			logger.ErrorContext(r.Context(), "error setting player role", slog.Any("err", err))
-			flash.SetError(w, "Could not update role. Try again.", 0)
-			redirectToPlayerDetail(w, r, playerID)
-
+		if !writeRoleChange(w, r, logger, store, flash, playerID, desired) {
 			return
 		}
 
@@ -374,6 +377,28 @@ func guardLastAdmin(
 	}
 
 	return true
+}
+
+// writeRoleChange persists the role and maps a write failure onto its
+// response: a missing target is a 404, any other store error a flashed
+// retry + 303. Returns true only when the role was written.
+func writeRoleChange(
+	w http.ResponseWriter, r *http.Request, logger *slog.Logger,
+	store auth.AdminPlayerStore, flash *auth.SignedFlash, playerID int64, desired string,
+) bool {
+	err := store.SetPlayerRole(r.Context(), playerID, desired)
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, auth.ErrPlayerNotFound):
+		http.NotFound(w, r)
+	default:
+		logger.ErrorContext(r.Context(), "error setting player role", slog.Any("err", err))
+		flash.SetError(w, "Could not update role. Try again.", 0)
+		redirectToPlayerDetail(w, r, playerID)
+	}
+
+	return false
 }
 
 // roleLabel maps a role constant to its human word, so the success
@@ -622,6 +647,23 @@ func requireAdminActor(w http.ResponseWriter, r *http.Request) (*auth.Player, bo
 	}
 
 	return p, true
+}
+
+// parseActionForm parses the POST body of a player Set* action, returning
+// false (after answering 400) when MaxFormSizeMiddleware's MaxBytesReader
+// has tripped. Without this, the lazy PostFormValue parse would swallow
+// the error and hand the handler empty values, surfacing a misleading
+// validation flash instead of the real "body too large" failure. action
+// names the handler in the log line.
+func parseActionForm(w http.ResponseWriter, r *http.Request, logger *slog.Logger, action string) bool {
+	if err := r.ParseForm(); err != nil {
+		logger.InfoContext(r.Context(), action+" form parse failed", slog.Any("err", err))
+		http.Error(w, "Form was malformed or too large.", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
 }
 
 // loadActionTarget fetches the target player's detail row. A missing

--- a/internal/admin/playeractions_credentials_test.go
+++ b/internal/admin/playeractions_credentials_test.go
@@ -212,6 +212,51 @@ func TestHandlePlayerSetPassword_TooShortRejectedNoMutation(t *testing.T) {
 	}
 }
 
+func TestHandlePlayerSetEmail_OversizedFormRejectedWith400(t *testing.T) {
+	t.Parallel()
+
+	env := newAdminEnv(t)
+	target := env.seedPlayer(t, "before")
+
+	handler := HandlePlayerSetEmail(slog.New(slog.DiscardHandler), env.admin, newCredFlash(t))
+
+	// A well-formed email body that MaxFormSizeMiddleware caps before the
+	// handler reads it. Wrapping the body in a tiny MaxBytesReader trips
+	// ParseForm the same way an oversized submission does, so the values
+	// come back empty and the handler must answer 400 rather than the
+	// misleading "Enter a valid email address." validation flash.
+	form := url.Values{"email": {"new@example.test"}}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/admin/players/"+strconv.FormatInt(target, 10)+"/email",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("playerID", strconv.FormatInt(target, 10))
+	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}))
+
+	rec := httptest.NewRecorder()
+	req.Body = http.MaxBytesReader(rec, req.Body, 1)
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusBadRequest; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), "Enter a valid email address."; strings.Contains(got, want) {
+		t.Errorf("body = %q, must not contain the validation message %q", got, want)
+	}
+	// The oversized request must not mutate the target or audit anything.
+	detail, err := env.admin.GetPlayerDetail(t.Context(), target)
+	if err != nil {
+		t.Fatalf("GetPlayerDetail err = %v, want nil", err)
+	}
+	if got := detail.Email; got != "" {
+		t.Errorf("email = %q, want empty (no mutation on a rejected form)", got)
+	}
+	if got, want := len(env.auditEntries(t, target)), 0; got != want {
+		t.Errorf("audit entries = %d, want %d on a rejected form", got, want)
+	}
+}
+
 // newPlayerInputRequest builds a POST request carrying the create-player
 // form fields as a urlencoded body. httptest.NewRequest is banned by the
 // noctx linter, so the request is built with a context.

--- a/internal/db/invites.sql.go
+++ b/internal/db/invites.sql.go
@@ -84,7 +84,7 @@ WHERE status = 'pending'
 // Housekeeping for the startup + periodic sweep. Drops every still-pending
 // invite whose link has expired so the table does not grow without bound.
 // Accepted and revoked rows are kept as an audit trail. The caller passes
-// 'now' so the comparison runs in the driver's RFC3339 encoding.
+// 'now' so the comparison runs in the driver's time.Time.String() text encoding.
 func (q *Queries) DeleteExpiredInvites(ctx context.Context, now time.Time) error {
 	_, err := q.db.ExecContext(ctx, deleteExpiredInvites, now)
 	return err
@@ -114,9 +114,9 @@ type GetLiveInviteByTokenHashRow struct {
 // pending (not accepted, not revoked) and not expired. Used by the
 // GET /accept-invite preflight to short-circuit the form render for dead
 // links, and re-checked by POST. The caller passes 'now' so both sides of the
-// expires_at comparison use the driver's RFC3339 encoding (mixing time.Time
-// with CURRENT_TIMESTAMP produces strings of different lengths and the
-// lexicographic comparison silently lies). sql.ErrNoRows means consumed,
+// expires_at comparison use the driver's time.Time.String() text encoding
+// (mixing time.Time with CURRENT_TIMESTAMP produces strings of different
+// lengths and the lexicographic comparison silently lies). sql.ErrNoRows means consumed,
 // revoked, expired, or never existed; the caller maps that to a single
 // user-facing "invite link is no longer valid" response.
 func (q *Queries) GetLiveInviteByTokenHash(ctx context.Context, arg GetLiveInviteByTokenHashParams) (GetLiveInviteByTokenHashRow, error) {

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -192,9 +192,10 @@ type ConsumeEmailVerifyTokenRow struct {
 // in the same transaction, plus pending_email so the caller can branch on
 // the in-session email-change variant (#497) without a second round trip.
 // The caller passes the wall clock as 'now' so both sides of the
-// expires_at comparison use the same RFC3339 encoding the modernc/sqlite
-// driver writes - mixing time.Time with CURRENT_TIMESTAMP produces strings
-// of different lengths and the lexicographic comparison silently lies.
+// expires_at comparison use the same time.Time.String() text encoding the
+// modernc/sqlite driver writes - mixing time.Time with CURRENT_TIMESTAMP
+// produces strings of different lengths and the lexicographic comparison
+// silently lies.
 // sql.ErrNoRows means the token was consumed, expired, or never existed;
 // the caller maps that to a single user-facing "this link is no longer
 // valid" response.
@@ -224,7 +225,8 @@ type ConsumePasswordResetTokenParams struct {
 // not expired. Returns the player_id so the caller can stamp the new
 // password_hash + bump session_version in the same transaction. The
 // caller passes 'now' on both sides so the comparison runs in the
-// driver's RFC3339 encoding (same gotcha email_verify_tokens dodged).
+// driver's time.Time.String() text encoding (same gotcha
+// email_verify_tokens dodged).
 // sql.ErrNoRows means consumed, expired, or never existed; the caller
 // maps that to a single user-facing "link is no longer valid" response.
 func (q *Queries) ConsumePasswordResetToken(ctx context.Context, arg ConsumePasswordResetTokenParams) (int64, error) {

--- a/internal/db/retention.sql.go
+++ b/internal/db/retention.sql.go
@@ -146,8 +146,9 @@ WHERE p.role = 'player'
 // retention window ago". The window in days is a caller-supplied integer,
 // but the cutoff is computed in SQL (datetime('now', '-<days> days')) so
 // both sides of the comparison are SQLite text in the CURRENT_TIMESTAMP
-// encoding rows are minted with; a bound Go time.Time would arrive
-// RFC3339-encoded and the cross-format comparison would silently lie. A
+// encoding rows are minted with; a bound Go time.Time would arrive in the
+// driver's time.Time.String() text encoding and the cross-format
+// comparison would silently lie. A
 // guest with a finished game is kept regardless of age so the sweep never
 // erases a leaderboard score (#626); "finished" is every question of the
 // quiz issued as a game_question, the same finisher predicate the

--- a/internal/queries/invites.sql
+++ b/internal/queries/invites.sql
@@ -19,9 +19,9 @@ VALUES (
 -- pending (not accepted, not revoked) and not expired. Used by the
 -- GET /accept-invite preflight to short-circuit the form render for dead
 -- links, and re-checked by POST. The caller passes 'now' so both sides of the
--- expires_at comparison use the driver's RFC3339 encoding (mixing time.Time
--- with CURRENT_TIMESTAMP produces strings of different lengths and the
--- lexicographic comparison silently lies). sql.ErrNoRows means consumed,
+-- expires_at comparison use the driver's time.Time.String() text encoding
+-- (mixing time.Time with CURRENT_TIMESTAMP produces strings of different
+-- lengths and the lexicographic comparison silently lies). sql.ErrNoRows means consumed,
 -- revoked, expired, or never existed; the caller maps that to a single
 -- user-facing "invite link is no longer valid" response.
 SELECT id, email, invited_by_player_id
@@ -49,7 +49,7 @@ RETURNING id;
 -- Housekeeping for the startup + periodic sweep. Drops every still-pending
 -- invite whose link has expired so the table does not grow without bound.
 -- Accepted and revoked rows are kept as an audit trail. The caller passes
--- 'now' so the comparison runs in the driver's RFC3339 encoding.
+-- 'now' so the comparison runs in the driver's time.Time.String() text encoding.
 DELETE FROM invites
 WHERE status = 'pending'
   AND expires_at <= sqlc.arg('now');

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -377,9 +377,10 @@ LIMIT 1;
 -- in the same transaction, plus pending_email so the caller can branch on
 -- the in-session email-change variant (#497) without a second round trip.
 -- The caller passes the wall clock as 'now' so both sides of the
--- expires_at comparison use the same RFC3339 encoding the modernc/sqlite
--- driver writes - mixing time.Time with CURRENT_TIMESTAMP produces strings
--- of different lengths and the lexicographic comparison silently lies.
+-- expires_at comparison use the same time.Time.String() text encoding the
+-- modernc/sqlite driver writes - mixing time.Time with CURRENT_TIMESTAMP
+-- produces strings of different lengths and the lexicographic comparison
+-- silently lies.
 -- sql.ErrNoRows means the token was consumed, expired, or never existed;
 -- the caller maps that to a single user-facing "this link is no longer
 -- valid" response.
@@ -418,7 +419,8 @@ LIMIT 1;
 -- not expired. Returns the player_id so the caller can stamp the new
 -- password_hash + bump session_version in the same transaction. The
 -- caller passes 'now' on both sides so the comparison runs in the
--- driver's RFC3339 encoding (same gotcha email_verify_tokens dodged).
+-- driver's time.Time.String() text encoding (same gotcha
+-- email_verify_tokens dodged).
 -- sql.ErrNoRows means consumed, expired, or never existed; the caller
 -- maps that to a single user-facing "link is no longer valid" response.
 UPDATE password_reset_tokens

--- a/internal/queries/retention.sql
+++ b/internal/queries/retention.sql
@@ -7,8 +7,9 @@
 -- retention window ago". The window in days is a caller-supplied integer,
 -- but the cutoff is computed in SQL (datetime('now', '-<days> days')) so
 -- both sides of the comparison are SQLite text in the CURRENT_TIMESTAMP
--- encoding rows are minted with; a bound Go time.Time would arrive
--- RFC3339-encoded and the cross-format comparison would silently lie. A
+-- encoding rows are minted with; a bound Go time.Time would arrive in the
+-- driver's time.Time.String() text encoding and the cross-format
+-- comparison would silently lie. A
 -- guest with a finished game is kept regardless of age so the sweep never
 -- erases a leaderboard score (#626); "finished" is every question of the
 -- quiz issued as a game_question, the same finisher predicate the

--- a/internal/store/invite.go
+++ b/internal/store/invite.go
@@ -13,11 +13,11 @@ import (
 
 // CreateInvite inserts a row in invites with the given email, token hash,
 // optional note, audit actor, and absolute expiry (#318). expiresAt is
-// normalised to UTC so the driver's RFC3339 encoding lines up
-// lexicographically with the UTC clock the consume/sweep paths read -
-// mixing offsets between insert and read silently breaks the string
-// comparison. An invitedByPlayerID of 0 stores NULL (deleted/unknown
-// actor); an empty note stores NULL.
+// normalised to UTC so the driver's [time.Time.String] text encoding
+// lines up lexicographically with the UTC clock the consume/sweep paths
+// read - mixing offsets between insert and read silently breaks the
+// string comparison. An invitedByPlayerID of 0 stores NULL
+// (deleted/unknown actor); an empty note stores NULL.
 func (s *PlayerStore) CreateInvite(
 	ctx context.Context, email, tokenHash, note string, invitedByPlayerID int64, expiresAt time.Time,
 ) error {

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -311,9 +311,10 @@ func (s *PlayerStore) MarkPlayerEmailVerifiedIfNew(ctx context.Context, playerID
 
 // CreateVerifyToken inserts a row in email_verify_tokens with the given
 // hash, player id, and absolute expiry. expiresAt is normalised to UTC
-// so the driver's RFC3339 encoding lines up lexicographically with the
-// UTC clock the consume/sweep paths read - mixing offsets between
-// insert and read silently breaks the string comparison.
+// so the driver's [time.Time.String] text encoding lines up
+// lexicographically with the UTC clock the consume/sweep paths read -
+// mixing offsets between insert and read silently breaks the string
+// comparison.
 //
 // pendingEmail carries the new address an in-session email-change
 // request (#497) wants to switch to; "" mints a register/resend row
@@ -456,8 +457,8 @@ func classifyVerifyTokenMiss(ctx context.Context, q *db.Queries, tokenHash strin
 
 // DeleteExpiredVerifyTokens drops expired rows from email_verify_tokens.
 // UTC across all sites that read or write expires_at so the driver's
-// RFC3339 encoding stays lexicographically comparable regardless of the
-// host time zone.
+// [time.Time.String] text encoding stays lexicographically comparable
+// regardless of the host time zone.
 func (s *PlayerStore) DeleteExpiredVerifyTokens(ctx context.Context) error {
 	if err := s.q.DeleteExpiredEmailVerifyTokens(ctx, time.Now().UTC()); err != nil {
 		return fmt.Errorf("failed to delete expired verify tokens: %w", err)
@@ -468,9 +469,10 @@ func (s *PlayerStore) DeleteExpiredVerifyTokens(ctx context.Context) error {
 
 // CreateResetToken inserts a row in password_reset_tokens with the
 // given hash, player id, and absolute expiry. expiresAt is normalised
-// to UTC so the driver's RFC3339 encoding lines up lexicographically
-// with the UTC clock the consume/sweep paths read - mixing offsets
-// between insert and read silently breaks the string comparison.
+// to UTC so the driver's [time.Time.String] text encoding lines up
+// lexicographically with the UTC clock the consume/sweep paths read -
+// mixing offsets between insert and read silently breaks the string
+// comparison.
 func (s *PlayerStore) CreateResetToken(
 	ctx context.Context, tokenHash string, playerID int64, expiresAt time.Time,
 ) error {
@@ -985,17 +987,14 @@ func (s *PlayerStore) ListAdminAuditForTarget(
 	return out, nil
 }
 
-// parseSQLiteTimestamp accepts the two formats modernc.org/sqlite can
-// return for an aggregate over a DATETIME column ("YYYY-MM-DD
-// HH:MM:SS" if the column was written via SQLite helpers, RFC3339 if
-// written via [time.Time]). An unparseable value falls through to nil
-// so a single malformed row does not fail the whole admin list page.
+// parseSQLiteTimestamp parses the bare SQLite datetime format
+// ("YYYY-MM-DD HH:MM:SS") that modernc.org/sqlite returns for an
+// aggregate over a DATETIME column whose values were written by
+// CURRENT_TIMESTAMP. An unparseable value falls through to nil so a
+// single malformed row does not fail the whole admin list page.
 func parseSQLiteTimestamp(raw string) *time.Time {
 	const sqliteDateTime = "2006-01-02 15:04:05"
 	if t, err := time.Parse(sqliteDateTime, raw); err == nil {
-		return &t
-	}
-	if t, err := time.Parse(time.RFC3339, raw); err == nil {
 		return &t
 	}
 

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -1260,13 +1260,13 @@ func TestParseSQLiteTimestamp(t *testing.T) {
 		wantNil bool
 		want    time.Time
 	}{
-		"sqlite datetime format": {
+		"current_timestamp format": {
 			raw:  "2026-06-04 12:34:56",
 			want: time.Date(2026, 6, 4, 12, 34, 56, 0, time.UTC),
 		},
-		"rfc3339 format": {
-			raw:  "2026-06-04T12:34:56Z",
-			want: time.Date(2026, 6, 4, 12, 34, 56, 0, time.UTC),
+		"rfc3339 falls through to nil": {
+			raw:     "2026-06-04T12:34:56Z",
+			wantNil: true,
 		},
 		"unparseable falls through to nil": {
 			raw:     "not a timestamp",

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -267,7 +267,8 @@ func assertRetention(ctx context.Context, t *testing.T, db *sql.DB, s retentionS
 
 // The at argument is a trusted SQLite datetime expression (a test constant),
 // inlined into the statement so created_at evaluates server-side to a
-// CURRENT_TIMESTAMP-shaped string rather than a bound RFC3339 value.
+// CURRENT_TIMESTAMP-shaped string rather than a value bound in the driver's
+// time.Time.String() text encoding.
 func insertQuiz(ctx context.Context, t *testing.T, db *sql.DB, slug, at string, ownerID int64) int64 {
 	t.Helper()
 	res, err := db.ExecContext(ctx,


### PR DESCRIPTION
Closes #796
Closes #797

Note: the admin Set* routes run behind the CSRF middleware, which calls ParseForm and rejects an oversized/malformed body with 403 before the handler. The added 400 branch is therefore defense-in-depth that mirrors the existing HandlePlayerCreateSubmit / invites pattern (the ticket asked to match those), not a new live path.