### PR TITLE
Arm and wait when picking a quiz after a finished game

### DIFF
--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -745,11 +745,10 @@ func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, 
 // room per host (#851). It backs the quiz-view "Host live" control:
 //   - No active room -> open a new lobby armed with the quiz (host starts it
 //     when players are in), same as the prior "Play live".
-//   - Active empty staging lobby -> arm the quiz in it but stay in the lobby
-//     (reusing ArmQuiz), so the host gathers players and presses Start, the same
-//     as the no-active-room case (#863). No second room is spawned.
-//   - Active between-games intermission -> arm AND start the next game (reusing
-//     StartQuiz), the #836 between-games flow.
+//   - Active empty staging lobby OR between-games intermission -> arm the quiz
+//     in it but stay in the lobby (reusing ArmQuiz), so the host gathers players
+//     and presses Start, the same as the no-active-room case (#863, #875). No
+//     second room is spawned, and the post-game pick never auto-starts.
 //   - Active room with a game in flight -> leave it untouched and return it, so
 //     a stray pick never disrupts a running game (the end-and-restart confirm
 //     is deferred to #853).
@@ -791,16 +790,12 @@ func (s *Service) StartHosting(ctx context.Context, quizID, hostPlayerID int64) 
 	}
 
 	// An empty staging lobby and the between-games intermission both take a new
-	// quiz without spawning a second room, but they differ (#863): the empty
-	// lobby ARMS the quiz and stays in the lobby so the host gathers players and
-	// presses Start (matching the no-active-session case, which also lands on an
-	// armed lobby), while the intermission arms AND starts the next game (the
-	// #836 between-games flow). canArmQuiz guarantees active is one of these two.
-	if active.Phase == PhaseLobby {
-		err = s.ArmQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
-	} else {
-		err = s.StartQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
-	}
+	// quiz without spawning a second room, and both arm it and stay in the lobby
+	// so the host gathers players and presses Start (#875), matching the
+	// no-active-session case which also lands on an armed lobby. canArmQuiz
+	// guarantees active is one of these two; ArmQuiz handles both - RearmSession
+	// re-arms an intermission room back to an armed lobby with started_at cleared.
+	err = s.ArmQuiz(ctx, active.JoinCode, hostPlayerID, quizID)
 	switch {
 	case err == nil, errors.Is(err, ErrGameInFlight):
 		// ErrGameInFlight means the room raced into flight between the read above

--- a/internal/livesession/runner_test.go
+++ b/internal/livesession/runner_test.go
@@ -1210,6 +1210,80 @@ func TestRunner_RearmRunsNextGameWithResetScores(t *testing.T) {
 	}
 }
 
+// TestService_StartHosting_IntermissionArmsAndWaits pins StartHosting from the
+// between-games intermission (#875): after game 1 ends, the host picking a SECOND
+// quiz arms it and the room returns to the lobby WAITING - it must NOT auto-start
+// into game 2's first question. The host then presses Start, and only then does
+// game 2 run. This is the gap the bug shipped through: the intermission pick used
+// to arm-and-start, dropping still-joined players straight into round 1.
+func TestService_StartHosting_IntermissionArmsAndWaits(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newRunnerHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	game2 := seedRunnerQuizSlug(t, store.NewQuizStore(h.db, slog.New(slog.DiscardHandler)),
+		"start-hosting-intermission-g2", [][]bool{{true}})
+
+	// Play game 1 to its end-of-game intermission.
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (game 1) err = %v, want nil", err)
+	}
+	h.playSingleQuestionGame(t, []int64{h.players[0]})
+	if got, want := h.phase(t), PhaseIntermission; got != want {
+		t.Fatalf("phase after game 1 = %q, want %q", got, want)
+	}
+
+	// The host picks a second quiz from the intermission. StartHosting must ARM it
+	// and stay in the lobby, not start it.
+	if _, err := h.service.StartHosting(ctx, game2.ID, hostID); err != nil {
+		t.Fatalf("StartHosting (from intermission) err = %v, want nil", err)
+	}
+
+	armed := h.reload(t)
+	if armed.QuizID == nil {
+		t.Fatalf("armed QuizID = nil, want %d (game 2)", game2.ID)
+	}
+	if got, want := *armed.QuizID, game2.ID; got != want {
+		t.Errorf("armed QuizID = %d, want %d (game 2)", got, want)
+	}
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Errorf("armed Phase = %q, want %q (armed but waiting in the lobby, not auto-started)", got, want)
+	}
+	if armed.StartedAt != nil {
+		t.Errorf("armed StartedAt = %v, want nil (must not auto-start the picked quiz)", armed.StartedAt)
+	}
+
+	// A defensive tick must not advance the waiting lobby into a question on its
+	// own: the game waits for the host.
+	h.tick(ctx)
+	if got, want := h.phase(t), PhaseLobby; got != want {
+		t.Fatalf("phase after a tick = %q, want %q (still waiting on the host)", got, want)
+	}
+
+	// The host presses Start; only now does game 2 run, reaching its first question.
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (game 2) err = %v, want nil", err)
+	}
+	if got, want := h.phase(t), PhaseRoundIntro; got != want {
+		t.Fatalf("phase after host Start = %q, want %q (game 2 driving)", got, want)
+	}
+	h.clock.advance(runnerCfg.RoundIntroBeat)
+	h.tick(ctx)
+	q := h.reload(t)
+	if got, want := q.Phase, PhaseQuestion; got != want {
+		t.Fatalf("phase after intro beat = %q, want %q (game 2's first question)", got, want)
+	}
+	if q.CurrentQuestionID == nil {
+		t.Error("game 2 first question CurrentQuestionID = nil, want it set")
+	}
+	if got, want := q.GameSeq, int64(2); got != want {
+		t.Errorf("GameSeq for game 2 = %d, want %d", got, want)
+	}
+}
+
 // TestRunner_RearmSameQuizResetsScores pins that re-arming onto the SAME quiz
 // still resets scores per game (#836): a player who scored in game 1 starts
 // game 2 at zero, because the new game_seq scopes the standings to game 2's


### PR DESCRIPTION
Closes #875

After hosting a quiz to the end, picking another quiz started it immediately instead of arming and waiting in the lobby - the still-joined players were dropped straight into the first question.

Cause: when a game finishes, the runner moves the room to the between-games intermission (not a fresh lobby), and `StartHosting` routed the intermission pick to `StartQuiz` (arm AND start), while the empty-lobby pick used `ArmQuiz` (arm and wait). 

Fix: `StartHosting` now always arms-and-waits for a reused room - both the empty staging lobby and the between-games intermission go through `ArmQuiz`, so picking a quiz never auto-starts. The host presses Start when ready, the same as the first quiz. Game 2 still runs correctly on Start: `Runner.Rearm` is `forget + Begin` and the runner already forgets the room at intermission, so the normal `Start` -> `Begin` path drives the next game.

New layer test `TestService_StartHosting_IntermissionArmsAndWaits` pins it: after game 1 finishes, picking game 2 leaves the room armed in the lobby (Phase=lobby, StartedAt=nil), a stray runner tick does not auto-advance it, and only the host's Start runs game 2.

Scope: the UI-orphaned `/host/{code}/next-quiz` endpoint (test-harness only since #851) is left as-is. Full `make check` green; `make test-e2e` clean apart from a pre-existing load flake filed as #878 (passes in isolation on both browsers).