### PR TITLE
Confirm before ending a running session to host a different quiz

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -819,6 +819,14 @@ type ActiveSessionLookup interface {
 	GetActiveSessionForHost(ctx context.Context, hostPlayerID int64) (*livesession.Session, error)
 }
 
+// RunningGameLookup is the slice of the live-session service the quiz view needs
+// to gate the "Host live" confirm-and-restart prompt (#853): report whether the
+// signed-in host already has a game in flight. Kept narrow so the admin package
+// does not depend on the whole live-session service.
+type RunningGameLookup interface {
+	HostHasRunningGame(ctx context.Context, hostPlayerID int64) (bool, error)
+}
+
 // indexData feeds the admin dashboard. ResumeCode is the join code of the
 // host's current active room, empty when they have none. The single adaptive
 // host control reflects it: a "Resume session" link when set, the "Host a
@@ -969,7 +977,11 @@ type PlayerScoreData struct {
 // rather than spinning up a dedicated "list participants" service method -
 // see #145 for the rationale (and #141 for the performance ceilings).
 func HandleQuizView(
-	logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store, gameService *game.Service,
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	quizStore quiz.Store,
+	gameService *game.Service,
+	runningGames RunningGameLookup,
 ) http.Handler {
 	render := NewTemplateRenderer(logger, csrfMgr, "admin/pages/quizview.gohtml")
 
@@ -999,8 +1011,33 @@ func HandleQuizView(
 		quizData := quizDataFromQuiz(qz)
 		attachCanEdit(r, quizData)
 		data := newQuizViewData(quizData, players, rounds)
+		data.HostHasRunningGame = hostHasRunningGame(r, logger, runningGames)
 		render.Render(w, r, http.StatusOK, data)
 	})
+}
+
+// hostHasRunningGame reports whether the signed-in host already has a game in
+// flight, so the quiz view can gate the "Host live" confirm-and-restart prompt
+// (#853). A lookup failure is logged and degraded to false rather than failing
+// the whole render: the page still serves, and the #851 in-flight no-op still
+// protects the running game server-side. Returns false when the service is not
+// wired or no player is on the context.
+func hostHasRunningGame(r *http.Request, logger *slog.Logger, runningGames RunningGameLookup) bool {
+	if runningGames == nil {
+		return false
+	}
+	player, ok := auth.PlayerFromContext(r.Context())
+	if !ok {
+		return false
+	}
+	running, err := runningGames.HostHasRunningGame(r.Context(), player.ID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "error looking up running host game", slog.Any("err", err))
+
+		return false
+	}
+
+	return running
 }
 
 // QuizViewData is the data passed to the quiz view template. Questions
@@ -1013,6 +1050,11 @@ type QuizViewData struct {
 	// Rounds is the position-ordered round list, each carrying its own
 	// questions, for the grouped quiz view.
 	Rounds []RoundViewData
+	// HostHasRunningGame gates the "Host live" confirm-and-restart prompt
+	// (#853): true when the signed-in host already has a game in flight, so the
+	// control opens a modal that ends the running session before hosting this
+	// quiz instead of submitting straight away.
+	HostHasRunningGame bool
 }
 
 // RoundViewData is one round section on the quiz view: the round itself

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -283,7 +283,7 @@ func TestHandleQuizView(t *testing.T) {
 		env := newAdminEnv(t)
 		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz One", "quiz-one"))
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		rr := httptest.NewRecorder()
@@ -306,7 +306,7 @@ func TestHandleQuizView(t *testing.T) {
 
 		env := newAdminEnv(t)
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/999", nil)
 		req.SetPathValue("quizID", "999")
 		rr := httptest.NewRecorder()
@@ -322,6 +322,75 @@ func TestHandleQuizView(t *testing.T) {
 	})
 }
 
