### PR TITLE
Pin staging and production deploys to a verified image digest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,11 @@ env:
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
+    # Read-only token: the runner resolves + verifies the image digest
+    # and the host pulls by it; nothing here writes packages.
+    permissions:
+      contents: read
+      packages: read
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
     environment:
       name: staging
@@ -42,6 +47,50 @@ jobs:
           source: "deployments/demo/docker-compose.staging.yml"
           target: "~/topbanana-staging"
           strip_components: 2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Resolve the mutable :edge tag to the immutable digest the host
+      # pulls. CI publishes :edge only from main's docker-build, so it
+      # points at this commit's tested, signed image. Pinning the deploy
+      # to the digest means a later tag move cannot swap the running bytes.
+      - name: Resolve image digest
+        id: digest
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge
+        run: |
+          set -euo pipefail
+          DIGEST="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}')"
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: could not resolve a digest for ${IMAGE_REF} (got '${DIGEST}')" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # Reject the deploy unless the digest carries a valid keyless
+      # signature from this repo's CI workflow on main. docker-build
+      # signs the digest there; the signature binds to the digest, so a
+      # forged or untrusted image fails here before the host pulls it.
+      - name: Verify image signature
+        env:
+          IMAGE_DIGEST_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}
+        run: |
+          cosign verify "$IMAGE_DIGEST_REF" \
+            --certificate-identity-regexp '^https://github\.com/starquake/topbanana/\.github/workflows/ci\.yml@refs/heads/main$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
 
       - name: Deploy to staging server
         uses: appleboy/ssh-action@v1.2.5
@@ -78,7 +127,7 @@ jobs:
           # backfills.
           ADMIN_EMAILS: ${{ vars.ADMIN_EMAILS }}
           IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          IMAGE_TAG: edge
+          IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         with:
@@ -90,7 +139,7 @@ jobs:
           # bakes in a blank, which the compose ${VAR:?…} guard then
           # rejects on boot. Keep this list in lockstep with the env block
           # above and the .env heredoc below.
-          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,ADMIN_EMAILS,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,ADMIN_EMAILS,IMAGE_NAME,IMAGE_DIGEST,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
             if [ -z "$SESSION_KEY" ]; then
@@ -121,7 +170,7 @@ jobs:
             REGISTRATION_ENABLED='${REGISTRATION_ENABLED}'
             ADMIN_EMAILS='${ADMIN_EMAILS}'
             IMAGE_NAME='${IMAGE_NAME}'
-            IMAGE_TAG='${IMAGE_TAG}'
+            IMAGE_DIGEST='${IMAGE_DIGEST}'
             EOF
             mv -f docker-compose.staging.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
@@ -145,6 +194,11 @@ jobs:
 
   deploy-production:
     runs-on: ubuntu-latest
+    # Read-only token: the runner resolves + verifies the image digest
+    # and the host pulls by it; nothing here writes packages.
+    permissions:
+      contents: read
+      packages: read
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     environment:
       name: production
@@ -175,6 +229,51 @@ jobs:
           source: "deployments/demo/docker-compose.production.yml"
           target: "~/topbanana-production"
           strip_components: 2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Resolve the release tag to the immutable digest the host pulls.
+      # The version tag is created by promote retagging the tested,
+      # signed sha-<commit> image from main, so the digest is the same
+      # one CI signed. Pinning the deploy to it means a later tag move
+      # cannot swap the running bytes.
+      - name: Resolve image digest
+        id: digest
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          DIGEST="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}')"
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "ERROR: could not resolve a digest for ${IMAGE_REF} (got '${DIGEST}')" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # Reject the deploy unless the digest carries a valid keyless
+      # signature from this repo's CI workflow on main. docker-build
+      # signs the digest there; the signature binds to the digest, so a
+      # forged or untrusted image fails here before the host pulls it.
+      - name: Verify image signature
+        env:
+          IMAGE_DIGEST_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.digest }}
+        run: |
+          cosign verify "$IMAGE_DIGEST_REF" \
+            --certificate-identity-regexp '^https://github\.com/starquake/topbanana/\.github/workflows/ci\.yml@refs/heads/main$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
 
       - name: Deploy to production server
         uses: appleboy/ssh-action@v1.2.5
