### PR TITLE
Harden the host-armed-start e2e against load

### DIFF
--- a/test/e2e/tests/host-armed-start.spec.ts
+++ b/test/e2e/tests/host-armed-start.spec.ts
@@ -74,8 +74,11 @@ test.describe('host-armed last-call countdown', () => {
 
     // The countdown fires (SESSION_START_COUNTDOWN=2s): the runner starts the
     // game, so the player leaves the lobby into the round intro / first
-    // question and the host TV countdown controls disappear.
-    await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
+    // question and the host TV countdown controls disappear. Wait on the
+    // positive arrival of the player's question view rather than the lobby's
+    // disappearance; SSE state propagation can exceed a tight budget under
+    // full-suite load.
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 25_000 });
     await expect(host.getByTestId('start-countdown')).toBeHidden();
   });
 
@@ -90,9 +93,12 @@ test.describe('host-armed last-call countdown', () => {
     await host.getByTestId('arm-start').click();
     await expect(page.getByTestId('start-countdown')).toContainText('Starting in');
 
-    // Start now skips the rest of the countdown; the game begins at once.
+    // Start now skips the rest of the countdown; the game begins at once. Wait
+    // on the player's question view appearing rather than the lobby's
+    // disappearance, so SSE state propagation under full-suite load does not
+    // race a tight budget.
     await host.getByTestId('skip-start').click();
-    await expect(page.getByTestId('lobby-view')).toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 25_000 });
   });
 
   test('Cancel stops the countdown and the game stays in the lobby', async ({ page, hostSessions }) => {


### PR DESCRIPTION
Closes #878

The two start-success assertions in host-armed-start.spec.ts waited on the player lobby reaching count 0 with a 15s budget. Under full-suite load the start transition plus SSE state propagation can exceed that, so lobby-view was still present when the assertion timed out.

Replace the lobby count-0 wait with a positive post-start signal: the player question-view becoming visible (timeout 25s), the same signal session-first.spec.ts uses after start. Applied to both occurrences (auto-start at zero and start-now skip). Host-side assertions are unchanged. Test-only change.