### PR TITLE
Log authentication attempt outcomes

### DIFF
--- a/internal/auth/export_test.go
+++ b/internal/auth/export_test.go
@@ -2,8 +2,38 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+
+	"github.com/starquake/topbanana/internal/session"
 )
+
+// ExportFinalizeGoogleSignIn exposes finalizeGoogleSignIn so the success
+// tail of the OAuth callback (#872 sign-in log line) can be unit-tested
+// with a capturing logger and a real store, without staging the whole
+// OIDC dance. The collaborators that the log line does not touch (games,
+// admin allowlist, prior session, next) take their dormant zero values:
+// the empty allowlist means no promotion, nil games means no migration,
+// so the helper runs straight to the session-set + log line. players
+// doubles as the RoleSetter (the concrete store satisfies both).
+func ExportFinalizeGoogleSignIn(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	players interface {
+		PlayerStore
+		RoleSetter
+	},
+	sessions *session.Manager,
+	player *Player,
+) {
+	finalizeGoogleSignIn(w, r, googleSignInDeps{
+		logger:   logger,
+		players:  players,
+		roles:    players,
+		sessions: sessions,
+	}, player, nil, "")
+}
 
 // ExportLinkOrCreateGooglePlayer is the test-only alias for the
 // unexported find-or-link decision used by HandleGoogleCallback. Lets

--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -290,6 +290,9 @@ func finalizeGoogleSignIn(
 	)
 
 	deps.sessions.Set(w, player.ID, player.SessionVersion)
