### PR TITLE
Standardize host-session test hooks on data-testid

### DIFF
--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -2537,7 +2537,7 @@ func TestHandleIndex(t *testing.T) {
 	}
 	// The host control is a single adaptive slot (#850): with no active room
 	// the dashboard shows the "Host a session" submit and NOT the resume link.
-	if got := body; strings.Contains(got, "data-resume-hosting") {
+	if got := body; strings.Contains(got, `data-testid="resume-hosting"`) {
 		t.Errorf("body shows the resume control with no active room: %q", got)
 	}
 }
@@ -2568,7 +2568,7 @@ func TestHandleIndex_ResumeLink(t *testing.T) {
 		"Resume session",
 		`href="/host/ABC123"`,
 		"ABC123",
-		"data-resume-hosting",
+		`data-testid="resume-hosting"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)
@@ -2576,7 +2576,7 @@ func TestHandleIndex_ResumeLink(t *testing.T) {
 	}
 	// The two controls are mutually exclusive: with an active room the
 	// "Host a session" submit is gone.
-	if got := body; strings.Contains(got, "data-host-session-submit") {
+	if got := body; strings.Contains(got, `data-testid="host-session-submit"`) {
 		t.Errorf("body shows the Host a session submit alongside the resume link: %q", got)
 	}
 }

--- a/internal/web/tmpl/admin/pages/index.gohtml
+++ b/internal/web/tmpl/admin/pages/index.gohtml
@@ -20,17 +20,17 @@
              back to it instead of an entry that would open a second one. The
              per-quiz "Host live" entry preselects a quiz; this is the
              start-from-nothing entry. */}}
-        <div class="flex flex-col items-stretch gap-2 md:items-end" data-host-session>
+        <div class="flex flex-col items-stretch gap-2 md:items-end" data-testid="host-session">
             {{if .ResumeCode}}
                 <a href="/host/{{.ResumeCode}}"
                    class="inline-flex items-center justify-center gap-2 min-h-[44px] px-6 rounded-lg bg-accent text-bg font-display font-semibold uppercase tracking-tight text-sm no-underline transition-[filter] hover:brightness-110 focus-visible:outline-none focus-visible:shadow-focus cursor-pointer"
-                   data-resume-hosting>Resume session &mdash; room <span class="font-mono">{{.ResumeCode}}</span></a>
+                   data-testid="resume-hosting">Resume session &mdash; room <span class="font-mono">{{.ResumeCode}}</span></a>
             {{else}}
                 <form method="post" action="/host">
                     <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                     <button type="submit"
                             class="inline-flex items-center justify-center gap-2 min-h-[44px] px-6 rounded-lg bg-accent text-bg font-display font-semibold uppercase tracking-tight text-sm border-0 transition-[filter] hover:brightness-110 focus-visible:outline-none focus-visible:shadow-focus cursor-pointer"
-                            data-host-session-submit>Host a session</button>
+                            data-testid="host-session-submit">Host a session</button>
                 </form>
             {{end}}
         </div>

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -156,7 +156,7 @@
              has a game in flight; the "Host live" button above opens it. Confirm
              ends the running session and opens a fresh room hosting this quiz. */}}
         {{if .HostHasRunningGame}}
-        <div id="modal-restart-host-{{.Quiz.ID}}" data-restart-modal role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
+        <div id="modal-restart-host-{{.Quiz.ID}}" data-testid="restart-modal" role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
             <div class="absolute inset-0" onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"></div>
             <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">
                 <header class="flex items-center justify-between px-6 py-5 border-b border-border-soft">

--- a/internal/web/tmpl/host/pages/lobby.gohtml
+++ b/internal/web/tmpl/host/pages/lobby.gohtml
@@ -307,7 +307,7 @@
              instead, so this stays hidden there. */}}
         <div x-show="showsPickQuizLink()"
              class="shrink-0 px-[clamp(1.5rem,4vw,4rem)] pb-[clamp(1rem,2.5vh,2rem)]"
-             data-pick-quiz-link>
+             data-testid="pick-quiz-link">
             <a href="/admin/quizzes?mode=live" class="btn-primary gap-2">Pick a live quiz</a>
         </div>
 
@@ -340,23 +340,23 @@
                  uses the pick-a-live-quiz link above instead (#851). */}}
             <div x-show="phase === 'lobby' && hasQuiz && armed()"
                  class="flex flex-wrap items-center gap-4"
-                 data-start-countdown>
+                 data-testid="start-countdown">
                 <p class="m-0 font-display font-extrabold text-accent text-[clamp(1.1rem,2.4vw,1.75rem)] tabular-nums"
                    x-text="startCountdownLabel()"
                    role="status"
-                   data-start-countdown-label></p>
+                   data-testid="start-countdown-label"></p>
                 <form method="post" :action="'/host/' + encodeURIComponent(joinCode) + '/start'" @submit.prevent="start()">
                     <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                     <button type="submit"
                             class="inline-flex items-center justify-center gap-2 min-h-[52px] px-6 rounded-lg bg-accent text-bg font-display font-extrabold text-[clamp(0.9rem,1.7vw,1.15rem)] uppercase tracking-[0.12em] border-0 transition-[filter] hover:brightness-110 focus-visible:outline-none focus-visible:shadow-focus disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                             :disabled="starting"
-                            data-skip-start>Start now</button>
+                            data-testid="skip-start">Start now</button>
                 </form>
                 <button type="button"
                         class="inline-flex items-center justify-center gap-2 min-h-[52px] px-6 rounded-lg bg-surface text-text font-display font-bold text-[clamp(0.9rem,1.7vw,1.15rem)] uppercase tracking-[0.12em] border border-border-soft transition-colors hover:border-text-dim focus-visible:outline-none focus-visible:shadow-focus disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                         :disabled="arming"
                         @click="cancelStart()"
-                        data-cancel-start>Cancel</button>
+                        data-testid="cancel-start">Cancel</button>
             </div>
 
             {{/* Not armed: Start now + Start in 60s. Only when a quiz is queued
@@ -369,7 +369,7 @@
                     <button type="submit"
                             class="inline-flex items-center justify-center gap-2 min-h-[52px] px-8 rounded-lg bg-accent text-bg font-display font-extrabold text-[clamp(0.9rem,1.7vw,1.15rem)] uppercase tracking-[0.12em] border-0 transition-[filter] hover:brightness-110 focus-visible:outline-none focus-visible:shadow-focus disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                             :disabled="starting || arming || players.length === 0"
-                            data-start-now>
+                            data-testid="start-now">
                         <span x-text="players.length === 0 ? 'Waiting for players' : 'Start now'"></span>
                     </button>
                 </form>
@@ -377,7 +377,7 @@
                         class="inline-flex items-center justify-center gap-2 min-h-[52px] px-6 rounded-lg bg-surface text-text font-display font-bold text-[clamp(0.9rem,1.7vw,1.15rem)] uppercase tracking-[0.12em] border border-border-soft transition-colors hover:border-text-dim focus-visible:outline-none focus-visible:shadow-focus disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                         :disabled="starting || arming || players.length === 0"
                         @click="armStart()"
-                        data-arm-start>Start in 60s</button>
+                        data-testid="arm-start">Start in 60s</button>
             </div>
 
             {{/* End session (#836): the host control that closes the room for
@@ -390,11 +390,11 @@
                   method="post"
                   :action="'/host/' + encodeURIComponent(joinCode) + '/end'"
                   @submit="if (!confirm('End this session for everyone?')) $event.preventDefault()"
-                  data-end-session-form>
+                  data-testid="end-session-form">
                 <input type="hidden" name="csrf_token" value="{{csrfToken}}">
                 <button type="submit"
                         class="inline-flex items-center justify-center gap-2 min-h-[52px] px-6 rounded-lg bg-surface text-danger font-display font-bold text-[clamp(0.9rem,1.7vw,1.15rem)] uppercase tracking-[0.12em] border border-danger/50 transition-colors hover:border-danger focus-visible:outline-none focus-visible:shadow-focus cursor-pointer"
-                        data-end-session>End session</button>
+                        data-testid="end-session">End session</button>
             </form>
 
             {{/* Host-facing status line for the start controls. */}}

--- a/test/e2e/tests/confirm-restart.spec.ts
+++ b/test/e2e/tests/confirm-restart.spec.ts
@@ -93,7 +93,7 @@ test.describe('confirm-and-restart hosting', () => {
       await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
       await host.getByRole('button', { name: 'Host live' }).click();
 
-      const modal = host.locator('[data-restart-modal]');
+      const modal = host.getByTestId('restart-modal');
       await expect(modal).toBeVisible();
       await expect(modal).toContainText('A live session is already running');
 
@@ -106,8 +106,8 @@ test.describe('confirm-and-restart hosting', () => {
 
       // The new room is staged on quiz B: the host can start it (the Start
       // control is present, the empty-room pick link is not).
-      await expect(host.locator('[data-start-now]')).toBeVisible({ timeout: 15_000 });
-      await expect(host.locator('[data-pick-quiz-link]')).toBeHidden();
+      await expect(host.getByTestId('start-now')).toBeVisible({ timeout: 15_000 });
+      await expect(host.getByTestId('pick-quiz-link')).toBeHidden();
     } finally {
       if (runningCode) await endHostedSession(host, runningCode);
       if (newCode) await endHostedSession(host, newCode);
@@ -136,7 +136,7 @@ test.describe('confirm-and-restart hosting', () => {
       await host.goto('/admin/quizzes');
       await host.getByRole('link', { name: quizB }).click();
       await host.getByRole('button', { name: 'Host live' }).click();
-      const modal = host.locator('[data-restart-modal]');
+      const modal = host.getByTestId('restart-modal');
       await expect(modal).toBeVisible();
       await modal.getByRole('button', { name: 'Cancel' }).click();
       await expect(modal).toBeHidden();

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -358,7 +358,7 @@ export async function answerRemainingQuestions(page: Page, fromIndex = 0): Promi
 // x-show before deciding, then only drives the control when it is visible.
 export async function endHostedSession(host: Page, joinCode: string): Promise<void> {
   await host.goto(`/host/${joinCode}`);
-  const endBtn = host.locator('[data-end-session]');
+  const endBtn = host.getByTestId('end-session');
   if (await endBtn.count() === 0) return;
   // Let the lobby's first GET /state land so the Alpine x-show settles to the
   // real phase: the End control is briefly visible on the initial lobby-phase

--- a/test/e2e/tests/host-armed-start.spec.ts
+++ b/test/e2e/tests/host-armed-start.spec.ts
@@ -75,10 +75,10 @@ test.describe('host-armed last-call countdown', () => {
       await expect(page.getByTestId('waiting-hint')).toBeVisible();
 
       // Host arms the last-call countdown.
-      await host.locator('[data-arm-start]').click();
+      await host.getByTestId('arm-start').click();
 
       // Both surfaces show the live "Starting in M:SS" countdown.
-      await expect(host.locator('[data-start-countdown-label]')).toContainText('Starting in');
+      await expect(host.getByTestId('start-countdown-label')).toContainText('Starting in');
       await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
       // While armed the static waiting hint is gone on the player surface.
       await expect(page.getByTestId('waiting-hint')).toHaveCount(0);
@@ -87,7 +87,7 @@ test.describe('host-armed last-call countdown', () => {
       // game, so the player leaves the lobby into the round intro / first
       // question and the host TV countdown controls disappear.
       await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
-      await expect(host.locator('[data-start-countdown]')).toBeHidden();
+      await expect(host.getByTestId('start-countdown')).toBeHidden();
     } finally {
       await close();
     }
@@ -102,11 +102,11 @@ test.describe('host-armed last-call countdown', () => {
     try {
       await joinAsPlayer(page, joinCode, bob);
 
-      await host.locator('[data-arm-start]').click();
+      await host.getByTestId('arm-start').click();
       await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
 
       // Start now skips the rest of the countdown; the game begins at once.
-      await host.locator('[data-skip-start]').click();
+      await host.getByTestId('skip-start').click();
       await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
     } finally {
       await close();
@@ -122,12 +122,12 @@ test.describe('host-armed last-call countdown', () => {
     try {
       await joinAsPlayer(page, joinCode, cara);
 
-      await host.locator('[data-arm-start]').click();
+      await host.getByTestId('arm-start').click();
       await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
 
       // Cancel clears the countdown: the player lobby returns to the waiting
       // hint and the game does not start.
-      await host.locator('[data-cancel-start]').click();
+      await host.getByTestId('cancel-start').click();
       await expect(page.getByTestId('start-countdown')).toHaveCount(0);
       await expect(page.getByTestId('waiting-hint')).toBeVisible();
 

--- a/test/e2e/tests/session-first.spec.ts
+++ b/test/e2e/tests/session-first.spec.ts
@@ -51,15 +51,15 @@ async function hostASession(page: Page, baseURL: string | undefined): Promise<{
   // cleanup never ran): the dashboard then shows "Resume session" instead of the
   // submit. End that one room, then reload so the submit is offered. Not a drain
   // loop - one stray room is all an interrupted test can leave.
-  const resume = host.locator('[data-resume-hosting]');
+  const resume = host.getByTestId('resume-hosting');
   if (await resume.count() > 0) {
     const strayCode = (await resume.getAttribute('href'))?.split('/host/')[1] ?? '';
     if (strayCode) await endHostedSession(host, strayCode);
     await host.goto('/admin');
   }
 
-  await expect(host.locator('[data-host-session-submit]')).toBeVisible();
-  await host.locator('[data-host-session-submit]').click();
+  await expect(host.getByTestId('host-session-submit')).toBeVisible();
+  await host.getByTestId('host-session-submit').click();
   await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
   const joinCode = host.url().split('/host/')[1];
   expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
@@ -99,8 +99,8 @@ test.describe('session-first live hosting', () => {
       await seedLiveQuiz(host, quizTitle, 'What is 1+1?', 'two');
 
       // The empty room shows the pick-a-live-quiz link, not the Start controls.
-      await expect(host.locator('[data-pick-quiz-link]')).toBeVisible();
-      await expect(host.locator('[data-start-now]')).toBeHidden();
+      await expect(host.getByTestId('pick-quiz-link')).toBeVisible();
+      await expect(host.getByTestId('start-now')).toBeHidden();
 
       // A player joins the empty room and sees the staging waiting hint (no quiz
       // picked yet) rather than a broken screen.
@@ -111,7 +111,7 @@ test.describe('session-first live hosting', () => {
       // seeded quiz, and hits "Host live". Because the host already has this empty
       // staging room open, "Host live" arms+starts THAT room (one room per host),
       // so the still-joined player is carried straight into the game.
-      await host.locator('[data-pick-quiz-link] a').click();
+      await host.getByTestId('pick-quiz-link').locator('a').click();
       await expect(host).toHaveURL(/\/admin\/quizzes\?mode=live$/);
       await host.getByRole('link', { name: quizTitle }).click();
       await host.getByRole('button', { name: 'Host live' }).click();
@@ -144,7 +144,7 @@ test.describe('session-first live hosting', () => {
       // The End session control carries a confirm guard; accept it so the submit
       // proceeds.
       host.once('dialog', (dialog) => dialog.accept());
-      await host.locator('[data-end-session]').click();
+      await host.getByTestId('end-session').click();
 
       // The room is terminally closed: the still-joined player drops into the
       // finished view (the room ended out from under them).

--- a/test/integration/host_lobby_test.go
+++ b/test/integration/host_lobby_test.go
@@ -132,7 +132,7 @@ func TestHostLobby_RendersCodeQuizAndQR(t *testing.T) {
 	}
 	// The host can close the room from the lobby: the End session control is
 	// rendered across the live phases (#836).
-	if !strings.Contains(body, "data-end-session-form") {
+	if !strings.Contains(body, `data-testid="end-session-form"`) {
 		t.Error("host lobby missing the End session control")
 	}
 	// The big-screen brand logo itself returns to the admin console (#850):
@@ -188,7 +188,7 @@ func TestHostLobby_RendersPickQuizLink(t *testing.T) {
 		t.Fatalf("host lobby status = %d, want %d", got, want)
 	}
 	// The new list-driven flow: a link to the live-filtered quiz list.
-	if !strings.Contains(body, "data-pick-quiz-link") {
+	if !strings.Contains(body, `data-testid="pick-quiz-link"`) {
 		t.Error("host lobby missing the pick-a-live-quiz link")
 	}
 	if !strings.Contains(body, `href="/admin/quizzes?mode=live"`) {

--- a/test/integration/host_session_test.go
+++ b/test/integration/host_session_test.go
@@ -65,9 +65,9 @@ func TestHostSession_CreatesEmptyRoom(t *testing.T) {
 		t.Errorf("empty-room lobby status = %d, want %d", status, http.StatusOK)
 	}
 	for _, want := range []string{
-		"data-pick-quiz-link",
+		`data-testid="pick-quiz-link"`,
 		`href="/admin/quizzes?mode=live"`,
-		"data-end-session-form",
+		`data-testid="end-session-form"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("empty-room lobby missing %q", want)


### PR DESCRIPTION
Part 1 of 2 for #855 (the second PR adds the auto-teardown fixture). No `Closes` keyword - #855 is closed manually once both slices land.

The live-host **lifecycle controls** used bespoke test-only `data-*` attributes while the rest of the suite uses `data-testid`. This moves those controls to `data-testid` and switches the specs to `getByTestId(...)`.

## Converted (controls only)
Dashboard host control (`host-session`, `host-session-submit`, `resume-hosting`), the lobby start/end controls (`end-session`, `end-session-form`, `arm-start`, `skip-start`, `start-now`, `cancel-start`, `start-countdown`, `start-countdown-label`), the `pick-quiz-link`, and the quiz-view `restart-modal`.

## Deliberately left alone
- The in-game **display** assertion hooks (`data-phase-*`, `data-question-text`, `data-standings-*`, `data-answered-*`, `data-join-hint`, `data-connection-trouble`, `data-enter-code`, ...) - a separate, larger cluster, out of scope for this harness pass.
- The JS **behavior** hooks read by the FLIP/standings code (`data-standings-row`, `data-player-id`, `data-rank`, `data-correctness`, ...) - these are not test hooks and must stay.

Attribute-name-only change: no behavior, classes, or markup structure changed. The Go integration tests that assert on the rendered markup were updated to the new `data-testid="..."` strings.

`make check`, `make smoke`, and `make test-e2e` (195 passed) are green.