@@ -211,7 +310,7 @@ jobs:
           # backfills.
           ADMIN_EMAILS: ${{ vars.ADMIN_EMAILS }}
           IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          IMAGE_DIGEST: ${{ steps.digest.outputs.digest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         with:
@@ -223,7 +322,7 @@ jobs:
           # bakes in a blank, which the compose ${VAR:?…} guard then
           # rejects on boot. Keep this list in lockstep with the env block
           # above and the .env heredoc below.
-          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,ADMIN_EMAILS,IMAGE_NAME,IMAGE_TAG,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: SESSION_KEY,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URL,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_FROM,SMTP_TLS,BASE_URL,REGISTRATION_ENABLED,ADMIN_EMAILS,IMAGE_NAME,IMAGE_DIGEST,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -e
             if [ -z "$SESSION_KEY" ]; then
@@ -254,7 +353,7 @@ jobs:
             REGISTRATION_ENABLED='${REGISTRATION_ENABLED}'
             ADMIN_EMAILS='${ADMIN_EMAILS}'
             IMAGE_NAME='${IMAGE_NAME}'
-            IMAGE_TAG='${IMAGE_TAG}'
+            IMAGE_DIGEST='${IMAGE_DIGEST}'
             EOF
             mv -f docker-compose.production.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin

--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -1,6 +1,9 @@
 services:
   topbanana-production:
-    image: ${IMAGE_NAME}:${IMAGE_TAG:-latest}
+    # Pinned to an immutable digest, not a tag: deploy.yml resolves the
+    # release tag to its digest, verifies the cosign signature, and writes
+    # IMAGE_DIGEST into .env. The guard fails the boot loudly if it is unset.
+    image: ${IMAGE_NAME}@${IMAGE_DIGEST:?IMAGE_DIGEST must be set in .env or environment}
     container_name: topbanana-production
     environment:
       - APP_ENV=production

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -1,6 +1,9 @@
 services:
   topbanana-staging:
-    image: ${IMAGE_NAME}:${IMAGE_TAG:-edge}
+    # Pinned to an immutable digest, not a tag: deploy.yml resolves :edge
+    # to its digest, verifies the cosign signature, and writes IMAGE_DIGEST
+    # into .env. The guard fails the boot loudly if it is unset.
+    image: ${IMAGE_NAME}@${IMAGE_DIGEST:?IMAGE_DIGEST must be set in .env or environment}
     container_name: topbanana-staging
     environment:
       - APP_ENV=staging


### PR DESCRIPTION
Closes #632

Pins both the staging and production deploys to an immutable image digest and verifies its cosign signature on the runner before the host pulls it.

## What changes

For each deploy job (`deploy-staging`, `deploy-production`) in `deploy.yml`:

1. **Resolve the digest** of the tag the deploy already selects (`:edge` for staging, the version tag for production) with `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`, validating it looks like `sha256:<64 hex>`.
2. **Verify the signature** on `IMAGE_NAME@DIGEST` with `cosign verify`, pinned to this repo's CI workflow identity and the GitHub OIDC issuer. A forged or untrusted image fails the deploy here.
3. **Thread `IMAGE_DIGEST`** (replacing `IMAGE_TAG`) through the SSH `env:` / `envs:` allowlist / `.env` heredoc.
4. Both compose files now use `image: ${IMAGE_NAME}@${IMAGE_DIGEST:?...}` instead of a mutable tag, so a missing digest fails the boot loudly.

The job tokens are narrowed to `contents: read` + `packages: read` (resolve + verify + pull need no write, and verify needs no OIDC token).

## Why this shape

The image is built and cosign-signed once on `main` by `ci.yml`'s `docker-build`; the signature binds to the digest, so version tags created by `promote` inherit it. The runner resolves the tag to a digest, verifies *that digest*, and hands the host the digest to pull -- so a tag moved between resolve and pull cannot swap the running bytes. This is the pragmatic "resolve-at-deploy + verify" variant; the heavier "record the digest at build time and persist it" approach was considered and deferred as unnecessary given the build-once/promote model.

## Verification done

- `yq` parses `deploy.yml` and both compose files; step order and the new `permissions` blocks confirmed.
- `docker compose config` on both compose files: the `${IMAGE_DIGEST:?...}` guard fails loudly when unset and resolves to `ghcr.io/...@sha256:...` when set.
- Resolve command run against the live `:edge` image returns a valid digest.
- **cosign identity confirmed against the live signature**: decoded the leaf cert for the current `edge` digest -- SAN is `https://github.com/starquake/topbanana/.github/workflows/ci.yml@refs/heads/main` and the OIDC issuer is `https://token.actions.githubusercontent.com`, both matching the `cosign verify` flags exactly.

## Assumed defaults (per "assume the recommended")

- Scope is staging **and** production, both behind the same verify.
- Identity is pinned to `ci.yml@refs/heads/main` (where signing happens), not a looser repo-wide regexp.

## Notes / can't be exercised in PR CI

- The deploy jobs run post-merge via `workflow_run` (and on tag for production) over SSH to the host, so this path does not run in PR CI. First real exercise is the next staging deploy after merge.
- `cosign verify` requires the Rekor transparency-log entry, which exists because the package is public (the CI sign step only writes to Rekor for public repos). If the package is ever made private, signing stops writing to Rekor and verify would need `--insecure-ignore-tlog`.