+// TestHandleQuizView_RestartModalGating pins the confirm-and-restart gating
+// (#853): on a live quiz, the restart modal and its hidden restart=true field
+// render only when the host already has a game in flight; otherwise the plain
+// Host live form has no restart field and no modal.
+func TestHandleQuizView_RestartModalGating(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	seedLive := func(t *testing.T, env *adminEnv) *quiz.Quiz {
+		t.Helper()
+		live := twoQuestionQuiz("Hostable Quiz", "hostable-quiz")
+		live.Mode = quiz.ModeLive
+
+		return env.seedQuiz(t, live)
+	}
+
+	viewBody := func(t *testing.T, env *adminEnv, qz *quiz.Quiz, running RunningGameLookup) string {
+		t.Helper()
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), running)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
+		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, withTestAdmin(req))
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("quiz view status = %d, want %d", got, want)
+		}
+
+		return rr.Body.String()
+	}
+
+	t.Run("running game shows the restart modal and field", func(t *testing.T) {
+		t.Parallel()
+		env := newAdminEnv(t)
+		qz := seedLive(t, env)
+
+		body := viewBody(t, env, qz, runningGameLookup{running: true})
+		for _, want := range []string{
+			"modal-restart-host-" + strconv.FormatInt(qz.ID, 10),
+			`name="restart"`,
+			`value="true"`,
+			"End and start",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("running-game quiz view missing %q", want)
+			}
+		}
+	})
+
+	t.Run("no running game shows the plain form without restart", func(t *testing.T) {
+		t.Parallel()
+		env := newAdminEnv(t)
+		qz := seedLive(t, env)
+
+		body := viewBody(t, env, qz, runningGameLookup{running: false})
+		// The plain Host live form still renders, but with no restart field and no
+		// restart modal.
+		if !strings.Contains(body, "Host live") {
+			t.Error("no-running-game quiz view missing the Host live control")
+		}
+		if strings.Contains(body, `name="restart"`) {
+			t.Error("no-running-game quiz view rendered the restart hidden field")
+		}
+		if strings.Contains(body, "modal-restart-host-") {
+			t.Error("no-running-game quiz view rendered the restart modal")
+		}
+	})
+}
+
 func TestHandleQuizView_ErrorHandling(t *testing.T) {
 	t.Parallel()
 
@@ -333,7 +402,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 
 		env := newAdminEnv(t)
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/abc", nil)
 		req.SetPathValue("quizID", "abc")
 		rr := httptest.NewRecorder()
@@ -358,7 +427,7 @@ func TestHandleQuizView_ErrorHandling(t *testing.T) {
 		env.seedQuiz(t, ownedQuiz("Q", "q"))
 		env.closeStore(t)
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		req.SetPathValue("quizID", "1")
 		rr := httptest.NewRecorder()
@@ -2144,7 +2213,7 @@ func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
 		env.playThrough(t, qz, alice)
 		env.playThrough(t, qz, bob)
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		rr := httptest.NewRecorder()
@@ -2194,7 +2263,7 @@ func TestHandleQuizView_RendersPlayedBy(t *testing.T) {
 		env := newAdminEnv(t)
 		qz := env.seedQuiz(t, twoQuestionQuiz("Q1", "q-1"))
 
-		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService())
+		handler := HandleQuizView(logger, nil, env.quizzes, env.newGameService(), runningGameLookup{})
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/quizzes/1", nil)
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		rr := httptest.NewRecorder()
@@ -2527,6 +2596,15 @@ type activeSessionLookup struct{ code string }
 
 func (a activeSessionLookup) GetActiveSessionForHost(_ context.Context, _ int64) (*livesession.Session, error) {
 	return &livesession.Session{JoinCode: a.code}, nil
+}
+
+// runningGameLookup is a RunningGameLookup that reports the host's running-game
+// state by a fixed bool, so the quiz view test can toggle the confirm-and-restart
+// prompt (#853) without standing up a live session.
+type runningGameLookup struct{ running bool }
+
+func (l runningGameLookup) HostHasRunningGame(_ context.Context, _ int64) (bool, error) {
+	return l.running, nil
 }
 
 func TestHandleQuizCreate(t *testing.T) {

--- a/internal/host/create.go
+++ b/internal/host/create.go
@@ -21,6 +21,10 @@ import (
 //     [livesession.Service.StartHosting], which is one-room-per-host aware -
 //     it opens a new armed room, arms+starts the quiz in the host's existing
 //     empty/intermission room, or leaves a running game untouched.
+//   - With a quiz_id and restart=true (the confirm-and-restart path #853 when a
+//     game is already running): orchestrate through
+//     [livesession.Service.RestartHosting], which ends the host's running session
+//     and opens a fresh room hosting the picked quiz.
 //
 // Either way it 303-redirects the host to the TV lobby. The route is host-gated;
 // a non-live or missing quiz round-trips back to the quiz list rather than
@@ -48,6 +52,11 @@ func (h *Handlers) Create(w http.ResponseWriter, r *http.Request) {
 	id, err := handlers.IDFromString(raw)
 	if err != nil {
 		http.Error(w, "invalid quiz id", http.StatusBadRequest)
+
+		return
+	}
+	if r.FormValue("restart") == "true" {
+		h.hostLiveRestart(w, r, id, player.ID)
 
 		return
 	}
@@ -81,6 +90,26 @@ func (h *Handlers) hostLive(w http.ResponseWriter, r *http.Request, quizID, play
 			http.Redirect(w, r, "/admin/quizzes", http.StatusSeeOther)
 		default:
 			h.logger.ErrorContext(r.Context(), "error hosting live quiz", slog.Any("err", err))
+			http.Error(w, msgInternalError, http.StatusInternalServerError)
+		}
+
+		return
+	}
+	h.redirectToLobby(w, r, sess.JoinCode)
+}
+
+// hostLiveRestart ends the host's running session and opens a new room hosting
+// the picked quiz (#853): the confirm-and-restart path the host took to switch
+// the live quiz. A missing or solo quiz bounces back to the quiz list and
+// nothing is ended.
+func (h *Handlers) hostLiveRestart(w http.ResponseWriter, r *http.Request, quizID, playerID int64) {
+	sess, err := h.service.RestartHosting(r.Context(), quizID, playerID)
+	if err != nil {
+		switch {
+		case errors.Is(err, quiz.ErrQuizNotFound), errors.Is(err, livesession.ErrNotLiveQuiz):
+			http.Redirect(w, r, "/admin/quizzes", http.StatusSeeOther)
+		default:
+			h.logger.ErrorContext(r.Context(), "error restarting host session", slog.Any("err", err))
 			http.Error(w, msgInternalError, http.StatusInternalServerError)
 		}
 

--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -141,6 +141,12 @@ const beginTimeout = 10 * time.Second
 // ([ErrSessionNotFound]) still surfaces to callers via [errors.Is].
 const errGetSessionByCodeFmt = "failed to get session by join code: %w"
 
+// errGetActiveSessionFmt is the wrap format every host-keyed active-session
+// lookup shares when GetActiveSessionForHost fails, kept in one place so the
+// one-room-per-host paths (StartHosting, RestartHosting, HostHasRunningGame, the
+// resume lookup) word the error identically.
+const errGetActiveSessionFmt = "failed to get active session for host: %w"
+
 // Session is one hosted run of a live quiz. Players holds the lobby roster
 // when populated by [Store.GetSessionByJoinCode]; it is nil on the bare
 // create/get paths that do not fan out the roster.
@@ -742,7 +748,7 @@ func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, 
 func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) (*Session, error) {
 	active, err := s.store.GetActiveSessionForHost(ctx, hostPlayerID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get active session for host: %w", err)
+		return nil, fmt.Errorf(errGetActiveSessionFmt, err)
 	}
 
 	if active == nil {
@@ -767,6 +773,54 @@ func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) 
 	default:
 		return nil, err
 	}
+}
+
+// HostHasRunningGame reports whether the host has an active session with a game
+// in flight (#853): one that has left the lobby/intermission staging and so
+// cannot take a new quiz without ending it. The quiz view uses this to gate the
+// "Host live" confirm-and-restart prompt. An empty staging lobby, an
+// armed-but-not-started lobby, and the between-games intermission all return
+// false (a pick just arms them, no confirm needed).
+func (s *Service) HostHasRunningGame(ctx context.Context, hostPlayerID int64) (bool, error) {
+	active, err := s.store.GetActiveSessionForHost(ctx, hostPlayerID)
+	if err != nil {
+		return false, fmt.Errorf(errGetActiveSessionFmt, err)
+	}
+
+	return active != nil && !canArmQuiz(active), nil
+}
+
+// RestartHosting ends the host's active session (if any) and opens a new room
+// hosting quizID (#853) - the deliberate "switch the live quiz" path the host
+// confirms when a game is already running. The target quiz is validated BEFORE
+// the running session is ended, so an unhostable pick ([quiz.ErrQuizNotFound] /
+// [ErrNotLiveQuiz]) bounces with nothing torn down. A rarer failure of the
+// create after the end (e.g. join-code exhaustion) surfaces as an error; the old
+// session is already gone, so the host's retry simply opens the new room.
+func (s *Service) RestartHosting(ctx context.Context, quizID, hostPlayerID int64) (*Session, error) {
+	// Validate the target quiz up front; CreateSession re-checks it, but doing it
+	// here first guarantees we never end the running game for an unhostable pick.
+	qz, err := s.quizzes.GetQuiz(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get quiz for restart: %w", err)
+	}
+	if qz.Mode != quiz.ModeLive {
+		return nil, ErrNotLiveQuiz
+	}
+
+	active, err := s.store.GetActiveSessionForHost(ctx, hostPlayerID)
+	if err != nil {
+		return nil, fmt.Errorf(errGetActiveSessionFmt, err)
+	}
+	if active != nil {
+		if err = s.EndSession(ctx, active.JoinCode, hostPlayerID); err != nil {
+			return nil, fmt.Errorf("failed to end running session: %w", err)
+		}
+	}
+
+	// No active session now (just ended, or never any): CreateSession opens a new
+	// armed lobby hosting the picked quiz.
+	return s.CreateSession(ctx, &quizID, hostPlayerID)
 }
 
 // canArmQuiz reports whether a quiz can be armed to play in the room right now:
@@ -822,7 +876,7 @@ func (s *Service) EndSession(ctx context.Context, joinCode string, hostPlayerID 
 func (s *Service) GetActiveSessionForHost(ctx context.Context, hostPlayerID int64) (*Session, error) {
 	sess, err := s.store.GetActiveSessionForHost(ctx, hostPlayerID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get active session for host: %w", err)
+		return nil, fmt.Errorf(errGetActiveSessionFmt, err)
 	}
 
 	return sess, nil

--- a/internal/livesession/restart_hosting_test.go
+++ b/internal/livesession/restart_hosting_test.go
@@ -1,0 +1,278 @@
+package livesession_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/livesession"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// restartStart is the fixed clock origin the confirm-and-restart tests open
+// their rooms at; any instant works since these tests assert through the store.
+var restartStart = time.Date(2026, time.June, 10, 12, 0, 0, 0, time.UTC)
+
+// TestService_HostHasRunningGame_FalseWhenNoSession pins HostHasRunningGame
+// (#853): with no active room for the host, there is no game in flight.
+func TestService_HostHasRunningGame_FalseWhenNoSession(t *testing.T) {
+	t.Parallel()
+
+	h := newEmptyRoomHarness(t, restartStart)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	running, err := h.service.HostHasRunningGame(ctx, hostID)
+	if err != nil {
+		t.Fatalf("HostHasRunningGame (no session) err = %v, want nil", err)
+	}
+	if running {
+		t.Error("HostHasRunningGame = true with no session, want false")
+	}
+}
+
+// TestService_HostHasRunningGame_FalseWhenStaging pins that the staging phases a
+// pick can simply arm - an empty lobby, an armed-but-not-started lobby, and the
+// between-games intermission - all report no game in flight (#853), so the quiz
+// view shows the plain Host live control rather than the confirm prompt.
+func TestService_HostHasRunningGame_FalseWhenStaging(t *testing.T) {
+	t.Parallel()
+
+	const hostID int64 = 1
+
+	t.Run("empty staging lobby", func(t *testing.T) {
+		t.Parallel()
+		h := newEmptyRoomHarness(t, restartStart)
+		ctx := t.Context()
+		if _, err := h.service.CreateSession(ctx, nil, hostID); err != nil {
+			t.Fatalf("CreateSession (empty) err = %v, want nil", err)
+		}
+		if got, want := runningGame(t, h), false; got != want {
+			t.Errorf("HostHasRunningGame (empty lobby) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("armed but not started lobby", func(t *testing.T) {
+		t.Parallel()
+		h := newEmptyRoomHarness(t, restartStart)
+		ctx := t.Context()
+		qz := seedRunnerQuizSlug(t, h.quizStore, "restart-armed-lobby", [][]bool{{true}})
+		if _, err := h.service.CreateSession(ctx, &qz.ID, hostID); err != nil {
+			t.Fatalf("CreateSession (armed) err = %v, want nil", err)
+		}
+		// CreateSession leaves the room in the lobby with no started_at: the host
+		// has a quiz preselected but the game has not begun, so a pick can still
+		// just arm it.
+		if got, want := runningGame(t, h), false; got != want {
+			t.Errorf("HostHasRunningGame (armed lobby) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("between-games intermission", func(t *testing.T) {
+		t.Parallel()
+		h := newEmptyRoomHarness(t, restartStart)
+		ctx := t.Context()
+		qz := seedRunnerQuizSlug(t, h.quizStore, "restart-intermission", [][]bool{{true}})
+		sess, err := h.service.CreateSession(ctx, &qz.ID, hostID)
+		if err != nil {
+			t.Fatalf("CreateSession err = %v, want nil", err)
+		}
+		// Drive the game in flight, then end it into intermission via the store so
+		// the room sits at the between-games screen the host can re-arm from.
+		if err = h.service.StartQuiz(ctx, sess.JoinCode, hostID, qz.ID); err != nil {
+			t.Fatalf("StartQuiz err = %v, want nil", err)
+		}
+		if err = h.store.Intermission(ctx, sess.ID); err != nil {
+			t.Fatalf("Intermission err = %v, want nil", err)
+		}
+		if got, want := runningGame(t, h), false; got != want {
+			t.Errorf("HostHasRunningGame (intermission) = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestService_HostHasRunningGame_TrueWhenInFlight pins that a started, in-flight
+// game reports running (#853), so the quiz view gates the Host live control
+// behind the confirm-and-restart prompt.
+func TestService_HostHasRunningGame_TrueWhenInFlight(t *testing.T) {
+	t.Parallel()
+
+	h := newEmptyRoomHarness(t, restartStart)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	qz := seedRunnerQuizSlug(t, h.quizStore, "restart-inflight", [][]bool{{true}})
+	sess, err := h.service.CreateSession(ctx, &qz.ID, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	// The runner drives the game into round_intro: it has left the lobby staging,
+	// so a pick cannot simply arm it.
+	if err = h.service.StartQuiz(ctx, sess.JoinCode, hostID, qz.ID); err != nil {
+		t.Fatalf("StartQuiz err = %v, want nil", err)
+	}
+	if got, want := runningGame(t, h), true; got != want {
+		t.Errorf("HostHasRunningGame (in flight) = %v, want %v", got, want)
+	}
+}
+
+// TestService_RestartHosting_EndsRunningAndOpensNewRoom pins the confirm-and-
+// restart happy path (#853): with a game in flight on quiz A, RestartHosting
+// hosting quiz B finishes the running session and returns a NEW room (different
+// join code) armed onto B.
+func TestService_RestartHosting_EndsRunningAndOpensNewRoom(t *testing.T) {
+	t.Parallel()
+
+	h := newEmptyRoomHarness(t, restartStart)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	quizA := seedRunnerQuizSlug(t, h.quizStore, "restart-a", [][]bool{{true}})
+	quizB := seedRunnerQuizSlug(t, h.quizStore, "restart-b", [][]bool{{true}})
+
+	running, err := h.service.CreateSession(ctx, &quizA.ID, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	if err = h.service.StartQuiz(ctx, running.JoinCode, hostID, quizA.ID); err != nil {
+		t.Fatalf("StartQuiz err = %v, want nil", err)
+	}
+
+	fresh, err := h.service.RestartHosting(ctx, quizB.ID, hostID)
+	if err != nil {
+		t.Fatalf("RestartHosting err = %v, want nil", err)
+	}
+	if fresh == nil {
+		t.Fatal("RestartHosting returned nil session, want a new room")
+	}
+	// A brand new room: a different join code from the one just ended.
+	if fresh.JoinCode == running.JoinCode {
+		t.Errorf("RestartHosting reused join code %q, want a new room", fresh.JoinCode)
+	}
+	if fresh.QuizID == nil {
+		t.Fatalf("new room QuizID = nil, want %d", quizB.ID)
+	}
+	if got, want := *fresh.QuizID, quizB.ID; got != want {
+		t.Errorf("new room QuizID = %d, want %d (quiz B)", got, want)
+	}
+	if got, want := fresh.Phase, PhaseLobby; got != want {
+		t.Errorf("new room Phase = %q, want %q (host starts it later)", got, want)
+	}
+
+	// The old session is terminally finished.
+	ended, err := h.store.GetSessionByID(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID (old) err = %v, want nil", err)
+	}
+	if got, want := ended.Phase, PhaseFinished; got != want {
+		t.Errorf("old session Phase = %q, want %q (ended on restart)", got, want)
+	}
+
+	// The fresh room is now the host's active room.
+	active, err := h.service.GetActiveSessionForHost(ctx, hostID)
+	if err != nil {
+		t.Fatalf("GetActiveSessionForHost err = %v, want nil", err)
+	}
+	if active == nil {
+		t.Fatal("active session = nil, want the new room")
+	}
+	if got, want := active.ID, fresh.ID; got != want {
+		t.Errorf("active session ID = %q, want %q (the new room)", got, want)
+	}
+}
+
+// TestService_RestartHosting_RejectsSoloLeavesRunningUntouched pins that an
+// unhostable pick is validated BEFORE the running game is ended (#853): a solo
+// quiz B yields ErrNotLiveQuiz, no room is opened, and the running session on
+// quiz A is left untouched so the host is never stranded with nothing.
+func TestService_RestartHosting_RejectsSoloLeavesRunningUntouched(t *testing.T) {
+	t.Parallel()
+
+	h := newEmptyRoomHarness(t, restartStart)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	quizA := seedRunnerQuizSlug(t, h.quizStore, "restart-keep-a", [][]bool{{true}})
+	running, err := h.service.CreateSession(ctx, &quizA.ID, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	if err = h.service.StartQuiz(ctx, running.JoinCode, hostID, quizA.ID); err != nil {
+		t.Fatalf("StartQuiz err = %v, want nil", err)
+	}
+
+	solo := &quiz.Quiz{
+		Title:             "Solo",
+		Slug:              "restart-solo-b",
+		CreatedByPlayerID: hostID,
+		Mode:              quiz.ModeSolo,
+		Visibility:        quiz.VisibilityPublic,
+		Questions: []*quiz.Question{
+			{Text: "Q", Position: 1, Options: []*quiz.Option{{Text: "A", Correct: true}, {Text: "B"}}},
+		},
+	}
+	if err = h.quizStore.CreateQuiz(ctx, solo); err != nil {
+		t.Fatalf("CreateQuiz solo err = %v, want nil", err)
+	}
+
+	sess, err := h.service.RestartHosting(ctx, solo.ID, hostID)
+	if got, want := err, ErrNotLiveQuiz; !errors.Is(got, want) {
+		t.Errorf("RestartHosting (solo) err = %v, want %v", got, want)
+	}
+	if sess != nil {
+		t.Errorf("RestartHosting (solo) session = %v, want nil (no room opened)", sess)
+	}
+
+	// The running session is untouched: still active and not finished.
+	still, err := h.store.GetSessionByID(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	if still.Phase == PhaseFinished {
+		t.Error("running session was finished by a rejected restart, want it left running")
+	}
+}
+
+// TestService_RestartHosting_NoActiveSessionJustOpens pins that RestartHosting
+// works as a plain open when the host has no active session (#853): nothing to
+// end, so it just opens a new room hosting the picked quiz.
+func TestService_RestartHosting_NoActiveSessionJustOpens(t *testing.T) {
+	t.Parallel()
+
+	h := newEmptyRoomHarness(t, restartStart)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	qz := seedRunnerQuizSlug(t, h.quizStore, "restart-fresh-open", [][]bool{{true}})
+
+	sess, err := h.service.RestartHosting(ctx, qz.ID, hostID)
+	if err != nil {
+		t.Fatalf("RestartHosting (no active) err = %v, want nil", err)
+	}
+	if sess == nil {
+		t.Fatal("RestartHosting returned nil session, want a new room")
+	}
+	if sess.QuizID == nil {
+		t.Fatalf("new room QuizID = nil, want %d", qz.ID)
+	}
+	if got, want := *sess.QuizID, qz.ID; got != want {
+		t.Errorf("new room QuizID = %d, want %d", got, want)
+	}
+	if got, want := sess.Phase, PhaseLobby; got != want {
+		t.Errorf("new room Phase = %q, want %q", got, want)
+	}
+}
+
+// runningGame returns HostHasRunningGame for the seeded admin (host id 1, the
+// host every restart test uses), failing the test on a lookup error so the
+// caller can assert the bool inline with got/want.
+func runningGame(t *testing.T, h *emptyRoomHarness) bool {
+	t.Helper()
+	const hostID int64 = 1
+	got, err := h.service.HostHasRunningGame(t.Context(), hostID)
+	if err != nil {
+		t.Fatalf("HostHasRunningGame err = %v, want nil", err)
+	}
+
+	return got
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -57,22 +57,22 @@ func addRoutes(
 		mailConfigured: mail.Status.Configured,
 		tasks:          mail.Tasks,
 	}
+	gameDeps := adminGameDeps{gameService: gameService, runningGames: realtime.SessionService}
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
-	addAdminRoutes(mux, logger, stores, gameService, sessions, csrfMgr, emailDeps, playerDeps)
+	addAdminRoutes(mux, logger, stores, gameDeps, sessions, csrfMgr, emailDeps, playerDeps)
 	addProfileRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	addAPIRoutes(mux, logger, stores, gameService, realtime, sessions, cfg)
 	addHostRoutes(mux, logger, stores, sessions, csrfMgr, realtime.SessionService)
 
 	// Client
-	clientHandler := client.Handler(cfg)
 	shell := client.NewShellHandlers(cfg, stores.Quizzes, logger)
 	// The SPA root and the per-quiz share URL both go through the shell
 	// handler so the index template can render Open Graph metadata. The
 	// shell route wins over the file-server fallback below because Go's
 	// mux picks the more specific pattern (`{$}` + method).
 	mux.Handle("GET /client/{$}", http.HandlerFunc(shell.Index))
-	mux.Handle("/client/", clientHandler)
+	mux.Handle("/client/", client.Handler(cfg))
 	mux.Handle("GET /play/{slugID}", http.HandlerFunc(shell.Play))
 	// Player join + lobby surface (MP-4 / #681). The bare /join is the PC
 	// enter-code entry; /join/{code} is the QR deep-link target. Both render
@@ -444,11 +444,20 @@ type adminPlayerDeps struct {
 	tasks *bgtasks.Tracker
 }
 
+// adminGameDeps bundles the game-facing deps the admin quiz routes need
+// (leaderboard reads + the running-game lookup that gates the quiz-view
+// confirm-and-restart prompt, #853) so addAdminRoutes stays inside revive's
+// 8-argument limit, matching the adminEmailDeps / adminPlayerDeps packaging.
+type adminGameDeps struct {
+	gameService  *game.Service
+	runningGames admin.RunningGameLookup
+}
+
 func addAdminRoutes(
 	mux *http.ServeMux,
 	logger *slog.Logger,
 	stores *store.Stores,
-	gameService *game.Service,
+	gameDeps adminGameDeps,
 	sessions *session.Manager,
 	csrfMgr *csrf.Manager,
 	email adminEmailDeps,
@@ -477,7 +486,9 @@ func addAdminRoutes(
 	mux.Handle("GET /admin/quizzes", requireGameHost(admin.HandleQuizList(logger, csrfMgr, stores.Quizzes)))
 	mux.Handle(
 		"GET /admin/quizzes/{quizID}",
-		requireGameHost(admin.HandleQuizView(logger, csrfMgr, stores.Quizzes, gameService)),
+		requireGameHost(
+			admin.HandleQuizView(logger, csrfMgr, stores.Quizzes, gameDeps.gameService, gameDeps.runningGames),
+		),
 	)
 	mux.Handle("GET /admin/quizzes/new", requireGameHost(admin.HandleQuizCreate(logger, csrfMgr)))
 	mux.Handle("POST /admin/quizzes", csrfMW(requireGameHost(admin.HandleQuizSave(logger, csrfMgr, stores.Quizzes))))
@@ -504,7 +515,7 @@ func addAdminRoutes(
 	)
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/players/{playerID}/reset",
-		csrfMW(requireGameHost(admin.HandleResetGameForPlayer(logger, csrfMgr, stores.Quizzes, gameService))),
+		csrfMW(requireGameHost(admin.HandleResetGameForPlayer(logger, csrfMgr, stores.Quizzes, gameDeps.gameService))),
 	)
 
 	addAdminQuestionRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -58,8 +58,18 @@
                      the entry shows for mode='live' only. It is one-room-per-host
                      aware (#851): if the host already has an empty staging room
                      or is between games, the quiz is armed in that room rather
-                     than spawning a second one. */}}
+                     than spawning a second one. When the host already has a game
+                     in flight (#853), the control opens a confirm-and-restart
+                     modal instead of submitting straight away. */}}
                 {{if eq .Quiz.Mode "live"}}
+                {{if .HostHasRunningGame}}
+                <button type="button"
+                        onclick="openModal('modal-restart-host-{{.Quiz.ID}}')"
+                        class="btn-primary gap-2">
+                    <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M10.804 8 5 4.633v6.734zM5.696 4.41a.5.5 0 0 0-.696.46v6.266a.5.5 0 0 0 .696.46l5.453-3.133a.5.5 0 0 0 0-.866z"/><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/></svg>
+                    <span>Host live</span>
+                </button>
+                {{else}}
                 <form method="post" action="/host" class="inline-flex">
                     <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                     <input type="hidden" name="quiz_id" value="{{.Quiz.ID}}">
@@ -68,6 +78,7 @@
                         <span>Host live</span>
                     </button>
                 </form>
+                {{end}}
                 {{end}}
                 <button type="button"
                         onclick="openModal('modal-share-quiz-{{.Quiz.ID}}')"
@@ -140,6 +151,37 @@
                 </footer>
             </div>
         </div>
+
+        {{/* Confirm-and-restart modal (#853). Mounted only when the host already
+             has a game in flight; the "Host live" button above opens it. Confirm
+             ends the running session and opens a fresh room hosting this quiz. */}}
+        {{if .HostHasRunningGame}}
+        <div id="modal-restart-host-{{.Quiz.ID}}" data-restart-modal role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
+            <div class="absolute inset-0" onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"></div>
+            <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">
+                <header class="flex items-center justify-between px-6 py-5 border-b border-border-soft">
+                    <p id="modal-restart-host-{{.Quiz.ID}}-title" class="font-display text-sm font-semibold uppercase tracking-[0.14em]">End the current session and start a new one?</p>
+                    <button type="button" aria-label="close"
+                            onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"
+                            class="w-6 h-6 inline-flex items-center justify-center rounded-full bg-border-soft text-text-dim border-0 hover:bg-border hover:text-text cursor-pointer">&times;</button>
+                </header>
+                <section class="px-6 py-5 text-[0.95rem]">
+                    A live session is already running. End it and start hosting this quiz instead?
+                </section>
+                <footer class="flex justify-end gap-2 px-6 py-4 border-t border-border-soft">
+                    <button type="button"
+                            onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"
+                            class="btn-ghost">Cancel</button>
+                    <form method="post" action="/host" class="inline-flex">
+                        <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                        <input type="hidden" name="quiz_id" value="{{.Quiz.ID}}">
+                        <input type="hidden" name="restart" value="true">
+                        <button type="submit" class="btn-primary">End and start</button>
+                    </form>
+                </footer>
+            </div>
+        </div>
+        {{end}}
 
         {{/* Delete-quiz modal */}}
         <div id="modal-delete-quiz-{{.Quiz.ID}}" role="dialog" aria-modal="true" aria-labelledby="modal-delete-quiz-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">

--- a/test/e2e/tests/confirm-restart.spec.ts
+++ b/test/e2e/tests/confirm-restart.spec.ts
@@ -1,0 +1,155 @@
+import { adminStatePath } from '../e2e-auth';
+import { test, expect } from './fixtures';
+import { importQuiz, setQuizMode, claimAndJoin, endHostedSession } from './helpers';
+import type { Page } from '@playwright/test';
+
+// confirm-and-restart (#853): a host already running a game on quiz A opens
+// quiz B's view and clicks "Host live". Because a game is in flight, the control
+// opens a confirm modal ("End the current session and start a new one?"). Confirm
+// ends A's session and lands the host on a NEW big screen hosting B; Cancel
+// leaves the running game untouched.
+//
+// The whole host flow is driven through the real browser (admin storageState
+// passes the host gate); a single anonymous player joins over the API so the
+// host can Start the game and put it in flight. Phase transitions are
+// server-driven by the runner.
+
+// seedLiveQuiz seeds a quiz as the shared admin and flips it to mode='live' so it
+// is hostable. The per-quiz answer window is set generously (120s) so the game
+// stays in the in-flight question phase throughout the host's navigation to the
+// other quiz - otherwise the default 10s window could close and advance the room
+// past the question (or to finished) mid-test, flipping HostHasRunningGame and
+// the phase assertions. The session is ended in cleanup, so the long window
+// never slows the test.
+async function seedLiveQuiz(host: Page, title: string, questionText: string): Promise<void> {
+  await importQuiz(host, {
+    title,
+    description: 'E2E seeded quiz',
+    timeLimitSeconds: 120,
+    questions: [
+      {
+        text: questionText,
+        options: [
+          { text: 'right', correct: true },
+          { text: 'wrong-a', correct: false },
+          { text: 'wrong-b', correct: false },
+          { text: 'wrong-c', correct: false },
+        ],
+      },
+    ],
+  });
+  setQuizMode(title, 'live');
+}
+
+// hostAndStart opens quiz A's view, hits "Host live" to open a room, joins one
+// anonymous player over the API, and starts the game so it is in flight. Returns
+// the running room's join code so the test can assert the restart ends it.
+async function hostAndStart(host: Page, page: Page, quizTitle: string): Promise<string> {
+  await host.goto('/admin/quizzes');
+  await host.getByRole('link', { name: quizTitle }).click();
+  await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
+  await host.getByRole('button', { name: 'Host live' }).click();
+  await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
+  const code = host.url().split('/host/')[1];
+
+  // A single anonymous player joins so the host can start the game.
+  await claimAndJoin(page.request, code, `Pat-${Date.now()}`);
+  await expect(host.locator('[data-player-row]')).toHaveCount(1);
+
+  // Start now puts the game in flight. Wait for the durable question phase (the
+  // round intro is too brief to assert on reliably); with the generous window it
+  // stays here while the host navigates to the other quiz, so the room is solidly
+  // in flight (HostHasRunningGame = true) when quiz B's view loads.
+  await host.getByRole('button', { name: 'Start now' }).click();
+  await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
+
+  return code;
+}
+
+test.describe('confirm-and-restart hosting', () => {
+  test('confirm ends the running game and lands the host on a new big screen hosting the other quiz', async ({ page, baseURL }) => {
+    test.setTimeout(90_000);
+
+    const stamp = Date.now();
+    const quizA = `Restart-A ${stamp}`;
+    const quizB = `Restart-B ${stamp}`;
+
+    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
+    const host = await hostContext.newPage();
+
+    let runningCode = '';
+    let newCode = '';
+    try {
+      await seedLiveQuiz(host, quizA, 'What is 1+1?');
+      await seedLiveQuiz(host, quizB, 'What is 2+2?');
+
+      // A game is running on quiz A.
+      runningCode = await hostAndStart(host, page, quizA);
+
+      // Open quiz B's view. Because a game is in flight, "Host live" opens the
+      // confirm-and-restart modal rather than submitting straight away.
+      await host.goto('/admin/quizzes');
+      await host.getByRole('link', { name: quizB }).click();
+      await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
+      await host.getByRole('button', { name: 'Host live' }).click();
+
+      const modal = host.locator('[data-restart-modal]');
+      await expect(modal).toBeVisible();
+      await expect(modal).toContainText('A live session is already running');
+
+      // Confirm: end the current session and start a new one hosting quiz B. The
+      // host lands on a NEW big screen (a different /host/{code}).
+      await modal.getByRole('button', { name: 'End and start' }).click();
+      await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
+      newCode = host.url().split('/host/')[1];
+      expect(newCode).not.toBe(runningCode);
+
+      // The new room is staged on quiz B: the host can start it (the Start
+      // control is present, the empty-room pick link is not).
+      await expect(host.locator('[data-start-now]')).toBeVisible({ timeout: 15_000 });
+      await expect(host.locator('[data-pick-quiz-link]')).toBeHidden();
+    } finally {
+      if (runningCode) await endHostedSession(host, runningCode);
+      if (newCode) await endHostedSession(host, newCode);
+      await hostContext.close();
+    }
+  });
+
+  test('cancel leaves the modal without ending the running game', async ({ page, baseURL }) => {
+    test.setTimeout(90_000);
+
+    const stamp = Date.now();
+    const quizA = `Restart-Cancel-A ${stamp}`;
+    const quizB = `Restart-Cancel-B ${stamp}`;
+
+    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
+    const host = await hostContext.newPage();
+
+    let runningCode = '';
+    try {
+      await seedLiveQuiz(host, quizA, 'What is 1+1?');
+      await seedLiveQuiz(host, quizB, 'What is 2+2?');
+
+      runningCode = await hostAndStart(host, page, quizA);
+
+      // Open quiz B's view and open the restart modal, then Cancel.
+      await host.goto('/admin/quizzes');
+      await host.getByRole('link', { name: quizB }).click();
+      await host.getByRole('button', { name: 'Host live' }).click();
+      const modal = host.locator('[data-restart-modal]');
+      await expect(modal).toBeVisible();
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+      await expect(modal).toBeHidden();
+
+      // The host is still on quiz B's view (no navigation), and the running game
+      // on quiz A is untouched: its big screen still loads in the in-flight
+      // question phase (the generous window keeps it there).
+      await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
+      await host.goto(`/host/${runningCode}`);
+      await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
+    } finally {
+      if (runningCode) await endHostedSession(host, runningCode);
+      await hostContext.close();
+    }
+  });
+});

--- a/test/integration/host_restart_test.go
+++ b/test/integration/host_restart_test.go
@@ -1,0 +1,296 @@
+package integration_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/livesession"
+)
+
+// postHostRestart posts the confirm-and-restart control (#853): /host with the
+// picked quiz_id plus restart=true, seeding a CSRF token from a page the host can
+// load. Returns the response for the caller to assert on.
+func postHostRestart(
+	ctx context.Context, t *testing.T, host *http.Client, baseURL string, quizID int64,
+) *http.Response {
+	t.Helper()
+	token := fetchCSRFToken(ctx, t, host, baseURL+"/admin/quizzes")
+
+	return httpPostForm(ctx, t, host, baseURL+"/host", url.Values{
+		"csrf_token": {token},
+		"quiz_id":    {strconv.FormatInt(quizID, 10)},
+		"restart":    {"true"},
+	})
+}
+
+// postHostLive posts the plain Host live control (#851): /host with the picked
+// quiz_id and no restart flag.
+func postHostLive(
+	ctx context.Context, t *testing.T, host *http.Client, baseURL string, quizID int64,
+) *http.Response {
+	t.Helper()
+	token := fetchCSRFToken(ctx, t, host, baseURL+"/admin/quizzes")
+
+	return httpPostForm(ctx, t, host, baseURL+"/host", url.Values{
+		"csrf_token": {token},
+		"quiz_id":    {strconv.FormatInt(quizID, 10)},
+	})
+}
+
+// getQuizViewHTML fetches GET /admin/quizzes/{id} on the (host) client and
+// returns the response status and body.
+func getQuizViewHTML(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL string, quizID int64,
+) (int, string) {
+	t.Helper()
+	resp := httpGet(ctx, t, client, baseURL+"/admin/quizzes/"+strconv.FormatInt(quizID, 10))
+	defer closeBody(t, resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read quiz view body: %v", err)
+	}
+
+	return resp.StatusCode, string(body)
+}
+
+// TestHostRestart_QuizViewGatesModal pins the quiz-view gating end-to-end (#853):
+// with a game in flight, GET /admin/quizzes/{id} renders the restart modal and
+// the hidden restart=true field; with no running game the same view shows the
+// plain Host live form with neither.
+func TestHostRestart_QuizViewGatesModal(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	quizA := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-view-a")
+	quizB := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-view-b")
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "host-view-host", "host-view-pass-123")
+
+	restartField := `name="restart"`
+	restartModal := "modal-restart-host-" + strconv.FormatInt(quizB.ID, 10)
+
+	// With no running session, quiz B's view shows the plain Host live form and no
+	// restart affordance.
+	status, body := getQuizViewHTML(ctx, t, host, baseURL, quizB.ID)
+	if status != http.StatusOK {
+		t.Fatalf("quiz view (no running) status = %d, want %d", status, http.StatusOK)
+	}
+	if !strings.Contains(body, "Host live") {
+		t.Error("quiz view (no running) missing the Host live control")
+	}
+	if strings.Contains(body, restartField) {
+		t.Error("quiz view (no running) rendered the restart hidden field")
+	}
+	if strings.Contains(body, restartModal) {
+		t.Error("quiz view (no running) rendered the restart modal")
+	}
+
+	// Open a room on quiz A and start it so a game is in flight.
+	codeA := createSession(ctx, t, host, baseURL, quizA.ID)
+	player := newAnonClient(t)
+	joinSession(ctx, t, player, baseURL, codeA, "Solo")
+	startSession(ctx, t, host, baseURL, codeA)
+	waitForPhase(ctx, t, player, baseURL, codeA, "round_intro")
+
+	// Now quiz B's view gates Host live behind the confirm-and-restart modal.
+	status, body = getQuizViewHTML(ctx, t, host, baseURL, quizB.ID)
+	if status != http.StatusOK {
+		t.Fatalf("quiz view (running) status = %d, want %d", status, http.StatusOK)
+	}
+	for _, want := range []string{restartModal, restartField, `value="true"`, "End and start"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("quiz view (running) missing %q", want)
+		}
+	}
+}
+
+// TestHostRestart_EndsRunningAndOpensNewRoom pins the confirm-and-restart happy
+// path end-to-end (#853): with a game running on quiz A, posting /host with
+// restart=true and quiz B ends the running session and 303-redirects the host to
+// a NEW lobby (a different join code) hosting quiz B, leaving the old session
+// finished.
+func TestHostRestart_EndsRunningAndOpensNewRoom(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	quizA := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-restart-a")
+	quizB := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-restart-b")
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "host-restart-host", "host-restart-pass-123")
+
+	// Open a room on quiz A and start it so a game is in flight (round_intro).
+	codeA := createSession(ctx, t, host, baseURL, quizA.ID)
+	player := newAnonClient(t)
+	joinSession(ctx, t, player, baseURL, codeA, "Solo")
+	startSession(ctx, t, host, baseURL, codeA)
+	waitForPhase(ctx, t, player, baseURL, codeA, "round_intro")
+
+	// The host confirms the restart onto quiz B: a 303 to a NEW lobby.
+	resp := postHostRestart(ctx, t, host, baseURL, quizB.ID)
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("restart status = %d, want %d", got, want)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "/host/") {
+		t.Fatalf("restart redirect = %q, want a /host/{code} target", loc)
+	}
+	codeB := strings.TrimPrefix(loc, "/host/")
+	if codeB == codeA {
+		t.Fatalf("restart reused the old join code %q, want a new room", codeB)
+	}
+
+	// The new room hosts quiz B and is in the lobby (the host starts it later).
+	newRoom, err := setup.Stores.LiveSessions.GetSessionByJoinCode(ctx, codeB)
+	if err != nil {
+		t.Fatalf("GetSessionByJoinCode (new) err = %v, want nil", err)
+	}
+	if newRoom.QuizID == nil {
+		t.Fatalf("new room QuizID = nil, want %d (quiz B)", quizB.ID)
+	}
+	if got, want := *newRoom.QuizID, quizB.ID; got != want {
+		t.Errorf("new room QuizID = %d, want %d (quiz B)", got, want)
+	}
+	if got, want := newRoom.Phase, livesession.PhaseLobby; got != want {
+		t.Errorf("new room phase = %q, want %q", got, want)
+	}
+
+	// The old session is terminally finished.
+	old, err := setup.Stores.LiveSessions.GetSessionByJoinCode(ctx, codeA)
+	if err != nil {
+		t.Fatalf("GetSessionByJoinCode (old) err = %v, want nil", err)
+	}
+	if got, want := old.Phase, livesession.PhaseFinished; got != want {
+		t.Errorf("old session phase = %q, want %q (ended on restart)", got, want)
+	}
+}
+
+// TestHostRestart_PlainHostLiveWhileRunningIsNoOp pins that a plain Host live
+// post (no restart flag) while a game is running is the #851 in-flight no-op: it
+// 303s back to the SAME running room and the running session is untouched, so a
+// stray pick never disrupts a live game.
+func TestHostRestart_PlainHostLiveWhileRunningIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	quizA := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-noop-a")
+	quizB := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-noop-b")
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "host-noop-host", "host-noop-pass-123")
+
+	codeA := createSession(ctx, t, host, baseURL, quizA.ID)
+	player := newAnonClient(t)
+	joinSession(ctx, t, player, baseURL, codeA, "Solo")
+	startSession(ctx, t, host, baseURL, codeA)
+	waitForPhase(ctx, t, player, baseURL, codeA, "round_intro")
+
+	// A plain Host live (no restart) while running returns the running room.
+	resp := postHostLive(ctx, t, host, baseURL, quizB.ID)
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("plain host-live status = %d, want %d", got, want)
+	}
+	if got, want := resp.Header.Get("Location"), "/host/"+codeA; got != want {
+		t.Errorf("plain host-live redirect = %q, want %q (the running room)", got, want)
+	}
+
+	// The running room is untouched: still on quiz A, not finished.
+	still, err := setup.Stores.LiveSessions.GetSessionByJoinCode(ctx, codeA)
+	if err != nil {
+		t.Fatalf("GetSessionByJoinCode err = %v, want nil", err)
+	}
+	if still.QuizID == nil {
+		t.Fatal("running room QuizID = nil, want quiz A")
+	}
+	if got, want := *still.QuizID, quizA.ID; got != want {
+		t.Errorf("running room QuizID = %d, want %d (stray pick must not re-arm)", got, want)
+	}
+	if still.Phase == livesession.PhaseFinished {
+		t.Error("running room was finished by a plain host-live, want it left running")
+	}
+}
+
+// TestHostRestart_SoloLeavesRunningUntouched pins that a restart onto a solo quiz
+// bounces to the quiz list and never ends the running game (#853): the target is
+// validated before anything is torn down, so the host is not stranded.
+func TestHostRestart_SoloLeavesRunningUntouched(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	quizA := seedRunnerLiveQuiz(ctx, t, setup.Stores.Quizzes, "host-restart-solo-a")
+	solo := seedSoloQuiz(ctx, t, setup.Stores.Quizzes, "host-restart-solo-b")
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "host-restart-solo-host", "host-restart-solo-123")
+
+	codeA := createSession(ctx, t, host, baseURL, quizA.ID)
+	player := newAnonClient(t)
+	joinSession(ctx, t, player, baseURL, codeA, "Solo")
+	startSession(ctx, t, host, baseURL, codeA)
+	waitForPhase(ctx, t, player, baseURL, codeA, "round_intro")
+
+	// A restart onto a solo (unhostable) quiz bounces to the quiz list.
+	resp := postHostRestart(ctx, t, host, baseURL, solo.ID)
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		t.Fatalf("solo restart status = %d, want %d", got, want)
+	}
+	if got, want := resp.Header.Get("Location"), "/admin/quizzes"; got != want {
+		t.Errorf("solo restart redirect = %q, want %q", got, want)
+	}
+
+	// The running session is untouched: still on quiz A, not finished.
+	still, err := setup.Stores.LiveSessions.GetSessionByJoinCode(ctx, codeA)
+	if err != nil {
+		t.Fatalf("GetSessionByJoinCode err = %v, want nil", err)
+	}
+	if still.Phase == livesession.PhaseFinished {
+		t.Error("running session was finished by a rejected solo restart, want it left running")
+	}
+	if still.QuizID == nil {
+		t.Fatal("running room QuizID = nil, want quiz A")
+	}
+	if got, want := *still.QuizID, quizA.ID; got != want {
+		t.Errorf("running room QuizID = %d, want %d (unchanged)", got, want)
+	}
+}


### PR DESCRIPTION
Closes #853

Follow-up to #851. In #851, clicking "Host live" on a quiz while a session is already running with a game in flight does nothing (so a stray pick never disrupts a live game). This adds the deliberate switch path: the host is asked to confirm, and on confirm the running session ends and a fresh one starts hosting the picked quiz.

## What changed

- **`livesession.RestartHosting`** ends the host's active session (if any) and opens a new room hosting the picked quiz. The target quiz is validated **before** the running session is ended, so an unhostable pick never tears down a live game.
- **`livesession.HostHasRunningGame`** reports whether the host has a game in flight (an empty/armed lobby or intermission returns false - a pick just arms those in place, no confirm needed).
- **Quiz view** now gates the "Host live" control: with a game in flight it opens a confirm modal ("End the current session and start a new one?"); the confirm posts `restart=true`, which the `/host` handler routes to `RestartHosting`. With no running game it stays the plain one-click host (the #851 behaviour).

## Decisions

- **Modal, not a `confirm()` dialog** - the quiz view already uses modals for its destructive confirms (delete quiz / question / round, reset player), so the restart prompt follows that pattern.
- **Validate-before-end ordering** - the picked quiz is checked first; a rare create-failure after the end (e.g. join-code exhaustion) surfaces as an error and the host retries (the old session is already gone, so the retry just opens the new room).
- The running-game lookup reaches the admin quiz view through a narrow `RunningGameLookup` interface (mirrors the dashboard's `ActiveSessionLookup`), threaded through `addAdminRoutes` in a small `adminGameDeps` bundle to stay within the arg-count limit.

`make check` (coverage ~83%), `make smoke`, and `make test-e2e` (195 passed) are green.