### PR TITLE
Arm the quiz but stay in the lobby when hosting into an empty room

### DIFF
--- a/internal/livesession/empty_room_test.go
+++ b/internal/livesession/empty_room_test.go
@@ -166,9 +166,9 @@ func TestService_StartHosting_NoActiveRoomOpensArmedLobby(t *testing.T) {
 }
 
 // TestService_StartHosting_EmptyRoomArmsExistingRoom pins StartHosting case 2
-// (#851): with an active empty staging room for the host, it arms+starts the
-// quiz in THAT room (reusing StartQuiz) rather than spawning a second one, so
-// the returned session is the existing room driving the game.
+// (#851/#863): with an active empty staging room for the host, it arms the quiz
+// in THAT room (reusing ArmQuiz) rather than spawning a second one, and leaves it
+// in the lobby - NOT started - so the host gathers players and presses Start.
 func TestService_StartHosting_EmptyRoomArmsExistingRoom(t *testing.T) {
 	t.Parallel()
 
@@ -195,7 +195,9 @@ func TestService_StartHosting_EmptyRoomArmsExistingRoom(t *testing.T) {
 		t.Errorf("StartHosting room ID = %q, want %q (same room, no second spawned)", got, want)
 	}
 
-	// That room is now armed onto the quiz and driving the first game.
+	// That room is now armed onto the quiz but STILL IN THE LOBBY, not started
+	// (#863): the host gathers players and presses Start, same as the no-active
+	// case.
 	armed, err := h.store.GetSessionByID(ctx, empty.ID)
 	if err != nil {
 		t.Fatalf("GetSessionByID err = %v, want nil", err)
@@ -206,8 +208,11 @@ func TestService_StartHosting_EmptyRoomArmsExistingRoom(t *testing.T) {
 	if got, want := *armed.QuizID, qz.ID; got != want {
 		t.Errorf("armed QuizID = %d, want %d", got, want)
 	}
-	if got, want := armed.Phase, PhaseRoundIntro; got != want {
-		t.Errorf("armed Phase = %q, want %q (game driving in the existing room)", got, want)
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Errorf("armed Phase = %q, want %q (armed but waiting in the lobby)", got, want)
+	}
+	if armed.StartedAt != nil {
+		t.Errorf("armed StartedAt = %v, want nil (not started until the host presses Start)", armed.StartedAt)
 	}
 }
 
@@ -291,6 +296,63 @@ func TestService_StartHosting_RejectsSoloQuiz(t *testing.T) {
 	}
 	if sess != nil {
 		t.Errorf("StartHosting (solo) session = %v, want nil (no room opened)", sess)
+	}
+}
+
+// TestService_ArmQuiz pins the arm-without-start contract (#863): ArmQuiz points
+// an empty staging room at a live quiz and leaves it in the lobby (not started),
+// and rejects a solo quiz.
+func TestService_ArmQuiz(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+	h := newEmptyRoomHarness(t, start)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	empty, err := h.service.CreateSession(ctx, nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	qz := seedRunnerQuizSlug(t, h.quizStore, "armquiz-live", [][]bool{{true}})
+
+	if err = h.service.ArmQuiz(ctx, empty.JoinCode, hostID, qz.ID); err != nil {
+		t.Fatalf("ArmQuiz err = %v, want nil", err)
+	}
+
+	armed, err := h.store.GetSessionByID(ctx, empty.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	if armed.QuizID == nil {
+		t.Fatalf("armed QuizID = nil, want %d", qz.ID)
+	}
+	if got, want := *armed.QuizID, qz.ID; got != want {
+		t.Errorf("armed QuizID = %d, want %d", got, want)
+	}
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Errorf("armed Phase = %q, want %q (still in the lobby)", got, want)
+	}
+	if armed.StartedAt != nil {
+		t.Errorf("armed StartedAt = %v, want nil (not started until the host presses Start)", armed.StartedAt)
+	}
+
+	// A solo quiz cannot be armed.
+	solo := &quiz.Quiz{
+		Title:             "Solo",
+		Slug:              "armquiz-solo",
+		CreatedByPlayerID: hostID,
+		Mode:              quiz.ModeSolo,
+		Visibility:        quiz.VisibilityPublic,
+		Questions: []*quiz.Question{
+			{Text: "Q", Position: 1, Options: []*quiz.Option{{Text: "A", Correct: true}, {Text: "B"}}},
+		},
+	}
+	if err = h.quizStore.CreateQuiz(ctx, solo); err != nil {
+		t.Fatalf("CreateQuiz solo err = %v, want nil", err)
+	}
+	if got, want := h.service.ArmQuiz(ctx, empty.JoinCode, hostID, solo.ID), ErrNotLiveQuiz; !errors.Is(got, want) {
+		t.Errorf("ArmQuiz (solo) err = %v, want %v", got, want)
 	}
 }
 

--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -680,30 +680,9 @@ func (s *Service) Start(ctx context.Context, joinCode string, hostPlayerID int64
 // is not the host, [quiz.ErrQuizNotFound] / [ErrNotLiveQuiz] for an unhostable
 // quiz, and [ErrGameInFlight] when a game is already running.
 func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, quizID int64) error {
-	sess, err := s.store.GetSessionByJoinCode(ctx, normalizeJoinCode(joinCode))
+	sess, err := s.armRoomForHost(ctx, joinCode, hostPlayerID, quizID)
 	if err != nil {
-		return fmt.Errorf(errGetSessionByCodeFmt, err)
-	}
-	if sess.HostPlayerID != hostPlayerID {
-		return ErrNotHost
-	}
-	if !canArmQuiz(sess) {
-		return ErrGameInFlight
-	}
-
-	qz, err := s.quizzes.GetQuiz(ctx, quizID)
-	if err != nil {
-		return fmt.Errorf("failed to get quiz for next game: %w", err)
-	}
-	if qz.Mode != quiz.ModeLive {
-		return ErrNotLiveQuiz
-	}
-
-	// RearmSession is scoped to "no game in flight", so it is the real arbiter if
-	// the room left that state between the read above and this write (a concurrent
-	// arm or a start that raced this one); it returns ErrGameInFlight to the loser.
-	if err = s.store.RearmSession(ctx, sess.ID, qz.ID); err != nil {
-		return fmt.Errorf("failed to rearm session: %w", err)
+		return err
 	}
 
 	// Mark the re-armed lobby started so the new game begins now (start-now
@@ -732,16 +711,18 @@ func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, 
 // room per host (#851). It backs the quiz-view "Host live" control:
 //   - No active room -> open a new lobby armed with the quiz (host starts it
 //     when players are in), same as the prior "Play live".
-//   - Active room that can still arm a quiz (an empty staging lobby or the
-//     between-games intermission) -> arm that quiz in the existing room and
-//     start it (reusing StartQuiz), so a second room is never spawned.
+//   - Active empty staging lobby -> arm the quiz in it but stay in the lobby
+//     (reusing ArmQuiz), so the host gathers players and presses Start, the same
+//     as the no-active-room case (#863). No second room is spawned.
+//   - Active between-games intermission -> arm AND start the next game (reusing
+//     StartQuiz), the #836 between-games flow.
 //   - Active room with a game in flight -> leave it untouched and return it, so
 //     a stray pick never disrupts a running game (the end-and-restart confirm
 //     is deferred to #853).
 //
 // It returns the room the host should be redirected to; only its JoinCode is
 // authoritative (the redirect target). In the reuse branch the returned snapshot
-// predates StartQuiz, so its Phase/QuizID/StartedAt may lag the now-armed room -
+// predates the arm, so its Phase/QuizID/StartedAt may lag the now-armed room -
 // callers must re-read if they need post-arm state. [quiz.ErrQuizNotFound] and
 // [ErrNotLiveQuiz] propagate so the handler can bounce an unhostable quiz to the
 // quiz list.
@@ -761,9 +742,17 @@ func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) 
 		return active, nil
 	}
 
-	// An empty staging lobby or the between-games intermission can take a new
-	// quiz: arm it in the existing room and start it, so no second room spawns.
-	err = s.StartQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
+	// An empty staging lobby and the between-games intermission both take a new
+	// quiz without spawning a second room, but they differ (#863): the empty
+	// lobby ARMS the quiz and stays in the lobby so the host gathers players and
+	// presses Start (matching the no-active-session case, which also lands on an
+	// armed lobby), while the intermission arms AND starts the next game (the
+	// #836 between-games flow). canArmQuiz guarantees active is one of these two.
+	if active.Phase == PhaseLobby {
+		err = s.ArmQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
+	} else {
+		err = s.StartQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
+	}
 	switch {
 	case err == nil, errors.Is(err, ErrGameInFlight):
 		// ErrGameInFlight means the room raced into flight between the read above
@@ -821,6 +810,24 @@ func (s *Service) RestartHosting(ctx context.Context, quizID, hostPlayerID int64
 	// No active session now (just ended, or never any): CreateSession opens a new
 	// armed lobby hosting the picked quiz.
 	return s.CreateSession(ctx, &quizID, hostPlayerID)
+}
+
+// ArmQuiz arms a quiz to play in a room but leaves it in the lobby, not started
+// (#863): the host then begins it with the existing "Start now" control once
+// players are in, matching the no-active-session flow rather than starting the
+// game outright. Only the host may call it, and only when no game is in flight.
+// Returns the same errors as [Service.armRoomForHost].
+func (s *Service) ArmQuiz(ctx context.Context, joinCode string, hostPlayerID, quizID int64) error {
+	sess, err := s.armRoomForHost(ctx, joinCode, hostPlayerID, quizID)
+	if err != nil {
+		return err
+	}
+
+	// A newly armed quiz changes what the lobby shows (the Start controls appear),
+	// so signal subscribers to re-GET.
+	s.publish(sess.JoinCode, PhaseLobby)
+
+	return nil
 }
 
 // canArmQuiz reports whether a quiz can be armed to play in the room right now:
@@ -1108,6 +1115,44 @@ func (s *Service) Leave(ctx context.Context, joinCode string, playerID int64) er
 	s.publish(sess.JoinCode, sess.Phase)
 
 	return nil
+}
+
+// armRoomForHost validates that hostPlayerID hosts the room and that quizID is a
+// live quiz that can be armed now, then points the room at it via RearmSession
+// (which resets it to the lobby, not started) and returns the session. It does
+// not publish or start - the caller decides: [Service.ArmQuiz] stops here (the
+// room waits in the lobby), [Service.StartQuiz] marks it started. Returns
+// [ErrSessionNotFound] for an unknown code, [ErrNotHost] for a foreign host,
+// [quiz.ErrQuizNotFound] / [ErrNotLiveQuiz] for an unhostable quiz, and
+// [ErrGameInFlight] when a game is already running.
+func (s *Service) armRoomForHost(ctx context.Context, joinCode string, hostPlayerID, quizID int64) (*Session, error) {
+	sess, err := s.store.GetSessionByJoinCode(ctx, normalizeJoinCode(joinCode))
+	if err != nil {
+		return nil, fmt.Errorf(errGetSessionByCodeFmt, err)
+	}
+	if sess.HostPlayerID != hostPlayerID {
+		return nil, ErrNotHost
+	}
+	if !canArmQuiz(sess) {
+		return nil, ErrGameInFlight
+	}
+
+	qz, err := s.quizzes.GetQuiz(ctx, quizID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get quiz to arm: %w", err)
+	}
+	if qz.Mode != quiz.ModeLive {
+		return nil, ErrNotLiveQuiz
+	}
+
+	// RearmSession is scoped to "no game in flight", so it is the real arbiter if
+	// the room left that state between the read above and this write (a concurrent
+	// arm or a start that raced this one); it returns ErrGameInFlight to the loser.
+	if err = s.store.RearmSession(ctx, sess.ID, qz.ID); err != nil {
+		return nil, fmt.Errorf("failed to arm session: %w", err)
+	}
+
+	return sess, nil
 }
 
 // lobbyQuiz loads the room's quiz for the lobby state, or (nil, nil) for an empty

--- a/test/e2e/tests/session-first.spec.ts
+++ b/test/e2e/tests/session-first.spec.ts
@@ -60,15 +60,23 @@ test.describe('session-first live hosting', () => {
 
     // The host follows the lobby link to the live-filtered quiz list, opens the
     // seeded quiz, and hits "Host live". Because the host already has this empty
-    // staging room open, "Host live" arms+starts THAT room (one room per host),
-    // so the still-joined player is carried straight into the game.
+    // staging room open, "Host live" ARMS the quiz in that room but stays in the
+    // lobby (#863) - it does NOT auto-start - so the host starts when ready.
     await host.getByTestId('pick-quiz-link').locator('a').click();
     await expect(host).toHaveURL(/\/admin\/quizzes\?mode=live$/);
     await host.getByRole('link', { name: quizTitle }).click();
     await host.getByRole('button', { name: 'Host live' }).click();
 
-    // The still-joined player is carried into the game without re-entering a
-    // code: they reach the question and the room is no longer empty.
+    // Back on the lobby the quiz is now armed: the Start controls appear and the
+    // pick link is gone. The game has not started - the player is still waiting.
+    await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
+    await expect(host.getByTestId('start-now')).toBeVisible({ timeout: 15_000 });
+    await expect(host.getByTestId('pick-quiz-link')).toBeHidden();
+    await expect(page.getByTestId('question-view')).toBeHidden();
+
+    // The host starts the game; the still-joined player is carried into it
+    // without re-entering a code.
+    await host.getByTestId('start-now').click();
     await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 20_000 });
     await expect(page.getByTestId('question-text')).toHaveText('What is 1+1?');
     await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });

