### PR TITLE
Add live-session logging for game-night diagnostics

### DIFF
--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -573,6 +573,16 @@ func (s *Service) CreateSession(ctx context.Context, quizID *int64, hostPlayerID
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
+	attrs := []any{
+		slog.String(logSessionKey, sess.ID),
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID),
+	}
+	if quizID != nil {
+		attrs = append(attrs, slog.Int64(logQuizKey, *quizID))
+	}
+	s.logger.InfoContext(ctx, "live session created", attrs...)
+
 	return sess, nil
 }
 
@@ -598,6 +608,10 @@ func (s *Service) Join(ctx context.Context, joinCode string, playerID int64) (*P
 	// (AddPlayer revives their row, clearing left_at). Only a finished, closed
 	// room rejects joins.
 	if sess.Phase == PhaseFinished {
+		s.logger.InfoContext(ctx, "live session join rejected: room closed",
+			slog.String(logJoinCodeKey, sess.JoinCode),
+			slog.Int64(logPlayerKey, playerID))
+
 		return nil, ErrLobbyClosed
 	}
 
@@ -608,6 +622,10 @@ func (s *Service) Join(ctx context.Context, joinCode string, playerID int64) (*P
 
 	// A new roster row changes the lobby, so signal subscribers to re-GET.
 	s.publish(sess.JoinCode, sess.Phase)
+
+	s.logger.InfoContext(ctx, "player joined live session",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logPlayerKey, playerID))
 
 	return player, nil
 }
@@ -628,6 +646,11 @@ func (s *Service) SetReady(ctx context.Context, joinCode string, playerID int64,
 	// A flipped ready flag changes the lobby, so signal subscribers to re-GET.
 	s.publish(sess.JoinCode, sess.Phase)
 
+	s.logger.DebugContext(ctx, "player ready toggled",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logPlayerKey, playerID),
+		slog.Bool(logReadyKey, ready))
+
 	return nil
 }
 
@@ -644,6 +667,8 @@ func (s *Service) Start(ctx context.Context, joinCode string, hostPlayerID int64
 		return fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if sess.HostPlayerID != hostPlayerID {
+		s.logNonHostAttempt(ctx, "start", sess.JoinCode, hostPlayerID)
+
 		return ErrNotHost
 	}
 
@@ -654,6 +679,10 @@ func (s *Service) Start(ctx context.Context, joinCode string, hostPlayerID int64
 	if !won {
 		return ErrSessionAlreadyStarted
 	}
+
+	s.logger.InfoContext(ctx, "live session started",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID))
 
 	if s.advancer != nil {
 		// Detach from the request context so a host disconnect cannot cancel
@@ -695,6 +724,11 @@ func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, 
 	// signal subscribers to re-GET the state before the runner drives the game.
 	s.publish(sess.JoinCode, PhaseLobby)
 
+	s.logger.InfoContext(ctx, "live quiz started",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logQuizKey, quizID),
+		slog.Int64(logHostKey, hostPlayerID))
+
 	if s.advancer != nil {
 		// Detach from the request context (same reason as Start) so a host
 		// disconnect cannot strand the re-armed game in the lobby; the runner's
@@ -733,12 +767,26 @@ func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) 
 	}
 
 	if active == nil {
-		return s.CreateSession(ctx, &quizID, hostPlayerID)
+		var sess *Session
+		if sess, err = s.CreateSession(ctx, &quizID, hostPlayerID); err != nil {
+			return nil, err
+		}
+		s.logger.InfoContext(ctx, "host started hosting: opened new room",
+			slog.String(logJoinCodeKey, sess.JoinCode),
+			slog.Int64(logHostKey, hostPlayerID),
+			slog.Int64(logQuizKey, quizID))
+
+		return sess, nil
 	}
 
 	if !canArmQuiz(active) {
 		// A game is in flight: leave the running room untouched and return it so
 		// a stray pick never disrupts it. The end-and-restart confirm is #853.
+		s.logger.InfoContext(ctx, "host started hosting: reused running room",
+			slog.String(logJoinCodeKey, active.JoinCode),
+			slog.Int64(logHostKey, hostPlayerID),
+			slog.Int64(logQuizKey, quizID))
+
 		return active, nil
 	}
 
