### PR TITLE
Add a button to switch a quiz between solo and live

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1758,6 +1758,47 @@ func HandleQuestionEdit(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore qu
 	})
 }
 
+// HandleQuizSetMode flips a quiz between solo and live without going through
+// the edit form (#830). The target mode is the {mode} path segment, mirroring
+// the {direction} segment on the question-move route; only the quiz owner (or
+// an admin) may change it. On success it redirects back to the quiz view so
+// the re-rendered page reflects the new mode.
+func HandleQuizSetMode(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+
+		var quizID int64
+		if quizID, ok = handlers.ParseIDFromPath(w, r, logger, "quizID"); !ok {
+			return
+		}
+
+		if _, ok = requireQuizOwner(w, r, logger, csrfMgr, quizStore, quizID); !ok {
+			return
+		}
+
+		mode := r.PathValue("mode")
+		if !quiz.IsValidMode(mode) {
+			render400(w, r, logger, csrfMgr, "invalid play mode")
+
+			return
+		}
+
+		if err := quizStore.SetQuizMode(r.Context(), quizID, mode); err != nil {
+			if errors.Is(err, quiz.ErrQuizNotFound) {
+				render404(w, r, logger, csrfMgr)
+
+				return
+			}
+			logger.ErrorContext(r.Context(), "error setting quiz mode", slog.Any("err", err))
+			render500(w, r, logger, csrfMgr)
+
+			return
+		}
+
+		http.Redirect(w, r, "/admin/quizzes/"+strconv.FormatInt(quizID, 10), http.StatusSeeOther)
+	})
+}
+
 // HandleQuizDelete deletes a quiz and all its questions and options.
 func HandleQuizDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -369,6 +369,86 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 	})
 }
 
+func TestHandleQuizSetMode(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("flips solo to live", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		qz := env.seedQuiz(t, ownedQuiz("Quiz One", "quiz-one"))
+
+		handler := HandleQuizSetMode(logger, nil, env.quizzes)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1/mode/live", nil)
+		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
+		req.SetPathValue("mode", quiz.ModeLive)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, withTestAdmin(req))
+
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+		if got, want := rr.Header().Get("Location"), "/admin/quizzes/"+strconv.FormatInt(qz.ID, 10); got != want {
+			t.Errorf("Location = %q, want %q", got, want)
+		}
+
+		updated, err := env.quizzes.GetQuiz(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("GetQuiz err = %v, want nil", err)
+		}
+		if got, want := updated.Mode, quiz.ModeLive; got != want {
+			t.Errorf("Mode = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rejects an invalid mode without persisting it", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		qz := env.seedQuiz(t, ownedQuiz("Quiz One", "quiz-one"))
+
+		handler := HandleQuizSetMode(logger, nil, env.quizzes)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/1/mode/sideways", nil)
+		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
+		req.SetPathValue("mode", "sideways")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, withTestAdmin(req))
+
+		if got, want := rr.Code, http.StatusBadRequest; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+		updated, err := env.quizzes.GetQuiz(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("GetQuiz err = %v, want nil", err)
+		}
+		if got, want := updated.Mode, quiz.ModeSolo; got != want {
+			t.Errorf("Mode = %q, want %q (unchanged)", got, want)
+		}
+	})
+
+	t.Run("missing quiz renders 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+
+		handler := HandleQuizSetMode(logger, nil, env.quizzes)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/quizzes/999/mode/live", nil)
+		req.SetPathValue("quizID", "999")
+		req.SetPathValue("mode", quiz.ModeLive)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, withTestAdmin(req))
+
+		if got, want := rr.Code, http.StatusNotFound; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+	})
+}
+
 func TestHandleQuizEdit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -842,3 +842,22 @@ func (q *Queries) UpdateQuiz(ctx context.Context, arg UpdateQuizParams) (sql.Res
 		arg.ID,
 	)
 }
