### PR TITLE
Promote allowlisted admins on Google sign-in

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -158,14 +158,26 @@ func HandleGoogleLogin(logger *slog.Logger, authn *GoogleAuthenticator) http.Han
 //
 // The find-or-link decision lives in linkOrCreateGooglePlayer; this
 // handler is just the request-shaped wrapper around it.
+//
+// adminEmails is the ADMIN_EMAILS allowlist; once the callback has a
+// verified, persisted player it promotes that player to admin when the
+// now-proven address matches an entry (#824), mirroring the verify-token
+// path. Google attests the address on every callback (the unverified
+// branch is already refused), so this upholds the "admin only on a
+// verified address" invariant. roles is the narrow setter used for that
+// promotion.
+//
+//nolint:revive // argument-limit: the callback genuinely needs every collaborator threaded in; the success tail is already split into finalizeGoogleSignIn (with its deps bundled), so the remaining list is the irreducible request-shaped surface.
 func HandleGoogleCallback(
 	logger *slog.Logger,
 	authn *GoogleAuthenticator,
 	csrfMgr *csrf.Manager,
 	identities OAuthIdentityStore,
 	players PlayerStore,
+	roles RoleSetter,
 	sessions *session.Manager,
 	games AnonymousGameMigrator,
+	adminEmails []string,
 	registrationEnabled bool,
 ) http.Handler {
 	render := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
@@ -230,15 +242,70 @@ func HandleGoogleCallback(
 			return
 		}
 
-		sessions.Set(w, player.ID, player.SessionVersion)
-		migrateGamesAfterSignIn(r.Context(), logger, players, games, sessionPlayerID, player.ID)
-		target := next
-		if target == "" {
-			target = landingPathFor(player.Role)
-		}
-		//nolint:gosec // G710: target is either landingPathFor (constant) or a SafeNextPath-validated relative path returned by readGoogleNext.
-		http.Redirect(w, r, target, http.StatusSeeOther)
+		finalizeGoogleSignIn(w, r, googleSignInDeps{
+			logger:      logger,
+			players:     players,
+			roles:       roles,
+			sessions:    sessions,
+			games:       games,
+			adminEmails: adminEmails,
+		}, player, sessionPlayerID, next)
 	})
+}
+
+// googleSignInDeps groups the collaborators finalizeGoogleSignIn needs.
+// Bundling them keeps the helper under revive's argument-count cap
+// without flattening the call site into a long positional list, the same
+// packaging the verify handler uses for verifyOutcome.
+type googleSignInDeps struct {
+	logger      *slog.Logger
+	players     PlayerStore
+	roles       RoleSetter
+	sessions    *session.Manager
+	games       AnonymousGameMigrator
+	adminEmails []string
+}
+
+// finalizeGoogleSignIn runs the success tail of the callback once a
+// verified, persisted player is in hand: best-effort admin promotion on
+// the now-proven address, the session cookie, anonymous-game migration,
+// and the redirect to the validated next path or the role landing. Split
+// out of HandleGoogleCallback so the constructor stays under revive's
+// function-length cap.
+//
+// Promotion mirrors the verify-token path (#824) and is idempotent: the
+// helper skips when the row is already admin or the email is not on the
+// allowlist, and logs+swallows any failure, so a promotion error never
+// blocks the login.
+func finalizeGoogleSignIn(
+	w http.ResponseWriter,
+	r *http.Request,
+	deps googleSignInDeps,
+	player *Player,
+	sessionPlayerID *int64,
+	next string,
+) {
+	promoteVerifiedAdminIfAllowlisted(
+		r.Context(), deps.logger, deps.players, deps.roles, deps.adminEmails, player.ID,
+	)
+
+	deps.sessions.Set(w, player.ID, player.SessionVersion)
+	migrateGamesAfterSignIn(r.Context(), deps.logger, deps.players, deps.games, sessionPlayerID, player.ID)
+	target := next
+	if target == "" {
+		// Resolve the landing from the freshly persisted role: the promotion
+		// above may have just changed it, and `player` was read before that.
+		// Mirrors the verify-token path's postVerifyLanding so a just-promoted
+		// admin reaches /admin instead of the player home. A read failure
+		// falls back to the pre-promotion role.
+		role := player.Role
+		if fresh, err := deps.players.GetPlayerByID(r.Context(), player.ID); err == nil {
+			role = fresh.Role
+		}
+		target = landingPathFor(role)
+	}
+	//nolint:gosec // G710: target is either landingPathFor (constant) or a SafeNextPath-validated relative path returned by readGoogleNext.
+	http.Redirect(w, r, target, http.StatusSeeOther)
 }
 
 // validateCallbackRequest walks the cheap up-front checks on a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,10 +151,11 @@ type Config struct {
 
 	SessionKey string
 
