### PR TITLE
Replace per-spec host-session e2e cleanup with a fixture

### DIFF
--- a/test/e2e/tests/confirm-restart.spec.ts
+++ b/test/e2e/tests/confirm-restart.spec.ts
@@ -1,6 +1,6 @@
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { importQuiz, setQuizMode, claimAndJoin, endHostedSession } from './helpers';
+import type { HostSessions } from './fixtures';
+import { importQuiz, setQuizMode, claimAndJoin } from './helpers';
 import type { Page } from '@playwright/test';
 
 // confirm-and-restart (#853): a host already running a game on quiz A opens
@@ -41,16 +41,16 @@ async function seedLiveQuiz(host: Page, title: string, questionText: string): Pr
   setQuizMode(title, 'live');
 }
 
-// hostAndStart opens quiz A's view, hits "Host live" to open a room, joins one
-// anonymous player over the API, and starts the game so it is in flight. Returns
-// the running room's join code so the test can assert the restart ends it.
-async function hostAndStart(host: Page, page: Page, quizTitle: string): Promise<string> {
-  await host.goto('/admin/quizzes');
-  await host.getByRole('link', { name: quizTitle }).click();
-  await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
-  await host.getByRole('button', { name: 'Host live' }).click();
-  await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
-  const code = host.url().split('/host/')[1];
+// hostAndStart opens quiz A's view, hits "Host live" to open a room (tracked by
+// the factory for teardown), joins one anonymous player over the API, and starts
+// the game so it is in flight. Returns the host page plus the running room's join
+// code so the test can assert the restart ends it.
+async function hostAndStart(
+  hostSessions: HostSessions,
+  page: Page,
+  quizTitle: string,
+): Promise<{ host: Page; code: string }> {
+  const { host, joinCode: code } = await hostSessions.hostLive(quizTitle);
 
   // A single anonymous player joins so the host can start the game.
   await claimAndJoin(page.request, code, `Pat-${Date.now()}`);
@@ -63,93 +63,78 @@ async function hostAndStart(host: Page, page: Page, quizTitle: string): Promise<
   await host.getByRole('button', { name: 'Start now' }).click();
   await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
 
-  return code;
+  return { host, code };
 }
 
 test.describe('confirm-and-restart hosting', () => {
-  test('confirm ends the running game and lands the host on a new big screen hosting the other quiz', async ({ page, baseURL }) => {
+  test('confirm ends the running game and lands the host on a new big screen hosting the other quiz', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
     const quizA = `Restart-A ${stamp}`;
     const quizB = `Restart-B ${stamp}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
+    await seedLiveQuiz(host, quizA, 'What is 1+1?');
+    await seedLiveQuiz(host, quizB, 'What is 2+2?');
 
-    let runningCode = '';
-    let newCode = '';
-    try {
-      await seedLiveQuiz(host, quizA, 'What is 1+1?');
-      await seedLiveQuiz(host, quizB, 'What is 2+2?');
+    // A game is running on quiz A.
+    const { code: runningCode } = await hostAndStart(hostSessions, page, quizA);
 
-      // A game is running on quiz A.
-      runningCode = await hostAndStart(host, page, quizA);
+    // Open quiz B's view. Because a game is in flight, "Host live" opens the
+    // confirm-and-restart modal rather than submitting straight away.
+    await host.goto('/admin/quizzes');
+    await host.getByRole('link', { name: quizB }).click();
+    await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
+    await host.getByRole('button', { name: 'Host live' }).click();
 
-      // Open quiz B's view. Because a game is in flight, "Host live" opens the
-      // confirm-and-restart modal rather than submitting straight away.
-      await host.goto('/admin/quizzes');
-      await host.getByRole('link', { name: quizB }).click();
-      await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
-      await host.getByRole('button', { name: 'Host live' }).click();
+    const modal = host.getByTestId('restart-modal');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText('A live session is already running');
 
-      const modal = host.getByTestId('restart-modal');
-      await expect(modal).toBeVisible();
-      await expect(modal).toContainText('A live session is already running');
+    // Confirm: end the current session and start a new one hosting quiz B. The
+    // host lands on a NEW big screen (a different /host/{code}).
+    await modal.getByRole('button', { name: 'End and start' }).click();
+    await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
+    const newCode = host.url().split('/host/')[1];
+    expect(newCode).not.toBe(runningCode);
+    // The restart created this second room out of band (not via a factory open),
+    // so register it for teardown too.
+    hostSessions.track(host, newCode);
 
-      // Confirm: end the current session and start a new one hosting quiz B. The
-      // host lands on a NEW big screen (a different /host/{code}).
-      await modal.getByRole('button', { name: 'End and start' }).click();
-      await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
-      newCode = host.url().split('/host/')[1];
-      expect(newCode).not.toBe(runningCode);
-
-      // The new room is staged on quiz B: the host can start it (the Start
-      // control is present, the empty-room pick link is not).
-      await expect(host.getByTestId('start-now')).toBeVisible({ timeout: 15_000 });
-      await expect(host.getByTestId('pick-quiz-link')).toBeHidden();
-    } finally {
-      if (runningCode) await endHostedSession(host, runningCode);
-      if (newCode) await endHostedSession(host, newCode);
-      await hostContext.close();
-    }
+    // The new room is staged on quiz B: the host can start it (the Start
+    // control is present, the empty-room pick link is not).
+    await expect(host.getByTestId('start-now')).toBeVisible({ timeout: 15_000 });
+    await expect(host.getByTestId('pick-quiz-link')).toBeHidden();
   });
 
-  test('cancel leaves the modal without ending the running game', async ({ page, baseURL }) => {
+  test('cancel leaves the modal without ending the running game', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
     const quizA = `Restart-Cancel-A ${stamp}`;
     const quizB = `Restart-Cancel-B ${stamp}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
+    await seedLiveQuiz(host, quizA, 'What is 1+1?');
+    await seedLiveQuiz(host, quizB, 'What is 2+2?');
 
-    let runningCode = '';
-    try {
-      await seedLiveQuiz(host, quizA, 'What is 1+1?');
-      await seedLiveQuiz(host, quizB, 'What is 2+2?');
+    const { code: runningCode } = await hostAndStart(hostSessions, page, quizA);
 
-      runningCode = await hostAndStart(host, page, quizA);
+    // Open quiz B's view and open the restart modal, then Cancel.
+    await host.goto('/admin/quizzes');
+    await host.getByRole('link', { name: quizB }).click();
+    await host.getByRole('button', { name: 'Host live' }).click();
+    const modal = host.getByTestId('restart-modal');
+    await expect(modal).toBeVisible();
+    await modal.getByRole('button', { name: 'Cancel' }).click();
+    await expect(modal).toBeHidden();
 
-      // Open quiz B's view and open the restart modal, then Cancel.
-      await host.goto('/admin/quizzes');
-      await host.getByRole('link', { name: quizB }).click();
-      await host.getByRole('button', { name: 'Host live' }).click();
-      const modal = host.getByTestId('restart-modal');
-      await expect(modal).toBeVisible();
-      await modal.getByRole('button', { name: 'Cancel' }).click();
-      await expect(modal).toBeHidden();
-
-      // The host is still on quiz B's view (no navigation), and the running game
-      // on quiz A is untouched: its big screen still loads in the in-flight
-      // question phase (the generous window keeps it there).
-      await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
-      await host.goto(`/host/${runningCode}`);
-      await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
-    } finally {
-      if (runningCode) await endHostedSession(host, runningCode);
-      await hostContext.close();
-    }
+    // The host is still on quiz B's view (no navigation), and the running game
+    // on quiz A is untouched: its big screen still loads in the in-flight
+    // question phase (the generous window keeps it there).
+    await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
+    await host.goto(`/host/${runningCode}`);
+    await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
   });
 });

--- a/test/e2e/tests/connection-trouble.spec.ts
+++ b/test/e2e/tests/connection-trouble.spec.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
 import {
   seedQuiz,
@@ -11,7 +10,6 @@ import {
   markAdmin,
   login,
   setQuizMode,
-  endHostedSession,
 } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' and returns its id, mirroring
@@ -41,19 +39,16 @@ function makeQuizLive(title: string): number {
 // clears on the next good read, and a 404 still flips the closed view (not the
 // trouble banner) - the existing room-gone signal is untouched.
 test.describe('live client connection trouble', () => {
-  test('player lobby surfaces the banner after repeated state failures and clears on success', async ({ page, baseURL }) => {
+  test('player lobby surfaces the banner after repeated state failures and clears on success', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Conn Player ${Date.now()}`;
     const eve = `Eve-${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     await page.goto(`/join/${joinCode}`);
     await page.getByTestId('join-name-input').fill(eve);
@@ -84,12 +79,9 @@ test.describe('live client connection trouble', () => {
     await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')));
     await expect(page.getByTestId('connection-trouble')).toHaveCount(0, { timeout: 10_000 });
     await expect(page.getByTestId('lobby-view')).toBeVisible();
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
-  test('host TV surfaces the banner after repeated state failures and clears on success', async ({ page, context, baseURL, browserName }) => {
+  test('host TV surfaces the banner after repeated state failures and clears on success', async ({ page, hostSessions, browserName }) => {
     test.setTimeout(60_000);
 
     const displayName = `e2e-conn-host-${browserName}-${Date.now()}`;
@@ -114,9 +106,13 @@ test.describe('live client connection trouble', () => {
     await page.getByRole('button', { name: 'Host live' }).click();
     await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
     const code = page.url().split('/host/')[1];
+    // page is this test's own freshly-registered admin host (not the shared
+    // admin the factory opens), so register the room with the factory so
+    // teardown ends it through page (#850).
+    hostSessions.track(page, code);
 
     // A player joins so the roster is populated before the failure window.
-    const playerContext = await context.browser()!.newContext({ storageState: undefined, baseURL });
+    const playerContext = await hostSessions.newPlayerContext();
     await claimAndJoin(playerContext.request, code, fred);
     await expect(page.locator('[data-player-row]')).toHaveCount(1);
     await expect(page.locator('[data-connection-trouble]')).toHaveCount(0);
@@ -145,10 +141,5 @@ test.describe('live client connection trouble', () => {
       return cmp.refresh();
     });
     await expect(page.locator('[data-connection-trouble]')).toHaveCount(0, { timeout: 10_000 });
-
-    // page is the host here (no separate host context), so end the room through
-    // it so the dashboard returns hostable for the next test (#850).
-    await endHostedSession(page, code);
-    await playerContext.close();
   });
 });

--- a/test/e2e/tests/fixtures.ts
+++ b/test/e2e/tests/fixtures.ts
@@ -4,11 +4,145 @@
 // (#398). Test files import { test, expect, ... } from this module
 // instead of '@playwright/test' so the per-worker baseURL is wired
 // automatically — no per-test setup required.
-import { test as base } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 
-import { SEED_ADMIN_PASSWORD_HASH } from '../e2e-auth';
+import { SEED_ADMIN_PASSWORD_HASH, adminStatePath } from '../e2e-auth';
+import { endHostedSession } from './helpers';
 import { execSqlite } from './sqlite';
+
+// HostSessions is the test-scoped factory the host-session specs use to open
+// live rooms. It owns the admin host context (opened once, lazily, and reused -
+// a host runs one room at a time) plus every extra player context it spins up,
+// and in teardown ends every room it opened and closes every context it owns.
+// Specs no longer roll their own try/finally cleanup: opening a room through
+// the factory registers it for an end-on-teardown that runs even when the test
+// times out or throws.
+export type HostSessions = {
+  // openViaApi creates a session straight over the REST API for the given quiz
+  // id (POST /api/sessions) and returns the admin host page plus the new join
+  // code. The room is registered for teardown.
+  openViaApi(quizId: number): Promise<{ host: Page; joinCode: string }>;
+  // openEmptyRoom drives the dashboard "Host a session" control to open an empty
+  // staging room (no quiz armed) and returns the host page plus the join code
+  // read off the lobby URL. The room is registered for teardown. A stray room
+  // from a crashed prior test is defensively ended first so the dashboard offers
+  // the submit rather than a resume link.
+  openEmptyRoom(): Promise<{ host: Page; joinCode: string }>;
+  // hostLive opens the named quiz's admin view and clicks "Host live", landing
+  // the host on a fresh big screen, and returns the host page plus the join code
+  // read off the /host/{code} URL. The room is registered for teardown.
+  hostLive(quizTitle: string): Promise<{ host: Page; joinCode: string }>;
+  // adminHost returns the lazily-opened, reused admin host page so a spec can
+  // drive the host browser directly (seed a quiz, resolve an id) before opening
+  // a room.
+  adminHost(): Promise<Page>;
+  // track registers a join code created indirectly (e.g. a confirm-restart
+  // restart that swaps the host onto a new room) so teardown ends it too.
+  track(host: Page, joinCode: string): void;
+  // newPlayerContext opens a tracked anonymous browser context (its own session
+  // cookie -> a distinct anonymous player), auto-closed in teardown.
+  newPlayerContext(): Promise<BrowserContext>;
+};
+
+async function makeHostSessions(
+  browser: Browser,
+  baseURL: string | undefined,
+): Promise<{ factory: HostSessions; teardown: () => Promise<void> }> {
+  const contexts: BrowserContext[] = [];
+  const sessions: { host: Page; joinCode: string }[] = [];
+  let adminPage: Page | null = null;
+
+  async function adminHost(): Promise<Page> {
+    if (adminPage) return adminPage;
+    const context = await browser.newContext({ storageState: adminStatePath(), baseURL });
+    contexts.push(context);
+    adminPage = await context.newPage();
+    return adminPage;
+  }
+
+  const factory: HostSessions = {
+    adminHost,
+
+    async openViaApi(quizId) {
+      const host = await adminHost();
+      const createResp = await host.request.post('/api/sessions', { data: { quizId } });
+      const status = createResp.status();
+      if (status !== 201) {
+        throw new Error(`create session: ${status} ${await createResp.text()}`);
+      }
+      const { joinCode } = (await createResp.json()) as { joinCode: string };
+      sessions.push({ host, joinCode });
+      return { host, joinCode };
+    },
+
+    async openEmptyRoom() {
+      const host = await adminHost();
+      await host.goto('/admin');
+      // Defensive single end for a stray room a crashed prior test left open
+      // (its cleanup never ran): the dashboard then shows "Resume session"
+      // instead of the submit. End that one room, then reload so the submit is
+      // offered. Not a drain loop - one stray room is all an interrupted test
+      // can leave.
+      const resume = host.getByTestId('resume-hosting');
+      if ((await resume.count()) > 0) {
+        const strayCode = (await resume.getAttribute('href'))?.split('/host/')[1] ?? '';
+        if (strayCode) await endHostedSession(host, strayCode);
+        await host.goto('/admin');
+      }
+      const submit = host.getByTestId('host-session-submit');
+      await expect(submit).toBeVisible();
+      await submit.click();
+      await host.waitForURL(/\/host\/[A-Z0-9]{6}$/);
+      const joinCode = host.url().split('/host/')[1];
+      sessions.push({ host, joinCode });
+      return { host, joinCode };
+    },
+
+    async hostLive(quizTitle) {
+      const host = await adminHost();
+      await host.goto('/admin/quizzes');
+      await host.getByRole('link', { name: quizTitle }).click();
+      await host.waitForURL(/\/admin\/quizzes\/\d+$/);
+      await host.getByRole('button', { name: 'Host live' }).click();
+      await host.waitForURL(/\/host\/[A-Z0-9]{6}$/);
+      const joinCode = host.url().split('/host/')[1];
+      sessions.push({ host, joinCode });
+      return { host, joinCode };
+    },
+
+    track(host, joinCode) {
+      sessions.push({ host, joinCode });
+    },
+
+    async newPlayerContext() {
+      const context = await browser.newContext({ storageState: undefined, baseURL });
+      contexts.push(context);
+      return context;
+    },
+  };
+
+  async function teardown(): Promise<void> {
+    for (const { host, joinCode } of sessions) {
+      try {
+        await endHostedSession(host, joinCode);
+      } catch {
+        // endHostedSession is best-effort cleanup; one failed room must not
+        // skip ending the rest or closing the contexts.
+      }
+    }
+    for (const context of contexts) {
+      try {
+        await context.close();
+      } catch {
+        // Already-closed contexts are fine to ignore on teardown.
+      }
+    }
+  }
+
+  return { factory, teardown };
+}
 
 // playwright.config.ts discovers a free port per worker and publishes
 // the list as TOPBANANA_E2E_PORTS (comma-separated, indexed by worker).
@@ -16,11 +150,20 @@ import { execSqlite } from './sqlite';
 // worker re-loads the config first. Read it at use-time and index by
 // the worker's parallelIndex so each worker hits its own server (#398,
 // #476).
-export const test = base.extend<{}, { seedAdminTopTier: void }>({
+export const test = base.extend<{ hostSessions: HostSessions }, { seedAdminTopTier: void }>({
   baseURL: async ({}, use, testInfo) => {
     const ports = (process.env.TOPBANANA_E2E_PORTS ?? '').split(',').map(Number);
     const port = ports[testInfo.parallelIndex];
     await use(`http://127.0.0.1:${port}`);
+  },
+
+  // Test-scoped host-session factory: owns the admin host context(s) and any
+  // anonymous player contexts a host-session spec opens, and tears them all
+  // down (ending every room it opened) after the test, even on timeout/failure.
+  hostSessions: async ({ browser, baseURL }, use) => {
+    const { factory, teardown } = await makeHostSessions(browser, baseURL);
+    await use(factory);
+    await teardown();
   },
 
   // Make the migration-seeded admin (players.id = 1) the shared admin the

--- a/test/e2e/tests/host-armed-start.spec.ts
+++ b/test/e2e/tests/host-armed-start.spec.ts
@@ -1,6 +1,6 @@
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, setQuizMode, endHostedSession } from './helpers';
+import type { HostSessions } from './fixtures';
+import { seedQuiz, setQuizMode } from './helpers';
 import type { Page } from '@playwright/test';
 
 // host-armed last-call countdown (#735): a hosted session never auto-starts.
@@ -9,36 +9,26 @@ import type { Page } from '@playwright/test';
 // cancel; at zero the runner starts the game. SESSION_START_COUNTDOWN is shrunk
 // to 2s in playwright.config.ts so the fire path is observable but quick.
 
-// openHostLobby seeds a live quiz as the shared admin in its own context, opens
-// a session, and returns the host TV page plus the join code. The admin
+// openHostLobby seeds a live quiz as the shared admin, opens a session through
+// the host-session factory (auto-ended on teardown), navigates the host to the
+// big screen, and returns the host TV page plus the join code. The admin
 // storageState passes the host gate; the player page stays anonymous.
 async function openHostLobby(
-  page: Page,
-  baseURL: string | undefined,
+  hostSessions: HostSessions,
   quizTitle: string,
-): Promise<{ host: Page; joinCode: string; close: () => Promise<void> }> {
-  const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-  const host = await hostContext.newPage();
+): Promise<{ host: Page; joinCode: string }> {
+  const host = await hostSessions.adminHost();
 
   await seedQuiz(host, quizTitle);
   setQuizMode(quizTitle, 'live');
 
-  const createResp = await host.request.post('/api/sessions', { data: { quizId: await quizIdFor(host, quizTitle) } });
-  expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-  const { joinCode } = await createResp.json() as { joinCode: string };
+  const { joinCode } = await hostSessions.openViaApi(await quizIdFor(host, quizTitle));
   expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
   await host.goto(`/host/${joinCode}`);
   await expect(host.getByText(joinCode, { exact: true })).toBeVisible();
 
-  return {
-    host,
-    joinCode,
-    close: async () => {
-      await endHostedSession(host, joinCode);
-      await hostContext.close();
-    },
-  };
+  return { host, joinCode };
 }
 
 // quizIdFor resolves a seeded quiz's id via the admin quiz page URL so the
@@ -62,80 +52,68 @@ async function joinAsPlayer(page: Page, joinCode: string, name: string): Promise
 }
 
 test.describe('host-armed last-call countdown', () => {
-  test('host arms the countdown, host + player see it, and the game auto-starts at zero', async ({ page, baseURL }) => {
+  test('host arms the countdown, host + player see it, and the game auto-starts at zero', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
     const quizTitle = `Armed Fire ${Date.now()}`;
     const alice = `Alice-${Date.now()}`;
 
-    const { host, joinCode, close } = await openHostLobby(page, baseURL, quizTitle);
-    try {
-      await joinAsPlayer(page, joinCode, alice);
+    const { host, joinCode } = await openHostLobby(hostSessions, quizTitle);
+    await joinAsPlayer(page, joinCode, alice);
 
-      // Before arming, the player lobby shows the static waiting hint.
-      await expect(page.getByTestId('waiting-hint')).toBeVisible();
+    // Before arming, the player lobby shows the static waiting hint.
+    await expect(page.getByTestId('waiting-hint')).toBeVisible();
 
-      // Host arms the last-call countdown.
-      await host.getByTestId('arm-start').click();
+    // Host arms the last-call countdown.
+    await host.getByTestId('arm-start').click();
 
-      // Both surfaces show the live "Starting in M:SS" countdown.
-      await expect(host.getByTestId('start-countdown-label')).toContainText('Starting in');
-      await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
-      // While armed the static waiting hint is gone on the player surface.
-      await expect(page.getByTestId('waiting-hint')).toHaveCount(0);
+    // Both surfaces show the live "Starting in M:SS" countdown.
+    await expect(host.getByTestId('start-countdown-label')).toContainText('Starting in');
+    await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
+    // While armed the static waiting hint is gone on the player surface.
+    await expect(page.getByTestId('waiting-hint')).toHaveCount(0);
 
-      // The countdown fires (SESSION_START_COUNTDOWN=2s): the runner starts the
-      // game, so the player leaves the lobby into the round intro / first
-      // question and the host TV countdown controls disappear.
-      await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
-      await expect(host.getByTestId('start-countdown')).toBeHidden();
-    } finally {
-      await close();
-    }
+    // The countdown fires (SESSION_START_COUNTDOWN=2s): the runner starts the
+    // game, so the player leaves the lobby into the round intro / first
+    // question and the host TV countdown controls disappear.
+    await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
+    await expect(host.getByTestId('start-countdown')).toBeHidden();
   });
 
-  test('Start now during the countdown begins the game immediately', async ({ page, baseURL }) => {
+  test('Start now during the countdown begins the game immediately', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
     const quizTitle = `Armed Skip ${Date.now()}`;
     const bob = `Bob-${Date.now()}`;
 
-    const { host, joinCode, close } = await openHostLobby(page, baseURL, quizTitle);
-    try {
-      await joinAsPlayer(page, joinCode, bob);
+    const { host, joinCode } = await openHostLobby(hostSessions, quizTitle);
+    await joinAsPlayer(page, joinCode, bob);
 
-      await host.getByTestId('arm-start').click();
-      await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
+    await host.getByTestId('arm-start').click();
+    await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
 
-      // Start now skips the rest of the countdown; the game begins at once.
-      await host.getByTestId('skip-start').click();
-      await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
-    } finally {
-      await close();
-    }
+    // Start now skips the rest of the countdown; the game begins at once.
+    await host.getByTestId('skip-start').click();
+    await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
   });
 
-  test('Cancel stops the countdown and the game stays in the lobby', async ({ page, baseURL }) => {
+  test('Cancel stops the countdown and the game stays in the lobby', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
     const quizTitle = `Armed Cancel ${Date.now()}`;
     const cara = `Cara-${Date.now()}`;
 
-    const { host, joinCode, close } = await openHostLobby(page, baseURL, quizTitle);
-    try {
-      await joinAsPlayer(page, joinCode, cara);
+    const { host, joinCode } = await openHostLobby(hostSessions, quizTitle);
+    await joinAsPlayer(page, joinCode, cara);
 
-      await host.getByTestId('arm-start').click();
-      await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
+    await host.getByTestId('arm-start').click();
+    await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
 
-      // Cancel clears the countdown: the player lobby returns to the waiting
-      // hint and the game does not start.
-      await host.getByTestId('cancel-start').click();
-      await expect(page.getByTestId('start-countdown')).toHaveCount(0);
-      await expect(page.getByTestId('waiting-hint')).toBeVisible();
+    // Cancel clears the countdown: the player lobby returns to the waiting
+    // hint and the game does not start.
+    await host.getByTestId('cancel-start').click();
+    await expect(page.getByTestId('start-countdown')).toHaveCount(0);
+    await expect(page.getByTestId('waiting-hint')).toBeVisible();
 
-      // Well past the original 2s deadline the game is still in the lobby.
-      await page.waitForTimeout(4_000);
-      await expect(page.getByTestId('lobby-view')).toBeVisible();
-    } finally {
-      await close();
-    }
+    // Well past the original 2s deadline the game is still in the lobby.
+    await page.waitForTimeout(4_000);
+    await expect(page.getByTestId('lobby-view')).toBeVisible();
   });
 });

--- a/test/e2e/tests/join-mid-game.spec.ts
+++ b/test/e2e/tests/join-mid-game.spec.ts
@@ -1,6 +1,5 @@
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { importQuiz, setQuizMode, claimAndJoin, endHostedSession } from './helpers';
+import { importQuiz, setQuizMode, claimAndJoin } from './helpers';
 import type { Page } from '@playwright/test';
 
 // join-mid-game (#852): the host big screen keeps the join code + URL visible
@@ -45,7 +44,7 @@ async function seedLiveQuiz(host: Page, title: string, questionText: string, cor
 }
 
 test.describe('join mid-game', () => {
-  test('the big screen keeps the join code visible in-game and a new player joins and answers the current question', async ({ page, baseURL }) => {
+  test('the big screen keeps the join code visible in-game and a new player joins and answers the current question', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
@@ -58,79 +57,65 @@ test.describe('join mid-game', () => {
     const latecomer = `Late-${stamp}`;
 
     // Host side: seed the quiz, make it live, and open the big screen at
-    // /host/{code} as the admin (storageState) in its own context so the host TV
-    // is real and the player pages stay anonymous.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    // /host/{code} as the admin (storageState) so the host TV is real and the
+    // player pages stay anonymous.
+    const host = await hostSessions.adminHost();
+    await seedLiveQuiz(host, quizTitle, questionText, correct);
 
     // The latecomer joins from its own anonymous context (its own session cookie
     // -> a distinct anonymous player) via the join UI.
-    const lateContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const lateContext = await hostSessions.newPlayerContext();
     const late = await lateContext.newPage();
 
-    let joinCode = '';
-    try {
-      await seedLiveQuiz(host, quizTitle, questionText, correct);
+    // Open the TV by hosting the seeded live quiz from the admin quiz view.
+    const { joinCode } = await hostSessions.hostLive(quizTitle);
+    expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
-      // Open the TV by hosting the seeded live quiz from the admin quiz view.
-      await host.goto('/admin/quizzes');
-      await host.getByRole('link', { name: quizTitle }).click();
-      await expect(host).toHaveURL(/\/admin\/quizzes\/\d+$/);
-      await host.getByRole('button', { name: 'Host live' }).click();
-      await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
-      joinCode = host.url().split('/host/')[1];
-      expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
+    // The lobby keeps the full QR + code card and HIDES the compact mid-game
+    // strip - it only appears once the quiz is running.
+    await expect(host.locator('[data-join-hint]')).toBeHidden();
 
-      // The lobby keeps the full QR + code card and HIDES the compact mid-game
-      // strip - it only appears once the quiz is running.
-      await expect(host.locator('[data-join-hint]')).toBeHidden();
+    // A first player joins via the API (the default anonymous context, a
+    // distinct session/player from the latecomer's lateContext) so the host
+    // start has a non-empty roster; the runner then advances round_intro ->
+    // question.
+    await claimAndJoin(page.request, joinCode, firstPlayer);
 
-      // A first player joins via the API (the default anonymous context, a
-      // distinct session/player from the latecomer's lateContext) so the host
-      // start has a non-empty roster; the runner then advances round_intro ->
-      // question.
-      await claimAndJoin(page.request, joinCode, firstPlayer);
+    // Host starts the game now. The runner drives round_intro -> question on
+    // its own beat; the TV swaps phases off the SSE tick.
+    await host.getByRole('button', { name: 'Start now' }).click();
 
-      // Host starts the game now. The runner drives round_intro -> question on
-      // its own beat; the TV swaps phases off the SSE tick.
-      await host.getByRole('button', { name: 'Start now' }).click();
+    // The TV reaches the live question phase.
+    await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
+    await expect(host.locator('[data-question-text]')).toHaveText(questionText);
 
-      // The TV reaches the live question phase.
-      await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
-      await expect(host.locator('[data-question-text]')).toHaveText(questionText);
+    // Acceptance: the compact join strip is now visible in-game and carries
+    // the room code (and the bare join URL), so a latecomer reading the TV can
+    // still join.
+    const joinHint = host.locator('[data-join-hint]');
+    await expect(joinHint).toBeVisible();
+    await expect(joinHint).toContainText(joinCode);
 
-      // Acceptance: the compact join strip is now visible in-game and carries
-      // the room code (and the bare join URL), so a latecomer reading the TV can
-      // still join.
-      const joinHint = host.locator('[data-join-hint]');
-      await expect(joinHint).toBeVisible();
-      await expect(joinHint).toContainText(joinCode);
+    // A brand-new anonymous player joins mid-game via the deep link join UI -
+    // not the API - to prove the player surface accepts a mid-game join.
+    await late.goto(`/join/${joinCode}`);
+    await late.getByTestId('join-name-input').fill(latecomer);
+    await late.getByTestId('join-name-submit').click();
 
-      // A brand-new anonymous player joins mid-game via the deep link join UI -
-      // not the API - to prove the player surface accepts a mid-game join.
-      await late.goto(`/join/${joinCode}`);
-      await late.getByTestId('join-name-input').fill(latecomer);
-      await late.getByTestId('join-name-submit').click();
+    // The latecomer is carried straight into the current question (the room is
+    // already in the question phase), reaching the same question text.
+    await expect(late.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
+    await expect(late.getByTestId('question-text')).toHaveText(questionText);
 
-      // The latecomer is carried straight into the current question (the room is
-      // already in the question phase), reaching the same question text.
-      await expect(late.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
-      await expect(late.getByTestId('question-text')).toHaveText(questionText);
+    // The answer window is open and the latecomer can answer the current
+    // question: the option button is enabled and clickable.
+    await expect(late.getByTestId('question-options')).toBeVisible({ timeout: 15_000 });
+    const correctButton = late.getByTestId('question-options').getByRole('button', { name: correct });
+    await expect(correctButton).toBeEnabled({ timeout: 15_000 });
+    await correctButton.click();
 
-      // The answer window is open and the latecomer can answer the current
-      // question: the option button is enabled and clickable.
-      await expect(late.getByTestId('question-options')).toBeVisible({ timeout: 15_000 });
-      const correctButton = late.getByTestId('question-options').getByRole('button', { name: correct });
-      await expect(correctButton).toBeEnabled({ timeout: 15_000 });
-      await correctButton.click();
-
-      // The pick locks in for the latecomer, confirming a mid-game joiner can
-      // answer the current question from the moment they arrive.
-      await expect(correctButton).toHaveAttribute('data-picked', 'true', { timeout: 15_000 });
-    } finally {
-      if (joinCode) await endHostedSession(host, joinCode);
-      await lateContext.close();
-      await hostContext.close();
-    }
+    // The pick locks in for the latecomer, confirming a mid-game joiner can
+    // answer the current question from the moment they arrive.
+    await expect(correctButton).toHaveAttribute('data-picked', 'true', { timeout: 15_000 });
   });
 });

--- a/test/e2e/tests/join-named.spec.ts
+++ b/test/e2e/tests/join-named.spec.ts
@@ -1,9 +1,8 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import type { Page } from './fixtures';
-import { seedQuiz, registerForPending, login, markEmailVerified, execSqlite, endHostedSession } from './helpers';
+import type { HostSessions } from './fixtures';
+import { seedQuiz, registerForPending, login, markEmailVerified, execSqlite } from './helpers';
 
 // A logged-in player who has chosen a custom name skips the name-entry form on
 // the live-session join surface: they auto-join under their account name and
@@ -37,25 +36,22 @@ function makeQuizLive(title: string): number {
 }
 
 // hostLiveSession seeds a quiz as the admin (host), flips it live, opens a
-// session, and returns the join code.
-async function hostLiveSession(host: Page, quizTitle: string): Promise<string> {
+// session through the host-session factory, and returns the join code.
+async function hostLiveSession(hostSessions: HostSessions, quizTitle: string): Promise<string> {
+  const host = await hostSessions.adminHost();
   await seedQuiz(host, quizTitle);
   const quizID = makeQuizLive(quizTitle);
-  const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-  expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-  const { joinCode } = await createResp.json() as { joinCode: string };
+  const { joinCode } = await hostSessions.openViaApi(quizID);
   expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
   return joinCode;
 }
 
 test.describe('player join name skip for named players', () => {
-  test('a logged-in player with a custom name auto-joins via deep link, skipping the name form', async ({ page, baseURL, browserName }) => {
+  test('a logged-in player with a custom name auto-joins via deep link, skipping the name form', async ({ page, hostSessions, browserName }) => {
     test.setTimeout(45_000);
     const quizTitle = `Named Join ${browserName} ${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-    const joinCode = await hostLiveSession(host, quizTitle);
+    const joinCode = await hostLiveSession(hostSessions, quizTitle);
 
     // Sign in as a freshly registered player: registration claims a display
     // name, so this account has hasCustomName=true and isAuthenticated=true.
@@ -80,18 +76,13 @@ test.describe('player join name skip for named players', () => {
     expect(stateResp.ok()).toBeTruthy();
     const state = await stateResp.json() as { players: { displayName: string }[] };
     expect(state.players.some((p) => p.displayName === displayName)).toBe(true);
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
-  test('a logged-in named player entering the code on /join auto-joins without the name form', async ({ page, baseURL, browserName }) => {
+  test('a logged-in named player entering the code on /join auto-joins without the name form', async ({ page, hostSessions, browserName }) => {
     test.setTimeout(45_000);
     const quizTitle = `Named Code ${browserName} ${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-    const joinCode = await hostLiveSession(host, quizTitle);
+    const joinCode = await hostLiveSession(hostSessions, quizTitle);
 
     const displayName = `e2e-named-code-${browserName}-${Date.now()}`;
     await registerForPending(page, displayName);
@@ -110,26 +101,18 @@ test.describe('player join name skip for named players', () => {
     // The name form lives under x-show (kept in DOM, toggled via CSS), so
     // assert it never became visible rather than that it is absent.
     await expect(page.getByTestId('join-name-input')).toBeHidden();
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
-  test('an anonymous visitor still sees the name form on a deep link', async ({ page, baseURL, browserName }) => {
+  test('an anonymous visitor still sees the name form on a deep link', async ({ page, hostSessions, browserName }) => {
     test.setTimeout(45_000);
     const quizTitle = `Anon Join ${browserName} ${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-    const joinCode = await hostLiveSession(host, quizTitle);
+    const joinCode = await hostLiveSession(hostSessions, quizTitle);
 
     // Anonymous: no login. The name form must show on the deep link, and the
     // lobby must not appear until a name is submitted.
     await page.goto(`/join/${joinCode}`);
     await expect(page.getByTestId('join-name-input')).toBeVisible();
     await expect(page.getByTestId('lobby-roster')).toHaveCount(0);
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 });

--- a/test/e2e/tests/join.spec.ts
+++ b/test/e2e/tests/join.spec.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, execSqlite, claimAndJoin, endHostedSession } from './helpers';
+import { seedQuiz, execSqlite, claimAndJoin } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' (the importer always lands
 // quizzes on 'solo', and only live quizzes are hostable, MP-0 / #677) and
@@ -28,12 +27,12 @@ function makeQuizLive(title: string): number {
   return id;
 }
 
-// The host setup (seed quiz, make it live, open a session) runs as the shared
-// admin so POST /api/sessions passes the host gate. The player join flow then
-// runs in the default anonymous context. test.use scopes the storageState to
-// this file's host-side request only; the page-driven join is anonymous.
+// The host setup (seed quiz, make it live, open a session via the hostSessions
+// fixture) runs as the shared admin so POST /api/sessions passes the host gate;
+// the fixture ends the room and closes its context on teardown. The player join
+// flow runs in the default anonymous page context.
 test.describe('player join + lobby', () => {
-  test('joins via typed code, enters a name, lands in the lobby, and toggles ready', async ({ page }) => {
+  test('joins via typed code, enters a name, lands in the lobby, and toggles ready', async ({ page, hostSessions }) => {
     const quizTitle = `Live Quiz ${Date.now()}`;
     // Player names are global on players.display_name now (#716), so a unique
     // name avoids a collision with a parallel spec sharing the worker DB.
@@ -42,17 +41,11 @@ test.describe('player join + lobby', () => {
     // Seed + host setup as the admin (storageState) in a separate browser
     // context so the player page itself stays anonymous. seedQuiz drives the
     // admin importer, which needs the admin cookie jar.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath() });
-    const host = await hostContext.newPage();
-
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', {
-      data: { quizId: quizID },
-    });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
     expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
     // Player flow: anonymous page, typed code -> name -> lobby. GET /join
@@ -99,22 +92,16 @@ test.describe('player join + lobby', () => {
     expect(armResp.status(), `arm-start: ${armResp.status()} ${await armResp.text()}`).toBe(204);
     await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
     await expect(page.getByTestId('waiting-hint')).toHaveCount(0);
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
-  test('a deep-linked /join/{code} skips straight to the name form', async ({ page }) => {
+  test('a deep-linked /join/{code} skips straight to the name form', async ({ page, hostSessions }) => {
     const quizTitle = `Live Deep ${Date.now()}`;
     const bob = `Bob-${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath() });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status()).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     await page.goto(`/join/${joinCode}`);
     // No enter-code step: the name input is shown immediately, with the code
@@ -125,31 +112,25 @@ test.describe('player join + lobby', () => {
     await page.getByTestId('join-name-input').fill(bob);
     await page.getByTestId('join-name-submit').click();
     await expect(page.getByTestId('lobby-roster').getByText(bob)).toBeVisible();
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
   // #793: a player who reaches the name form, then submits after the host has
   // already started the game, gets a 409 closed on join. They must land on the
   // terminal "this game is no longer available" view, not sit on the dead name
   // form with an error under it.
-  test('submitting the name after the game has started joins mid-game and lands in the live phase', async ({ page }) => {
+  test('submitting the name after the game has started joins mid-game and lands in the live phase', async ({ page, hostSessions }) => {
     const quizTitle = `Live Latecomer ${Date.now()}`;
     const cara = `Cara-${Date.now()}`;
     const rex = `Rex-${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath() });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status()).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     // An early API-only player joins and readies, then deliberately holds their
     // answer so the question phase stays open for the latecomer to land in.
-    const earlyContext = await page.context().browser()!.newContext({ storageState: undefined });
+    const earlyContext = await hostSessions.newPlayerContext();
     await claimAndJoin(earlyContext.request, joinCode, rex);
     const readyResp = await earlyContext.request.post(`/api/sessions/${joinCode}/ready`, { data: { ready: true } });
     expect(readyResp.status()).toBe(204);
@@ -179,9 +160,5 @@ test.describe('player join + lobby', () => {
     await page.getByTestId('join-name-submit').click();
     await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
     await expect(page.getByTestId('lobby-closed')).toHaveCount(0);
-
-    await endHostedSession(host, joinCode);
-    await earlyContext.close();
-    await hostContext.close();
   });
 });

--- a/test/e2e/tests/persistent-rooms.spec.ts
+++ b/test/e2e/tests/persistent-rooms.spec.ts
@@ -2,9 +2,8 @@ import { join } from 'node:path';
 
 import type { APIRequestContext } from '@playwright/test';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { importQuiz, claimAndJoin, csrfTokenPattern, execSqlite, endHostedSession } from './helpers';
+import { importQuiz, claimAndJoin, csrfTokenPattern, execSqlite } from './helpers';
 
 // #836 persistent live rooms: a host runs a live quiz to its between-games
 // intermission, the player sees the intermission/standings view while staying
@@ -69,7 +68,7 @@ async function postNextQuiz(
 }
 
 test.describe('persistent live rooms', () => {
-  test('carries a still-joined player from game 1 intermission into game 2', async ({ page, baseURL }) => {
+  test('carries a still-joined player from game 1 intermission into game 2', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
@@ -77,77 +76,68 @@ test.describe('persistent live rooms', () => {
     const quiz2Title = `Persistent G2 ${stamp}`;
     const player = `Pat-${stamp}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-    let joinCode = '';
+    const host = await hostSessions.adminHost();
 
-    try {
-      // Two single-question live quizzes: game 1 the room opens on, game 2 the
-      // host arms at intermission. Importing live + flipping the mode (a no-op
-      // re-assert) resolves each id off the worker DB.
-      await importQuiz(host, singleQuestionDoc(quiz1Title, 'Game 1: what is 1+1?', 'two'), 'live');
-      await importQuiz(host, singleQuestionDoc(quiz2Title, 'Game 2: what is 2+2?', 'four'), 'live');
-      const quiz1Id = makeLiveAndResolveId(quiz1Title);
-      const quiz2Id = makeLiveAndResolveId(quiz2Title);
+    // Two single-question live quizzes: game 1 the room opens on, game 2 the
+    // host arms at intermission. Importing live + flipping the mode (a no-op
+    // re-assert) resolves each id off the worker DB.
+    await importQuiz(host, singleQuestionDoc(quiz1Title, 'Game 1: what is 1+1?', 'two'), 'live');
+    await importQuiz(host, singleQuestionDoc(quiz2Title, 'Game 2: what is 2+2?', 'four'), 'live');
+    const quiz1Id = makeLiveAndResolveId(quiz1Title);
+    const quiz2Id = makeLiveAndResolveId(quiz2Title);
 
-      // Open the room on game 1.
-      const createResp = await host.request.post('/api/sessions', { data: { quizId: quiz1Id } });
-      expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-      ({ joinCode } = await createResp.json() as { joinCode: string });
-      expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
+    // Open the room on game 1.
+    const { joinCode } = await hostSessions.openViaApi(quiz1Id);
+    expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
-      // The page-driven player joins via the deep link and lands in the lobby.
-      await page.goto(`/join/${joinCode}`);
-      await page.getByTestId('join-name-input').fill(player);
-      await page.getByTestId('join-name-submit').click();
-      await expect(page.getByTestId('lobby-roster').getByText(player)).toBeVisible();
+    // The page-driven player joins via the deep link and lands in the lobby.
+    await page.goto(`/join/${joinCode}`);
+    await page.getByTestId('join-name-input').fill(player);
+    await page.getByTestId('join-name-submit').click();
+    await expect(page.getByTestId('lobby-roster').getByText(player)).toBeVisible();
 
-      // Host starts game 1; the runner drives round_intro -> question.
-      const startResp = await host.request.post(`/api/sessions/${joinCode}/start`);
-      expect(startResp.status(), `start: ${startResp.status()} ${await startResp.text()}`).toBe(204);
+    // Host starts game 1; the runner drives round_intro -> question.
+    const startResp = await host.request.post(`/api/sessions/${joinCode}/start`);
+    expect(startResp.status(), `start: ${startResp.status()} ${await startResp.text()}`).toBe(204);
 
-      await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 15_000 });
-      await expect(page.getByTestId('question-text')).toHaveText('Game 1: what is 1+1?');
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('question-text')).toHaveText('Game 1: what is 1+1?');
 
-      // The page player answers game 1's only question via the page UI. With
-      // the single active player in, the runner closes the question, reveals,
-      // and ends the game into intermission.
-      await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
-      await page.getByTestId('question-options').getByRole('button', { name: 'two' }).click();
-      await expect(page.getByTestId('answered-waiting')).toBeVisible();
+    // The page player answers game 1's only question via the page UI. With
+    // the single active player in, the runner closes the question, reveals,
+    // and ends the game into intermission.
+    await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('question-options').getByRole('button', { name: 'two' }).click();
+    await expect(page.getByTestId('answered-waiting')).toBeVisible();
 
-      // Game 1 ends into intermission: the player sees the intermission view
-      // (final standings + the waiting message), staying joined - no re-join,
-      // no enter-code form.
-      await expect(page.getByTestId('intermission-view')).toBeVisible({ timeout: 20_000 });
-      await expect(page.getByTestId('intermission-waiting')).toContainText('Waiting for the host');
-      await expect(page.getByTestId('standings-bars').locator('[data-standings-row]')).toHaveCount(1);
-      await expect(page.getByTestId('standings-bars').getByText(player)).toBeVisible();
-      // Still joined: the enter-code form is not shown.
-      await expect(page.getByTestId('join-code-input')).toBeHidden();
+    // Game 1 ends into intermission: the player sees the intermission view
+    // (final standings + the waiting message), staying joined - no re-join,
+    // no enter-code form.
+    await expect(page.getByTestId('intermission-view')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('intermission-waiting')).toContainText('Waiting for the host');
+    await expect(page.getByTestId('standings-bars').locator('[data-standings-row]')).toHaveCount(1);
+    await expect(page.getByTestId('standings-bars').getByText(player)).toBeVisible();
+    // Still joined: the enter-code form is not shown.
+    await expect(page.getByTestId('join-code-input')).toBeHidden();
 
-      // The host arms game 2. The room re-arms onto quiz 2 and the runner drives
-      // the new game; the player is carried in off the SSE -> GET state loop.
-      await postNextQuiz(host.request, joinCode, quiz2Id);
+    // The host arms game 2. The room re-arms onto quiz 2 and the runner drives
+    // the new game; the player is carried in off the SSE -> GET state loop.
+    await postNextQuiz(host.request, joinCode, quiz2Id);
 
-      // Game 2 plays for the still-joined player: they reach the new question
-      // without re-entering a code, and no stale game-1 state leaks (the new
-      // question text is shown, options are fresh).
-      await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
-      await expect(page.getByTestId('question-text')).toHaveText('Game 2: what is 2+2?');
-      await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
-      // No stale pick from game 1: the answered/waiting state is gone and the
-      // options are tappable again.
-      await expect(page.getByTestId('answered-waiting')).toBeHidden();
-      const game2Correct = page.getByTestId('question-options').getByRole('button', { name: 'four' });
-      await expect(game2Correct).toBeEnabled();
-    } finally {
-      if (joinCode) await endHostedSession(host, joinCode);
-      await hostContext.close();
-    }
+    // Game 2 plays for the still-joined player: they reach the new question
+    // without re-entering a code, and no stale game-1 state leaks (the new
+    // question text is shown, options are fresh).
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('question-text')).toHaveText('Game 2: what is 2+2?');
+    await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
+    // No stale pick from game 1: the answered/waiting state is gone and the
+    // options are tappable again.
+    await expect(page.getByTestId('answered-waiting')).toBeHidden();
+    const game2Correct = page.getByTestId('question-options').getByRole('button', { name: 'four' });
+    await expect(game2Correct).toBeEnabled();
   });
 
-  test('a latecomer joins a live room mid-game and lands in the question', async ({ page, baseURL }) => {
+  test('a latecomer joins a live room mid-game and lands in the question', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
@@ -155,52 +145,41 @@ test.describe('persistent live rooms', () => {
     const early = `Early-${stamp}`;
     const late = `Late-${stamp}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-    let joinCode = '';
+    const host = await hostSessions.adminHost();
 
-    try {
-      await importQuiz(host, singleQuestionDoc(quizTitle, 'Latecomer: what is 3+3?', 'six'), 'live');
-      const quizId = makeLiveAndResolveId(quizTitle);
+    await importQuiz(host, singleQuestionDoc(quizTitle, 'Latecomer: what is 3+3?', 'six'), 'live');
+    const quizId = makeLiveAndResolveId(quizTitle);
 
-      const createResp = await host.request.post('/api/sessions', { data: { quizId } });
-      expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-      ({ joinCode } = await createResp.json() as { joinCode: string });
+    const { joinCode } = await hostSessions.openViaApi(quizId);
 
-      // An early player joins via the API and readies so the game can start.
-      // They deliberately do NOT answer, so the question phase stays open long
-      // enough for the latecomer to land in it.
-      const earlyCtx = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
-      await claimAndJoin(earlyCtx.request, joinCode, early);
-      const readyResp = await earlyCtx.request.post(`/api/sessions/${joinCode}/ready`, { data: { ready: true } });
-      expect(readyResp.status()).toBe(204);
+    // An early player joins via the API and readies so the game can start.
+    // They deliberately do NOT answer, so the question phase stays open long
+    // enough for the latecomer to land in it.
+    const earlyCtx = await hostSessions.newPlayerContext();
+    await claimAndJoin(earlyCtx.request, joinCode, early);
+    const readyResp = await earlyCtx.request.post(`/api/sessions/${joinCode}/ready`, { data: { ready: true } });
+    expect(readyResp.status()).toBe(204);
 
-      const startResp = await host.request.post(`/api/sessions/${joinCode}/start`);
-      expect(startResp.status(), `start: ${startResp.status()} ${await startResp.text()}`).toBe(204);
+    const startResp = await host.request.post(`/api/sessions/${joinCode}/start`);
+    expect(startResp.status(), `start: ${startResp.status()} ${await startResp.text()}`).toBe(204);
 
-      // Wait until the room is in the question phase (the early player holds
-      // their answer, so it stays open).
-      await expect(async () => {
-        const resp = await earlyCtx.request.get(`/api/sessions/${joinCode}/state`);
-        expect(resp.ok()).toBeTruthy();
-        const state = await resp.json() as { phase: string };
-        expect(state.phase).toBe('question');
-      }).toPass({ timeout: 15_000 });
+    // Wait until the room is in the question phase (the early player holds
+    // their answer, so it stays open).
+    await expect(async () => {
+      const resp = await earlyCtx.request.get(`/api/sessions/${joinCode}/state`);
+      expect(resp.ok()).toBeTruthy();
+      const state = await resp.json() as { phase: string };
+      expect(state.phase).toBe('question');
+    }).toPass({ timeout: 15_000 });
 
-      // The latecomer joins mid-game via the page UI: they land directly in the
-      // in-flight question phase, not a lobby, and render the question.
-      await page.goto(`/join/${joinCode}`);
-      await page.getByTestId('join-name-input').fill(late);
-      await page.getByTestId('join-name-submit').click();
+    // The latecomer joins mid-game via the page UI: they land directly in the
+    // in-flight question phase, not a lobby, and render the question.
+    await page.goto(`/join/${joinCode}`);
+    await page.getByTestId('join-name-input').fill(late);
+    await page.getByTestId('join-name-submit').click();
 
-      await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
-      await expect(page.getByTestId('question-text')).toHaveText('Latecomer: what is 3+3?');
-
-      await earlyCtx.close();
-    } finally {
-      if (joinCode) await endHostedSession(host, joinCode);
-      await hostContext.close();
-    }
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('question-text')).toHaveText('Latecomer: what is 3+3?');
   });
 });
 

--- a/test/e2e/tests/play-live.spec.ts
+++ b/test/e2e/tests/play-live.spec.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, importQuiz, QUIZ_QUESTIONS, claimAndJoin, execSqlite, endHostedSession } from './helpers';
+import { seedQuiz, importQuiz, QUIZ_QUESTIONS, claimAndJoin, execSqlite } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' (the importer lands quizzes
 // on 'solo', and only live quizzes are hostable, MP-0 / #677) and returns its
@@ -40,7 +39,7 @@ function makeQuizLive(title: string): number {
 // enough to assert the "answered, waiting" state with no correctness shown,
 // then answers via the API to trigger the close -> reveal transition.
 test.describe('player synchronized play', () => {
-  test('answers a question, waits with no correctness shown, then sees the revealed answer', async ({ page, baseURL }) => {
+  test('answers a question, waits with no correctness shown, then sees the revealed answer', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Live Play ${Date.now()}`;
@@ -51,22 +50,18 @@ test.describe('player synchronized play', () => {
 
     // Host side: seed the quiz, make it live, and open a session as the admin
     // (storageState) in its own context so the player page stays anonymous.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
     expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
     // A second, API-only player joins from its own anonymous context (its own
     // session cookie -> a distinct anonymous player) and holds its answer so
     // the question does not early-close the instant the page player answers.
     // The join carries no name (#716): it claims players.display_name first.
-    const otherContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const otherContext = await hostSessions.newPlayerContext();
     await claimAndJoin(otherContext.request, joinCode, robin);
 
     // Player joins via the deep link and lands in the lobby.
@@ -156,10 +151,6 @@ test.describe('player synchronized play', () => {
     await expect(correctReveal).toHaveAttribute('data-correct', 'true');
     // Exactly one option is marked correct for this single-correct question.
     await expect(revealButtons.and(page.locator('[data-correct="true"]'))).toHaveCount(1);
-
-    await endHostedSession(host, joinCode);
-    await otherContext.close();
-    await hostContext.close();
   });
 
   // #755 cross-surface contract (player half): the live round-intro card names
@@ -172,7 +163,7 @@ test.describe('player synchronized play', () => {
   // reflects the real round position, so the first round can never read as a
   // between-rounds screen. The TV half is pinned in host-game.spec.ts; the
   // standings half is in standings-bargraph.spec.ts.
-  test('round intro shows the round title, summary, and an accurate Round N of M heading', async ({ page, baseURL }) => {
+  test('round intro shows the round title, summary, and an accurate Round N of M heading', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Live Round Intro ${Date.now()}`;
@@ -180,8 +171,7 @@ test.describe('player synchronized play', () => {
     const robin = `Robin-${Date.now()}`;
     const quincy = `Quincy-${Date.now()}`;
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
 
     // A two-round quiz, imported live: the first round carries a summary so the
     // optional copy is exercised, and the round count is 2 so the eyebrow reads
@@ -219,13 +209,11 @@ test.describe('player synchronized play', () => {
     // session opener is addressed by.
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     // A second, API-only player keeps the roster non-empty so the start is not
     // blocked and the runner advances into the round intro.
-    const otherContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const otherContext = await hostSessions.newPlayerContext();
     await claimAndJoin(otherContext.request, joinCode, robin);
 
     await page.goto(`/join/${joinCode}`);
@@ -243,9 +231,5 @@ test.describe('player synchronized play', () => {
     await expect(page.getByTestId('round-summary')).toHaveText(roundSummary);
     await expect(page.getByTestId('round-intro-eyebrow')).toHaveText('Round 1 of 2');
     await expect(page.getByTestId('round-intro')).not.toContainText('Next round');
-
-    await endHostedSession(host, joinCode);
-    await otherContext.close();
-    await hostContext.close();
   });
 });

--- a/test/e2e/tests/reconnect-resume.spec.ts
+++ b/test/e2e/tests/reconnect-resume.spec.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, QUIZ_QUESTIONS, claimAndJoin, execSqlite, endHostedSession } from './helpers';
+import { seedQuiz, QUIZ_QUESTIONS, claimAndJoin, execSqlite } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' (the importer lands quizzes
 // on 'solo', and only live quizzes are hostable, MP-0 / #677) and returns its
@@ -34,7 +33,7 @@ function makeQuizLive(title: string): number {
 // resume re-Joins, and the server's resume gate revives a prior participant's
 // row regardless of left_at - so the reload is harmless.
 test.describe('reconnect and resume', () => {
-  test('reloading mid-question lands back on the question and can still answer', async ({ page, baseURL }) => {
+  test('reloading mid-question lands back on the question and can still answer', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Resume Live ${Date.now()}`;
@@ -45,22 +44,18 @@ test.describe('reconnect and resume', () => {
 
     // Host side: seed the quiz, make it live, and open a session as the admin
     // (storageState) in its own context so the player page stays anonymous.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
     expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
     // A second, API-only player joins from its own anonymous context and holds
     // its answer so the question never early-closes while the page player
     // reloads and resumes. The runner only closes once every active player has
     // answered.
-    const otherContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const otherContext = await hostSessions.newPlayerContext();
     await claimAndJoin(otherContext.request, joinCode, robin);
 
     // Player joins via the deep link and lands in the lobby (claims their name
@@ -119,10 +114,6 @@ test.describe('reconnect and resume', () => {
 
     await expect(page.getByTestId('reveal-view')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('reveal-verdict')).toHaveText('Correct!');
-
-    await endHostedSession(host, joinCode);
-    await otherContext.close();
-    await hostContext.close();
   });
 
   test('a fresh visitor with no remembered session sees the code-entry form', async ({ page }) => {

--- a/test/e2e/tests/session-first.spec.ts
+++ b/test/e2e/tests/session-first.spec.ts
@@ -1,6 +1,5 @@
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, setQuizMode, endHostedSession } from './helpers';
+import { seedQuiz, setQuizMode } from './helpers';
 import type { Page } from '@playwright/test';
 
 // session-first live hosting (#836, #851): a host opens a live room BEFORE
@@ -26,54 +25,6 @@ async function seedLiveQuiz(host: Page, title: string, questionText: string, cor
   setQuizMode(title, 'live');
 }
 
-// hostASession drives the dashboard "Host a session" entry through the browser:
-// it opens the admin dashboard and clicks the empty-room control, landing on the
-// host lobby. It returns the host page and the room's join code read off the
-// lobby URL. The room is empty (no quiz armed) at this point.
-//
-// The dashboard host control is a single adaptive slot (#850): with no active
-// room it is the "Host a session" submit; with one already open it becomes a
-// "Resume session" link instead. Each session-hosting spec now ends its own
-// room in cleanup (endHostedSession), so the shared seed admin's dashboard
-// stays hostable between tests and this just clicks the submit. The one
-// defensive end below covers only the rare case a prior test crashed before its
-// cleanup ran and left a stray room open.
-async function hostASession(page: Page, baseURL: string | undefined): Promise<{
-  host: Page;
-  joinCode: string;
-  close: () => Promise<void>;
-}> {
-  const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-  const host = await hostContext.newPage();
-
-  await host.goto('/admin');
-  // Defensive single end for a stray room a crashed prior test left open (its
-  // cleanup never ran): the dashboard then shows "Resume session" instead of the
-  // submit. End that one room, then reload so the submit is offered. Not a drain
-  // loop - one stray room is all an interrupted test can leave.
-  const resume = host.getByTestId('resume-hosting');
-  if (await resume.count() > 0) {
-    const strayCode = (await resume.getAttribute('href'))?.split('/host/')[1] ?? '';
-    if (strayCode) await endHostedSession(host, strayCode);
-    await host.goto('/admin');
-  }
-
-  await expect(host.getByTestId('host-session-submit')).toBeVisible();
-  await host.getByTestId('host-session-submit').click();
-  await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
-  const joinCode = host.url().split('/host/')[1];
-  expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
-
-  return {
-    host,
-    joinCode,
-    close: async () => {
-      await endHostedSession(host, joinCode);
-      await hostContext.close();
-    },
-  };
-}
-
 // joinAsPlayer lands the anonymous page in the lobby via the deep link.
 async function joinAsPlayer(page: Page, joinCode: string, name: string): Promise<void> {
   await page.goto(`/join/${joinCode}`);
@@ -83,74 +34,68 @@ async function joinAsPlayer(page: Page, joinCode: string, name: string): Promise
 }
 
 test.describe('session-first live hosting', () => {
-  test('host opens an empty room, a player joins, then the host picks the first quiz and it runs', async ({ page, baseURL }) => {
+  test('host opens an empty room, a player joins, then the host picks the first quiz and it runs', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
     const quizTitle = `Session-first ${stamp}`;
     const player = `Pat-${stamp}`;
 
-    const { host, joinCode, close } = await hostASession(page, baseURL);
-    try {
-      // The quiz the host will host. Seeded via the API (the host page stays on
-      // the lobby), after the room is open, to prove the room can stage before a
-      // quiz exists. It shows up when the host follows the pick link to the
-      // live-filtered quiz list, which is fetched fresh on navigation.
-      await seedLiveQuiz(host, quizTitle, 'What is 1+1?', 'two');
+    const { host, joinCode } = await hostSessions.openEmptyRoom();
 
-      // The empty room shows the pick-a-live-quiz link, not the Start controls.
-      await expect(host.getByTestId('pick-quiz-link')).toBeVisible();
-      await expect(host.getByTestId('start-now')).toBeHidden();
+    // The quiz the host will host. Seeded via the API (the host page stays on
+    // the lobby), after the room is open, to prove the room can stage before a
+    // quiz exists. It shows up when the host follows the pick link to the
+    // live-filtered quiz list, which is fetched fresh on navigation.
+    await seedLiveQuiz(host, quizTitle, 'What is 1+1?', 'two');
 
-      // A player joins the empty room and sees the staging waiting hint (no quiz
-      // picked yet) rather than a broken screen.
-      await joinAsPlayer(page, joinCode, player);
-      await expect(page.getByTestId('waiting-hint')).toContainText('start a quiz');
+    // The empty room shows the pick-a-live-quiz link, not the Start controls.
+    await expect(host.getByTestId('pick-quiz-link')).toBeVisible();
+    await expect(host.getByTestId('start-now')).toBeHidden();
 
-      // The host follows the lobby link to the live-filtered quiz list, opens the
-      // seeded quiz, and hits "Host live". Because the host already has this empty
-      // staging room open, "Host live" arms+starts THAT room (one room per host),
-      // so the still-joined player is carried straight into the game.
-      await host.getByTestId('pick-quiz-link').locator('a').click();
-      await expect(host).toHaveURL(/\/admin\/quizzes\?mode=live$/);
-      await host.getByRole('link', { name: quizTitle }).click();
-      await host.getByRole('button', { name: 'Host live' }).click();
+    // A player joins the empty room and sees the staging waiting hint (no quiz
+    // picked yet) rather than a broken screen.
+    await joinAsPlayer(page, joinCode, player);
+    await expect(page.getByTestId('waiting-hint')).toContainText('start a quiz');
 
-      // The still-joined player is carried into the game without re-entering a
-      // code: they reach the question and the room is no longer empty.
-      await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
-      await expect(page.getByTestId('question-text')).toHaveText('What is 1+1?');
-      await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
-      await expect(
-        page.getByTestId('question-options').getByRole('button', { name: 'two' }),
-      ).toBeEnabled();
-    } finally {
-      await close();
-    }
+    // The host follows the lobby link to the live-filtered quiz list, opens the
+    // seeded quiz, and hits "Host live". Because the host already has this empty
+    // staging room open, "Host live" arms+starts THAT room (one room per host),
+    // so the still-joined player is carried straight into the game.
+    await host.getByTestId('pick-quiz-link').locator('a').click();
+    await expect(host).toHaveURL(/\/admin\/quizzes\?mode=live$/);
+    await host.getByRole('link', { name: quizTitle }).click();
+    await host.getByRole('button', { name: 'Host live' }).click();
+
+    // The still-joined player is carried into the game without re-entering a
+    // code: they reach the question and the room is no longer empty.
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('question-text')).toHaveText('What is 1+1?');
+    await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByTestId('question-options').getByRole('button', { name: 'two' }),
+    ).toBeEnabled();
   });
 
-  test('the host ends the session and the room closes for the joined player', async ({ page, baseURL }) => {
+  test('the host ends the session and the room closes for the joined player', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const stamp = Date.now();
     const player = `Quinn-${stamp}`;
 
-    const { host, joinCode, close } = await hostASession(page, baseURL);
-    try {
-      // A player joins the empty room.
-      await joinAsPlayer(page, joinCode, player);
-      await expect(page.getByTestId('waiting-hint')).toBeVisible();
+    const { host, joinCode } = await hostSessions.openEmptyRoom();
 
-      // The End session control carries a confirm guard; accept it so the submit
-      // proceeds.
-      host.once('dialog', (dialog) => dialog.accept());
-      await host.getByTestId('end-session').click();
+    // A player joins the empty room.
+    await joinAsPlayer(page, joinCode, player);
+    await expect(page.getByTestId('waiting-hint')).toBeVisible();
 
-      // The room is terminally closed: the still-joined player drops into the
-      // finished view (the room ended out from under them).
-      await expect(page.getByTestId('finished-view')).toBeVisible({ timeout: 20_000 });
-    } finally {
-      await close();
-    }
+    // The End session control carries a confirm guard; accept it so the submit
+    // proceeds.
+    host.once('dialog', (dialog) => dialog.accept());
+    await host.getByTestId('end-session').click();
+
+    // The room is terminally closed: the still-joined player drops into the
+    // finished view (the room ended out from under them).
+    await expect(page.getByTestId('finished-view')).toBeVisible({ timeout: 20_000 });
   });
 });

--- a/test/e2e/tests/session-leave.spec.ts
+++ b/test/e2e/tests/session-leave.spec.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
 import {
   registerForPending,
@@ -11,7 +10,6 @@ import {
   setQuizMode,
   claimAndJoin,
   execSqlite,
-  endHostedSession,
 } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' and returns its id, mirroring
@@ -44,8 +42,7 @@ function makeQuizLive(title: string): number {
 // exact request the beacon issues.
 test('a player leaving drops out of the host roster live', async ({
   page,
-  context,
-  baseURL,
+  hostSessions,
   browserName,
 }) => {
   const displayName = `e2e-leave-host-${browserName}`;
@@ -67,35 +64,31 @@ test('a player leaving drops out of the host roster live', async ({
 
   await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
   const code = page.url().split('/host/')[1];
+  // page is this test's own freshly-registered admin host (not the shared admin
+  // the factory opens), so register the room with the factory so teardown ends
+  // it through page and the dashboard returns hostable for the next test (#850).
+  hostSessions.track(page, code);
 
   // Player names are global on players.display_name now (#716), so use unique
   // names to avoid colliding with a parallel spec on the worker DB.
   const alice = `Alice-${browserName}-${Date.now()}`;
   const bob = `Bob-${browserName}-${Date.now()}`;
-  const aliceContext = await context.browser()!.newContext({ storageState: undefined, baseURL });
-  const bobContext = await context.browser()!.newContext({ storageState: undefined, baseURL });
-  try {
-    await claimAndJoin(aliceContext.request, code, alice);
-    await claimAndJoin(bobContext.request, code, bob);
+  const aliceContext = await hostSessions.newPlayerContext();
+  const bobContext = await hostSessions.newPlayerContext();
+  await claimAndJoin(aliceContext.request, code, alice);
+  await claimAndJoin(bobContext.request, code, bob);
 
-    // Both rows show on the TV once the join ticks land.
-    const roster = page.locator('[data-player-row]');
-    await expect(roster).toHaveCount(2);
+  // Both rows show on the TV once the join ticks land.
+  const roster = page.locator('[data-player-row]');
+  await expect(roster).toHaveCount(2);
 
-    // Alice leaves; the endpoint accepts an empty body (the sendBeacon shape).
-    const leaveResp = await aliceContext.request.post(`/api/sessions/${code}/leave`);
-    expect(leaveResp.status()).toBe(204);
+  // Alice leaves; the endpoint accepts an empty body (the sendBeacon shape).
+  const leaveResp = await aliceContext.request.post(`/api/sessions/${code}/leave`);
+  expect(leaveResp.status()).toBe(204);
 
-    // The TV roster drops to just Bob without a reload.
-    await expect(roster).toHaveCount(1);
-    await expect(roster.first()).toContainText(bob);
-  } finally {
-    // page is the host here (no separate host context), so end the room through
-    // it so the dashboard returns hostable for the next test (#850).
-    await endHostedSession(page, code);
-    await aliceContext.close();
-    await bobContext.close();
-  }
+  // The TV roster drops to just Bob without a reload.
+  await expect(roster).toHaveCount(1);
+  await expect(roster.first()).toContainText(bob);
 });
 
 // #794: the leave beacon must fire on pagehide, not only beforeunload, because
@@ -104,7 +97,7 @@ test('a player leaving drops out of the host roster live', async ({
 // the component must sendBeacon to the leave endpoint. The guard against a
 // double-send is pinned by dispatching pagehide twice and asserting the beacon
 // went out exactly once.
-test('the leave beacon fires once on pagehide', async ({ page, baseURL }) => {
+test('the leave beacon fires once on pagehide', async ({ page, hostSessions }) => {
   test.setTimeout(60_000);
 
   const quizTitle = `Leave Pagehide ${Date.now()}`;
@@ -123,13 +116,10 @@ test('the leave beacon fires once on pagehide', async ({ page, baseURL }) => {
     };
   });
 
-  const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-  const host = await hostContext.newPage();
+  const host = await hostSessions.adminHost();
   await seedQuiz(host, quizTitle);
   const quizID = makeQuizLive(quizTitle);
-  const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-  expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-  const { joinCode } = await createResp.json() as { joinCode: string };
+  const { joinCode } = await hostSessions.openViaApi(quizID);
 
   await page.goto(`/join/${joinCode}`);
   await page.getByTestId('join-name-input').fill(dana);
@@ -149,7 +139,4 @@ test('the leave beacon fires once on pagehide', async ({ page, baseURL }) => {
   );
   const leaveBeacons = beacons.filter((url) => url.includes(`/api/sessions/${joinCode}/leave`));
   expect(leaveBeacons).toHaveLength(1);
-
-  await endHostedSession(host, joinCode);
-  await hostContext.close();
 });

--- a/test/e2e/tests/standings-bargraph.spec.ts
+++ b/test/e2e/tests/standings-bargraph.spec.ts
@@ -1,9 +1,8 @@
-import type { APIRequestContext, BrowserContext, Page } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { importQuiz, claimAndJoin, execSqlite, endHostedSession } from './helpers';
+import { importQuiz, claimAndJoin, execSqlite } from './helpers';
 
 // MP-9 (#686): the between-rounds standings bar graph on the round_results /
 // finished screens, on BOTH the host TV surface and the player join surface.
@@ -165,7 +164,7 @@ async function readFinishedStanding(
 
 test('the standings bar graph shows final order and totals on the TV and player surfaces', async ({
   page,
-  baseURL,
+  hostSessions,
   browserName,
 }) => {
   test.setTimeout(90_000);
@@ -178,13 +177,11 @@ test('the standings bar graph shows final order and totals on the TV and player 
   const robin = `Robin-${suffix}`;
 
   // Host context (shared admin) seeds a two-round quiz, makes it live, opens a
-  // session, and watches the TV. The player surface (page) stays anonymous.
-  const hostContext = await page.context().browser()!.newContext({
-    storageState: adminStatePath(),
-    baseURL,
-    reducedMotion: 'reduce',
-  });
-  const host = await hostContext.newPage();
+  // session, and watches the TV. The player surface (page) stays anonymous. The
+  // standings animation is asserted at its settled (reduced-motion) state, so
+  // the host TV runs under prefers-reduced-motion like the player page below.
+  const host = await hostSessions.adminHost();
+  await host.emulateMedia({ reducedMotion: 'reduce' });
 
   // Two rounds, one question each. The page player answers the correct option
   // every time and the API player answers a wrong one, so the page player leads
@@ -219,19 +216,14 @@ test('the standings bar graph shows final order and totals on the TV and player 
   });
   const quizID = makeQuizLiveByTitle(quizTitle);
 
-  const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-  expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-  const { joinCode } = await createResp.json() as { joinCode: string };
+  const { joinCode } = await hostSessions.openViaApi(quizID);
 
   // The host opens the TV surface.
   await host.goto(`/host/${joinCode}`);
 
-  // An API-only second player joins from its own anonymous context.
-  const otherContext: BrowserContext = await page.context().browser()!.newContext({
-    storageState: undefined,
-    baseURL,
-    reducedMotion: 'reduce',
-  });
+  // An API-only second player joins from its own anonymous context. It only
+  // drives answers over the request API, so reduced motion is moot for it.
+  const otherContext = await hostSessions.newPlayerContext();
   const other = otherContext.request;
   await claimAndJoin(other, joinCode, robin);
 
@@ -365,8 +357,4 @@ test('the standings bar graph shows final order and totals on the TV and player 
   expect(quincyFinal.roundScore).toBeGreaterThan(0);
   expect(quincyFinal.totalScore - quincyFinal.roundScore).toBeLessThan(quincyFinal.totalScore);
   expect(robinFinal.roundScore).toBe(0);
-
-  await endHostedSession(host, joinCode);
-  await otherContext.close();
-  await hostContext.close();
 });

--- a/test/e2e/tests/standings-swap-video.spec.ts
+++ b/test/e2e/tests/standings-swap-video.spec.ts
@@ -1,9 +1,8 @@
-import type { APIRequestContext, BrowserContext, Page } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { importQuiz, claimAndJoin, execSqlite, endHostedSession } from './helpers';
+import { importQuiz, claimAndJoin, execSqlite } from './helpers';
 
 // Motion-ON capture of the standings animation (the #729 grow + the #730 row
 // slide) so the real motion can actually be eyeballed. The standings-bargraph
@@ -103,7 +102,7 @@ async function answerOnPage(page: Page, text: string): Promise<void> {
   }
 }
 
-test('standings swap video: a player row slides up to first at the finish', async ({ page, baseURL, browserName }) => {
+test('standings swap video: a player row slides up to first at the finish', async ({ page, hostSessions, browserName }) => {
   test.skip(!!process.env.CI, 'manual animation capture tool; run locally, not in CI');
   test.setTimeout(120_000);
 
@@ -114,11 +113,7 @@ test('standings swap video: a player row slides up to first at the finish', asyn
 
   // The host (shared admin) seeds a two-round quiz, makes it live, and opens a
   // session. The recorded `page` is the climber's player surface.
-  const hostContext: BrowserContext = await page.context().browser()!.newContext({
-    storageState: adminStatePath(),
-    baseURL,
-  });
-  const host = await hostContext.newPage();
+  const host = await hostSessions.adminHost();
 
   await importQuiz(host, {
     title: quizTitle,
@@ -150,12 +145,10 @@ test('standings swap video: a player row slides up to first at the finish', asyn
   });
   const quizID = makeQuizLiveByTitle(quizTitle);
 
-  const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-  expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-  const { joinCode } = await createResp.json() as { joinCode: string };
+  const { joinCode } = await hostSessions.openViaApi(quizID);
 
   // The API rival joins; the recorded player joins via the deep link.
-  const leaderContext: BrowserContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+  const leaderContext = await hostSessions.newPlayerContext();
   await claimAndJoin(leaderContext.request, joinCode, leader);
 
   await page.goto(`/join/${joinCode}`);
@@ -236,8 +229,4 @@ test('standings swap video: a player row slides up to first at the finish', asyn
 
   // Dwell so the recording includes the full settle.
   await page.waitForTimeout(3_000);
-
-  await endHostedSession(host, joinCode);
-  await leaderContext.close();
-  await hostContext.close();
 });

--- a/test/e2e/tests/visibility-reconnect.spec.ts
+++ b/test/e2e/tests/visibility-reconnect.spec.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, claimAndJoin, QUIZ_QUESTIONS, execSqlite, endHostedSession } from './helpers';
+import { seedQuiz, claimAndJoin, QUIZ_QUESTIONS, execSqlite } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' (the importer lands quizzes
 // on 'solo', and only live quizzes are hostable, MP-0 / #677) and returns its
@@ -41,7 +40,7 @@ function makeQuizLive(title: string): number {
 // the visibilitychange the browser raises on return. The fix's handler re-reads
 // state and re-subscribes, so the new player appears.
 test.describe('lobby visibility reconnect', () => {
-  test('returning to a backgrounded tab repopulates a stale roster', async ({ page, baseURL }) => {
+  test('returning to a backgrounded tab repopulates a stale roster', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Visibility Live ${Date.now()}`;
@@ -53,20 +52,16 @@ test.describe('lobby visibility reconnect', () => {
 
     // Host side: seed the quiz, make it live, open a session as the admin in
     // its own context so the player page stays anonymous.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
     expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
     // A second player (API-only, own anonymous context) is already in the lobby
     // before the page player joins, so the page roster starts with two names.
-    const benContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const benContext = await hostSessions.newPlayerContext();
     await claimAndJoin(benContext.request, joinCode, ben);
 
     // Page player joins via the deep link and lands in the lobby.
@@ -96,7 +91,7 @@ test.describe('lobby visibility reconnect', () => {
 
     // A third player joins while the stream is dead. With no SSE tick reaching
     // the page, the roster cannot learn about them - it stays stale.
-    const cleoContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const cleoContext = await hostSessions.newPlayerContext();
     await claimAndJoin(cleoContext.request, joinCode, cleo);
 
     await expect(roster.getByText(cleo)).toHaveCount(0);
@@ -112,11 +107,6 @@ test.describe('lobby visibility reconnect', () => {
     await expect(roster.getByText(cleo)).toBeVisible({ timeout: 15_000 });
     await expect(roster.getByText(ava)).toBeVisible();
     await expect(roster.getByText(ben)).toBeVisible();
-
-    await endHostedSession(host, joinCode);
-    await cleoContext.close();
-    await benContext.close();
-    await hostContext.close();
   });
 
   // #751 (same root cause): a player who backgrounds the tab in the lobby and
@@ -132,7 +122,7 @@ test.describe('lobby visibility reconnect', () => {
   // reconnects on its own) BEFORE the host starts, so the page genuinely misses
   // every transition tick and is still rendering the lobby. The
   // visibilitychange the browser raises on return then drives the recovery.
-  test('returning after the host starts advances off the lobby to the live question', async ({ page, baseURL }) => {
+  test('returning after the host starts advances off the lobby to the live question', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Visibility Start ${Date.now()}`;
@@ -143,22 +133,18 @@ test.describe('lobby visibility reconnect', () => {
 
     // Host side: seed the quiz, make it live, open a session as the admin in
     // its own context so the player page stays anonymous.
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
-
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
 
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
     expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
 
     // A second player (API-only, own anonymous context) keeps the question open
     // after the runner issues it: the runner early-closes only once every
     // active player has answered, and this player holds their answer, so the
     // returning page player still finds the question phase live on recovery.
-    const benContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const benContext = await hostSessions.newPlayerContext();
     await claimAndJoin(benContext.request, joinCode, ben);
 
     // Page player joins via the deep link and lands in the lobby.
@@ -210,9 +196,5 @@ test.describe('lobby visibility reconnect', () => {
     await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('question-text')).toHaveText(QUIZ_QUESTIONS[0].text);
     await expect(page.getByTestId('lobby-view')).toHaveCount(0);
-
-    await endHostedSession(host, joinCode);
-    await benContext.close();
-    await hostContext.close();
   });
 });

--- a/test/e2e/tests/wake-lock.spec.ts
+++ b/test/e2e/tests/wake-lock.spec.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 
-import { adminStatePath } from '../e2e-auth';
 import { test, expect } from './fixtures';
-import { seedQuiz, claimAndJoin, QUIZ_QUESTIONS, execSqlite, endHostedSession } from './helpers';
+import { seedQuiz, claimAndJoin, QUIZ_QUESTIONS, execSqlite } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' and returns its id, mirroring
 // the sqlite3 shortcut the other live specs use.
@@ -137,7 +136,7 @@ function readWakeLock(page: import('./fixtures').Page): Promise<WakeLockState> {
 // API is feature-detected and best-effort, so these assertions run against a
 // stubbed navigator.wakeLock rather than the genuine OS lock.
 test.describe('live player screen wake lock', () => {
-  test('acquires the wake lock on entering the lobby and re-acquires on return to foreground', async ({ page, baseURL }) => {
+  test('acquires the wake lock on entering the lobby and re-acquires on return to foreground', async ({ page, hostSessions }) => {
     test.setTimeout(60_000);
 
     const quizTitle = `Wake Lobby ${Date.now()}`;
@@ -145,13 +144,10 @@ test.describe('live player screen wake lock', () => {
 
     await stubWakeLock(page);
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     // No lock yet on the name form: the request only fires once the player has
     // entered the lobby (the join/ready gesture).
@@ -185,12 +181,9 @@ test.describe('live player screen wake lock', () => {
     await expect.poll(async () => (await readWakeLock(page)).requests).toBe(2);
     expect((await readWakeLock(page)).held).toBe(true);
     expect((await readWakeLock(page)).releases).toBe(0);
-
-    await endHostedSession(host, joinCode);
-    await hostContext.close();
   });
 
-  test('releases the wake lock when the game reaches the end-of-game intermission', async ({ page, baseURL }) => {
+  test('releases the wake lock when the game reaches the end-of-game intermission', async ({ page, hostSessions }) => {
     test.setTimeout(90_000);
 
     const quizTitle = `Wake Finish ${Date.now()}`;
@@ -199,18 +192,15 @@ test.describe('live player screen wake lock', () => {
 
     await stubWakeLock(page);
 
-    const hostContext = await page.context().browser()!.newContext({ storageState: adminStatePath(), baseURL });
-    const host = await hostContext.newPage();
+    const host = await hostSessions.adminHost();
     await seedQuiz(host, quizTitle);
     const quizID = makeQuizLive(quizTitle);
-    const createResp = await host.request.post('/api/sessions', { data: { quizId: quizID } });
-    expect(createResp.status(), `create session: ${createResp.status()} ${await createResp.text()}`).toBe(201);
-    const { joinCode } = await createResp.json() as { joinCode: string };
+    const { joinCode } = await hostSessions.openViaApi(quizID);
 
     // A second API-only player answers each question alongside the page player
     // so the runner closes every question and the game reaches the end-of-game
     // intermission (#836).
-    const otherContext = await page.context().browser()!.newContext({ storageState: undefined, baseURL });
+    const otherContext = await hostSessions.newPlayerContext();
     await claimAndJoin(otherContext.request, joinCode, ben);
 
     await page.goto(`/join/${joinCode}`);
@@ -255,9 +245,5 @@ test.describe('live player screen wake lock', () => {
     await expect(page.getByTestId('intermission-view')).toBeVisible({ timeout: 20_000 });
     await expect.poll(async () => (await readWakeLock(page)).held, { timeout: 10_000 }).toBe(false);
     expect((await readWakeLock(page)).releases).toBeGreaterThanOrEqual(1);
-
-    await endHostedSession(host, joinCode);
-    await otherContext.close();
-    await hostContext.close();
   });
 });


### PR DESCRIPTION
Closes #855 (Part 2 of 2; Part 1 - the data-testid rename - was #860).

The 15 host-session e2e specs each hand-rolled their own host context + `try { … } finally { await endHostedSession(host, code); await ctx.close() }`. This replaces that with a single auto-teardown `hostSessions` fixture, so teardown is guaranteed even on timeout/failure and specs stop rolling their own.

## The fixture (`test/e2e/tests/fixtures.ts`)
A test-scoped factory that owns the admin host context (opened once, lazily, reused) plus any anonymous player contexts a spec opens, and in teardown ends every room it opened and closes every context. Methods cover the three creation paths in use:
- `openViaApi(quizId)` - `POST /api/sessions`
- `openEmptyRoom()` - the dashboard "Host a session" button (carries the defensive stray-room check that used to live in session-first)
- `hostLive(quizTitle)` - the quiz-view "Host live" button
- `track(host, joinCode)` - register a room created indirectly (e.g. confirm-restart's restart) for teardown
- `newPlayerContext()` - a tracked anonymous context, auto-closed

All 15 specs drop their `try/finally` and context boilerplate; assertions and test logic are unchanged. Net -127 lines.

## Verification
`make check` green. Full `make test-e2e` (both browsers): 193 passed. Two chromium specs hit a local `chrome-headless-shell` SIGSEGV (a Fedora-box browser crash, not a test/fixture defect) - both pass on firefox and on a clean chromium re-run, and this does not occur on CI's runners.