@@ -758,6 +806,12 @@ func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) 
 		// ErrGameInFlight means the room raced into flight between the read above
 		// and the arm; treat it the same as "in flight, do nothing" and return
 		// the room so the host lands on it.
+		s.logger.InfoContext(ctx, "host started hosting: reused active room",
+			slog.String(logJoinCodeKey, active.JoinCode),
+			slog.Int64(logHostKey, hostPlayerID),
+			slog.Int64(logQuizKey, quizID),
+			slog.String(logPhaseKey, string(active.Phase)))
+
 		return active, nil
 	default:
 		return nil, err
@@ -809,7 +863,16 @@ func (s *Service) RestartHosting(ctx context.Context, quizID, hostPlayerID int64
 
 	// No active session now (just ended, or never any): CreateSession opens a new
 	// armed lobby hosting the picked quiz.
-	return s.CreateSession(ctx, &quizID, hostPlayerID)
+	var sess *Session
+	if sess, err = s.CreateSession(ctx, &quizID, hostPlayerID); err != nil {
+		return nil, err
+	}
+	s.logger.InfoContext(ctx, "host restarted hosting: opened new room",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID),
+		slog.Int64(logQuizKey, quizID))
+
+	return sess, nil
 }
 
 // ArmQuiz arms a quiz to play in a room but leaves it in the lobby, not started
@@ -826,6 +889,11 @@ func (s *Service) ArmQuiz(ctx context.Context, joinCode string, hostPlayerID, qu
 	// A newly armed quiz changes what the lobby shows (the Start controls appear),
 	// so signal subscribers to re-GET.
 	s.publish(sess.JoinCode, PhaseLobby)
+
+	s.logger.InfoContext(ctx, "live quiz armed",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logQuizKey, quizID),
+		slog.Int64(logHostKey, hostPlayerID))
 
 	return nil
 }
