### PR TITLE
Offer a sign-in option on the anonymous join name prompt

### DIFF
--- a/internal/client/static/join.html
+++ b/internal/client/static/join.html
@@ -147,6 +147,19 @@
                             :disabled="busy"
                             x-text="busy ? 'Joining...' : 'Join game'"></button>
                 </form>
+                <!-- Sign-in affordance (#865): the login deep-link return
+                     (/login?next=/join/{code} -> 303 back) lands the player back
+                     on this room, where init() auto-joins under their account
+                     name. Anonymous-only: a signed-in player with a custom name
+                     never reaches the name form. -->
+                <template x-if="!isAuthenticated()">
+                    <p class="mt-3 text-sm text-text-dim text-right">
+                        Already have an account?
+                        <a :href="'/login?next=' + encodeURIComponent('/join/' + code)"
+                           class="text-text hover:text-accent underline-offset-2 hover:underline"
+                           data-testid="join-name-signin">Sign in</a>.
+                    </p>
+                </template>
             </div>
 
             <!-- Joined: the lobby roster through play and final standings, all

--- a/test/e2e/tests/join-sign-in.spec.ts
+++ b/test/e2e/tests/join-sign-in.spec.ts
@@ -1,0 +1,101 @@
+import { join } from 'node:path';
+
+import { test, expect } from './fixtures';
+import {
+  PASSWORD,
+  seedQuiz,
+  setQuizMode,
+  registerForPending,
+  markEmailVerified,
+  execSqlite,
+} from './helpers';
+
+// quizIdFor resolves a seeded quiz's id by title via the same sqlite shortcut
+// the role/verify helpers use, so openViaApi can target it. setQuizMode flips
+// the mode but returns void (the importer only makes solo quizzes, #677), so
+// the id is read separately here.
+function quizIdFor(title: string): number {
+  const dataDir = process.env.TOPBANANA_E2E_DATA_DIR;
+  if (!dataDir) {
+    throw new Error('TOPBANANA_E2E_DATA_DIR is not set; cannot resolve a quiz id');
+  }
+  const dbFile = join(dataDir, `e2e-${test.info().parallelIndex}.db`);
+  const escapedTitle = title.replace(/'/g, "''");
+  const output = execSqlite(dbFile, `SELECT id FROM quizzes WHERE title = '${escapedTitle}';`);
+  const id = Number.parseInt(output, 10);
+  if (!Number.isInteger(id)) {
+    throw new Error(`quizIdFor(${title}): could not resolve quiz id from sqlite output ${JSON.stringify(output)}`);
+  }
+  return id;
+}
+
+// #865: an anonymous joiner asked for a display name can sign in instead. The
+// Sign-in link carries a login deep-link return (/login?next=/join/{code}), so
+// after a successful login the player lands back on the same room and JoinApp's
+// init() resolves their account name and auto-joins under it - no ad-hoc
+// anonymous name. The host setup (seed, mark live, open a room) runs as the
+// shared admin via the hostSessions fixture, which ends the room on teardown;
+// the player flow runs in the default anonymous page context.
+test.describe('player join sign-in', () => {
+  test('anonymous join name prompt offers sign-in; signing in returns to the room and joins under the account name', async ({ page, hostSessions }) => {
+    // Generous budget: the flow registers + verifies an account, opens a live
+    // room, navigates the login deep-link return, then waits for the auto-join
+    // roster to settle off the SSE -> GET state loop.
+    test.setTimeout(60_000);
+
+    const stamp = Date.now();
+    const quizTitle = `Live SignIn ${stamp}`;
+    // Player names are global on players.display_name (#716), so a unique
+    // stamped name avoids a collision with a parallel spec sharing the worker
+    // DB. A chosen display name marks the row hasCustomName=true, which is what
+    // makes the post-login auto-join land under the account name.
+    const regName = `Reg-${stamp}`;
+
+    // Register + verify the player on the anonymous page. Post-#574 register
+    // hands out no session, so the page stays anonymous afterward - exactly the
+    // state a fresh joiner is in when the name form is shown.
+    await registerForPending(page, regName);
+    markEmailVerified(regName);
+
+    // Seed + host setup as the admin (storageState) in a separate context so
+    // the player page stays anonymous. The importer only makes solo quizzes
+    // (#677), so seed then flip the mode to live.
+    const host = await hostSessions.adminHost();
+    await seedQuiz(host, quizTitle);
+    setQuizMode(quizTitle, 'live');
+
+    const quizID = quizIdFor(quizTitle);
+    const { joinCode } = await hostSessions.openViaApi(quizID);
+    expect(joinCode).toMatch(/^[A-Z0-9]{6}$/);
+
+    // The anonymous joiner reaches the name form via the deep link.
+    await page.goto(`/join/${joinCode}`);
+    await expect(page.getByTestId('join-name-input')).toBeVisible();
+
+    // The Sign-in affordance is offered for the anonymous player.
+    const signIn = page.getByTestId('join-name-signin');
+    await expect(signIn).toBeVisible();
+
+    // Following it navigates to login with the deep-link return back to this
+    // exact room (URL-encoded).
+    await signIn.click();
+    await expect(page).toHaveURL(new RegExp(`/login\\?next=%2Fjoin%2F${joinCode}$`));
+
+    // Sign in here, on the deep-link login page itself, so the next field
+    // carried in the query survives into the form post (login() in helpers.ts
+    // navigates to a bare /login, which would drop it).
+    await page.locator('input[name=email]').fill(`${regName}@example.test`);
+    await page.locator('input[name=password]').fill(PASSWORD);
+    await page.locator('button[type=submit]').click();
+
+    // The login 303s back to the room. JoinApp resolves /api/players/me, sees
+    // the custom name, and auto-joins: the roster shows the account name and
+    // the anonymous name form is gone. This proves the deep-link return plus a
+    // join under the account name.
+    await expect(page).toHaveURL(new RegExp(`/join/${joinCode}$`));
+    const roster = page.getByTestId('lobby-roster');
+    await expect(roster).toBeVisible();
+    await expect(roster.getByText(regName)).toBeVisible();
+    await expect(page.getByTestId('join-name-input')).toBeHidden();
+  });
+});

--- a/test/integration/join_shell_test.go
+++ b/test/integration/join_shell_test.go
@@ -44,6 +44,12 @@ func assertJoinShell(ctx context.Context, t *testing.T, url string) {
 		// header rides in flow on every other screen and hides during a
 		// question.
 		`x-show="!inActiveQuestion()"`,
+		// #865: the name phase carries a Sign-in affordance for anonymous
+		// joiners, whose href is built with Alpine so it carries the login
+		// deep-link return (/login?next=/join/{code}) back to this same room.
+		// Both /join and /join/{code} serve this markup.
+		`data-testid="join-name-signin"`,
+		`'/login?next=' + encodeURIComponent('/join/' + code)`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("%s body missing %q", url, want)


### PR DESCRIPTION
Closes #865

The live-session join name prompt now shows a Sign in link for anonymous players. It carries a login deep-link return (`/login?next=/join/{code}`), so after signing in the player lands back on the same room and joins under their account display name instead of an ad-hoc anonymous one.

- New e2e spec drives the full flow: anonymous name prompt -> Sign in -> login -> auto-join under the account name.
- The join-shell integration test pins the affordance and its deep-link href on both `/join` and `/join/{code}`.