-	// AdminEmails is the list of email addresses that are promoted to admin on registration.
-	// Parsed from the comma-separated ADMIN_EMAILS env var. Match against the verified
-	// email keeps admin status pinned to the identity we already authenticate, not the
-	// display name a player can change.
+	// AdminEmails is the allowlist of email addresses promoted to admin once the
+	// address is proven verified (at email-verify-token consume or OAuth callback),
+	// not at registration. Parsed from the comma-separated ADMIN_EMAILS env var.
+	// Matching against the verified email keeps admin status pinned to the identity
+	// we already authenticate, not the display name a player can change.
 	AdminEmails []string
 
 	// RegistrationEnabled gates the /register routes. Defaults to false so registration is

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -290,8 +290,8 @@ func addAuthRoutes(
 		mux.Handle(
 			"GET /login/google/callback",
 			auth.HandleGoogleCallback(
-				logger, googleAuth, csrfMgr, stores.OAuth, stores.Players, sessions, stores.GameMigrator,
-				cfg.RegistrationEnabled,
+				logger, googleAuth, csrfMgr, stores.OAuth, stores.Players, stores.AdminPlayers, sessions,
+				stores.GameMigrator, cfg.AdminEmails, cfg.RegistrationEnabled,
 			),
 		)
 	} else {

--- a/test/integration/google_login_test.go
+++ b/test/integration/google_login_test.go
@@ -329,6 +329,106 @@ func TestGoogleLogin_CallbackRejectsStateMismatch(t *testing.T) {
 	}
 }
 