@@ -857,6 +925,8 @@ func (s *Service) EndSession(ctx context.Context, joinCode string, hostPlayerID 
 		return fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if sess.HostPlayerID != hostPlayerID {
+		s.logNonHostAttempt(ctx, "end", sess.JoinCode, hostPlayerID)
+
 		return ErrNotHost
 	}
 	if sess.Phase == PhaseFinished {
@@ -870,6 +940,10 @@ func (s *Service) EndSession(ctx context.Context, joinCode string, hostPlayerID 
 	// The room is now terminal; signal subscribers to re-GET so every surface
 	// lands on the finished state and the live clients tear down.
 	s.publish(sess.JoinCode, PhaseFinished)
+
+	s.logger.InfoContext(ctx, "live session ended",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID))
 
 	return nil
 }
@@ -903,6 +977,8 @@ func (s *Service) ArmStart(ctx context.Context, joinCode string, hostPlayerID in
 		return fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if sess.HostPlayerID != hostPlayerID {
+		s.logNonHostAttempt(ctx, "armStart", sess.JoinCode, hostPlayerID)
+
 		return ErrNotHost
 	}
 
@@ -910,13 +986,19 @@ func (s *Service) ArmStart(ctx context.Context, joinCode string, hostPlayerID in
 	if countdown <= 0 {
 		countdown = DefaultStartCountdown
 	}
-	if err = s.store.ArmStart(ctx, sess.ID, now.Add(countdown)); err != nil {
+	deadline := now.Add(countdown)
+	if err = s.store.ArmStart(ctx, sess.ID, deadline); err != nil {
 		return fmt.Errorf("failed to arm session start: %w", err)
 	}
 
 	// An armed countdown changes what every surface shows, so signal
 	// subscribers to re-GET the state (which now carries the deadline).
 	s.publish(sess.JoinCode, sess.Phase)
+
+	s.logger.InfoContext(ctx, "live session start countdown armed",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID),
+		slog.Time(logDeadlineKey, deadline))
 
 	return nil
 }
@@ -932,6 +1014,8 @@ func (s *Service) CancelStart(ctx context.Context, joinCode string, hostPlayerID
 		return fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if sess.HostPlayerID != hostPlayerID {
+		s.logNonHostAttempt(ctx, "cancelStart", sess.JoinCode, hostPlayerID)
+
 		return ErrNotHost
 	}
 
@@ -942,6 +1026,10 @@ func (s *Service) CancelStart(ctx context.Context, joinCode string, hostPlayerID
 	// A cleared countdown changes what every surface shows, so signal
 	// subscribers to re-GET the state.
 	s.publish(sess.JoinCode, sess.Phase)
+
+	s.logger.InfoContext(ctx, "live session start countdown cancelled",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logHostKey, hostPlayerID))
 
 	return nil
 }
@@ -961,18 +1049,26 @@ func (s *Service) SubmitAnswer(
 		return fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if !s.isParticipant(sess, playerID) {
+		s.logger.InfoContext(ctx, "answer rejected: not a participant",
+			slog.String(logJoinCodeKey, sess.JoinCode),
+			slog.Int64(logPlayerKey, playerID))
+
 		return ErrNotParticipant
 	}
 	if sess.Phase != PhaseQuestion ||
 		sess.CurrentQuestionID == nil ||
 		sess.QuestionStartedAt == nil ||
 		sess.QuestionExpiresAt == nil {
+		s.logAnswerNotOpen(ctx, sess, playerID, "wrong-phase")
+
 		return ErrQuestionNotOpen
 	}
 	// The window opens at StartedAt (after the read beat) and closes at
 	// ExpiresAt; a pick outside [StartedAt, ExpiresAt] is rejected, so a client
 	// cannot pre-submit during the read beat.
 	if answeredAt.Before(*sess.QuestionStartedAt) || answeredAt.After(*sess.QuestionExpiresAt) {
+		s.logAnswerNotOpen(ctx, sess, playerID, "out-of-window")
+
 		return ErrQuestionNotOpen
 	}
 
@@ -981,6 +1077,8 @@ func (s *Service) SubmitAnswer(
 		return err
 	}
 	if !optionBelongsToQuestion(question, optionID) {
+		s.logAnswerNotOpen(ctx, sess, playerID, "option-mismatch")
+
 		return ErrQuestionNotOpen
 	}
 
@@ -992,6 +1090,12 @@ func (s *Service) SubmitAnswer(
 	// re-GET. The runner closes the question on the next beat if everyone has
 	// now answered.
 	s.publish(sess.JoinCode, sess.Phase)
+
+	s.logger.DebugContext(ctx, "answer accepted",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logPlayerKey, playerID),
+		slog.Int64(logQuestionKey, *sess.CurrentQuestionID),
+		slog.Int64(logOptionKey, optionID))
 
 	return nil
 }
@@ -1114,6 +1218,10 @@ func (s *Service) Leave(ctx context.Context, joinCode string, playerID int64) er
 	// The roster shrank, so signal subscribers to re-GET the smaller state.
 	s.publish(sess.JoinCode, sess.Phase)
 
+	s.logger.InfoContext(ctx, "player left live session",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logPlayerKey, playerID))
+
 	return nil
 }
 