+
+const updateQuizMode = `-- name: UpdateQuizMode :execresult
+UPDATE quizzes
+SET mode       = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+`
+
+type UpdateQuizModeParams struct {
+	Mode string
+	ID   int64
+}
+
+// Flips just the play mode without touching the question tree, so the
+// solo/live toggle (#830) cannot clobber a concurrent question edit the way
+// the full UpdateQuiz would.
+func (q *Queries) UpdateQuizMode(ctx context.Context, arg UpdateQuizModeParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateQuizMode, arg.Mode, arg.ID)
+}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -191,6 +191,7 @@ func (stubQuizStore) GetQuizVisibility(_ context.Context, _ int64) (string, erro
 func (stubQuizStore) CreateQuiz(_ context.Context, _ *quiz.Quiz) error         { return errStub }
 func (stubQuizStore) UpdateQuiz(_ context.Context, _ *quiz.Quiz) error         { return errStub }
 func (stubQuizStore) DeleteQuiz(_ context.Context, _ int64) error              { return errStub }
+func (stubQuizStore) SetQuizMode(_ context.Context, _ int64, _ string) error   { return errStub }
 func (stubQuizStore) CreateQuestion(_ context.Context, _ *quiz.Question) error { return errStub }
 func (stubQuizStore) CreateQuestionAtNextPosition(_ context.Context, _ *quiz.Question) error {
 	return errStub

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -115,6 +115,15 @@ SET title              = ?,
     updated_at         = CURRENT_TIMESTAMP
 WHERE id = ?;
 
+-- name: UpdateQuizMode :execresult
+-- Flips just the play mode without touching the question tree, so the
+-- solo/live toggle (#830) cannot clobber a concurrent question edit the way
+-- the full UpdateQuiz would.
+UPDATE quizzes
+SET mode       = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?;
+
 -- name: DeleteQuiz :execresult
 DELETE
 FROM quizzes

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -47,6 +47,10 @@ type Store interface {
 	CreateQuiz(ctx context.Context, qz *Quiz) error
 	// UpdateQuiz updates a quiz.
 	UpdateQuiz(ctx context.Context, qz *Quiz) error
+	// SetQuizMode flips just the play mode of a quiz between ModeSolo and
+	// ModeLive without touching its questions (#830). Returns ErrInvalidMode
+	// when mode is neither, and ErrQuizNotFound when no row matches the id.
+	SetQuizMode(ctx context.Context, id int64, mode string) error
 	// ListQuestions returns all questions for a quiz by its ID.
 	ListQuestions(ctx context.Context, quizID int64) ([]*Question, error)
 	// GetQuestion returns a question with options, by its question ID.
@@ -164,6 +168,9 @@ var (
 	// ErrInvalidDirection is returned by SwapQuestionPositions when the
 	// supplied direction is neither "up" nor "down".
 	ErrInvalidDirection = errors.New("invalid direction")
+	// ErrInvalidMode is returned by SetQuizMode when the supplied mode is
+	// neither ModeSolo nor ModeLive (#830).
+	ErrInvalidMode = errors.New("invalid play mode")
 	// ErrCreatorRequired is returned by CreateQuiz when the caller did
 	// not set Quiz.CreatedByPlayerID. The column is NOT NULL at the DB
 	// level (#281, migration 20260520200000); the sentinel lets handler

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -496,6 +496,10 @@ func addAdminRoutes(
 		csrfMW(requireGameHost(admin.HandleQuizSave(logger, csrfMgr, stores.Quizzes))),
 	)
 	mux.Handle(
+		"POST /admin/quizzes/{quizID}/mode/{mode}",
+		csrfMW(requireGameHost(admin.HandleQuizSetMode(logger, csrfMgr, stores.Quizzes))),
+	)
+	mux.Handle(
 		"POST /admin/quizzes/{quizID}/delete",
 		csrfMW(requireGameHost(admin.HandleQuizDelete(logger, csrfMgr, stores.Quizzes))),
 	)
@@ -503,6 +507,23 @@ func addAdminRoutes(
 		"POST /admin/quizzes/{quizID}/players/{playerID}/reset",
 		csrfMW(requireGameHost(admin.HandleResetGameForPlayer(logger, csrfMgr, stores.Quizzes, gameService))),
 	)
+
+	addAdminQuestionRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)
+	addAdminRoundRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)
+}
+
+// addAdminQuestionRoutes registers the question CRUD + reorder routes
+// (#16). Split out of addAdminRoutes so that function stays under revive's
+// function-length cap; the block is structurally identical to the rounds
+// block in addAdminRoundRoutes.
+func addAdminQuestionRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	csrfMW func(http.Handler) http.Handler,
+	requireGameHost func(http.Handler) http.Handler,
+	csrfMgr *csrf.Manager,
+) {
 	mux.Handle(
 		"GET /admin/quizzes/{quizID}/questions/new",
 		requireGameHost(admin.HandleQuestionCreate(logger, csrfMgr, stores.Quizzes)),
@@ -527,8 +548,6 @@ func addAdminRoutes(
 		"POST /admin/quizzes/{quizID}/questions/{questionID}/move/{direction}",
 		csrfMW(requireGameHost(admin.HandleQuestionMove(logger, csrfMgr, stores.Quizzes))),
 	)
-
-	addAdminRoundRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)
 }
 
 // addAdminSettingsRoutes registers the Admin settings page (#320/#538): the

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -208,6 +208,25 @@ func (s *QuizStore) UpdateQuiz(ctx context.Context, qz *quiz.Quiz) error {
 	return nil
 }
 
+// SetQuizMode flips just the quiz's play mode (#830). It validates the mode
+// up front so an invalid value never reaches the DB CHECK constraint, and
+// maps a no-op update (id gone) to ErrQuizNotFound.
+func (s *QuizStore) SetQuizMode(ctx context.Context, id int64, mode string) error {
+	if !quiz.IsValidMode(mode) {
+		return fmt.Errorf("%w: %q", quiz.ErrInvalidMode, mode)
+	}
+
+	res, err := s.q.UpdateQuizMode(ctx, db.UpdateQuizModeParams{Mode: mode, ID: id})
+	if err != nil {
+		return fmt.Errorf("failed to update quiz mode: %w", err)
+	}
+	if database.MustRowsAffected(res) == 0 {
+		return quiz.ErrQuizNotFound
+	}
+
+	return nil
+}
+
 // ListQuestions retrieves a list of questions for the specified quiz ID, including their options, from the data store.
 func (s *QuizStore) ListQuestions(ctx context.Context, quizID int64) ([]*quiz.Question, error) {
 	rows, err := s.q.ListQuestionsByQuizID(ctx, quizID)

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -992,6 +992,80 @@ func TestQuizStore_UpdateQuiz(t *testing.T) {
 	}
 }
 
+// modeOf reads a quiz's persisted play mode, failing the test if the read
+// errors. Keeps the SetQuizMode assertions free of repeated GetQuiz plumbing.
+func modeOf(t *testing.T, s *QuizStore, id int64) string {
+	t.Helper()
+
+	qz, err := s.GetQuiz(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetQuiz(%d) err = %v, want nil", id, err)
+	}
+
+	return qz.Mode
+}
+
+func TestQuizStore_SetQuizMode(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("flips solo to live and back", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, logger)
+
+		qz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), qz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		if err := quizStore.SetQuizMode(t.Context(), qz.ID, quiz.ModeLive); err != nil {
+			t.Fatalf("SetQuizMode(live) err = %v, want nil", err)
+		}
+		if got, want := modeOf(t, quizStore, qz.ID), quiz.ModeLive; got != want {
+			t.Errorf("Mode = %q, want %q", got, want)
+		}
+
+		if err := quizStore.SetQuizMode(t.Context(), qz.ID, quiz.ModeSolo); err != nil {
+			t.Fatalf("SetQuizMode(solo) err = %v, want nil", err)
+		}
+		if got, want := modeOf(t, quizStore, qz.ID), quiz.ModeSolo; got != want {
+			t.Errorf("Mode = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rejects an unknown mode", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, logger)
+
+		qz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), qz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		err := quizStore.SetQuizMode(t.Context(), qz.ID, "sideways")
+		if got, want := err, quiz.ErrInvalidMode; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("missing quiz returns ErrQuizNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, logger)
+
+		err := quizStore.SetQuizMode(t.Context(), 9999, quiz.ModeLive)
+		if got, want := err, quiz.ErrQuizNotFound; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestQuizStore_UpdateQuiz_ErrorHandling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -73,6 +73,18 @@
                     <span>Share</span>
                 </button>
                 {{if $canEdit}}
+                {{/* Solo<->live toggle (#830): flip the play mode without
+                     opening the edit form. The action targets the opposite of
+                     the current mode; the server validates the {mode} segment. */}}
+                <form method="post"
+                      action="/admin/quizzes/{{.Quiz.ID}}/mode/{{if eq .Quiz.Mode "live"}}solo{{else}}live{{end}}"
+                      class="inline-flex">
+                    <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                    <button type="submit" class="btn-ghost gap-2">
+                        <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9"/><path d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5 5 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6 6 0 0 1 2.083 9z"/></svg>
+                        <span>{{if eq .Quiz.Mode "live"}}Switch to solo{{else}}Switch to live{{end}}</span>
+                    </button>
+                </form>
                 <a href="/admin/quizzes/{{.Quiz.ID}}/edit"
                    class="btn-ghost gap-2">
                     <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>


### PR DESCRIPTION
Closes #830

## What

A one-click **Switch to live** / **Switch to solo** button lets a host flip a quiz's play mode without opening the edit form.

## Decisions

- **Placement: the quiz overview page** (`/admin/quizzes/{id}`), in the **header action row next to Edit / Delete** - not on the list cards (those show the read-only badge from #829).
- **Target mode in the URL** (`POST /admin/quizzes/{quizID}/mode/{mode}`), mirroring the `questions/{id}/move/{direction}` route; the handler validates the `{mode}` segment (unknown -> 400).
- **Dedicated `SetQuizMode` store method** (minimal `UpdateQuizMode` query touching only `mode` + `updated_at`) so flipping the mode can't clobber a concurrent question edit the way the question-syncing `UpdateQuiz` would.
- Owner/admin-gated via `requireQuizOwner`; authz checked before the mode is validated or applied.

## Tests

`TestQuizStore_SetQuizMode` (store: flip both ways, invalid mode -> `ErrInvalidMode`, missing id -> `ErrQuizNotFound`) and `TestHandleQuizSetMode` (handler: flip persists + 303, invalid `{mode}` 400, missing quiz 404).

Rebased onto the post-#832 structure. `make check` green. (`addAdminQuestionRoutes` was extracted to keep `addAdminRoutes` under the function-length cap.)