### PR TITLE
Add tests for multi-quiz live session re-arm and sequential games

### DIFF
--- a/internal/livesession/empty_room_test.go
+++ b/internal/livesession/empty_room_test.go
@@ -3,6 +3,7 @@ package livesession_test
 import (
 	"errors"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,9 +21,10 @@ import (
 // drives straight into the first round, but the tests assert through the service
 // and store rather than stepping the runner clock directly.
 type emptyRoomHarness struct {
-	service   *Service
-	store     *store.LiveSessionStore
-	quizStore *store.QuizStore
+	service     *Service
+	store       *store.LiveSessionStore
+	quizStore   *store.QuizStore
+	playerStore *store.PlayerStore
 }
 
 // newEmptyRoomHarness builds the service/runner over real stores with a fake
@@ -34,6 +36,7 @@ func newEmptyRoomHarness(t *testing.T, start time.Time) *emptyRoomHarness {
 	logger := slog.New(slog.DiscardHandler)
 	quizStore := store.NewQuizStore(db, logger)
 	sessionStore := store.NewLiveSessionStore(db, logger)
+	playerStore := store.NewPlayerStore(db, logger)
 
 	service := NewService(sessionStore, quizStore, logger)
 	hub := NewHub()
@@ -45,10 +48,45 @@ func newEmptyRoomHarness(t *testing.T, start time.Time) *emptyRoomHarness {
 	service.SetAdvancer(runner)
 
 	return &emptyRoomHarness{
-		service:   service,
-		store:     sessionStore,
-		quizStore: quizStore,
+		service:     service,
+		store:       sessionStore,
+		quizStore:   quizStore,
+		playerStore: playerStore,
 	}
+}
+
+// joinNewPlayer creates a fresh anonymous player and joins them to the room,
+// returning the new player id. The empty-room tests build a roster ad-hoc to
+// check it survives a re-arm.
+func (h *emptyRoomHarness) joinNewPlayer(t *testing.T, joinCode, name string) int64 {
+	t.Helper()
+	ctx := t.Context()
+	p, err := h.playerStore.CreateAnonymousPlayer(ctx, name)
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+	if _, err = h.service.Join(ctx, joinCode, p.ID); err != nil {
+		t.Fatalf("Join err = %v, want nil", err)
+	}
+
+	return p.ID
+}
+
+// rosterIDs returns the active roster player ids for the room, sorted ascending,
+// so a test can assert the roster carried across a re-arm unchanged.
+func (h *emptyRoomHarness) rosterIDs(t *testing.T, sessionID string) []int64 {
+	t.Helper()
+	sess, err := h.store.GetSessionByID(t.Context(), sessionID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	ids := make([]int64, 0, len(sess.Players))
+	for _, p := range sess.Players {
+		ids = append(ids, p.PlayerID)
+	}
+	slices.Sort(ids)
+
+	return ids
 }
 
 // TestService_CreateEmptyRoom pins that a host can open a room with no quiz
@@ -468,5 +506,74 @@ func TestService_GetActiveSessionForHost(t *testing.T) {
 	}
 	if gone != nil {
 		t.Errorf("active session after finish = %v, want nil", gone)
+	}
+}
+
+// TestService_StartHosting_RearmBeforeStartFromEmptyLobby pins re-arming before
+// start (#877): from an empty staging lobby with players already in, the host
+// arms quiz A, then changes their mind to B, then to C - all before pressing
+// Start. The room must end up armed on the LAST pick (C), still in the lobby and
+// not started, with no second room spawned and the roster carried across every
+// re-arm. StartHosting -> ArmQuiz -> armRoomForHost -> RearmSession is idempotent
+// and always reflects the latest quiz id.
+func TestService_StartHosting_RearmBeforeStartFromEmptyLobby(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+	h := newEmptyRoomHarness(t, start)
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	empty, err := h.service.CreateSession(ctx, nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession (empty) err = %v, want nil", err)
+	}
+	p1 := h.joinNewPlayer(t, empty.JoinCode, "rearm-empty-a")
+	p2 := h.joinNewPlayer(t, empty.JoinCode, "rearm-empty-b")
+	wantRoster := []int64{p1, p2}
+	slices.Sort(wantRoster)
+
+	quizA := seedRunnerQuizSlug(t, h.quizStore, "rearm-empty-a", [][]bool{{true}})
+	quizB := seedRunnerQuizSlug(t, h.quizStore, "rearm-empty-b", [][]bool{{true}})
+	quizC := seedRunnerQuizSlug(t, h.quizStore, "rearm-empty-c", [][]bool{{true}})
+
+	// The host arms A, then changes the pick to B, then to C, all before Start.
+	for _, qz := range []*quiz.Quiz{quizA, quizB, quizC} {
+		sess, hostErr := h.service.StartHosting(ctx, qz.ID, hostID)
+		if hostErr != nil {
+			t.Fatalf("StartHosting (arm %s) err = %v, want nil", qz.Slug, hostErr)
+		}
+		// No second room spawned: every pick reuses the one empty room.
+		if got, want := sess.ID, empty.ID; got != want {
+			t.Fatalf("StartHosting room ID = %q, want %q (same room, no second spawned)", got, want)
+		}
+	}
+
+	armed, err := h.store.GetSessionByID(ctx, empty.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	// Armed on the LAST pick (C), not A or B: re-arm reflects the latest quiz id.
+	if armed.QuizID == nil {
+		t.Fatalf("armed QuizID = nil, want %d (last pick C)", quizC.ID)
+	}
+	if got, want := *armed.QuizID, quizC.ID; got != want {
+		t.Errorf("armed QuizID = %d, want %d (last pick C, not A or B)", got, want)
+	}
+	// Still waiting in the lobby, not started: changing the pick never starts.
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Errorf("armed Phase = %q, want %q (armed but waiting in the lobby)", got, want)
+	}
+	if armed.StartedAt != nil {
+		t.Errorf("armed StartedAt = %v, want nil (re-arming must not start the game)", armed.StartedAt)
+	}
+	// The first game from an empty lobby never bumps game_seq, and re-arming from
+	// the lobby (not intermission) keeps it, so three lobby picks stay at 1.
+	if got, want := armed.GameSeq, int64(1); got != want {
+		t.Errorf("armed GameSeq = %d, want %d (lobby re-arms do not bump)", got, want)
+	}
+	// The roster is carried across every re-arm: nobody is dropped.
+	if got := h.rosterIDs(t, empty.ID); !slices.Equal(got, wantRoster) {
+		t.Errorf("roster after re-arms = %v, want %v (roster intact)", got, wantRoster)
 	}
 }

--- a/internal/livesession/runner_test.go
+++ b/internal/livesession/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -252,6 +253,20 @@ func (h *runnerHarness) phase(t *testing.T) Phase {
 	t.Helper()
 
 	return h.reload(t).Phase
+}
+
+// rosterIDs returns the active roster player ids for the room, sorted ascending,
+// so a multi-game test can assert the roster carried across a re-arm unchanged.
+func (h *runnerHarness) rosterIDs(t *testing.T) []int64 {
+	t.Helper()
+	sess := h.reload(t)
+	ids := make([]int64, 0, len(sess.Players))
+	for _, p := range sess.Players {
+		ids = append(ids, p.PlayerID)
+	}
+	slices.Sort(ids)
+
+	return ids
 }
 
 // TestRunner_FullFlow drives a two-round session (two questions, then one)
@@ -1281,6 +1296,209 @@ func TestService_StartHosting_IntermissionArmsAndWaits(t *testing.T) {
 	}
 	if got, want := q.GameSeq, int64(2); got != want {
 		t.Errorf("GameSeq for game 2 = %d, want %d", got, want)
+	}
+}
+
+// TestService_StartHosting_RearmBeforeStartFromIntermission pins re-arming
+// before start from the between-games intermission (#877): after game 1 ends, the
+// host picks quiz B, then changes their mind to C - both before pressing Start.
+// The room must end up armed on the LAST pick (C), waiting in the lobby and not
+// started, with the roster carried across. game_seq bumps once (the first
+// intermission re-arm) and then holds across the second lobby re-arm, so it does
+// not skip a number per change of mind.
+func TestService_StartHosting_RearmBeforeStartFromIntermission(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newRunnerHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+
+	const hostID int64 = 1
+	quizStore := store.NewQuizStore(h.db, slog.New(slog.DiscardHandler))
+	quizB := seedRunnerQuizSlug(t, quizStore, "rearm-intermission-b", [][]bool{{true}})
+	quizC := seedRunnerQuizSlug(t, quizStore, "rearm-intermission-c", [][]bool{{true}})
+
+	wantRoster := slices.Clone(h.players)
+	slices.Sort(wantRoster)
+
+	// Play game 1 to its end-of-game intermission.
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (game 1) err = %v, want nil", err)
+	}
+	h.playSingleQuestionGame(t, []int64{h.players[0]})
+	if got, want := h.phase(t), PhaseIntermission; got != want {
+		t.Fatalf("phase after game 1 = %q, want %q", got, want)
+	}
+
+	// The host picks B from the intermission, then changes to C - both before Start.
+	for _, qz := range []*quiz.Quiz{quizB, quizC} {
+		if _, err := h.service.StartHosting(ctx, qz.ID, hostID); err != nil {
+			t.Fatalf("StartHosting (arm %s) err = %v, want nil", qz.Slug, err)
+		}
+	}
+
+	armed := h.reload(t)
+	// Armed on the LAST pick (C), not B: re-arm reflects the latest quiz id.
+	if armed.QuizID == nil {
+		t.Fatalf("armed QuizID = nil, want %d (last pick C)", quizC.ID)
+	}
+	if got, want := *armed.QuizID, quizC.ID; got != want {
+		t.Errorf("armed QuizID = %d, want %d (last pick C, not B)", got, want)
+	}
+	// Waiting in the lobby, not started: changing the pick never auto-starts.
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Errorf("armed Phase = %q, want %q (armed but waiting in the lobby)", got, want)
+	}
+	if armed.StartedAt != nil {
+		t.Errorf("armed StartedAt = %v, want nil (re-arming must not start the game)", armed.StartedAt)
+	}
+	// game_seq bumped once at the first intermission re-arm and then held across
+	// the second lobby re-arm, so two picks land on game 2, not game 3.
+	if got, want := armed.GameSeq, int64(2); got != want {
+		t.Errorf("armed GameSeq = %d, want %d (one bump at intermission, lobby re-arm holds)", got, want)
+	}
+	// The roster carried across both re-arms: nobody was forced to re-join.
+	if got := h.rosterIDs(t); !slices.Equal(got, wantRoster) {
+		t.Errorf("roster after re-arms = %v, want %v (roster intact)", got, wantRoster)
+	}
+
+	// A defensive tick must not advance the waiting lobby on its own.
+	h.tick(ctx)
+	if got, want := h.phase(t), PhaseLobby; got != want {
+		t.Fatalf("phase after a tick = %q, want %q (still waiting on the host)", got, want)
+	}
+
+	// The host presses Start; only now does the last-picked game (C) run.
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (game 2) err = %v, want nil", err)
+	}
+	if got, want := h.phase(t), PhaseRoundIntro; got != want {
+		t.Fatalf("phase after host Start = %q, want %q (game 2 driving)", got, want)
+	}
+}
+
+// TestRunner_ThreeGamesBackToBack pins the multi-quiz marathon (#877): three
+// distinct quizzes run back-to-back in one room. Per game it asserts the roster
+// carries across (players are never forced to re-join), live scores are
+// per-session and scoped to the game (a player who scored in game A starts game B
+// at zero), standings render for each game, and no per-game runner state bleeds
+// across (current question/round cleared between games). A different player
+// scores each game so the standings cannot accidentally pass by carrying a stale
+// total.
+func TestRunner_ThreeGamesBackToBack(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newRunnerHarness(t, start, [][]bool{{true}})
+	ctx := t.Context()
+	alice, bob := h.players[0], h.players[1]
+
+	const hostID int64 = 1
+	quizStore := store.NewQuizStore(h.db, slog.New(slog.DiscardHandler))
+	gameB := seedRunnerQuizSlug(t, quizStore, "marathon-b", [][]bool{{true}})
+	gameC := seedRunnerQuizSlug(t, quizStore, "marathon-c", [][]bool{{true}})
+
+	wantRoster := slices.Clone(h.players)
+	slices.Sort(wantRoster)
+
+	// Game A: alice scores, bob does not.
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (game A) err = %v, want nil", err)
+	}
+	if got, want := h.reload(t).GameSeq, int64(1); got != want {
+		t.Fatalf("game A GameSeq = %d, want %d", got, want)
+	}
+	aStandings := h.playSingleQuestionGame(t, []int64{alice})
+	assertWinnerScoredLoserZero(t, aStandings, alice, bob, "A")
+	if got := h.rosterIDs(t); !slices.Equal(got, wantRoster) {
+		t.Errorf("game A roster = %v, want %v (roster intact)", got, wantRoster)
+	}
+
+	// Arm + start game B (a different quiz). armNextGame pins that the re-arm
+	// cleared every per-game runner column before Start, so the room enters game B
+	// with no stale question/round.
+	armNextGame(t, h, hostID, gameB.ID)
+	if got, want := h.reload(t).GameSeq, int64(2); got != want {
+		t.Errorf("game B GameSeq = %d, want %d", got, want)
+	}
+
+	// Game B: bob scores, alice does not. alice must start B at zero (per-game
+	// scope), inverting game A - proof game A's points did not carry over.
+	bStandings := h.playSingleQuestionGame(t, []int64{bob})
+	assertWinnerScoredLoserZero(t, bStandings, bob, alice, "B")
+	if got := h.rosterIDs(t); !slices.Equal(got, wantRoster) {
+		t.Errorf("game B roster = %v, want %v (roster intact)", got, wantRoster)
+	}
+
+	// Arm + start game C (a third quiz).
+	armNextGame(t, h, hostID, gameC.ID)
+	if got, want := h.reload(t).GameSeq, int64(3); got != want {
+		t.Errorf("game C GameSeq = %d, want %d", got, want)
+	}
+
+	// Game C: alice scores again; her game-C total reflects only game C, never
+	// the sum of games A and C.
+	cStandings := h.playSingleQuestionGame(t, []int64{alice})
+	assertWinnerScoredLoserZero(t, cStandings, alice, bob, "C")
+	if got := h.rosterIDs(t); !slices.Equal(got, wantRoster) {
+		t.Errorf("game C roster = %v, want %v (roster intact)", got, wantRoster)
+	}
+
+	// alice scored the same single correct answer in games A and C; the per-game
+	// scope means her game-C total equals her game-A total, not double it.
+	if got, want := findRunnerStanding(t, cStandings, alice).TotalScore,
+		findRunnerStanding(t, aStandings, alice).TotalScore; got != want {
+		t.Errorf("game C alice TotalScore = %d, want %d (per-game scope, no A+C sum)", got, want)
+	}
+}
+
+// armNextGame arms quizID from the between-games intermission and presses Start,
+// driving the room into the next game's first round_intro. It pins the
+// arm-then-start handoff the marathon test repeats per game, and that the re-arm
+// cleared the previous game's per-game runner state (current round/question)
+// before the new game starts.
+func armNextGame(t *testing.T, h *runnerHarness, hostID, quizID int64) {
+	t.Helper()
+	ctx := t.Context()
+	if got, want := h.phase(t), PhaseIntermission; got != want {
+		t.Fatalf("phase before arming next game = %q, want %q", got, want)
+	}
+	if _, err := h.service.StartHosting(ctx, quizID, hostID); err != nil {
+		t.Fatalf("StartHosting (arm next game) err = %v, want nil", err)
+	}
+	armed := h.reload(t)
+	if got, want := armed.Phase, PhaseLobby; got != want {
+		t.Fatalf("phase after arm = %q, want %q (armed, waiting on Start)", got, want)
+	}
+	// The re-arm cleared the finished game's per-game runner columns, so the next
+	// game starts with no stale question/round bleeding in.
+	if armed.CurrentQuestionID != nil {
+		t.Errorf("armed CurrentQuestionID = %v, want nil (cleared between games)", *armed.CurrentQuestionID)
+	}
+	if armed.CurrentRoundID != nil {
+		t.Errorf("armed CurrentRoundID = %v, want nil (cleared between games)", *armed.CurrentRoundID)
+	}
+	if err := h.service.Start(ctx, h.code, hostID); err != nil {
+		t.Fatalf("Start (next game) err = %v, want nil", err)
+	}
+	if got, want := h.phase(t), PhaseRoundIntro; got != want {
+		t.Fatalf("phase after Start = %q, want %q (next game driving)", got, want)
+	}
+}
+
+// assertWinnerScoredLoserZero pins a single-question game's standings: the winner
+// has a positive total and the loser zero, with both present so the standings
+// render for the whole roster. label names the game in failures.
+func assertWinnerScoredLoserZero(t *testing.T, standings []*Standing, winner, loser int64, label string) {
+	t.Helper()
+	if got, want := len(standings), 2; got != want {
+		t.Fatalf("game %s standings count = %d, want %d (both players ranked)", label, got, want)
+	}
+	if got := findRunnerStanding(t, standings, winner).TotalScore; got <= 0 {
+		t.Errorf("game %s winner TotalScore = %d, want > 0", label, got)
+	}
+	if got, want := findRunnerStanding(t, standings, loser).TotalScore, 0; got != want {
+		t.Errorf("game %s loser TotalScore = %d, want %d (no cross-game carryover)", label, got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #877

Adds layer tests for two thinly-covered multi-quiz live-session paths (test-only; no production change was needed - no bug surfaced).

- Re-arm before starting: from an empty staging lobby and from a between-games intermission, the host arms one quiz then changes the pick twice before Start. The room ends up armed on the last pick, still in the lobby, not started, no second room spawned, and the roster carried across every re-arm. game_seq stays put for lobby re-arms and bumps once at the intermission transition.
- Three games back-to-back in one room: each game asserts the roster carries across, the per-game runner state (current question/round) is cleared between games, standings render for the whole roster, and live scores are per-session - a player who scored in an earlier game starts the next at zero and a re-score does not sum across games.

Reuses the existing runner/empty-room harnesses and helpers (playSingleQuestionGame, StartHosting/Start/ArmQuiz).