### PR TITLE
Harden admin promotion, login limiting, and the unverified-login message

### DIFF
--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -105,6 +105,11 @@ var (
 // the per-IP cool-down without sleeping (#494).
 var NewLoginRateLimiterWithClock = newLoginRateLimiterWithClock
 
+// NewAccountLoginLimiterWithClock exposes the internal clock-injected
+// per-account limiter constructor so the external auth_test package can
+// pin the cooldown expiry and prune without sleeping (#786).
+var NewAccountLoginLimiterWithClock = newAccountLoginLimiterWithClock
+
 // ValidateAcceptInviteInput exposes validateAcceptInviteInput so the
 // external test package can pin the display-name + password rule table
 // from input strings without staging an HTTP request.

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -7,7 +7,6 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -117,7 +116,6 @@ func HandleRegisterForm(
 // zero values and SendVerifyEmailBestEffort logs a warning instead of
 // sending, which is the right behaviour for unit tests.
 type RegisterDeps struct {
-	AdminEmails   []string
 	GoogleEnabled bool
 	Mailer        VerifyEmailSender
 	Tokens        VerifyTokenStore
@@ -131,11 +129,13 @@ type RegisterDeps struct {
 // HandleRegisterSubmit handles POST /register. When the caller already
 // has an anonymous session row, the handler upgrades that row via
 // ClaimPlayer so the visitor's game history follows them; if the row
-// was concurrently claimed it falls back to CreatePlayer. Emails in
-// deps.AdminEmails are promoted to admin; the first password-bearing
-// registrant is atomically promoted by the store (see CreatePlayer).
-// On success the handler dispatches a verification email best-effort
-// so an SMTP outage does not block the signup.
+// was concurrently claimed it falls back to CreatePlayer. Registrants
+// are always created as plain players: the ADMIN_EMAILS allowlist is
+// consulted at email-verify time (#785), not here, so admin is never
+// stamped on an unproven address. The first password-bearing registrant
+// is still atomically promoted by the store (see CreatePlayer). On
+// success the handler dispatches a verification email best-effort so an
+// SMTP outage does not block the signup.
 func HandleRegisterSubmit(
 	logger *slog.Logger,
 	csrfMgr *csrf.Manager,
@@ -173,11 +173,12 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		role := RolePlayer
-		if slices.Contains(deps.AdminEmails, input.CleanedEmail) {
-			role = RoleAdmin
-		}
-
+		// Do NOT promote to admin based on the submitted email here: the
+		// address is unproven at registration. The ADMIN_EMAILS allowlist
+		// is consulted at email-verify time instead (#785), once the
+		// address is proven. The store's own "first password-bearing
+		// registrant becomes admin" rule (CreatePlayer/ClaimPlayer) is a
+		// separate bootstrap concern and stays.
 		hashed, err := HashPassword(password)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "error hashing password", slog.Any("err", err))
@@ -189,7 +190,7 @@ func HandleRegisterSubmit(
 		renderers := registerRenderers{form: render, pending: pending, sessions: sessions}
 
 		player, err := claimOrCreatePlayer(
-			r, players, sessions, input.CleanedDisplayName, input.CleanedEmail, hashed, role,
+			r, players, sessions, input.CleanedDisplayName, input.CleanedEmail, hashed, RolePlayer,
 		)
 		if err != nil {
 			handleRegisterError(w, r, logger, renderers, deps, input, err)
@@ -461,14 +462,18 @@ func redirectIfSignedIn(
 // player attempts to log in (#492). Mailer / Tokens / BaseURL together
 // cover the verify-email side; ResendLimiter is the per-IP cooldown
 // shared with the public resend form, so a hot bucket on the login
-// branch cannot starve the user-driven resend and vice versa. The
-// bundle exists so HandleLoginSubmit stays under revive's argument
-// limit as the dep set grows.
+// branch cannot starve the user-driven resend and vice versa. Limiter
+// is the per-IP gap; AccountLimiter is the per-account backoff (#786),
+// folded into the invalid-credentials path so a cooled-down account
+// stays indistinguishable from a wrong password. The bundle exists so
+// HandleLoginSubmit stays under revive's argument limit as the dep set
+// grows.
 type LoginDeps struct {
 	Players             PlayerStore
 	Sessions            *session.Manager
 	Games               AnonymousGameMigrator
 	Limiter             *LoginRateLimiter
+	AccountLimiter      *AccountLoginLimiter
 	Mailer              VerifyEmailSender
 	Tokens              VerifyTokenStore
 	ResendLimiter       *VerifyResendLimiter
@@ -547,31 +552,101 @@ func HandleLoginSubmit(
 			return
 		}
 
-		player, ok := authenticateLogin(logger, formCfg, w, r, deps.Players, dummyHash, email, password)
+		creds := loginCreds{
+			email:          email,
+			password:       password,
+			dummyHash:      dummyHash,
+			accountLimiter: deps.AccountLimiter,
+		}
+		player, ok := authenticateLogin(logger, formCfg, w, r, deps.Players, creds)
 		if !ok {
 			return
 		}
 
-		// Credentials are correct but the account email is unverified
-		// (#492): refuse the sign-in, re-render the login form with a
-		// banner that names the address, and dispatch a fresh verify
-		// link best-effort. The login limiter was already stamped above,
-		// so this branch counts toward the per-IP cap just like a
-		// wrong-password attempt.
-		if !player.IsEmailVerified() {
-			renderUnverifiedLogin(logger, formCfg, deps, w, r, player)
-
-			return
-		}
-
-		var priorSessionPlayerID *int64
-		if id, ok := deps.Sessions.PlayerID(r); ok {
-			priorSessionPlayerID = &id
-		}
-		deps.Sessions.Set(w, player.ID, player.SessionVersion)
-		migrateGamesAfterSignIn(r.Context(), logger, deps.Players, deps.Games, priorSessionPlayerID, player.ID)
-		redirectAfterLogin(w, r, player.Role)
+		completeLogin(logger, formCfg, deps, w, r, player, email)
 	})
+}
+
+// completeLogin finishes a credential-valid login: it applies the
+// per-account cooldown gate (#786), refuses an unverified account (#492),
+// or sets the session and redirects. Split out of HandleLoginSubmit so
+// that constructor stays under revive's function-length limit.
+func completeLogin(
+	logger *slog.Logger,
+	formCfg loginFormCfg,
+	deps LoginDeps,
+	w http.ResponseWriter,
+	r *http.Request,
+	player *Player,
+	email string,
+) {
+	// Per-account backoff (#786): once an account has crossed the
+	// failure threshold, refuse even a correct password until the
+	// cooldown elapses, and render the SAME generic invalid-credentials
+	// response a wrong password gets. This denies a brute-force the
+	// chance to land a correct guess mid-spray without ever signalling
+	// that the account is throttled or that it exists.
+	if registerAccountFailureIfCooledDown(deps.AccountLimiter, email) {
+		renderInvalidCredentials(formCfg, w, r, email)
+
+		return
+	}
+
+	// Credentials are correct and the account is not cooled down, so
+	// clear its failure streak (a user who finally typed the right
+	// password is not penalised for earlier typos).
+	clearAccountFailures(deps.AccountLimiter, email)
+
+	// Credentials are correct but the account email is unverified
+	// (#492): refuse the sign-in, re-render the login form with a
+	// generic "check your email" banner, and dispatch a fresh verify
+	// link best-effort. The banner names no address and does not confirm
+	// the password (#787).
+	if !player.IsEmailVerified() {
+		renderUnverifiedLogin(logger, formCfg, deps, w, r, player, email)
+
+		return
+	}
+
+	var priorSessionPlayerID *int64
+	if id, ok := deps.Sessions.PlayerID(r); ok {
+		priorSessionPlayerID = &id
+	}
+	deps.Sessions.Set(w, player.ID, player.SessionVersion)
+	migrateGamesAfterSignIn(r.Context(), logger, deps.Players, deps.Games, priorSessionPlayerID, player.ID)
+	redirectAfterLogin(w, r, player.Role)
+}
+
+// registerAccountFailureIfCooledDown reports whether account is in the
+// per-account cooldown (#786) and, if so, records the current attempt as
+// another failure so a brute-force that keeps guessing keeps extending
+// the window. Nil limiter (unit tests that don't wire it) is never in
+// cooldown.
+func registerAccountFailureIfCooledDown(limiter *AccountLoginLimiter, account string) bool {
+	if limiter == nil || !limiter.InCooldown(account) {
+		return false
+	}
+	limiter.RegisterFailure(account)
+
+	return true
+}
+
+// clearAccountFailures resets account's failure streak after a genuine
+// credential match. Nil limiter is a no-op.
+func clearAccountFailures(limiter *AccountLoginLimiter, account string) {
+	if limiter == nil {
+		return
+	}
+	limiter.RegisterSuccess(account)
+}
+
+// recordAccountFailure records one failed login for account (#786). Nil
+// limiter is a no-op.
+func recordAccountFailure(limiter *AccountLoginLimiter, account string) {
+	if limiter == nil {
+		return
+	}
+	limiter.RegisterFailure(account)
 }
 
 // loginFormCfg bundles the per-handler login form render config so
@@ -583,28 +658,42 @@ type loginFormCfg struct {
 	googleEnabled       bool
 }
 
+// loginCreds bundles the per-attempt credential inputs so
+// authenticateLogin stays under revive's argument-limit once the
+// dummy-hash and per-account limiter are threaded through it.
+type loginCreds struct {
+	email          string
+	password       string
+	dummyHash      func() string
+	accountLimiter *AccountLoginLimiter
+}
+
 // authenticateLogin runs the lookup-then-bcrypt half of the login
 // flow. Returns (player, true) on a valid match; writes the response
 // itself and returns (nil, false) on every miss/error path so the
 // caller can early-return. Extracted from HandleLoginSubmit so that
 // handler stays under revive's function-length limit once the rate
 // limiter check is wired in front of it (#494).
+//
+// Each credential-mismatch branch records a per-account failure (#786)
+// so a focused brute-force trips the account cooldown; the internal-
+// error branch does not, since a DB hiccup is not the user's fault.
 func authenticateLogin(
 	logger *slog.Logger,
 	cfg loginFormCfg,
 	w http.ResponseWriter,
 	r *http.Request,
 	players PlayerStore,
-	dummyHash func() string,
-	email, password string,
+	creds loginCreds,
 ) (*Player, bool) {
-	player, err := players.GetPlayerByEmail(r.Context(), email)
+	player, err := players.GetPlayerByEmail(r.Context(), creds.email)
 	if err != nil {
 		if errors.Is(err, ErrPlayerNotFound) {
 			// Equalise timing with the valid-email path so an attacker
 			// cannot enumerate emails by response time.
-			_ = CheckPassword(dummyHash(), password)
-			renderInvalidCredentials(cfg, w, r, email)
+			_ = CheckPassword(creds.dummyHash(), creds.password)
+			recordAccountFailure(creds.accountLimiter, creds.email)
+			renderInvalidCredentials(cfg, w, r, creds.email)
 
 			return nil, false
 		}
@@ -617,14 +706,16 @@ func authenticateLogin(
 	if player.PasswordHash == "" {
 		// Legacy seed admin with no hash on file. Run the dummy compare
 		// to keep timing consistent.
-		_ = CheckPassword(dummyHash(), password)
-		renderInvalidCredentials(cfg, w, r, email)
+		_ = CheckPassword(creds.dummyHash(), creds.password)
+		recordAccountFailure(creds.accountLimiter, creds.email)
+		renderInvalidCredentials(cfg, w, r, creds.email)
 
 		return nil, false
 	}
 
-	if err := CheckPassword(player.PasswordHash, password); err != nil {
-		renderInvalidCredentials(cfg, w, r, email)
+	if err := CheckPassword(player.PasswordHash, creds.password); err != nil {
+		recordAccountFailure(creds.accountLimiter, creds.email)
+		renderInvalidCredentials(cfg, w, r, creds.email)
 
 		return nil, false
 	}
@@ -632,18 +723,21 @@ func authenticateLogin(
 	return player, true
 }
 
-// renderUnverifiedLogin re-renders the login form with the
-// "please verify your email" banner naming the resolved address, and
-// fires a fresh verify-email send through the per-IP resend limiter.
-// Status stays 200 OK so an unverified visitor who reloads sees the
-// form again without the browser flagging a 4xx (the response shape
-// mirrors the verify-email/request flow's success render).
+// renderUnverifiedLogin re-renders the login form with a generic
+// "check your email" banner and fires a fresh verify-email send through
+// the per-IP resend limiter. Status stays 200 OK so an unverified
+// visitor who reloads sees the form again without the browser flagging a
+// 4xx (the response shape mirrors the verify-email/request flow's
+// success render).
 //
-// Telling the visitor "we resent the link to <email>" leaks that the
-// credentials were correct - an enumeration oracle. Accepted as the
-// UX cost: a generic "invalid email or password" here would make
-// unverified-but-correct logins feel like wrong-password to a real
-// user. Decided in #492.
+// The banner deliberately names no address and does not confirm the
+// password was right. Echoing the address ("we resent the link to
+// <email>") only happens when credentials are correct, so it would leak
+// both account existence and password correctness - an enumeration /
+// password oracle. The generic wording (#787, reversing the #492
+// address echo) keeps an unverified-but-correct attempt indistinguishable
+// from a wrong-password one. The submitted email is preserved in the
+// field only so a real user does not have to retype it.
 func renderUnverifiedLogin(
 	logger *slog.Logger,
 	cfg loginFormCfg,
@@ -651,12 +745,13 @@ func renderUnverifiedLogin(
 	w http.ResponseWriter,
 	r *http.Request,
 	player *Player,
+	email string,
 ) {
 	dispatchVerifyResend(r, logger, deps, player)
 	cfg.render.render(w, r, http.StatusOK, formData{
 		Title:        "Log in",
-		Email:        player.Email,
-		Message:      "Please verify your email - we just resent the link to " + player.Email + ".",
+		Email:        email,
+		Message:      "Check your email to finish signing in.",
 		ShowRegister: cfg.registrationEnabled,
 		ShowGoogle:   cfg.googleEnabled,
 		Next:         SafeNextPath(r.PostFormValue("next")),

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -164,11 +164,17 @@ func TestHandleRegisterSubmit_SecondUser_DefaultsToPlayer(t *testing.T) {
 	}
 }
 
-func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
+// TestHandleRegisterSubmit_AdminEmail_StaysPlayerUntilVerified pins #785:
+// registration must NOT promote to admin off the submitted (unverified)
+// email even when it is on the allowlist. The address is unproven here,
+// so the registrant lands as a plain player; the verify-consume path is
+// the only place the admin role is stamped.
+func TestHandleRegisterSubmit_AdminEmail_StaysPlayerUntilVerified(t *testing.T) {
 	t.Parallel()
 
 	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
-	// Pre-seed first user so the count > 0 and the env var path is exercised.
+	// Pre-seed a credentialled user so the store's first-registrant admin
+	// rule does not fire for carol and confound the allowlist check.
 	if _, err := players.CreatePlayer(t.Context(), "first", "first@example.test", "h", RolePlayer); err != nil {
 		t.Fatalf("CreatePlayer err = %v, want nil", err)
 	}
@@ -178,7 +184,7 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 		nil,
 		players,
 		session.New([]byte("k"), true),
-		RegisterDeps{AdminEmails: []string{"alice@example.test", "carol@example.test"}},
+		RegisterDeps{},
 	)
 	rec := postForm(t, handler, "/register", url.Values{
 		"display_name":     {"carol"},
@@ -193,8 +199,8 @@ func TestHandleRegisterSubmit_AdminEmailsEnv_PromotesToAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPlayerByDisplayName err = %v, want nil", err)
 	}
-	if got, want := p.Role, RoleAdmin; got != want {
-		t.Errorf("Role = %q, want %q", got, want)
+	if got, want := p.Role, RolePlayer; got != want {
+		t.Errorf("Role = %q, want %q (admin must not be granted on an unverified email)", got, want)
 	}
 }
 
@@ -1122,10 +1128,14 @@ func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 	}
 }
 
-// TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends pins #492:
-// valid credentials against a row whose email_verified_at is NULL must
-// re-render the login form (no 303 to landing, no session cookie set)
-// and trigger a fresh verify-email send through the wired-in mailer.
+// TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends pins #492 +
+// #787: valid credentials against a row whose email_verified_at is NULL
+// must re-render the login form (no 303 to landing, no session cookie
+// set) and trigger a fresh verify-email send through the wired-in
+// mailer. The banner is the generic "check your email" message that
+// names no address and does not confirm the password (#787), so an
+// unverified-but-correct attempt is indistinguishable from a
+// wrong-password one.
 func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 	t.Parallel()
 
@@ -1160,11 +1170,14 @@ func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if want := "verify your email"; !strings.Contains(body, want) {
-		t.Errorf("body missing verify-email banner; body=%.300q", body)
+	if want := "Check your email to finish signing in."; !strings.Contains(body, want) {
+		t.Errorf("body missing generic check-email banner; body=%.300q", body)
 	}
-	if want := "unv@example.test"; !strings.Contains(body, want) {
-		t.Errorf("body missing recipient address; body=%.300q", body)
+	// The banner must NOT echo the address or otherwise confirm the
+	// credentials were correct (#787); doing so would make this an
+	// account-existence + password oracle.
+	if dontWant := "resent the link to"; strings.Contains(body, dontWant) {
+		t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, body)
 	}
 	for _, c := range rec.Result().Cookies() {
 		if c.Name == session.CookieName && c.Value != "" {

--- a/internal/auth/login_limiter.go
+++ b/internal/auth/login_limiter.go
@@ -9,12 +9,54 @@ import (
 	"github.com/starquake/topbanana/internal/request"
 )
 
+// POST /login is throttled on two independent axes:
+//
+//   - Per-IP gap ([LoginRateLimiter]): a short minimum gap between
+//     consecutive attempts from one client address, checked BEFORE the
+//     credential lookup. Blocks distributed spraying from a single host
+//     and returns a 429; keyed on IP, so it reveals nothing about which
+//     accounts exist (#494).
+//   - Per-account backoff ([AccountLoginLimiter]): a failed-attempt
+//     counter keyed on the submitted email. After accountLoginThreshold
+//     consecutive failures the account enters a cooldown during which
+//     even a correct password is refused with the ordinary
+//     invalid-credentials response (#786). Slows a focused brute-force
+//     against one account without an IP rotation defeating it.
+//
+// The per-account limiter is deliberately enumeration-opaque: a cooled-
+// down account responds IDENTICALLY to a normal wrong-password attempt
+// (same 401, same generic "invalid email or password" banner, same
+// dummy-hash timing), so a probe cannot tell a hammered/known account
+// apart from a never-tried one. It changes only WHETHER a correct
+// password is accepted, never the response shape.
+
 // loginCooldown is the per-IP minimum gap between consecutive
 // POST /login attempts. A few seconds is short enough that a user
 // fixing a typo barely notices, long enough that a distributed
 // brute-force still spends real wall-clock time per guess on top of
 // the bcrypt compare cost (#494).
 const loginCooldown = 3 * time.Second
+
+// accountLoginThreshold is the number of consecutive failed attempts
+// for one account before the per-account cooldown engages. A handful of
+// fat-fingered passwords stays under it; a brute-force trips it fast.
+const accountLoginThreshold = 5
+
+// accountLoginCooldown is how long an account stays in backoff after the
+// threshold is reached. Measured from the most recent failure, so a
+// brute-force that keeps guessing keeps the account locked while a real
+// user who walks away is admitted again once it elapses.
+const accountLoginCooldown = 15 * time.Minute
+
+// AccountLoginThreshold exposes the per-account failure threshold so the
+// wiring layer (and tests) can build an [AccountLoginLimiter] with the
+// same value the handler reasons about.
+func AccountLoginThreshold() int { return accountLoginThreshold }
+
+// AccountLoginCooldown exposes the per-account backoff window so the
+// wiring layer (and tests) can build an [AccountLoginLimiter] with the
+// same value the handler reasons about.
+func AccountLoginCooldown() time.Duration { return accountLoginCooldown }
 
 // LoginCooldown exposes the per-IP cool-down so the wiring layer can
 // build a [LoginRateLimiter] with the same window the handler logs
@@ -94,4 +136,113 @@ func (l *LoginRateLimiter) Allow(ip string) (time.Duration, bool) {
 	l.last[ip] = now
 
 	return 0, true
+}
+
+// accountFailures tracks one account's recent failed-login streak.
+type accountFailures struct {
+	count    int
+	lastSeen time.Time
+}
+
+// AccountLoginLimiter is the per-account half of the login throttle
+// (#786). It counts consecutive failed attempts keyed on the submitted
+// email and reports a cooldown once the streak reaches the threshold.
+// Unlike [LoginRateLimiter] it does NOT short-circuit the handler with a
+// distinct status: the caller folds [AccountLoginLimiter.InCooldown]
+// into the ordinary invalid-credentials path so a cooled-down account is
+// indistinguishable from a wrong-password attempt (no "locked" signal,
+// no enumeration oracle).
+//
+// Concurrency-safe; stale entries are pruned on every call so memory
+// stays proportional to the live attacked-account set rather than the
+// lifetime set.
+type AccountLoginLimiter struct {
+	mu        sync.Mutex
+	entries   map[string]*accountFailures
+	threshold int
+	cooldown  time.Duration
+	now       func() time.Time
+}
+
+// NewAccountLoginLimiter returns a limiter that trips after threshold
+// consecutive failures for one account and holds the cooldown from the
+// most recent failure. [time.Now] is the clock; the export_test seam
+// injects a fake clock so tests fast-forward without sleeping.
+func NewAccountLoginLimiter(threshold int, cooldown time.Duration) *AccountLoginLimiter {
+	return newAccountLoginLimiterWithClock(threshold, cooldown, time.Now)
+}
+
+func newAccountLoginLimiterWithClock(
+	threshold int, cooldown time.Duration, now func() time.Time,
+) *AccountLoginLimiter {
+	return &AccountLoginLimiter{
+		entries:   map[string]*accountFailures{},
+		threshold: threshold,
+		cooldown:  cooldown,
+		now:       now,
+	}
+}
+
+// InCooldown reports whether account has reached the failure threshold
+// and is still inside the cooldown window. An empty account string is
+// never in cooldown (a blank submitted email cannot identify a row).
+func (l *AccountLoginLimiter) InCooldown(account string) bool {
+	if account == "" {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.pruneLocked(l.now())
+	e, ok := l.entries[account]
+	if !ok {
+		return false
+	}
+
+	return e.count >= l.threshold
+}
+
+// RegisterFailure records one failed attempt for account, extending the
+// cooldown window from the current time. A blank account is ignored.
+func (l *AccountLoginLimiter) RegisterFailure(account string) {
+	if account == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.pruneLocked(now)
+	e, ok := l.entries[account]
+	if !ok {
+		e = &accountFailures{}
+		l.entries[account] = e
+	}
+	e.count++
+	e.lastSeen = now
+}
+
+// RegisterSuccess clears account's failure streak after a genuine
+// sign-in, so a user who eventually types the right password is not
+// penalised by earlier typos. A blank account is ignored.
+func (l *AccountLoginLimiter) RegisterSuccess(account string) {
+	if account == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.entries, account)
+}
+
+// pruneLocked drops entries whose last failure has aged past the
+// cooldown window, so a one-off wrong password does not pin memory.
+// Caller holds l.mu.
+func (l *AccountLoginLimiter) pruneLocked(now time.Time) {
+	cutoff := now.Add(-l.cooldown)
+	for k, e := range l.entries {
+		if e.lastSeen.Before(cutoff) {
+			delete(l.entries, k)
+		}
+	}
 }

--- a/internal/auth/login_limiter_test.go
+++ b/internal/auth/login_limiter_test.go
@@ -172,3 +172,202 @@ func postLogin(t *testing.T, handler http.Handler, displayName, password string)
 
 	return rec
 }
+
+// TestHandleLoginSubmit_AccountCooldown_RejectsCorrectPassword pins the
+// #786 contract end to end: after the threshold of failures for one
+// account, even the correct password is refused, and the refusal is the
+// SAME generic 401 invalid-credentials response a wrong password gets -
+// no "locked" signal, no status change. The per-IP limiter is given a
+// zero window so it never fires and the per-account path is what gates.
+func TestHandleLoginSubmit_AccountCooldown_RejectsCorrectPassword(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	hash, err := HashPassword("correctbattery")
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	if _, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RoleAdmin); err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	markVerified(t, players, "alice")
+
+	accountLimiter := NewAccountLoginLimiter(3, time.Minute)
+	handler := HandleLoginSubmit(discardLogger(), nil, LoginDeps{
+		Players:        players,
+		Sessions:       session.New([]byte("k"), true),
+		Limiter:        NewLoginRateLimiter(0, nil),
+		AccountLimiter: accountLimiter,
+	})
+
+	// Three wrong-password attempts trip the per-account cooldown; each
+	// is the ordinary 401.
+	for i := range 3 {
+		rec := postLoginEmail(t, handler, "alice@example.test", "wrong-password")
+		if got, want := rec.Code, http.StatusUnauthorized; got != want {
+			t.Fatalf("attempt %d status = %d, want %d", i+1, got, want)
+		}
+	}
+
+	// The correct password now arrives, but the account is cooled down:
+	// refused with the identical generic 401, no session cookie.
+	rec := postLoginEmail(t, handler, "alice@example.test", "correctbattery")
+	if got, want := rec.Code, http.StatusUnauthorized; got != want {
+		t.Fatalf("correct-password-during-cooldown status = %d, want %d (must read as wrong password)", got, want)
+	}
+	if got, want := rec.Body.String(), "Invalid email or password."; !strings.Contains(got, want) {
+		t.Errorf("body should be the generic invalid-credentials banner; got %.300q", got)
+	}
+	if dontWant := "locked"; strings.Contains(strings.ToLower(rec.Body.String()), dontWant) {
+		t.Errorf("body leaks a lock signal %q; got %.300q", dontWant, rec.Body.String())
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == session.CookieName && c.Value != "" {
+			t.Errorf("session cookie set during account cooldown: %+v", c)
+		}
+	}
+}
+
+// TestHandleLoginSubmit_AccountCooldown_OtherAccountUnaffected pins that
+// the per-account cooldown is scoped to the hammered account: a
+// different account with correct credentials still signs in while the
+// first is locked.
+func TestHandleLoginSubmit_AccountCooldown_OtherAccountUnaffected(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	hash, err := HashPassword("correctbattery")
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	for _, name := range []string{"alice", "bob"} {
+		if _, err := players.CreatePlayer(t.Context(), name, name+"@example.test", hash, RolePlayer); err != nil {
+			t.Fatalf("CreatePlayer %q err = %v, want nil", name, err)
+		}
+		markVerified(t, players, name)
+	}
+
+	accountLimiter := NewAccountLoginLimiter(3, time.Minute)
+	handler := HandleLoginSubmit(discardLogger(), nil, LoginDeps{
+		Players:        players,
+		Sessions:       session.New([]byte("k"), true),
+		Limiter:        NewLoginRateLimiter(0, nil),
+		AccountLimiter: accountLimiter,
+	})
+
+	for range 3 {
+		postLoginEmail(t, handler, "alice@example.test", "wrong-password")
+	}
+	// Alice is now cooled down; bob's correct credentials still admit.
+	rec := postLoginEmail(t, handler, "bob@example.test", "correctbattery")
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Errorf("bob login status = %d, want %d (other account must be unaffected)", got, want)
+	}
+}
+
+// postLoginEmail POSTs /login with the email field the handler actually
+// reads (distinct from postLogin, which posts a displayName field for
+// the wrong-credentials rate-limit cases).
+func postLoginEmail(t *testing.T, handler http.Handler, email, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"email": {email}, "password": {password}}
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost, "/login", strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// TestAccountLoginLimiter_TripsAfterThreshold pins #786: the limiter
+// reports no cooldown until the failure count reaches the threshold,
+// then reports a cooldown.
+func TestAccountLoginLimiter_TripsAfterThreshold(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewAccountLoginLimiter(3, time.Minute)
+	if limiter.InCooldown("alice@example.test") {
+		t.Fatal("InCooldown before any failure = true, want false")
+	}
+	for i := range 2 {
+		limiter.RegisterFailure("alice@example.test")
+		if limiter.InCooldown("alice@example.test") {
+			t.Fatalf("InCooldown after %d failures = true, want false (threshold 3)", i+1)
+		}
+	}
+	limiter.RegisterFailure("alice@example.test")
+	if !limiter.InCooldown("alice@example.test") {
+		t.Error("InCooldown after reaching threshold = false, want true")
+	}
+}
+
+// TestAccountLoginLimiter_PerAccount pins that the failure streak is
+// keyed on the account: hammering one account never cools down another.
+func TestAccountLoginLimiter_PerAccount(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewAccountLoginLimiter(3, time.Minute)
+	for range 3 {
+		limiter.RegisterFailure("alice@example.test")
+	}
+	if !limiter.InCooldown("alice@example.test") {
+		t.Fatal("alice InCooldown = false, want true")
+	}
+	if limiter.InCooldown("bob@example.test") {
+		t.Error("bob InCooldown = true, want false (limiter is per-account)")
+	}
+}
+
+// TestAccountLoginLimiter_SuccessClears pins that a genuine sign-in
+// resets the streak so earlier typos do not penalise the user.
+func TestAccountLoginLimiter_SuccessClears(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewAccountLoginLimiter(3, time.Minute)
+	limiter.RegisterFailure("alice@example.test")
+	limiter.RegisterFailure("alice@example.test")
+	limiter.RegisterSuccess("alice@example.test")
+	limiter.RegisterFailure("alice@example.test")
+	if limiter.InCooldown("alice@example.test") {
+		t.Error("InCooldown after success reset + 1 failure = true, want false")
+	}
+}
+
+// TestAccountLoginLimiter_PrunesAfterCooldown pins that an aged-out
+// streak is forgotten: once the cooldown window elapses past the last
+// failure, the account is no longer in cooldown and its entry prunes.
+// Uses the injected clock so no real time passes.
+func TestAccountLoginLimiter_PrunesAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	limiter := NewAccountLoginLimiterWithClock(3, 15*time.Minute, clock)
+
+	for range 3 {
+		limiter.RegisterFailure("alice@example.test")
+	}
+	if !limiter.InCooldown("alice@example.test") {
+		t.Fatal("InCooldown right after threshold = false, want true")
+	}
+
+	now = now.Add(16 * time.Minute)
+	if limiter.InCooldown("alice@example.test") {
+		t.Error("InCooldown after cooldown elapsed = true, want false (entry should prune)")
+	}
+}
+
+// TestAccountLoginLimiter_BlankAccountIgnored pins that a blank
+// submitted email never trips a cooldown: an empty identifier cannot
+// name a real row, so counting failures on "" would be meaningless.
+func TestAccountLoginLimiter_BlankAccountIgnored(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewAccountLoginLimiter(1, time.Minute)
+	limiter.RegisterFailure("")
+	if limiter.InCooldown("") {
+		t.Error("InCooldown for blank account = true, want false")
+	}
+}

--- a/internal/auth/verify_handler.go
+++ b/internal/auth/verify_handler.go
@@ -1,13 +1,25 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 
 	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/session"
 )
+
+// RoleSetter promotes a player to a role at email-verify time. The
+// concrete store.PlayerStore satisfies it via SetPlayerRole; the narrow
+// interface lives here so the verify handler can stamp the admin role
+// without importing internal/store.
+type RoleSetter interface {
+	// SetPlayerRole sets the role on the row identified by id. Returns
+	// ErrPlayerNotFound when no row matches.
+	SetPlayerRole(ctx context.Context, playerID int64, role string) error
+}
 
 // verifyEmailPageData is the payload the verify-email page renders.
 // ShowContinue gates the "Continue" CTA: the success and already-used
@@ -29,6 +41,11 @@ type verifyEmailPageData struct {
 // clients prefetching the link cannot keep the user from completing
 // verification in a fresh browser window.
 //
+// adminEmails is the ADMIN_EMAILS allowlist; on a fresh verify the
+// handler stamps the admin role when the now-proven address matches an
+// entry (#785). Registration deliberately leaves the role at player so
+// admin is never granted on an unverified address.
+//
 // The success branch covers both the register-time verify (the
 // historical case) and the in-session email-change consume (#497).
 // The store layer chooses which side effect runs based on the token
@@ -43,7 +60,9 @@ func HandleVerifyEmail(
 	csrfMgr *csrf.Manager,
 	tokens VerifyTokenStore,
 	players PlayerStore,
+	roles RoleSetter,
 	sessions *session.Manager,
+	adminEmails []string,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/verify_email.gohtml")
 
@@ -65,6 +84,9 @@ func HandleVerifyEmail(
 		}
 
 		ownerID, err := tokens.ConsumeVerifyToken(r.Context(), HashVerifyToken(raw))
+		if err == nil {
+			promoteVerifiedAdminIfAllowlisted(r.Context(), logger, players, roles, adminEmails, ownerID)
+		}
 		landing := postVerifyLanding(w, r, players, sessions, ownerID)
 		renderVerifyOutcome(w, r, logger, render, verifyOutcome{
 			logger:   logger,
@@ -75,6 +97,44 @@ func HandleVerifyEmail(
 			err:      err,
 		})
 	})
+}
+
+// promoteVerifiedAdminIfAllowlisted stamps the admin role on the player
+// whose verify token just consumed, when the now-proven email matches
+// the ADMIN_EMAILS allowlist (#785). The check runs against the freshly
+// verified address, not the address submitted at registration, so admin
+// is only ever granted on an address the user controls.
+//
+// Best-effort: a lookup or role-write failure is logged and the verify
+// flow still renders success. The player keeps their current (player)
+// role and an operator can promote them by hand or the next verify hits
+// the same path. A row already at admin is left untouched so the write
+// is skipped on the common already-promoted re-verify.
+func promoteVerifiedAdminIfAllowlisted(
+	ctx context.Context,
+	logger *slog.Logger,
+	players PlayerStore,
+	roles RoleSetter,
+	adminEmails []string,
+	ownerID int64,
+) {
+	if ownerID == 0 || len(adminEmails) == 0 {
+		return
+	}
+	p, err := players.GetPlayerByID(ctx, ownerID)
+	if err != nil {
+		logger.WarnContext(ctx, "verify admin promotion: player lookup failed",
+			slog.Int64("player_id", ownerID), slog.Any("err", err))
+
+		return
+	}
+	if p.Role == RoleAdmin || !slices.Contains(adminEmails, p.Email) {
+		return
+	}
+	if err := roles.SetPlayerRole(ctx, ownerID, RoleAdmin); err != nil {
+		logger.WarnContext(ctx, "verify admin promotion: set role failed",
+			slog.Int64("player_id", ownerID), slog.Any("err", err))
+	}
 }
 
 // verifyOutcome groups the consume-result plumbing renderVerifyOutcome

--- a/internal/auth/verify_handler_test.go
+++ b/internal/auth/verify_handler_test.go
@@ -104,7 +104,9 @@ func TestHandleVerifyEmail_MismatchedSessionClears(t *testing.T) {
 	sessions.Set(rec, sessionPlayer.ID, sessionPlayer.SessionVersion)
 	cookie := rec.Result().Cookies()[0]
 
-	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
+	handler := HandleVerifyEmail(
+		discardLogger(), nil, stores.VerifyTokens, stores.Players, stores.AdminPlayers, sessions, nil,
+	)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token="+raw, nil)
 	req.AddCookie(cookie)
 	out := httptest.NewRecorder()
@@ -146,7 +148,9 @@ func TestHandleVerifyEmail_MatchingSessionKeepsLanding(t *testing.T) {
 	sessions.Set(rec, player.ID, player.SessionVersion)
 	cookie := rec.Result().Cookies()[0]
 
-	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
+	handler := HandleVerifyEmail(
+		discardLogger(), nil, stores.VerifyTokens, stores.Players, stores.AdminPlayers, sessions, nil,
+	)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/verify-email?token="+raw, nil)
 	req.AddCookie(cookie)
 	out := httptest.NewRecorder()
@@ -160,12 +164,88 @@ func TestHandleVerifyEmail_MatchingSessionKeepsLanding(t *testing.T) {
 	}
 }
 
+// TestHandleVerifyEmail_AllowlistedEmail_PromotesToAdmin pins the
+// verify-time half of #785: a registrant whose now-proven email is on
+// the ADMIN_EMAILS allowlist is stamped admin only after consuming the
+// verify token, not at registration.
+func TestHandleVerifyEmail_AllowlistedEmail_PromotesToAdmin(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	// Seed a credentialled player first so the store's first-registrant
+	// admin rule does not auto-promote alice and mask the allowlist path.
+	createVerifyPlayer(t, stores.Players, "first", "first@example.test", RolePlayer)
+	player := createVerifyPlayer(t, stores.Players, "alice", "alice@example.test", RolePlayer)
+	if got, want := player.Role, RolePlayer; got != want {
+		t.Fatalf("seed player Role = %q, want %q (must start as plain player)", got, want)
+	}
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(time.Hour))
+
+	rec := runVerifyEmailWithAdminEmails(t, db, raw, []string{"alice@example.test"})
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	promoted, err := stores.Players.GetPlayerByID(t.Context(), player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := promoted.Role, RoleAdmin; got != want {
+		t.Errorf("Role after verify = %q, want %q", got, want)
+	}
+}
+
+// TestHandleVerifyEmail_NotAllowlisted_StaysPlayer pins the negative
+// case for #785: a registrant absent from the allowlist keeps the
+// player role after verifying.
+func TestHandleVerifyEmail_NotAllowlisted_StaysPlayer(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	stores := store.New(db, discardLogger())
+	// Seed a credentialled player first so bob is not the first-registrant
+	// the store would auto-promote to admin.
+	createVerifyPlayer(t, stores.Players, "first", "first@example.test", RolePlayer)
+	player := createVerifyPlayer(t, stores.Players, "bob", "bob@example.test", RolePlayer)
+	if got, want := player.Role, RolePlayer; got != want {
+		t.Fatalf("seed player Role = %q, want %q (must start as plain player)", got, want)
+	}
+	raw := seedVerifyToken(t, stores.VerifyTokens, player.ID, time.Now().Add(time.Hour))
+
+	rec := runVerifyEmailWithAdminEmails(t, db, raw, []string{"alice@example.test"})
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	after, err := stores.Players.GetPlayerByID(t.Context(), player.ID)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+	if got, want := after.Role, RolePlayer; got != want {
+		t.Errorf("Role after verify = %q, want %q", got, want)
+	}
+}
+
 func runVerifyEmail(t *testing.T, db *sql.DB, raw string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	return runVerifyEmailWithAdminEmails(t, db, raw, nil)
+}
+
+// runVerifyEmailWithAdminEmails drives the verify handler with the given
+// ADMIN_EMAILS allowlist so the #785 promotion path can be exercised; a
+// nil allowlist is the no-promotion default the other cases use.
+func runVerifyEmailWithAdminEmails(
+	t *testing.T, db *sql.DB, raw string, adminEmails []string,
+) *httptest.ResponseRecorder {
 	t.Helper()
 
 	stores := store.New(db, discardLogger())
 	sessions := session.New([]byte("test-key-32-bytes-test-key-32byt"), true)
-	handler := HandleVerifyEmail(discardLogger(), nil, stores.VerifyTokens, stores.Players, sessions)
+	handler := HandleVerifyEmail(
+		discardLogger(), nil, stores.VerifyTokens, stores.Players, stores.AdminPlayers, sessions, adminEmails,
+	)
 
 	target := "/verify-email"
 	if raw != "" {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -127,7 +127,7 @@ func addEmailFlowRoutes(
 	csrfMW := csrfMgr.Middleware
 
 	mux.Handle("GET /verify-email", auth.HandleVerifyEmail(
-		logger, csrfMgr, stores.VerifyTokens, stores.Players, sessions,
+		logger, csrfMgr, stores.VerifyTokens, stores.Players, stores.AdminPlayers, sessions, cfg.AdminEmails,
 	))
 
 	verifyFlash := auth.NewSignedFlash(
@@ -265,7 +265,6 @@ func addAuthRoutes(
 			csrfMW(auth.HandleRegisterSubmit(
 				logger, csrfMgr, stores.Players, sessions,
 				auth.RegisterDeps{
-					AdminEmails:   cfg.AdminEmails,
 					GoogleEnabled: googleEnabled,
 					Mailer:        mail.Tester,
 					Tokens:        stores.VerifyTokens,
@@ -275,36 +274,7 @@ func addAuthRoutes(
 			)),
 		)
 	}
-	loginLimiter := auth.NewLoginRateLimiter(cfg.LoginCooldown, cfg.TrustedProxyCIDRs)
-	// loginResendLimiter is a dedicated per-IP cooldown for the
-	// verify-email send the login handler issues on an unverified-but-
-	// correct credential attempt (#492). Separate from the resend
-	// limiter on the verify-email/pending form so a stampede on one
-	// path cannot starve the other.
-	loginResendLimiter := auth.NewVerifyResendLimiter(auth.VerifyResendCooldown(), cfg.TrustedProxyCIDRs)
-	mux.Handle(
-		"GET /login",
-		auth.HandleLoginForm(logger, csrfMgr, stores.Players, sessions, cfg.RegistrationEnabled, googleEnabled),
-	)
-	mux.Handle(
-		"POST /login",
-		csrfMW(auth.HandleLoginSubmit(
-			logger, csrfMgr, auth.LoginDeps{
-				Players:             stores.Players,
-				Sessions:            sessions,
-				Games:               stores.GameMigrator,
-				Limiter:             loginLimiter,
-				Mailer:              mail.Tester,
-				Tokens:              stores.VerifyTokens,
-				ResendLimiter:       loginResendLimiter,
-				BaseURL:             cfg.BaseURL,
-				RegistrationEnabled: cfg.RegistrationEnabled,
-				GoogleEnabled:       googleEnabled,
-				Tasks:               mail.Tasks,
-			},
-		)),
-	)
-	mux.Handle("POST /logout", csrfMW(auth.HandleLogout(sessions)))
+	addLoginRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail, googleEnabled)
 
 	addEmailFlowRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 
@@ -329,6 +299,56 @@ func addAuthRoutes(
 			"google sign-in disabled (set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URL to enable)",
 		)
 	}
+}
+
+// addLoginRoutes registers GET/POST /login and POST /logout with the
+// two-tier login throttle (#494/#786). Split out of addAuthRoutes so
+// that function stays under revive's function-length cap. loginLimiter
+// is the per-IP gap; accountLoginLimiter is the per-account backoff that
+// the per-IP limiter cannot provide once an attacker rotates source
+// addresses against one account. loginResendLimiter is a dedicated per-IP
+// cooldown for the verify-email send the login handler issues on an
+// unverified-but-correct attempt (#492), separate from the
+// verify-email/pending resend so a stampede on one path cannot starve
+// the other.
+func addLoginRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+	cfg *config.Config,
+	mail Mail,
+	googleEnabled bool,
+) {
+	csrfMW := csrfMgr.Middleware
+	loginLimiter := auth.NewLoginRateLimiter(cfg.LoginCooldown, cfg.TrustedProxyCIDRs)
+	accountLoginLimiter := auth.NewAccountLoginLimiter(auth.AccountLoginThreshold(), auth.AccountLoginCooldown())
+	loginResendLimiter := auth.NewVerifyResendLimiter(auth.VerifyResendCooldown(), cfg.TrustedProxyCIDRs)
+	mux.Handle(
+		"GET /login",
+		auth.HandleLoginForm(logger, csrfMgr, stores.Players, sessions, cfg.RegistrationEnabled, googleEnabled),
+	)
+	mux.Handle(
+		"POST /login",
+		csrfMW(auth.HandleLoginSubmit(
+			logger, csrfMgr, auth.LoginDeps{
+				Players:             stores.Players,
+				Sessions:            sessions,
+				Games:               stores.GameMigrator,
+				Limiter:             loginLimiter,
+				AccountLimiter:      accountLoginLimiter,
+				Mailer:              mail.Tester,
+				Tokens:              stores.VerifyTokens,
+				ResendLimiter:       loginResendLimiter,
+				BaseURL:             cfg.BaseURL,
+				RegistrationEnabled: cfg.RegistrationEnabled,
+				GoogleEnabled:       googleEnabled,
+				Tasks:               mail.Tasks,
+			},
+		)),
+	)
+	mux.Handle("POST /logout", csrfMW(auth.HandleLogout(sessions)))
 }
 
 // addProfileRoutes registers the per-player profile page (#410) and

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -34,8 +34,14 @@ export async function registerAdmin(page: Page, displayName: string): Promise<vo
   // home.spec.ts uses to wipe games) rather than clicking the emailed
   // link: this is the setup shortcut for the many specs that just need a
   // signed-in admin. The real link round-trip is covered on its own in
-  // email-roundtrip.spec.ts. Then log in to land on the admin dashboard.
+  // email-roundtrip.spec.ts.
   markEmailVerified(displayName);
+  // Stamp the admin role directly too. Admin promotion for an ADMIN_EMAILS
+  // address now happens when the verify token is consumed via the endpoint
+  // (#785); this direct email_verified_at stamp bypasses that endpoint, so the
+  // role would otherwise never be granted. Set it explicitly rather than
+  // relying on the register-time promotion the shortcut no longer triggers.
+  markAdmin(displayName);
   await login(page, displayName);
   await expect(page).toHaveURL(/\/admin\/quizzes$/);
 }

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -205,6 +205,55 @@ func registerVerifyAndMint(
 	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 }
 
+// registerVerifyViaLinkAndMint is registerVerifyAndMint's
+// real-verify-flow variant: it proves the email through GET /verify-email
+// (verifyPlayerEmailViaLink) instead of a direct DB stamp, so the
+// verify-time ADMIN_EMAILS promotion (#785) actually fires. Use it when
+// the account must end up an admin via the allowlist rather than the
+// first-registrant rule.
+func registerVerifyViaLinkAndMint(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, dbURI, displayName, password string,
+) {
+	t.Helper()
+
+	registerForPending(ctx, t, client, baseURL, displayName, password)
+	verifyPlayerEmailViaLink(ctx, t, baseURL, dbURI, displayName)
+	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
+}
+
+// verifyPlayerEmailViaLink proves the named player's email through the
+// real GET /verify-email endpoint rather than a direct DB stamp. Mints a
+// verify token, consumes it over HTTP, and asserts the 200. Use this
+// (not verifyPlayerEmail) when the test depends on the verify-time side
+// effects the endpoint applies - notably the ADMIN_EMAILS promotion
+// (#785), which a direct DB stamp bypasses.
+func verifyPlayerEmailViaLink(
+	ctx context.Context, t *testing.T, baseURL, dbURI, displayName string,
+) {
+	t.Helper()
+
+	dbConn, stores := openStores(t, dbURI)
+	defer dbConn.Close() //nolint:errcheck // cleanup.
+
+	player, err := stores.Players.GetPlayerByDisplayName(ctx, displayName)
+	if err != nil {
+		t.Fatalf("verifyPlayerEmailViaLink GetPlayerByDisplayName err = %v, want nil", err)
+	}
+	raw, hash, err := auth.GenerateVerifyToken()
+	if err != nil {
+		t.Fatalf("verifyPlayerEmailViaLink GenerateVerifyToken err = %v, want nil", err)
+	}
+	if err := stores.VerifyTokens.CreateVerifyToken(ctx, hash, player.ID, futureHour(), ""); err != nil {
+		t.Fatalf("verifyPlayerEmailViaLink CreateVerifyToken err = %v, want nil", err)
+	}
+
+	resp := httpGet(ctx, t, authClient(t), baseURL+"/verify-email?"+url.Values{"token": {raw}}.Encode())
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("verifyPlayerEmailViaLink verify status = %d, want %d", got, want)
+	}
+}
+
 // registerAndMint registers displayName and mints a session cookie onto
 // client's jar WITHOUT stamping email_verified_at, leaving the player
 // signed in but unverified. Use it when a test needs a signed-in row

--- a/test/integration/host_lobby_test.go
+++ b/test/integration/host_lobby_test.go
@@ -247,9 +247,12 @@ func TestHostLobby_Authz(t *testing.T) {
 	// against the same server. ADMIN_EMAILS promotes them to admin so they
 	// clear the RequireGameHost gate - the point of the check is that even a
 	// legitimate host gets 404 on a session they do not own, not that a plain
-	// player is gated. The foreign host is registered + minted in the parent
-	// body (before the parallel subtests) so its DB writes are serialized and
-	// it sidesteps the per-IP login cooldown.
+	// player is gated. The promotion now happens at verify time (#785), so
+	// the foreign host proves its email through the real /verify-email link
+	// (registerVerifyViaLinkAndMint) rather than a direct DB stamp. It is
+	// registered + minted in the parent body (before the parallel subtests)
+	// so its DB writes are serialized and it sidesteps the per-IP login
+	// cooldown.
 	const foreignEmail = "host-authz-other@example.test"
 	ctx, setup := setupIntegrationWithEnv(t, map[string]string{"ADMIN_EMAILS": foreignEmail})
 	baseURL := setup.BaseURL
@@ -266,7 +269,7 @@ func TestHostLobby_Authz(t *testing.T) {
 		Jar:           mustJar(t),
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 	}
-	registerVerifyAndMint(ctx, t, foreign, baseURL, setup.DBURI, "host-authz-other", "host-authz-other-123")
+	registerVerifyViaLinkAndMint(ctx, t, foreign, baseURL, setup.DBURI, "host-authz-other", "host-authz-other-123")
 
 	t.Run("anonymous visitor is redirected to login", func(t *testing.T) {
 		t.Parallel()

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -80,11 +80,14 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAll err = %v, want nil", err)
 	}
-	if got, want := string(body), "verify your email"; !strings.Contains(got, want) {
-		t.Errorf("body missing verify banner; body=%.300q", got)
+	if got, want := string(body), "Check your email to finish signing in."; !strings.Contains(got, want) {
+		t.Errorf("body missing generic check-email banner; body=%.300q", got)
 	}
-	if got, want := string(body), displayName+"@example.test"; !strings.Contains(got, want) {
-		t.Errorf("body missing recipient address; body=%.300q", got)
+	// The banner must not confirm the credentials were correct (#787):
+	// an unverified-but-correct attempt has to read the same as a
+	// wrong-password one, so no "we resent the link to <address>" echo.
+	if dontWant := "resent the link to"; strings.Contains(string(body), dontWant) {
+		t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, string(body))
 	}
 	for _, c := range resp.Cookies() {
 		if c.Name == session.CookieName && c.Value != "" {

--- a/test/integration/quiz_ownership_test.go
+++ b/test/integration/quiz_ownership_test.go
@@ -131,14 +131,18 @@ func TestQuizOwnership_Integration(t *testing.T) {
 }
 
 // registerAdminClient builds a cookie-jar HTTP client, registers the
-// supplied displayName through the public /register form (which promotes
-// to admin via ADMIN_EMAILS), stamps email_verified_at, and mints a
-// session cookie onto the jar so follow-up admin requests pass both the
-// auth middleware and the #111 PR3 verified-email gate. After the #574
-// hard gate, register no longer hands out a session, so the cookie is
-// minted directly (startServer signs with the default testSessionKey).
-// Minting also sidesteps the per-IP login cooldown that several
-// back-to-back logins would trip.
+// supplied displayName through the public /register form, proves the
+// email through the real /verify-email link, and mints a session cookie
+// onto the jar so follow-up admin requests pass both the auth middleware
+// and the #111 PR3 verified-email gate. Verifying through the link (not a
+// direct DB stamp) is what fires the verify-time ADMIN_EMAILS promotion
+// (#785), so an allowlisted account becomes admin even when it is not the
+// first registrant. The first registrant is promoted by the store's
+// first-credentialled-registrant rule regardless, so the link verify is a
+// no-op promotion for them. After the #574 hard gate, register no longer
+// hands out a session, so the cookie is minted directly (startServer
+// signs with the default testSessionKey). Minting also sidesteps the
+// per-IP login cooldown that several back-to-back logins would trip.
 func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, displayName string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
@@ -153,7 +157,7 @@ func registerAdminClient(ctx context.Context, t *testing.T, baseURL, dbURI, disp
 	}
 
 	registerForPending(ctx, t, client, baseURL, displayName, "integration-pass-123")
-	verifyPlayerEmail(ctx, t, dbURI, displayName)
+	verifyPlayerEmailViaLink(ctx, t, baseURL, dbURI, displayName)
 	mintSessionCookie(ctx, t, client, baseURL, dbURI, displayName)
 
 	return client


### PR DESCRIPTION
Closes #785
Closes #786
Closes #787

Notes for review:
- #787 reverses the deliberate address-echo UX from #492 (you approved this). The login message is now a generic "Check your email to finish signing in." with no address. Caveat: this removes the address leak but does not fully eliminate the correct-password oracle for an unverified account — the unverified-but-correct case still renders 200 + "check your email" vs a wrong password's 401 + "invalid", which is inherent to telling a legitimate unverified user to verify. The meaningful win is no longer naming which address.
- #786 is enumeration-opaque: a cooled-down account renders the identical generic 401 a wrong password gets and records another failure; bcrypt still runs so timing matches. In-memory, per-process (same model as the per-IP limiter).
- #785 moves admin promotion from registration to email-verify-consume time. Two integration tests that relied on register-time promotion were updated to prove the email through the real /verify-email endpoint.