### PR TITLE
Harden the host round-intro e2e test against its brief phase

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -238,6 +238,13 @@ func runnerConfig(cfg *config.Config) livesession.RunnerConfig {
 		rc.RevealBeat = cfg.SessionRevealBeat
 	}
 
+	// Likewise the round-intro beat: a shrunk runner beat leaves the round-intro
+	// card too brief for a loaded browser to observe before the phase advances
+	// (#859).
+	if cfg.SessionRoundIntroBeat > 0 {
+		rc.RoundIntroBeat = cfg.SessionRoundIntroBeat
+	}
+
 	return rc
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,10 @@ var ErrSessionRunnerBeatNegative = errors.New("SESSION_RUNNER_BEAT must not be n
 // negative duration.
 var ErrSessionRevealBeatNegative = errors.New("SESSION_REVEAL_BEAT must not be negative")
 
+// ErrSessionRoundIntroBeatNegative is returned when SESSION_ROUND_INTRO_BEAT
+// parses to a negative duration.
+var ErrSessionRoundIntroBeatNegative = errors.New("SESSION_ROUND_INTRO_BEAT must not be negative")
+
 // ErrSessionStartCountdownNegative is returned when SESSION_START_COUNTDOWN
 // parses to a negative duration. It is the length of the host-armed last-call
 // countdown, so a negative value is meaningless; reject it rather than
@@ -189,6 +193,15 @@ type Config struct {
 	// advances; this knob keeps the reveal comfortably observable without
 	// slowing the other beats (mirrors REVEAL_DELAY for the pre-answer beat).
 	SessionRevealBeat time.Duration
+
+	// SessionRoundIntroBeat overrides only the round-intro beat, on top of
+	// SessionRunnerBeat. Zero means "track SessionRunnerBeat". Parsed from
+	// SESSION_ROUND_INTRO_BEAT. Like SessionRevealBeat, the e2e suite shrinks
+	// SessionRunnerBeat for speed, but that leaves the round-intro card (round
+	// title + "Round N of M" eyebrow) too brief for a loaded browser to observe
+	// before the phase advances; this knob keeps it observable without slowing
+	// the other beats (#859).
+	SessionRoundIntroBeat time.Duration
 
 	// SessionStartCountdown is the length of the host-armed last-call countdown
 	// (#735): the host arms "Start in 60s" and the runner starts the game when
@@ -503,6 +516,12 @@ func parseTypedEnvVars(getenv func(string) string, c *Config) error {
 
 	if err := parseNonNegativeDuration(
 		getenv, "SESSION_REVEAL_BEAT", ErrSessionRevealBeatNegative, &c.SessionRevealBeat,
+	); err != nil {
+		return err
+	}
+
+	if err := parseNonNegativeDuration(
+		getenv, "SESSION_ROUND_INTRO_BEAT", ErrSessionRoundIntroBeatNegative, &c.SessionRoundIntroBeat,
 	); err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -580,6 +580,69 @@ func TestParse_SessionRunnerBeat(t *testing.T) {
 	})
 }
 
+func TestParse_SessionRoundIntroBeat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid values", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			value string
+			want  time.Duration
+		}{
+			{"unset defaults to zero", "", 0},
+			{"explicit zero parses", "0s", 0},
+			{"2s parses", "2s", 2 * time.Second},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				getenv := func(key string) string {
+					if key == "SESSION_ROUND_INTRO_BEAT" {
+						return tt.value
+					}
+					if key == "APP_ENV" {
+						return "development"
+					}
+
+					return ""
+				}
+
+				c, err := Parse(getenv)
+				if err != nil {
+					t.Fatalf("Parse() err = %v, want nil", err)
+				}
+				if got, want := c.SessionRoundIntroBeat, tt.want; got != want {
+					t.Errorf("SessionRoundIntroBeat = %v, want %v", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("unparseable value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("SESSION_ROUND_INTRO_BEAT", "snappy"))
+		if err == nil {
+			t.Fatal("Parse() with invalid SESSION_ROUND_INTRO_BEAT: err = nil, want non-nil")
+		}
+		if got, want := err.Error(), "invalid SESSION_ROUND_INTRO_BEAT"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("SESSION_ROUND_INTRO_BEAT", "-1s"))
+		if got, want := err, ErrSessionRoundIntroBeatNegative; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestParse_SessionStartCountdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/tmpl/host/pages/lobby.gohtml
+++ b/internal/web/tmpl/host/pages/lobby.gohtml
@@ -128,16 +128,16 @@
              title and optional summary come from the round metadata. ----- */}}
         <div x-show="phase === 'round_intro'"
              class="flex-1 flex flex-col items-center justify-center gap-4 px-[clamp(1.5rem,4vw,4rem)] text-center"
-             data-phase-intro>
+             data-testid="phase-intro">
             <p class="m-0 text-text-dim text-[clamp(0.9rem,1.8vw,1.25rem)] font-semibold uppercase tracking-[0.18em]"
-               data-round-eyebrow
+               data-testid="round-eyebrow"
                x-text="roundEyebrow()"></p>
             <p class="m-0 font-display font-extrabold text-[clamp(2rem,6vw,4rem)] leading-tight"
-               data-round-title
+               data-testid="round-title"
                x-text="roundTitle()"></p>
             <p x-show="roundSummary()"
                class="m-0 text-text-dim text-[clamp(1rem,2.5vw,1.75rem)] leading-snug max-w-[40ch]"
-               data-round-summary
+               data-testid="round-summary"
                x-text="roundSummary()"></p>
         </div>
 

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -171,6 +171,12 @@ const workerServer = (workerIndex: number) => {
       // window for firefox to observe before the runner advances - mirrors
       // REVEAL_DELAY for the pre-answer read beat (see #719).
       SESSION_REVEAL_BEAT: '2s',
+      // Keep the round-intro card observable for the same reason as the reveal
+      // beat: the 500ms runner beat is too brief for a loaded browser to read
+      // the round title + "Round N of M" eyebrow before the phase advances, so
+      // the round-intro test raced it (#859). This widens only the round-intro
+      // beat; round-results stays on the fast runner beat.
+      SESSION_ROUND_INTRO_BEAT: '2s',
       // Shrink the host-armed last-call countdown (#735, default 60s) so the
       // armed-start spec can watch it fire without a minute of dead time. The
       // host arms "Start in 60s"; with this set the runner starts the game ~2s

--- a/test/e2e/tests/host-game.spec.ts
+++ b/test/e2e/tests/host-game.spec.ts
@@ -121,10 +121,9 @@ test('host TV shows the live question, answered order, and the reveal', async ({
     // quiz lands every question in the default round titled "Round 1", so the
     // title shows it and the eyebrow reads "Round 1 of 1" - never the old
     // generic "Next round" wording.
-    const introView = page.locator('[data-phase-intro]');
-    await expect(introView).toBeVisible({ timeout: 15_000 });
-    await expect(page.locator('[data-round-title]')).toHaveText('Round 1');
-    await expect(page.locator('[data-round-eyebrow]')).toHaveText('Round 1 of 1');
+    await expect(page.getByTestId('phase-intro')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('round-eyebrow')).toHaveText('Round 1 of 1');
+    await expect(page.getByTestId('round-title')).toHaveText('Round 1');
 
     const questionView = page.locator('[data-phase-question]');
     await expect(questionView).toBeVisible({ timeout: 15_000 });
@@ -253,9 +252,9 @@ test('the host TV roster reflects a player rename', async ({
 // and words its heading correctly, matching the live player surface (join.html)
 // and the solo client (index.html) field-for-field even though the TV uses its
 // own room-scale typography. A two-round quiz with a round summary exercises all
-// three round-intro fields the surfaces share: the title (data-round-title), the
-// optional summary (data-round-summary), and an accurate "Round N of M" eyebrow
-// (data-round-eyebrow) that is NOT the old generic "Next round" wording on the
+// three round-intro fields the surfaces share: the title (round-title), the
+// optional summary (round-summary), and an accurate "Round N of M" eyebrow
+// (round-eyebrow) that is NOT the old generic "Next round" wording on the
 // first round. Asserting "Round 1 of 2" (not the single-round "Round 1 of 1" the
 // in-game spec above checks) pins that N/M reflects the real round position. The
 // player half is pinned in play-live.spec.ts; the standings half is in
@@ -268,7 +267,10 @@ test('host TV round intro shows the round title, summary, and an accurate Round 
 }) => {
   test.setTimeout(60_000);
 
-  const displayName = `e2e-intro-host-${browserName}`;
+  // Unique per run (timestamp): player names are global (#716), so a bare
+  // `e2e-intro-host-${browserName}` would let a CI auto-retry collide on the
+  // name from the first attempt and fail in registration (#859).
+  const displayName = `e2e-intro-host-${browserName}-${Date.now()}`;
   const quizTitle = `E2E Host Intro ${browserName} ${Date.now()}`;
   const roundSummary = 'Warm up with the easy ones first.';
 
@@ -334,13 +336,17 @@ test('host TV round intro shows the round title, summary, and an accurate Round 
     await page.getByRole('button', { name: 'Start now' }).click();
 
     // Round intro: the TV names the first round, shows its summary, and the
-    // eyebrow reads "Round 1 of 2" - never "Next round" on the first round.
-    const introView = page.locator('[data-phase-intro]');
-    await expect(introView).toBeVisible({ timeout: 15_000 });
-    await expect(page.locator('[data-round-title]')).toHaveText('Opening round');
-    await expect(page.locator('[data-round-summary]')).toHaveText(roundSummary);
-    await expect(page.locator('[data-round-eyebrow]')).toHaveText('Round 1 of 2');
-    await expect(introView).not.toContainText('Next round');
+    // eyebrow reads "Round 1 of 2" - never the "Get ready" / "Next round"
+    // fallbacks on the first round (asserting "Round 1 of 2" + "Opening round"
+    // is that no-fallback contract). Assert the eyebrow first: it gates on the
+    // round_intro screen having rendered, and the title/summary then read the
+    // same card. The round_intro screen is brief (one runner beat), widened in
+    // the e2e config so these per-element checks land inside it without racing
+    // the phase advancing (#859).
+    await expect(page.getByTestId('phase-intro')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('round-eyebrow')).toHaveText('Round 1 of 2');
+    await expect(page.getByTestId('round-title')).toHaveText('Opening round');
+    await expect(page.getByTestId('round-summary')).toHaveText(roundSummary);
   } finally {
     await caseyCtx.close();
   }


### PR DESCRIPTION
Closes #859

`host-game.spec.ts` "host TV round intro ..." flaked on a `main` run: the round_intro screen lasts a single runner beat (500ms under e2e), and across several browser contexts on a loaded CI runner the host TV's render of the round-intro card can be too brief for the assertions to land before the phase advances (the eyebrow then reverts to "Get ready"). The deterministic display name made the CI auto-retry collide on the global player name (#716) and fail in registration, so the retry couldn't recover it.

## Fix
- **data-testid + per-element assertions.** The round-intro card hooks (`phase-intro`, `round-eyebrow`, `round-title`, `round-summary`) move from bespoke `data-*` attributes to `data-testid`, and the spec asserts each via `getByTestId` (eyebrow first - it gates on the card having rendered). This replaces the earlier fragile regex-on-concatenated-text match.
- **Give the round-intro beat an observable window.** Add a `SESSION_ROUND_INTRO_BEAT` config override (mirroring the existing `SESSION_REVEAL_BEAT`), set to `2s` in the e2e config, so the round-intro card stays observable on a loaded runner without slowing the other beats (round-results stays on the fast 500ms runner beat). This is the same loaded-CI rationale that `REVEAL_DELAY` / `SESSION_REVEAL_BEAT` already use.
- **Unique display name** (timestamp suffix) so a CI retry can't collide on the global player name.

## Verification
The round-intro test passes on chromium and firefox and 17/17 under `--repeat-each=8`; both host-game tests pass on both browsers; `make check` green (coverage 83.0%); go-style review clean. (A few chromium specs hit the local Fedora-box `chrome-headless-shell` SIGSEGV - they pass on firefox and don't occur on CI.)