+// TestGoogleLogin_CallbackAllowlistedEmail_PromotesToAdmin pins the
+// OAuth half of #824: a Google sign-in whose verified email is on the
+// ADMIN_EMAILS allowlist is promoted to admin at the callback, the same
+// way the verify-token path promotes. A credentialled player is seeded
+// first so the subject is not the bootstrap first-registrant, which
+// would auto-promote it regardless and mask the allowlist path.
+func TestGoogleLogin_CallbackAllowlistedEmail_PromotesToAdmin(t *testing.T) {
+	t.Parallel()
+
+	mock := newGoogleMock(t)
+	mock.email = "allow@example.test"
+	mock.emailVerified = true
+
+	ctx, srv := startGoogleServerEnv(t, mock, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"ADMIN_EMAILS":         mock.email,
+	})
+	seedCredentialledPlayer(t, srv.DBURI, "bootstrap-admin", "bootstrap@example.test")
+
+	finalResp := driveGoogleFlow(ctx, t, authClient(t), srv.BaseURL, mock)
+	if got, want := finalResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("callback status = %d, want %d (location=%q)", got, want, finalResp.Location)
+	}
+	// A just-promoted admin lands on the admin surface: finalizeGoogleSignIn
+	// resolves the landing from the post-promotion role (mirroring the
+	// verify-token path), not the role read before promotion.
+	if got, want := finalResp.Location, "/admin/quizzes"; got != want {
+		t.Errorf("callback Location = %q, want %q (admin landing after promotion)", got, want)
+	}
+	role, _ := lookupPlayerRoleByEmail(t, srv.DBURI, mock.email)
+	if got, want := role, "admin"; got != want {
+		t.Errorf("role after Google sign-in = %q, want %q", got, want)
+	}
+}
+
+// TestGoogleLogin_CallbackNotAllowlisted_StaysPlayer pins the negative
+// case for #824: a Google sign-in absent from the allowlist keeps the
+// player role. A credentialled player is seeded first so the subject is
+// not the bootstrap first-registrant.
+func TestGoogleLogin_CallbackNotAllowlisted_StaysPlayer(t *testing.T) {
+	t.Parallel()
+
+	mock := newGoogleMock(t)
+	mock.email = "plain@example.test"
+	mock.emailVerified = true
+
+	ctx, srv := startGoogleServerEnv(t, mock, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"ADMIN_EMAILS":         "someone-else@example.test",
+	})
+	seedCredentialledPlayer(t, srv.DBURI, "bootstrap-admin", "bootstrap@example.test")
+
+	finalResp := driveGoogleFlow(ctx, t, authClient(t), srv.BaseURL, mock)
+	if got, want := finalResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("callback status = %d, want %d (location=%q)", got, want, finalResp.Location)
+	}
+	if got, want := finalResp.Location, "/"; got != want {
+		t.Errorf("callback Location = %q, want %q (player landing)", got, want)
+	}
+
+	role, _ := lookupPlayerRoleByEmail(t, srv.DBURI, mock.email)
+	if got, want := role, "player"; got != want {
+		t.Errorf("role after Google sign-in = %q, want %q", got, want)
+	}
+}
+
+// TestGoogleLogin_CallbackAlreadyAdminAllowlisted_NoOp pins the
+// idempotent skip in #824: a Google sign-in that links by email onto a
+// row already at admin must not rewrite the role. The seed leaves
+// role_changed_at NULL; an unwanted SetPlayerRole would stamp it, so the
+// still-NULL timestamp proves the promotion skipped the write.
+func TestGoogleLogin_CallbackAlreadyAdminAllowlisted_NoOp(t *testing.T) {
+	t.Parallel()
+
+	mock := newGoogleMock(t)
+	mock.email = "already-admin@example.test"
+	mock.emailVerified = true
+
+	ctx, srv := startGoogleServerEnv(t, mock, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"ADMIN_EMAILS":         mock.email,
+	})
+	seedAdminPlayerWithEmail(t, srv.DBURI, "already-admin", mock.email)
+
+	finalResp := driveGoogleFlow(ctx, t, authClient(t), srv.BaseURL, mock)
+	if got, want := finalResp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("callback status = %d, want %d (location=%q)", got, want, finalResp.Location)
+	}
+	// Linked onto the existing admin row by email; no duplicate created.
+	requireDBRowCounts(t, srv.DBURI, mock.email, 1, 1)
+
+	role, roleChangedAt := lookupPlayerRoleByEmail(t, srv.DBURI, mock.email)
+	if got, want := role, "admin"; got != want {
+		t.Errorf("role after Google sign-in = %q, want %q (unchanged)", got, want)
+	}
+	if roleChangedAt.Valid {
+		t.Errorf("role_changed_at = %q, want NULL (no spurious role write)", roleChangedAt.String)
+	}
+}
+
 // driveGoogleFlow walks the GET /login/google -> mock auth ->
 // callback dance and returns the snapshot of the final callback
 // response. The body is drained + closed inside this helper so the
@@ -532,6 +632,98 @@ func seedPlayerWithEmail(t *testing.T, dbURI, displayName, email string) {
 	); err != nil {
 		t.Fatalf("seed insert err = %v, want nil", err)
 	}
