### PR TITLE
Give the standings-bargraph aria-current check the settle timeout

### DIFF
--- a/test/e2e/tests/standings-bargraph.spec.ts
+++ b/test/e2e/tests/standings-bargraph.spec.ts
@@ -266,10 +266,14 @@ test('the standings bar graph shows final order and totals on the TV and player 
     expect(Number(rows[1].total)).toBe(0);
   }).toPass({ timeout: STANDINGS_SETTLE_TIMEOUT });
 
-  // The player's own row is highlighted (aria-current).
+  // The player's own row is highlighted (aria-current). This settles
+  // separately from the totals above (the client tags its own row once the
+  // SSE state names it), so it gets the same generous settle timeout as the
+  // sibling assertions rather than the implicit 5s default — under CI load the
+  // highlight can lag past 5s, which flaked this assertion (#845).
   await expect(
     page.locator('[data-testid="round-results"] [data-standings-row]').first(),
-  ).toHaveAttribute('aria-current', 'true');
+  ).toHaveAttribute('aria-current', 'true', { timeout: STANDINGS_SETTLE_TIMEOUT });
 
   // Round 2: Quincy answers '6' (correct), Robin answers '5' (wrong).
   await answerOnPage(page, '6');


### PR DESCRIPTION
Closes #845

## What

The `standings-bargraph` e2e flaked on CI (it red-ed unrelated PRs, e.g. #846's runs). The exact failure:

```
expect(locator).toHaveAttribute(expected) failed
Locator: [data-testid="round-results"] [data-standings-row] (first)
Expected: "true"   Timeout: 5000ms
```

That's the `aria-current` assertion on the player's own round-results row. Every sibling settle-assertion in the spec uses `STANDINGS_SETTLE_TIMEOUT` (30s), but this one was left on Playwright's implicit 5s default. The player-row highlight settles separately from the totals (the client tags its own row once the SSE state names it), so under CI load it can lag past 5s and the assertion times out.

## Fix

One line: give the `aria-current` assertion the same `STANDINGS_SETTLE_TIMEOUT` the surrounding settle-assertions already use. No app change, no behavior change — just removes the timing race from the test.

Not the animation/frame-sampling issue: that `motion.tops.length` assertion lives in `standings-swap-video.spec.ts`, which self-skips on CI and is out of scope.

## Verification

`npx playwright test standings-bargraph` — passes on chromium + firefox.