--- a/test/integration/host_lobby_test.go
+++ b/test/integration/host_lobby_test.go
@@ -326,7 +326,9 @@ func TestHostLive_ArmsExistingEmptyRoom(t *testing.T) {
 		t.Errorf("host live (reuse) redirect = %q, want %q (the existing room)", got, want)
 	}
 
-	// The existing room is now armed onto the picked quiz (no second room spawned).
+	// The existing room is now armed onto the picked quiz (no second room
+	// spawned) but still in the lobby, NOT started (#863): the host presses Start
+	// when players are in.
 	sess, err := setup.Stores.LiveSessions.GetSessionByJoinCode(ctx, emptyCode)
 	if err != nil {
 		t.Fatalf("GetSessionByJoinCode err = %v, want nil", err)
@@ -336,6 +338,15 @@ func TestHostLive_ArmsExistingEmptyRoom(t *testing.T) {
 	}
 	if got, want := *sess.QuizID, qz.ID; got != want {
 		t.Errorf("reused room QuizID = %d, want %d (the picked quiz)", got, want)
+	}
+	if got, want := string(sess.Phase), "lobby"; got != want {
+		t.Errorf("reused room Phase = %q, want %q (armed but waiting in the lobby, #863)", got, want)
+	}
+	if sess.StartedAt != nil {
+		t.Errorf(
+			"reused room StartedAt = %v, want nil (not started until the host presses Start, #863)",
+			sess.StartedAt,
+		)
 	}
 }
 