+}
+
+// seedCredentialledPlayer inserts a row that carries a password_hash so
+// the OAuth bootstrap CASE (NOT EXISTS password OR identity) no longer
+// fires for the next Google sign-in. The allowlist-promotion tests seed
+// one of these first so the subject under test is not auto-promoted to
+// admin by the first-registrant rule, which would mask the allowlist
+// path.
+func seedCredentialledPlayer(t *testing.T, dbURI, displayName, email string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	if _, err := db.ExecContext(t.Context(),
+		`INSERT INTO players (display_name, email, password_hash, role, display_name_claimed)
+		 VALUES (?, ?, 'seed-hash', 'player', 1)`,
+		displayName, email,
+	); err != nil {
+		t.Fatalf("seed credentialled insert err = %v, want nil", err)
+	}
+}
+
+// seedAdminPlayerWithEmail inserts an already-admin row with the given
+// email so the already-admin no-op test has a row Google links onto by
+// email. role_changed_at is left NULL so the test can assert promotion
+// did not write it (an idempotent skip touches neither the role nor the
+// timestamp).
+func seedAdminPlayerWithEmail(t *testing.T, dbURI, displayName, email string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	if _, err := db.ExecContext(t.Context(),
+		`INSERT INTO players (display_name, email, role, display_name_claimed) VALUES (?, ?, 'admin', 1)`,
+		displayName, email,
+	); err != nil {
+		t.Fatalf("seed admin insert err = %v, want nil", err)
+	}
+}
+
+// lookupPlayerRoleByEmail returns the role + role_changed_at for the
+// single players row matching email. Fails when zero or more than one
+// row matches so the caller's assertion stays unambiguous.
+func lookupPlayerRoleByEmail(t *testing.T, dbURI, email string) (string, sql.NullString) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	var (
+		role          string
+		roleChangedAt sql.NullString
+		count         int
+	)
+	if scanErr := db.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM players WHERE email = ?`, email,
+	).Scan(&count); scanErr != nil {
+		t.Fatalf("count players by email %q err = %v, want nil", email, scanErr)
+	}
+	if got, want := count, 1; got != want {
+		t.Fatalf("players row count for email %q = %d, want %d", email, got, want)
+	}
+	if scanErr := db.QueryRowContext(t.Context(),
+		`SELECT role, role_changed_at FROM players WHERE email = ?`, email,
+	).Scan(&role, &roleChangedAt); scanErr != nil {
+		t.Fatalf("lookup role by email %q err = %v, want nil", email, scanErr)
+	}
+
+	return role, roleChangedAt
 }
 
 // startGoogleServer boots the app server with Google OAuth env vars


### PR DESCRIPTION
Closes #824

Promotes an `ADMIN_EMAILS`-allowlisted user to admin when they sign in with **Google**, not just via the email-verify-token path. The Google callback already proves the address (Google attests it; unverified addresses are refused), so it reuses the existing `promoteVerifiedAdminIfAllowlisted` helper once a verified, persisted player is in hand.

- Wires `cfg.AdminEmails` + the role-setter store into `HandleGoogleCallback`; the success tail is split into `finalizeGoogleSignIn` to stay under the function-length limit (deps bundled in a struct, mirroring the verify handler's `verifyOutcome`).
- A just-promoted admin lands on the admin surface -- the landing is resolved from the post-promotion role (mirroring the verify-token path's `postVerifyLanding`), not the role read before promotion.
- Idempotent: skips when the row is already admin or the email is not allowlisted; best-effort, so a promotion failure never blocks login. Role changes do not bump `session_version`, so the cookie set with the pre-promotion version stays valid.
- Updates the now-stale `config.go` comment ("promoted to admin on registration").

## Scope

This is the narrow allowlist gap. The **first** OAuth registrant is already bootstrapped to admin in `CreatePlayerFromOAuth`, so the tests seed a prior credentialled player to isolate the allowlist path (the real gap is a *subsequent* allowlisted Google sign-in).

## Tests (integration, real server + DB)

- allowlisted Google email -> promoted to `admin` + lands on `/admin/quizzes`
- non-allowlisted -> stays `player`, lands on `/`
- already-admin allowlisted -> no-op (`role_changed_at` stays NULL, proving no spurious role write)