@@ -1131,6 +1239,8 @@ func (s *Service) armRoomForHost(ctx context.Context, joinCode string, hostPlaye
 		return nil, fmt.Errorf(errGetSessionByCodeFmt, err)
 	}
 	if sess.HostPlayerID != hostPlayerID {
+		s.logNonHostAttempt(ctx, "arm", sess.JoinCode, hostPlayerID)
+
 		return nil, ErrNotHost
 	}
 	if !canArmQuiz(sess) {
@@ -1401,6 +1511,29 @@ func (s *Service) allocateJoinCode(ctx context.Context) (string, error) {
 	}
 
 	return "", ErrJoinCodeUnavailable
+}
+
+// logNonHostAttempt logs an Info line for a non-host caller trying a
+// host-gated control, naming the action and who attempted it. A host who
+// cannot start or end their room is a thing the host wants to see explained,
+// not just a bare 403 in the access log.
+func (s *Service) logNonHostAttempt(ctx context.Context, action, joinCode string, playerID int64) {
+	s.logger.InfoContext(ctx, "live session control rejected: not host",
+		slog.String("action", action),
+		slog.String(logJoinCodeKey, joinCode),
+		slog.Int64(logPlayerKey, playerID))
+}
+
+// logAnswerNotOpen logs a Debug line for an answer rejected because no question
+// is open for it, naming the reason (wrong-phase / out-of-window /
+// option-mismatch). Debug because a late tap can repeat the line per stray
+// submit, while a host who wants to know why a pick did not land still has it.
+func (s *Service) logAnswerNotOpen(ctx context.Context, sess *Session, playerID int64, reason string) {
+	s.logger.DebugContext(ctx, "answer rejected: question not open",
+		slog.String(logJoinCodeKey, sess.JoinCode),
+		slog.Int64(logPlayerKey, playerID),
+		slog.String(logPhaseKey, string(sess.Phase)),
+		slog.String(logReasonKey, reason))
 }
 
 // publish fans out a session tick if a publisher is wired. The single

