### PR TITLE
Harden the standings-bargraph and cooldown e2e specs against load

### DIFF
--- a/test/e2e/tests/cooldown.spec.ts
+++ b/test/e2e/tests/cooldown.spec.ts
@@ -39,24 +39,29 @@ test('forgot-password cooldown button counts down and re-enables', async ({ page
   // submit could not be clicked (disabled button + frozen virtual clock) - the
   // #643 flake. Instead: submit once, then submit again only if the button is
   // still enabled. Either path lands on the disabled state.
-  await page.locator('input[name=identifier]').fill('nobody@example.test');
-  await submit.click();
-  await page.waitForURL(/\/forgot-password$/);
-  await expect(submit).toBeVisible();
+  // Submit until the per-IP cooldown rejects us and the button renders
+  // disabled. The 60s bucket is shared across this spec's retries (and, locally,
+  // the other browser project), so the number of submits needed to trip it is
+  // not fixed: a clear bucket needs two (the first arms it, the second is
+  // rejected); an already-armed bucket trips on the first. The old one-shot
+  // `if (await submit.isEnabled())` decided whether to resubmit from a single
+  // read of the transitional post-redirect button state, which misread under
+  // load and left the button enabled where the assertion expected disabled
+  // (#818). Poll instead: resubmit whenever the button is enabled and stop once
+  // it is disabled. The frozen virtual clock keeps it disabled once tripped, so
+  // this converges.
+  await expect(async () => {
+    if (await submit.isEnabled()) {
+      await page.locator('input[name=identifier]').fill('nobody@example.test');
+      await submit.click();
+      await page.waitForURL(/\/forgot-password$/);
+    }
+    await expect(submit).toBeDisabled({ timeout: 1_000 });
+  }).toPass({ timeout: 30_000 });
 
-  if (await submit.isEnabled()) {
-    // Bucket was clear: the first submit was allowed (success notice, button
-    // still enabled). Submit again inside the window to trip the limiter.
-    await page.locator('input[name=identifier]').fill('nobody@example.test');
-    await submit.click();
-    await page.waitForURL(/\/forgot-password$/);
-  }
-
-  // The stable locator always resolves, so these state assertions auto-wait
-  // through the redirect and cooldown.js's relabel. Tolerate any countdown
-  // value rather than the exact "Wait 60s" frame: a contaminating prior run
-  // leaves a smaller remaining count, and the exact frame is racy under load.
-  await expect(submit).toBeDisabled({ timeout: 15_000 });
+  // The button shows the live countdown label. Tolerate any value rather than
+  // the exact "Wait 60s" frame: a contaminating prior run leaves a smaller
+  // remaining count, and the exact frame is racy under load.
   await expect(submit).toHaveText(/^Wait \d+s$/, { timeout: 15_000 });
 
   // Advance past the full 60s cooldown without real waiting. runFor

--- a/test/e2e/tests/standings-bargraph.spec.ts
+++ b/test/e2e/tests/standings-bargraph.spec.ts
@@ -18,6 +18,15 @@ import { importQuiz, claimAndJoin, execSqlite } from './helpers';
 // web-first matchers, and the terminal finished phase (stable) is asserted in
 // full on both surfaces.
 
+// SSE-driven standings settle only after the runner advances a phase and the
+// tick reaches the client. Under the full parallel e2e run the CI box is
+// saturated, so that round-trip occasionally takes far longer than the
+// happy-path sub-second. These waits are retrying matchers (toPass / web-first
+// toBeVisible) that resolve the instant the condition holds, so a generous
+// budget is free on the happy path and only spends time on a genuine failure -
+// headroom for worst-case contention, not a fixed wait (#811).
+const STANDINGS_SETTLE_TIMEOUT = 30_000;
+
 // makeQuizLiveByTitle flips a quiz to mode='live' (the importer lands quizzes
 // on 'solo', and only live quizzes are hostable) and returns its id. Mirrors
 // the sqlite3 shortcut the other live-session specs use.
@@ -243,7 +252,7 @@ test('the standings bar graph shows final order and totals on the TV and player 
   // did not). The window is brief, so use retrying matchers; reduced motion
   // means the final state is rendered on the first paint.
   await expect(page.locator('[data-testid="round-results"] [data-standings-row]').first())
-    .toBeVisible({ timeout: 15_000 });
+    .toBeVisible({ timeout: STANDINGS_SETTLE_TIMEOUT });
   await expect(async () => {
     const rows = await readStandingsRows(page);
     expect(rows.length).toBe(2);
@@ -253,7 +262,7 @@ test('the standings bar graph shows final order and totals on the TV and player 
     expect(rows[1].name).toBe(robin);
     expect(rows[1].rank).toBe('2');
     expect(Number(rows[1].total)).toBe(0);
-  }).toPass({ timeout: 15_000 });
+  }).toPass({ timeout: STANDINGS_SETTLE_TIMEOUT });
 
   // The player's own row is highlighted (aria-current).
   await expect(
@@ -270,7 +279,7 @@ test('the standings bar graph shows final order and totals on the TV and player 
   // server has reached the finished phase), then read the authoritative final
   // totals the grow + slide settles the displayed bars onto.
   await expect(host.locator('[data-phase-results] [data-standings-row]').first())
-    .toBeVisible({ timeout: 20_000 });
+    .toBeVisible({ timeout: STANDINGS_SETTLE_TIMEOUT });
   const quincyFinal = await readFinishedStanding(host.request, joinCode, quincy);
   const robinFinal = await readFinishedStanding(host.request, joinCode, robin);
 
@@ -283,7 +292,7 @@ test('the standings bar graph shows final order and totals on the TV and player 
     tvRows = await readStandingsRows(host);
     expect(tvRows.length).toBe(2);
     expect(Number(tvRows[0].total)).toBe(quincyFinal.totalScore);
-  }).toPass({ timeout: 15_000 });
+  }).toPass({ timeout: STANDINGS_SETTLE_TIMEOUT });
   expect(tvRows[0].name).toBe(quincy);
   expect(tvRows[0].rank).toBe('1');
   expect(Number(tvRows[0].total)).toBeGreaterThan(0);
@@ -292,13 +301,13 @@ test('the standings bar graph shows final order and totals on the TV and player 
   expect(Number(tvRows[1].total)).toBe(0);
 
   await expect(page.getByTestId('finished-view').locator('[data-standings-row]').first())
-    .toBeVisible({ timeout: 20_000 });
+    .toBeVisible({ timeout: STANDINGS_SETTLE_TIMEOUT });
   let playerRows = await readStandingsRows(page);
   await expect(async () => {
     playerRows = await readStandingsRows(page);
     expect(playerRows.length).toBe(2);
     expect(Number(playerRows[0].total)).toBe(quincyFinal.totalScore);
-  }).toPass({ timeout: 15_000 });
+  }).toPass({ timeout: STANDINGS_SETTLE_TIMEOUT });
   expect(playerRows[0].name).toBe(quincy);
   expect(playerRows[0].rank).toBe('1');
   expect(Number(playerRows[0].total)).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #811
Closes #818

Both are full-parallel-load timing flakes:
- #811 (standings-bargraph): the SSE-render waits are retrying matchers (toPass / web-first toBeVisible), so they cost nothing on the happy path and only spend time on a genuine failure. Pulled their budgets into a single STANDINGS_SETTLE_TIMEOUT=30s with a rationale comment - headroom for worst-case CI contention, not a fixed wait. (The earlier 10->15 bump in #738/#775 was the right kind, just under-budgeted.)
- #818 (cooldown): replaced the fragile one-shot `if (await submit.isEnabled())` (which misread the transitional post-redirect state under load and left the button enabled where the assertion expected disabled) with a poll-until-disabled. The frozen virtual clock keeps the button disabled once the limiter trips, so the poll converges deterministically.

Verified: both specs pass on chromium+firefox repeated x2 in isolation, and the full `make test-e2e` (the actual load condition) is green.