+	deps.logger.InfoContext(r.Context(), "google sign-in succeeded",
+		slog.Int64(logPlayerKey, player.ID),
+		slog.String(logEmailKey, player.Email))
 	migrateGamesAfterSignIn(r.Context(), deps.logger, deps.players, deps.games, sessionPlayerID, player.ID)
 	target := next
 	if target == "" {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -42,6 +42,32 @@ const (
 	playerLandingPath = "/"
 )
 
+// Structured-log attribute keys for the authentication-outcome lines
+// (#872). Each login attempt emits one line keyed on these so a host
+// reviewing the server log can tell why a player could not sign in.
+// Email appears here on purpose: this is the operator's private server
+// log, and it is what lets a host tell which player is stuck. The HTTP
+// response stays generic, so these keys must never be echoed back to a
+// caller (no enumeration regression).
+const (
+	logEmailKey  = "email"
+	logPlayerKey = "player"
+	logRoleKey   = "role"
+	logIPKey     = "ip"
+	logReasonKey = "reason"
+	logWaitKey   = "wait"
+)
+
+// Failure-reason values for the "login failed: invalid credentials"
+// line. Server-log only (see the attribute-key comment above): the HTTP
+// response is the same generic banner for all three, so surfacing this
+// distinction to the caller would reintroduce account enumeration.
+const (
+	reasonUnknownAccount = "unknown-account"
+	reasonNoPassword     = "no-password"
+	reasonWrongPassword  = "wrong-password"
+)
+
 // landingPathFor returns the post-auth redirect target for the given
 // role. Admins land on the quiz dashboard; everyone else lands on the
 // public home page, which is the only place a non-admin player has
@@ -547,7 +573,11 @@ func HandleLoginSubmit(
 		// blocks the bcrypt compare too, and so the limiter fires whether
 		// or not the submitted email exists - same shape the dummy-hash
 		// timing equalisation already gives the credential-check path.
-		if wait, allowed := deps.Limiter.Allow(deps.Limiter.ClientIP(r)); !allowed {
+		clientIP := deps.Limiter.ClientIP(r)
+		if wait, allowed := deps.Limiter.Allow(clientIP); !allowed {
+			logger.WarnContext(r.Context(), "login blocked: rate limited",
+				slog.String(logIPKey, clientIP),
+				slog.Duration(logWaitKey, wait))
 			renderLoginRateLimited(formCfg, w, r, email, wait)
 
 			return
@@ -588,6 +618,8 @@ func completeLogin(
 	// chance to land a correct guess mid-spray without ever signalling
 	// that the account is throttled or that it exists.
 	if registerAccountFailureIfCooledDown(deps.AccountLimiter, email) {
+		logger.WarnContext(r.Context(), "login blocked: account in cooldown",
+			slog.String(logEmailKey, email))
 		renderInvalidCredentials(formCfg, w, r, email)
 
 		return
@@ -604,6 +636,9 @@ func completeLogin(
 	// link best-effort. The banner names no address and does not confirm
 	// the password (#787).
 	if !player.IsEmailVerified() {
+		logger.InfoContext(r.Context(), "login blocked: email not verified",
+			slog.Int64(logPlayerKey, player.ID),
+			slog.String(logEmailKey, email))
 		renderUnverifiedLogin(logger, formCfg, deps, w, r, player, email)
 
 		return
@@ -614,6 +649,10 @@ func completeLogin(
 		priorSessionPlayerID = &id
 	}
 	deps.Sessions.Set(w, player.ID, player.SessionVersion)
+	logger.InfoContext(r.Context(), "login succeeded",
+		slog.Int64(logPlayerKey, player.ID),
+		slog.String(logEmailKey, player.Email),
+		slog.String(logRoleKey, player.Role))
 	migrateGamesAfterSignIn(r.Context(), logger, deps.Players, deps.Games, priorSessionPlayerID, player.ID)
 	redirectAfterLogin(w, r, player.Role)
 }
@@ -694,6 +733,9 @@ func authenticateLogin(
 			// cannot enumerate emails by response time.
 			_ = CheckPassword(creds.dummyHash(), creds.password)
 			recordAccountFailure(creds.accountLimiter, creds.email)
+			logger.InfoContext(r.Context(), "login failed: invalid credentials",
+				slog.String(logEmailKey, creds.email),
+				slog.String(logReasonKey, reasonUnknownAccount))
 			renderInvalidCredentials(cfg, w, r, creds.email)
 
 			return nil, false
@@ -709,6 +751,9 @@ func authenticateLogin(
 		// to keep timing consistent.
 		_ = CheckPassword(creds.dummyHash(), creds.password)
 		recordAccountFailure(creds.accountLimiter, creds.email)
+		logger.InfoContext(r.Context(), "login failed: invalid credentials",
+			slog.String(logEmailKey, creds.email),
+			slog.String(logReasonKey, reasonNoPassword))
 		renderInvalidCredentials(cfg, w, r, creds.email)
 
 		return nil, false
@@ -716,6 +761,9 @@ func authenticateLogin(
 
 	if err := CheckPassword(player.PasswordHash, creds.password); err != nil {
 		recordAccountFailure(creds.accountLimiter, creds.email)
+		logger.InfoContext(r.Context(), "login failed: invalid credentials",
+			slog.String(logEmailKey, creds.email),
+			slog.String(logReasonKey, reasonWrongPassword))
 		renderInvalidCredentials(cfg, w, r, creds.email)
 
 		return nil, false

--- a/internal/auth/logging_test.go
+++ b/internal/auth/logging_test.go
@@ -1,0 +1,300 @@
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/session"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// captureHandler is a slog.Handler that records every record at Debug+ so a
+// test can assert the auth layer emitted the expected login-outcome line
+// (#872) with the expected level and fields. Concurrency-safe so a handler
+// that logs from a background goroutine cannot race the assertion.
+type captureHandler struct {
+	mu      *sync.Mutex
+	records *[]slog.Record
+}
+
+func newCaptureHandler() captureHandler {
+	return captureHandler{mu: &sync.Mutex{}, records: &[]slog.Record{}}
+}
+
+func (captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, r.Clone())
+
+	return nil
+}
+
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h captureHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]slog.Record(nil), *h.records...)
+}
+
+// assertLog asserts that a record with msg was captured at level want, and
+// returns its attributes keyed by name so the caller can check fields.
+func (h captureHandler) assertLog(t *testing.T, msg string, want slog.Level) map[string]slog.Value {
+	t.Helper()
+
+	var rec slog.Record
+	found := false
+	var msgs []string
+	for _, r := range h.snapshot() {
+		msgs = append(msgs, r.Message)
+		if r.Message == msg {
+			rec = r
+			found = true
+
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no log record with message %q (captured: %v)", msg, msgs)
+	}
+	if got := rec.Level; got != want {
+		t.Errorf("log %q level = %v, want %v", msg, got, want)
+	}
+
+	attrs := make(map[string]slog.Value, rec.NumAttrs())
+	rec.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+
+		return true
+	})
+
+	return attrs
+}
+
+func assertStringAttr(t *testing.T, attrs map[string]slog.Value, key, want string) {
+	t.Helper()
+	if got := attrs[key].String(); got != want {
+		t.Errorf("attr %q = %q, want %q", key, got, want)
+	}
+}
+
+func assertInt64Attr(t *testing.T, attrs map[string]slog.Value, key string, want int64) {
+	t.Helper()
+	if got := attrs[key].Int64(); got != want {
+		t.Errorf("attr %q = %d, want %d", key, got, want)
+	}
+}
+
+// seedPassword is the known password every seedVerifiedPlayer row carries;
+// the login tests POST this to drive the correct-credentials paths.
+const seedPassword = "correctbattery"
+
+// seedVerifiedPlayer creates a verified player with the given role and the
+// known [seedPassword], returning the new row's id.
+func seedVerifiedPlayer(
+	t *testing.T, players *store.PlayerStore, displayName, email, role string,
+) int64 {
+	t.Helper()
+	hash, err := HashPassword(seedPassword)
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	p, err := players.CreatePlayer(t.Context(), displayName, email, hash, role)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	markVerified(t, players, displayName)
+
+	return p.ID
+}
+
+func TestHandleLoginSubmit_Logs_Success(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	id := seedVerifiedPlayer(t, players, "alice", "alice@example.test", RoleAdmin)
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+	postForm(t, handler, "/login", url.Values{
+		"email":    {"alice@example.test"},
+		"password": {seedPassword},
+	})
+
+	attrs := logs.assertLog(t, "login succeeded", slog.LevelInfo)
+	assertInt64Attr(t, attrs, "player", id)
+	assertStringAttr(t, attrs, "email", "alice@example.test")
+	assertStringAttr(t, attrs, "role", RoleAdmin)
+}
+
+func TestHandleLoginSubmit_Logs_UnknownAccount(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+	postForm(t, handler, "/login", url.Values{
+		"email":    {"ghost@example.test"},
+		"password": {"whatever-password"},
+	})
+
+	attrs := logs.assertLog(t, "login failed: invalid credentials", slog.LevelInfo)
+	assertStringAttr(t, attrs, "email", "ghost@example.test")
+	assertStringAttr(t, attrs, "reason", "unknown-account")
+}
+
+func TestHandleLoginSubmit_Logs_NoPassword(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	// A passwordless row (legacy seed admin): create anonymous then it has
+	// no password hash. CreateAnonymousPlayer leaves email empty, so claim
+	// the row with an email but a blank hash to model the no-password case.
+	if _, err := players.CreatePlayer(t.Context(), "nopass", "nopass@example.test", "", RolePlayer); err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	markVerified(t, players, "nopass")
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+	postForm(t, handler, "/login", url.Values{
+		"email":    {"nopass@example.test"},
+		"password": {"any-password"},
+	})
+
+	attrs := logs.assertLog(t, "login failed: invalid credentials", slog.LevelInfo)
+	assertStringAttr(t, attrs, "email", "nopass@example.test")
+	assertStringAttr(t, attrs, "reason", "no-password")
+}
+
+func TestHandleLoginSubmit_Logs_WrongPassword(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	seedVerifiedPlayer(t, players, "alice", "alice@example.test", RolePlayer)
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+	postForm(t, handler, "/login", url.Values{
+		"email":    {"alice@example.test"},
+		"password": {"wrong-password"},
+	})
+
+	attrs := logs.assertLog(t, "login failed: invalid credentials", slog.LevelInfo)
+	assertStringAttr(t, attrs, "email", "alice@example.test")
+	assertStringAttr(t, attrs, "reason", "wrong-password")
+}
+
+func TestHandleLoginSubmit_Logs_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+
+	// First POST primes the bucket; the second trips the per-IP limiter.
+	postForm(t, handler, "/login", url.Values{"email": {"a@example.test"}, "password": {"x"}})
+	postForm(t, handler, "/login", url.Values{"email": {"a@example.test"}, "password": {"x"}})
+
+	attrs := logs.assertLog(t, "login blocked: rate limited", slog.LevelWarn)
+	// httptest requests default to RemoteAddr 192.0.2.1:1234.
+	assertStringAttr(t, attrs, "ip", "192.0.2.1")
+	if got := attrs["wait"].Duration(); got <= 0 {
+		t.Errorf("attr %q = %v, want > 0", "wait", got)
+	}
+}
+
+func TestHandleLoginSubmit_Logs_AccountCooldown(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	seedVerifiedPlayer(t, players, "alice", "alice@example.test", RolePlayer)
+
+	logs := newCaptureHandler()
+	accountLimiter := NewAccountLoginLimiter(3, time.Minute)
+	handler := HandleLoginSubmit(slog.New(logs), nil, LoginDeps{
+		Players:        players,
+		Sessions:       session.New([]byte("k"), true),
+		Limiter:        NewLoginRateLimiter(0, nil),
+		AccountLimiter: accountLimiter,
+	})
+
+	// Trip the per-account cooldown, then a further attempt is blocked by it.
+	for range 3 {
+		postForm(t, handler, "/login", url.Values{
+			"email": {"alice@example.test"}, "password": {"wrong-password"},
+		})
+	}
+	postForm(t, handler, "/login", url.Values{
+		"email": {"alice@example.test"}, "password": {seedPassword},
+	})
+
+	attrs := logs.assertLog(t, "login blocked: account in cooldown", slog.LevelWarn)
+	assertStringAttr(t, attrs, "email", "alice@example.test")
+}
+
+func TestHandleLoginSubmit_Logs_EmailNotVerified(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	hash, err := HashPassword(seedPassword)
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	p, err := players.CreatePlayer(t.Context(), "alice", "alice@example.test", hash, RolePlayer)
+	if err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+	// Deliberately NOT verified.
+
+	logs := newCaptureHandler()
+	handler := HandleLoginSubmit(slog.New(logs), nil,
+		loginDeps(players, session.New([]byte("k"), true), NewLoginRateLimiter(time.Minute, nil)))
+	postForm(t, handler, "/login", url.Values{
+		"email":    {"alice@example.test"},
+		"password": {seedPassword},
+	})
+
+	attrs := logs.assertLog(t, "login blocked: email not verified", slog.LevelInfo)
+	assertInt64Attr(t, attrs, "player", p.ID)
+	assertStringAttr(t, attrs, "email", "alice@example.test")
+}
+
+func TestFinalizeGoogleSignIn_Logs_Success(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	id := seedVerifiedPlayer(t, players, "gopher", "gopher@example.test", RolePlayer)
+	player, err := players.GetPlayerByID(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetPlayerByID err = %v, want nil", err)
+	}
+
+	logs := newCaptureHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login/google/callback", nil)
+	ExportFinalizeGoogleSignIn(rec, req, slog.New(logs), players, session.New([]byte("k"), true), player)
+
+	attrs := logs.assertLog(t, "google sign-in succeeded", slog.LevelInfo)
+	assertInt64Attr(t, attrs, "player", id)
+	assertStringAttr(t, attrs, "email", "gopher@example.test")
+}


### PR DESCRIPTION
Closes #872

Follow-up to #870. Logs the outcome of each authentication attempt so a host can see why a player could not sign in. Server-side log lines only - the HTTP responses, anti-enumeration timing, and dummy-hash equalisation are unchanged.

- **Info** `login succeeded` (player, email, role) and **Info** `google sign-in succeeded`.
- **Info** `login failed: invalid credentials` with a `reason` (unknown-account / no-password / wrong-password).
- **Warn** `login blocked: rate limited` (ip, wait) and `login blocked: account in cooldown` (email).
- **Info** `login blocked: email not verified` (player, email).

Email is logged on purpose (operator's private server log; it is what lets a host tell which player is stuck) and is never echoed to a response. New `logging_test.go` asserts each outcome's message, level, and fields against a real store.