### PR DESCRIPTION
Closes #863

Follow-up to #851. When a host opens an empty staging room ("Host a session"), then picks a quiz and clicks "Host live", the game started immediately. Now it **arms the quiz but stays in the lobby**, so the host gathers players and presses Start when ready - the same as hosting a quiz with no active session (both flows end at an armed lobby awaiting Start).

## Change
- New `livesession.Service.ArmQuiz` arms a quiz onto a room and leaves it in the lobby, not started (the host begins it with the existing "Start now" control). It shares the validate-and-arm step (`armRoomForHost`, via `RearmSession`) with `StartQuiz`; `StartQuiz` then marks the game started, exactly as before (behavior unchanged - still used for the intermission / next-game flow and the host re-arm API).
- `StartHosting` splits the reuse branch by phase: an **empty staging lobby** arms-only (`ArmQuiz`); the **between-games intermission** keeps arm-and-start (`StartQuiz`, the #836 flow).

## Tests
- Layer: the StartHosting empty-room test now asserts the room is armed but in the lobby (`StartedAt == nil`); a new `ArmQuiz` test pins arm-not-started + solo rejection.
- Integration: the reuse test asserts the existing room is armed and still in the lobby, not started.
- e2e: `session-first` now asserts the Start controls appear (and the game has NOT started) after "Host live", then the host clicks Start and the player reaches the question.

`make check` green (coverage 83.0%); full `make test-e2e` passes (the one chromium failure was the local `chrome-headless-shell` SIGSEGV - firefox green, passes on a clean re-run, doesn't occur on CI).