--- a/internal/livesession/logging_test.go
+++ b/internal/livesession/logging_test.go
@@ -1,0 +1,370 @@
+package livesession_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/game"
+	. "github.com/starquake/topbanana/internal/livesession"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// captureHandler is a slog.Handler that records every record at Debug+ so a
+// test can assert the live-session domain layer emitted the expected log line
+// with the expected level and fields. Concurrency-safe because the runner
+// detaches its first-round transition onto a goroutine via the advancer.
+type captureHandler struct {
+	mu      *sync.Mutex
+	records *[]slog.Record
+}
+
+func newCaptureHandler() captureHandler {
+	return captureHandler{mu: &sync.Mutex{}, records: &[]slog.Record{}}
+}
+
+func (captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, r.Clone())
+
+	return nil
+}
+
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// snapshot returns a copy of the records captured so far.
+func (h captureHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]slog.Record(nil), *h.records...)
+}
+
+// findLog returns the first captured record with the given message, plus
+// whether one was found.
+func (h captureHandler) findLog(msg string) (slog.Record, bool) {
+	for _, r := range h.snapshot() {
+		if r.Message == msg {
+			return r, true
+		}
+	}
+
+	return slog.Record{}, false
+}
+
+// assertLog asserts that a record with msg was captured at level want, and
+// returns its attributes keyed by name so the caller can check fields.
+func assertLog(t *testing.T, h captureHandler, msg string, want slog.Level) map[string]slog.Value {
+	t.Helper()
+
+	rec, ok := h.findLog(msg)
+	if !ok {
+		t.Fatalf("no log record with message %q (captured: %v)", msg, logMessages(h))
+	}
+	if got := rec.Level; got != want {
+		t.Errorf("log %q level = %v, want %v", msg, got, want)
+	}
+
+	attrs := make(map[string]slog.Value, rec.NumAttrs())
+	rec.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+
+		return true
+	})
+
+	return attrs
+}
+
+// assertNoLog asserts that no record with msg was captured.
+func assertNoLog(t *testing.T, h captureHandler, msg string) {
+	t.Helper()
+	if _, ok := h.findLog(msg); ok {
+		t.Errorf("log %q was emitted, want none", msg)
+	}
+}
+
+// logMessages lists the captured messages so a failed assertion can show what
+// was actually logged.
+func logMessages(h captureHandler) []string {
+	recs := h.snapshot()
+	msgs := make([]string, 0, len(recs))
+	for _, r := range recs {
+		msgs = append(msgs, r.Message)
+	}
+
+	return msgs
+}
+
+func assertStringAttr(t *testing.T, attrs map[string]slog.Value, key, want string) {
+	t.Helper()
+	if got := attrs[key].String(); got != want {
+		t.Errorf("attr %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertInt64Attr(t *testing.T, attrs map[string]slog.Value, key string, want int64) {
+	t.Helper()
+	if got := attrs[key].Int64(); got != want {
+		t.Errorf("attr %q = %d, want %d", key, got, want)
+	}
+}
+
+// loggingHarness wires the live-session service + runner over real stores with
+// a capturing logger, so a test drives the service and asserts the emitted
+// domain log lines. Mirrors newRunnerHarness but exposes the captured records.
+type loggingHarness struct {
+	service *Service
+	runner  *Runner
+	clock   *fakeClock
+	store   *store.LiveSessionStore
+	logs    captureHandler
+	code    string
+	players []int64
+}
+
+func newLoggingHarness(t *testing.T, start time.Time, rounds [][]bool) *loggingHarness {
+	t.Helper()
+
+	const playerCount = 2
+
+	db := dbtest.Open(t)
+	logs := newCaptureHandler()
+	logger := slog.New(logs)
+	discard := slog.New(slog.DiscardHandler)
+	quizStore := store.NewQuizStore(db, discard)
+	playerStore := store.NewPlayerStore(db, discard)
+	sessionStore := store.NewLiveSessionStore(db, discard)
+
+	qz := seedRunnerQuiz(t, quizStore, rounds)
+
+	service := NewService(sessionStore, quizStore, logger)
+	hub := NewHub()
+	service.SetPublisher(hub)
+	service.SetStartCountdown(startCountdown)
+	scorer := game.NewService(nil, quizStore, discard)
+	clock := &fakeClock{now: start}
+	runner := NewRunner(sessionStore, quizStore, hub, scorer, discard, runnerCfg)
+	runner.SetClock(clock)
+	service.SetAdvancer(runner)
+
+	const hostID int64 = 1 // seeded admin
+	sess := &Session{QuizID: quizIDPtr(qz.ID), HostPlayerID: hostID, JoinCode: "LOG234"}
+	if err := sessionStore.CreateSession(t.Context(), sess); err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+
+	players := make([]int64, 0, playerCount)
+	for i := range playerCount {
+		p, err := playerStore.CreateAnonymousPlayer(t.Context(), "log-anon-"+string(rune('a'+i)))
+		if err != nil {
+			t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+		}
+		players = append(players, p.ID)
+	}
+
+	return &loggingHarness{
+		service: service,
+		runner:  runner,
+		clock:   clock,
+		store:   sessionStore,
+		logs:    logs,
+		code:    sess.JoinCode,
+		players: players,
+	}
+}
+
+func (h *loggingHarness) tick(ctx context.Context) {
+	ExportRunnerTick(ctx, h.runner, h.clock.Now())
+}
+
+// TestService_LogsLiveGameNightFlow drives a representative live game night
+// through the service - create, join, arm-start, host start, a submitted
+// answer, and end - and asserts each milestone emits its log line at the right
+// level with the identifying fields a host needs to reconstruct the night.
+func TestService_LogsLiveGameNightFlow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const hostID int64 = 1
+
+	if _, err := h.service.Join(ctx, h.code, h.players[0]); err != nil {
+		t.Fatalf("Join err = %v, want nil", err)
+	}
+	if _, err := h.service.Join(ctx, h.code, h.players[1]); err != nil {
+		t.Fatalf("Join err = %v, want nil", err)
+	}
+
+	joinAttrs := assertLog(t, h.logs, "player joined live session", slog.LevelInfo)
+	assertStringAttr(t, joinAttrs, "joinCode", h.code)
+	assertInt64Attr(t, joinAttrs, "player", h.players[0])
+
+	if err := h.service.SetReady(ctx, h.code, h.players[0], true); err != nil {
+		t.Fatalf("SetReady err = %v, want nil", err)
+	}
+	readyAttrs := assertLog(t, h.logs, "player ready toggled", slog.LevelDebug)
+	assertInt64Attr(t, readyAttrs, "player", h.players[0])
+	if got := readyAttrs["ready"].Bool(); !got {
+		t.Errorf("ready attr = %v, want true", got)
+	}
+
+	if err := h.service.ArmStart(ctx, h.code, hostID, h.clock.Now()); err != nil {
+		t.Fatalf("ArmStart err = %v, want nil", err)
+	}
+	armAttrs := assertLog(t, h.logs, "live session start countdown armed", slog.LevelInfo)
+	assertInt64Attr(t, armAttrs, "host", hostID)
+	if got, want := armAttrs["deadline"].Time(), h.clock.Now().Add(startCountdown); !got.Equal(want) {
+		t.Errorf("deadline attr = %v, want %v", got, want)
+	}
+
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start err = %v, want nil", err)
+	}
+	startAttrs := assertLog(t, h.logs, "live session started", slog.LevelInfo)
+	assertStringAttr(t, startAttrs, "joinCode", h.code)
+	assertInt64Attr(t, startAttrs, "host", hostID)
+
+	// Drive into the question phase and submit an accepted answer.
+	h.clock.advance(runnerCfg.RoundIntroBeat)
+	h.tick(ctx)
+	state, err := h.service.GetLobbyState(ctx, h.code, h.players[0])
+	if err != nil {
+		t.Fatalf("GetLobbyState err = %v, want nil", err)
+	}
+	if state.CurrentQuestion == nil {
+		t.Fatalf("no current question after round intro beat (phase=%q)", state.Session.Phase)
+	}
+	optID := state.CurrentQuestion.Options[0].ID
+	answerAt := h.clock.Now().Add(time.Second)
+	h.clock.advance(time.Second)
+	if err := h.service.SubmitAnswer(ctx, h.code, h.players[0], optID, answerAt); err != nil {
+		t.Fatalf("SubmitAnswer err = %v, want nil", err)
+	}
+	answerAttrs := assertLog(t, h.logs, "answer accepted", slog.LevelDebug)
+	assertInt64Attr(t, answerAttrs, "player", h.players[0])
+	assertInt64Attr(t, answerAttrs, "option", optID)
+	assertInt64Attr(t, answerAttrs, "question", *state.Session.CurrentQuestionID)
+
+	if err := h.service.EndSession(ctx, h.code, hostID); err != nil {
+		t.Fatalf("EndSession err = %v, want nil", err)
+	}
+	endAttrs := assertLog(t, h.logs, "live session ended", slog.LevelInfo)
+	assertStringAttr(t, endAttrs, "joinCode", h.code)
+	assertInt64Attr(t, endAttrs, "host", hostID)
+}
+
+// TestService_LogsCreateSession pins the create milestone, including the quiz
+// id field that only appears when a quiz is armed up front.
+func TestService_LogsCreateSession(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	sess, err := h.service.CreateSession(ctx, nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	attrs := assertLog(t, h.logs, "live session created", slog.LevelInfo)
+	assertStringAttr(t, attrs, "session", sess.ID)
+	assertStringAttr(t, attrs, "joinCode", sess.JoinCode)
+	assertInt64Attr(t, attrs, "host", hostID)
+	if _, ok := attrs["quiz"]; ok {
+		t.Error("quiz attr present for a quiz-less room, want absent")
+	}
+}
+
+// TestService_LogsClosedRoomJoinRejection pins that a join into a finished room
+// names the reason at Info, not just a bare 409 in the access log.
+func TestService_LogsClosedRoomJoinRejection(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	if err := h.service.EndSession(ctx, h.code, hostID); err != nil {
+		t.Fatalf("EndSession err = %v, want nil", err)
+	}
+
+	if _, err := h.service.Join(ctx, h.code, h.players[0]); err == nil {
+		t.Fatal("Join into a closed room err = nil, want ErrLobbyClosed")
+	}
+	attrs := assertLog(t, h.logs, "live session join rejected: room closed", slog.LevelInfo)
+	assertStringAttr(t, attrs, "joinCode", h.code)
+	assertInt64Attr(t, attrs, "player", h.players[0])
+	assertNoLog(t, h.logs, "player joined live session")
+}
+
+// TestService_LogsNotParticipantAnswerRejection pins the not-a-participant
+// rejection log at Info for an answer from a player who never joined.
+func TestService_LogsNotParticipantAnswerRejection(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const stranger int64 = 999
+	if err := h.service.SubmitAnswer(ctx, h.code, stranger, 1, h.clock.Now()); err == nil {
+		t.Fatal("SubmitAnswer from a non-participant err = nil, want ErrNotParticipant")
+	}
+	attrs := assertLog(t, h.logs, "answer rejected: not a participant", slog.LevelInfo)
+	assertStringAttr(t, attrs, "joinCode", h.code)
+	assertInt64Attr(t, attrs, "player", stranger)
+}
+
+// TestService_LogsQuestionNotOpenAnswerRejection pins the question-not-open
+// rejection log at Debug, naming the wrong-phase reason for an answer submitted
+// while the room is still in the lobby.
+func TestService_LogsQuestionNotOpenAnswerRejection(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	if _, err := h.service.Join(ctx, h.code, h.players[0]); err != nil {
+		t.Fatalf("Join err = %v, want nil", err)
+	}
+	// Still in the lobby: no question is open, so the pick is rejected.
+	if err := h.service.SubmitAnswer(ctx, h.code, h.players[0], 1, h.clock.Now()); err == nil {
+		t.Fatal("SubmitAnswer in the lobby err = nil, want ErrQuestionNotOpen")
+	}
+	attrs := assertLog(t, h.logs, "answer rejected: question not open", slog.LevelDebug)
+	assertInt64Attr(t, attrs, "player", h.players[0])
+	assertStringAttr(t, attrs, "phase", string(PhaseLobby))
+	assertStringAttr(t, attrs, "reason", "wrong-phase")
+}
+
+// TestService_LogsNonHostControlRejection pins that a non-host attempt to start
+// a room names the reason at Info, not just a bare 403 in the access log.
+func TestService_LogsNonHostControlRejection(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newLoggingHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const notHost int64 = 999
+	if err := h.service.Start(ctx, h.code, notHost); err == nil {
+		t.Fatal("Start by a non-host err = nil, want ErrNotHost")
+	}
+	attrs := assertLog(t, h.logs, "live session control rejected: not host", slog.LevelInfo)
+	assertStringAttr(t, attrs, "action", "start")
+	assertStringAttr(t, attrs, "joinCode", h.code)
+	assertInt64Attr(t, attrs, "player", notHost)
+	assertNoLog(t, h.logs, "live session started")
+}

--- a/internal/livesession/runner.go
+++ b/internal/livesession/runner.go
@@ -43,6 +43,22 @@ const (
 // under on every warning.
 const logSessionKey = "session"
 
+// slog attribute keys shared by the domain-layer log lines, so every
+// live-session log line names the same field the same way. logPhaseKey
+// matches the literal "phase" the runner already logs under.
+const (
+	logJoinCodeKey = "joinCode"
+	logPlayerKey   = "player"
+	logHostKey     = "host"
+	logQuizKey     = "quiz"
+	logPhaseKey    = "phase"
+	logQuestionKey = "question"
+	logOptionKey   = "option"
+	logReadyKey    = "ready"
+	logDeadlineKey = "deadline"
+	logReasonKey   = "reason"
+)
+
 // errNoQuiz guards the runner against driving a quiz-less room (#836). A room
 // created without a quiz stays in the empty lobby until the host arms one, so the
 // gameplay advance never runs without a quiz; this is the defensive error the


### PR DESCRIPTION
Closes #870

Adds structured, leveled logging to the live-session domain layer (`livesession.Service`, which held a logger it never used) so a live game night can be reconstructed from the server log.

- **Info** milestones: session created, hosting started (new room vs reused running/active room), quiz armed/started, start-now, start countdown armed/cancelled, session ended, player joined/left.
- **Debug** high-volume lines: answer accepted (question + option), ready toggled.
- **Expected rejections now name the reason** instead of a bare 4xx in the access log: join into a closed room, answer rejected (not-a-participant / wrong-phase / out-of-window / option-mismatch), non-host control attempts.

Shared slog attribute keys keep every line's fields consistent. Unexpected store errors are untouched (they already log via writeInternalError - no double-logging). New layer test (`logging_test.go`) drives a representative flow plus the rejection branches against a real DB and asserts the messages, levels, and fields. Coverage 83.0%.