### PR TITLE
Add a request-scoped logger carried in context

### DIFF
--- a/internal/auth/logging_test.go
+++ b/internal/auth/logging_test.go
@@ -20,9 +20,15 @@ import (
 // test can assert the auth layer emitted the expected login-outcome line
 // (#872) with the expected level and fields. Concurrency-safe so a handler
 // that logs from a background goroutine cannot race the assertion.
+//
+// WithAttrs accumulates the bound attrs and Handle merges them onto each
+// record, so a logger derived via slog.With surfaces its bound fields here:
+// slog.With binds attrs at the handler level (WithAttrs), not on the Record,
+// so returning the receiver unchanged would silently drop them.
 type captureHandler struct {
 	mu      *sync.Mutex
 	records *[]slog.Record
+	attrs   []slog.Attr
 }
 
 func newCaptureHandler() captureHandler {
@@ -32,15 +38,23 @@ func newCaptureHandler() captureHandler {
 func (captureHandler) Enabled(context.Context, slog.Level) bool { return true }
 
 func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := r.Clone()
+	rec.AddAttrs(h.attrs...)
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	*h.records = append(*h.records, r.Clone())
+	*h.records = append(*h.records, rec)
 
 	return nil
 }
 
-func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+func (h captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.attrs = append(append([]slog.Attr(nil), h.attrs...), attrs...)
+
+	return h
+}
+
+func (h captureHandler) WithGroup(string) slog.Handler { return h }
 
 func (h captureHandler) snapshot() []slog.Record {
 	h.mu.Lock()
@@ -297,4 +311,19 @@ func TestFinalizeGoogleSignIn_Logs_Success(t *testing.T) {
 	attrs := logs.assertLog(t, "google sign-in succeeded", slog.LevelInfo)
 	assertInt64Attr(t, attrs, "player", id)
 	assertStringAttr(t, attrs, "email", "gopher@example.test")
+}
+
+// TestCaptureHandler_SurfacesWithBoundAttrs pins that the capture handler
+// honours WithAttrs, so a logger derived via slog.With carries its bound
+// field through to the asserted record. Without the fix this fails: a no-op
+// WithAttrs drops the bound field. Guards future slog.With use in this layer.
+func TestCaptureHandler_SurfacesWithBoundAttrs(t *testing.T) {
+	t.Parallel()
+
+	logs := newCaptureHandler()
+	logger := slog.New(logs).With(slog.String("email", "bound@example.test"))
+	logger.Info("bound line")
+
+	attrs := logs.assertLog(t, "bound line", slog.LevelInfo)
+	assertStringAttr(t, attrs, "email", "bound@example.test")
 }

--- a/internal/clientapi/sessions.go
+++ b/internal/clientapi/sessions.go
@@ -25,7 +25,7 @@ import (
 // A non-existent quiz and a solo quiz both map to 404 so the endpoint does
 // not betray which quizzes exist or their mode to a host probing ids - it
 // stays a "no hostable quiz here" answer either way.
-func HandleSessionCreate(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionCreate(service *livesession.Service) http.Handler {
 	type createRequest struct {
 		QuizID *int64 `json:"quizId"`
 	}
@@ -35,6 +35,7 @@ func HandleSessionCreate(logger *slog.Logger, service *livesession.Service) http
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -43,6 +44,7 @@ func HandleSessionCreate(logger *slog.Logger, service *livesession.Service) http
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 		// Host gate (decision 4): only host/admin can open a session. A
 		// signed-in Player gets a 403 - the create endpoint's existence is
 		// not secret, unlike the admin surface.
@@ -85,7 +87,7 @@ func HandleSessionCreate(logger *slog.Logger, service *livesession.Service) http
 // 404 when the join code is unknown and 409 when the room is closed - a
 // terminally finished room rejects joins, but a latecomer may join a live game
 // at any phase (#836).
-func HandleSessionJoin(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionJoin(service *livesession.Service) http.Handler {
 	type joinResponse struct {
 		DisplayName string `json:"displayName"`
 		IsReady     bool   `json:"isReady"`
@@ -93,6 +95,7 @@ func HandleSessionJoin(logger *slog.Logger, service *livesession.Service) http.H
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -101,6 +104,7 @@ func HandleSessionJoin(logger *slog.Logger, service *livesession.Service) http.H
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		joined, err := service.Join(ctx, r.PathValue("code"), player.ID)
 		if err != nil {
@@ -127,13 +131,14 @@ func HandleSessionJoin(logger *slog.Logger, service *livesession.Service) http.H
 // carries the desired state so the same endpoint marks ready and un-ready.
 // Returns 404 for an unknown code or a non-participant (the code stays
 // opaque to outsiders, mirroring the game participant gate, #272).
-func HandleSessionReady(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionReady(service *livesession.Service) http.Handler {
 	type readyRequest struct {
 		Ready bool `json:"ready"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -142,6 +147,7 @@ func HandleSessionReady(logger *slog.Logger, service *livesession.Service) http.
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		req, err := handlers.DecodeJSON[readyRequest](w, r)
 		if err != nil {
@@ -174,13 +180,13 @@ func HandleSessionReady(logger *slog.Logger, service *livesession.Service) http.
 // already-started game for start, an already-left lobby for arm/cancel) that
 // maps to a 204 no-op; what names the action in the log messages.
 func hostSessionAction(
-	logger *slog.Logger,
 	what string,
 	idempotent error,
 	action func(ctx context.Context, code string, playerID int64) error,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -189,6 +195,7 @@ func hostSessionAction(
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		err := action(ctx, r.PathValue("code"), player.ID)
 		switch {
@@ -209,8 +216,8 @@ func hostSessionAction(
 // it. Returns 204 on success, 403 when the caller is not the host, 404 for an
 // unknown code, and 204 (idempotent no-op) when the session has already
 // started.
-func HandleSessionStart(logger *slog.Logger, service *livesession.Service) http.Handler {
-	return hostSessionAction(logger, "start", livesession.ErrSessionAlreadyStarted, service.Start)
+func HandleSessionStart(service *livesession.Service) http.Handler {
+	return hostSessionAction("start", livesession.ErrSessionAlreadyStarted, service.Start)
 }
 
 // HandleSessionArmStart arms the host's last-call countdown (the "Start in 60s"
@@ -218,8 +225,8 @@ func HandleSessionStart(logger *slog.Logger, service *livesession.Service) http.
 // Only the host may call it. Returns 204 on success, 403 when the caller is not
 // the host, 404 for an unknown code, and 204 (idempotent no-op) when the
 // session has already left the lobby.
-func HandleSessionArmStart(logger *slog.Logger, service *livesession.Service) http.Handler {
-	return hostSessionAction(logger, "arm-start", livesession.ErrNotInLobby,
+func HandleSessionArmStart(service *livesession.Service) http.Handler {
+	return hostSessionAction("arm-start", livesession.ErrNotInLobby,
 		func(ctx context.Context, code string, playerID int64) error {
 			return service.ArmStart(ctx, code, playerID, time.Now().UTC())
 		})
@@ -230,8 +237,8 @@ func HandleSessionArmStart(logger *slog.Logger, service *livesession.Service) ht
 // Returns 204 on success, 403 when the caller is not the host, 404 for an
 // unknown code, and 204 (idempotent no-op) when the session has already left
 // the lobby.
-func HandleSessionCancelStart(logger *slog.Logger, service *livesession.Service) http.Handler {
-	return hostSessionAction(logger, "cancel-start", livesession.ErrNotInLobby, service.CancelStart)
+func HandleSessionCancelStart(service *livesession.Service) http.Handler {
+	return hostSessionAction("cancel-start", livesession.ErrNotInLobby, service.CancelStart)
 }
 
 // HandleSessionAnswer records the calling participant's pick for the session's
@@ -240,13 +247,14 @@ func HandleSessionCancelStart(logger *slog.Logger, service *livesession.Service)
 // 204 on success, 404 for an unknown code or a non-participant (the code stays
 // opaque to outsiders), and 409 when no question is currently open for
 // answers.
-func HandleSessionAnswer(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionAnswer(service *livesession.Service) http.Handler {
 	type answerRequest struct {
 		OptionID int64 `json:"optionId"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -255,6 +263,7 @@ func HandleSessionAnswer(logger *slog.Logger, service *livesession.Service) http
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		req, err := handlers.DecodeJSON[answerRequest](w, r)
 		if err != nil {
@@ -285,9 +294,10 @@ func HandleSessionAnswer(logger *slog.Logger, service *livesession.Service) http
 // Returns 204 on success and 404 for an unknown code, a non-participant, or a
 // repeat leave (the row is already marked left) - the code stays opaque to
 // outsiders, mirroring the other session gates.
-func HandleSessionLeave(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionLeave(service *livesession.Service) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -296,6 +306,7 @@ func HandleSessionLeave(logger *slog.Logger, service *livesession.Service) http.
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		err := service.Leave(ctx, r.PathValue("code"), player.ID)
 		switch {
@@ -439,9 +450,10 @@ type sessionQuestionResponse struct {
 // gated: only a roster player or the host may read it, so a stranger with
 // the code cannot enumerate the room. Returns 404 for an unknown code or a
 // non-participant.
-func HandleSessionState(logger *slog.Logger, service *livesession.Service) http.Handler {
+func HandleSessionState(service *livesession.Service) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -450,6 +462,7 @@ func HandleSessionState(logger *slog.Logger, service *livesession.Service) http.
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		state, err := service.GetLobbyState(ctx, r.PathValue("code"), player.ID)
 		if err != nil {
@@ -744,9 +757,10 @@ func beatPresence(ctx context.Context, logger *slog.Logger, touch func(context.C
 // no game data - each tick is {version, phase}, a signal to re-GET
 // /api/sessions/{code}/state. A reconnect re-runs the gate and resends the
 // current version, which doubles as the resync path.
-func HandleSessionEvents(logger *slog.Logger, service *livesession.Service, hub *livesession.Hub) http.Handler {
+func HandleSessionEvents(service *livesession.Service, hub *livesession.Hub) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := handlers.LoggerFromContext(ctx)
 
 		player, ok := auth.PlayerFromContext(ctx)
 		if !ok {
@@ -755,6 +769,7 @@ func HandleSessionEvents(logger *slog.Logger, service *livesession.Service, hub 
 
 			return
 		}
+		logger = logger.With(slog.Int64("player", player.ID))
 
 		// Gate BEFORE any header write so a non-participant / unknown code
 		// can still be surfaced as a proper HTTP 404 rather than a half-open

--- a/internal/clientapi/sessions_test.go
+++ b/internal/clientapi/sessions_test.go
@@ -1,0 +1,156 @@
+package clientapi_test
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/auth"
+	. "github.com/starquake/topbanana/internal/clientapi"
+	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/livesession"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// boundCaptureHandler is a slog.Handler that records each record's attrs,
+// merging any WithAttrs-bound prefix attrs (the request-scoped logger's
+// request id, the per-handler player) so a test can assert a handler line
+// inherited the bound correlation fields. slog.With binds attrs via
+// WithAttrs, not on the Record, so a no-op WithAttrs would drop them.
+type boundCaptureHandler struct {
+	mu      *sync.Mutex
+	records *[]map[string]slog.Value
+	attrs   []slog.Attr
+}
+
+func newBoundCaptureHandler() boundCaptureHandler {
+	return boundCaptureHandler{mu: &sync.Mutex{}, records: &[]map[string]slog.Value{}}
+}
+
+func (boundCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h boundCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	flat := make(map[string]slog.Value, len(h.attrs)+r.NumAttrs())
+	for _, a := range h.attrs {
+		flat[a.Key] = a.Value
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		flat[a.Key] = a.Value
+
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, flat)
+
+	return nil
+}
+
+func (h boundCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.attrs = append(append([]slog.Attr(nil), h.attrs...), attrs...)
+
+	return h
+}
+
+func (h boundCaptureHandler) WithGroup(string) slog.Handler { return h }
+
+// hasRecordWith reports whether any captured record carries every wanted
+// attribute key with a non-empty string value.
+func (h boundCaptureHandler) hasRecordWith(keys ...string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, rec := range *h.records {
+		ok := true
+		for _, k := range keys {
+			if _, present := rec[k]; !present {
+				ok = false
+
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sessionTestEnv bundles a live-session service over real stores on a
+// dbtest DB so a session handler test hits real data.
+type sessionTestEnv struct {
+	db      *sql.DB
+	service *livesession.Service
+	players auth.PlayerStore
+}
+
+func newSessionTestEnv(t *testing.T) *sessionTestEnv {
+	t.Helper()
+
+	discard := slog.New(slog.DiscardHandler)
+	conn := dbtest.Open(t)
+	stores := store.New(conn, discard)
+	service := livesession.NewService(stores.LiveSessions, stores.Quizzes, discard)
+
+	return &sessionTestEnv{db: conn, service: service, players: stores.Players}
+}
+
+func (e *sessionTestEnv) seedAnonymousPlayer(t *testing.T, name string) int64 {
+	t.Helper()
+
+	p, err := e.players.CreateAnonymousPlayer(t.Context(), name)
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer(%q) err = %v, want nil", name, err)
+	}
+
+	return p.ID
+}
+
+// TestHandleSessionState_LogLineInheritsRequestScopedFields pins the request-
+// scoped logger adoption: a session handler pulls the logger off the context
+// and binds the player id, so the line it emits on a store failure carries
+// both the middleware-bound requestId and the handler-bound player without
+// restating either at the call site.
+func TestHandleSessionState_LogLineInheritsRequestScopedFields(t *testing.T) {
+	t.Parallel()
+
+	env := newSessionTestEnv(t)
+	hostID := env.seedAnonymousPlayer(t, "host")
+
+	sess, err := env.service.CreateSession(t.Context(), nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+
+	logs := newBoundCaptureHandler()
+	// Mimic the middleware: a request-scoped logger carrying a request id,
+	// stashed on the context exactly as requestLogger does in production.
+	reqLogger := slog.New(logs).With(slog.String("requestId", "req-xyz"))
+	ctx := handlers.WithLogger(t.Context(), reqLogger)
+	ctx = withPlayer(ctx, hostID)
+
+	// Close the DB so GetLobbyState fails, driving the writeInternalError
+	// branch that logs through the request-scoped, player-bound logger.
+	if cerr := env.db.Close(); cerr != nil {
+		t.Fatalf("closing test DB: %v", cerr)
+	}
+
+	handler := HandleSessionState(env.service)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/sessions/"+sess.JoinCode+"/state", nil)
+	req.SetPathValue("code", sess.JoinCode)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if !logs.hasRecordWith("requestId", "player") {
+		t.Error("no log line carried both requestId and player; want the handler to inherit both")
+	}
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -2,6 +2,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,29 @@ import (
 	"strconv"
 	"strings"
 )
+
+// loggerCtxKey is the unexported context-key type for the request-scoped
+// logger. A struct (not a string) so no other package can collide with it.
+type loggerCtxKey struct{}
+
+// WithLogger returns a copy of ctx carrying logger as the request-scoped
+// logger. A middleware binds the stable correlation attrs (a request id, the
+// player once known) on logger via [slog.Logger.With] and stashes it here, so
+// every downstream line inherits them without restating them.
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerCtxKey{}, logger)
+}
+
+// LoggerFromContext returns the request-scoped logger stashed by WithLogger,
+// or [slog.Default] for a context that was never annotated (a handler invoked
+// outside the middleware chain, e.g. in a unit test).
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(loggerCtxKey{}).(*slog.Logger); ok {
+		return l
+	}
+
+	return slog.Default()
+}
 
 const (
 	base10    = 10

--- a/internal/handlers/logger_test.go
+++ b/internal/handlers/logger_test.go
@@ -1,0 +1,33 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/handlers"
+)
+
+func TestLoggerFromContext_ReturnsStashedLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	stashed := slog.New(slog.NewTextHandler(&buf, nil)).With(slog.String("requestId", "abc123"))
+
+	ctx := WithLogger(t.Context(), stashed)
+	LoggerFromContext(ctx).Info("line")
+
+	if got, want := buf.String(), "requestId=abc123"; !strings.Contains(got, want) {
+		t.Errorf("log output %q missing %q", got, want)
+	}
+}
+
+func TestLoggerFromContext_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := LoggerFromContext(context.Background()); got == nil {
+		t.Error("LoggerFromContext on a bare context = nil, want a usable logger")
+	}
+}

--- a/internal/livesession/logging_test.go
+++ b/internal/livesession/logging_test.go
@@ -17,9 +17,15 @@ import (
 // test can assert the live-session domain layer emitted the expected log line
 // with the expected level and fields. Concurrency-safe because the runner
 // detaches its first-round transition onto a goroutine via the advancer.
+//
+// WithAttrs accumulates the bound attrs and Handle merges them onto each
+// record, so a logger derived via slog.With surfaces its bound fields here:
+// slog.With binds attrs at the handler level (WithAttrs), not on the Record,
+// so returning the receiver unchanged would silently drop them.
 type captureHandler struct {
 	mu      *sync.Mutex
 	records *[]slog.Record
+	attrs   []slog.Attr
 }
 
 func newCaptureHandler() captureHandler {
@@ -29,15 +35,23 @@ func newCaptureHandler() captureHandler {
 func (captureHandler) Enabled(context.Context, slog.Level) bool { return true }
 
 func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := r.Clone()
+	rec.AddAttrs(h.attrs...)
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	*h.records = append(*h.records, r.Clone())
+	*h.records = append(*h.records, rec)
 
 	return nil
 }
 
-func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+func (h captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.attrs = append(append([]slog.Attr(nil), h.attrs...), attrs...)
+
+	return h
+}
+
+func (h captureHandler) WithGroup(string) slog.Handler { return h }
 
 // snapshot returns a copy of the records captured so far.
 func (h captureHandler) snapshot() []slog.Record {
@@ -367,4 +381,19 @@ func TestService_LogsNonHostControlRejection(t *testing.T) {
 	assertStringAttr(t, attrs, "joinCode", h.code)
 	assertInt64Attr(t, attrs, "player", notHost)
 	assertNoLog(t, h.logs, "live session started")
+}
+
+// TestCaptureHandler_SurfacesWithBoundAttrs pins that the capture handler
+// honours WithAttrs, so a logger derived via slog.With carries its bound
+// field through to the asserted record. Without the fix this fails: a no-op
+// WithAttrs drops the bound field. Guards future slog.With use in this layer.
+func TestCaptureHandler_SurfacesWithBoundAttrs(t *testing.T) {
+	t.Parallel()
+
+	logs := newCaptureHandler()
+	logger := slog.New(logs).With(slog.String("joinCode", "ABC123"))
+	logger.Info("bound line")
+
+	attrs := assertLog(t, logs, "bound line", slog.LevelInfo)
+	assertStringAttr(t, attrs, "joinCode", "ABC123")
 }

--- a/internal/server/capturehandler_test.go
+++ b/internal/server/capturehandler_test.go
@@ -1,0 +1,117 @@
+package server_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureHandler is a slog.Handler that records every record so a test can
+// assert on the lines a middleware emitted. It honours WithAttrs and
+// WithGroup: slog.With binds attributes at the handler level (via WithAttrs),
+// not on the Record, so a handler that returned the receiver unchanged would
+// silently drop With-bound fields like the request id. The accumulated prefix
+// attrs are merged into each captured record's own attrs, under any active
+// group prefix, so the assertions see the same key=value pairs a real handler
+// would format.
+type captureHandler struct {
+	mu      *sync.Mutex
+	records *[]capturedRecord
+	attrs   []slog.Attr
+	groups  []string
+}
+
+// capturedRecord is one record flattened to its attribute map, with the
+// With-bound prefix attrs already merged in.
+type capturedRecord struct {
+	message string
+	attrs   map[string]slog.Value
+}
+
+func newCaptureHandler() captureHandler {
+	return captureHandler{mu: &sync.Mutex{}, records: &[]capturedRecord{}}
+}
+
+func (captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	flat := make(map[string]slog.Value, len(h.attrs)+r.NumAttrs())
+	for _, a := range h.attrs {
+		flat[a.Key] = a.Value
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		flat[h.qualify(a.Key)] = a.Value
+
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, capturedRecord{message: r.Message, attrs: flat})
+
+	return nil
+}
+
+func (h captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	next = append(next, h.attrs...)
+	for _, a := range attrs {
+		next = append(next, slog.Attr{Key: h.qualify(a.Key), Value: a.Value})
+	}
+	h.attrs = next
+
+	return h
+}
+
+func (h captureHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h.groups = append(append([]string(nil), h.groups...), name)
+
+	return h
+}
+
+// qualify joins any active group prefix onto an attribute key, mirroring how
+// a real handler namespaces grouped attrs as "group.key".
+func (h captureHandler) qualify(key string) string {
+	if len(h.groups) == 0 {
+		return key
+	}
+
+	return strings.Join(h.groups, ".") + "." + key
+}
+
+// attrsFor returns the attribute map of the first captured record with the
+// given message, failing the test if none was captured.
+func (h captureHandler) attrsFor(t *testing.T, msg string) map[string]slog.Value {
+	t.Helper()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range *h.records {
+		if r.message == msg {
+			return r.attrs
+		}
+	}
+	t.Fatalf("no captured record with message %q", msg)
+
+	return nil
+}
+
+// attrValuesFor returns the string value of attr key for every captured
+// record with the given message, in capture order.
+func (h captureHandler) attrValuesFor(msg, key string) []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []string
+	for _, r := range *h.records {
+		if r.message == msg {
+			out = append(out, r.attrs[key].String())
+		}
+	}
+
+	return out
+}

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -4,6 +4,8 @@ var (
 	ExportAddRoutes         = addRoutes
 	ExportLogRequests       = logRequests
 	ExportRecoverPanic      = recoverPanic
+	ExportRequestLogger     = requestLogger
+	ExportLoggerFrom        = loggerFrom
 	ExportSameOriginCheck   = sameOriginCheck
 	ExportOriginFromBaseURL = originFromBaseURL
 )

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,12 +1,57 @@
 package server
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"time"
+
+	"github.com/starquake/topbanana/internal/handlers"
 )
+
+// loggerFrom returns the request-scoped logger stashed on ctx by
+// requestLogger, or a usable default for a context that was never annotated.
+// A thin alias over handlers.LoggerFromContext so the server middleware reads
+// naturally at every call site.
+func loggerFrom(ctx context.Context) *slog.Logger {
+	return handlers.LoggerFromContext(ctx)
+}
+
+// requestIDBytes is the entropy width of a generated request id. Eight bytes
+// (16 hex chars) keeps ids distinct across a game night's worth of requests
+// while staying short enough to eyeball in a log line.
+const requestIDBytes = 8
+
+// newRequestID returns a random hex request id. [crypto/rand.Read] does not
+// return a short read or error on the platforms we target, so the error
+// path is defensive only; an empty id still yields a usable (if unscoped)
+// log line rather than failing the request.
+func newRequestID() string {
+	var b [requestIDBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+
+	return hex.EncodeToString(b[:])
+}
+
+// requestLogger derives a per-request logger that carries a generated
+// request id (bound once via [slog.Logger.With]) and stashes it on the request
+// context, so every downstream line - the access log, the panic log, and
+// any handler that pulls it with loggerFrom - inherits the id without
+// repeating it. Mount it as the outermost wrapper so the id is bound
+// before recoverPanic and logRequests run.
+func requestLogger(base *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqLogger := base.With(slog.String("requestId", newRequestID()))
+		ctx := handlers.WithLogger(r.Context(), reqLogger)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 type responseWriter struct {
 	http.ResponseWriter
@@ -29,11 +74,14 @@ func (rw *responseWriter) Unwrap() http.ResponseWriter {
 // the stdlib's default-logger stderr dump that loses every request
 // field (#346). A panic unwinds straight past logRequests without its
 // post-call log line firing, so this recover is the only entry that
-// records the request when a handler panics; mount it as the outermost
-// wrapper so the recover happens before the stdlib server sees the
-// panic.
-func recoverPanic(logger *slog.Logger, next http.Handler) http.Handler {
+// records the request when a handler panics. Mount it just inside
+// requestLogger so the recover happens before the stdlib server sees the
+// panic, yet still draws its line from the request-scoped logger (carrying
+// the request id) via loggerFrom.
+func recoverPanic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := loggerFrom(ctx)
 		defer func() {
 			rec := recover()
 			if rec == nil {
@@ -45,14 +93,14 @@ func recoverPanic(logger *slog.Logger, next http.Handler) http.Handler {
 			// the 500. Anything else is a real bug. recover() returns
 			// `any`, so type-assert to error before errors.Is.
 			if recErr, ok := rec.(error); ok && errors.Is(recErr, http.ErrAbortHandler) {
-				logger.WarnContext(r.Context(), "handler aborted via http.ErrAbortHandler",
+				logger.WarnContext(ctx, "handler aborted via http.ErrAbortHandler",
 					slog.String("method", r.Method),
 					slog.String("path", r.URL.Path),
 				)
 
 				return
 			}
-			logger.ErrorContext(r.Context(), "handler panic recovered",
+			logger.ErrorContext(ctx, "handler panic recovered",
 				slog.Any("panic", rec),
 				slog.String("stack", string(debug.Stack())),
 				slog.String("method", r.Method),
@@ -64,12 +112,12 @@ func recoverPanic(logger *slog.Logger, next http.Handler) http.Handler {
 	})
 }
 
-func logRequests(logger *slog.Logger, next http.Handler) http.Handler {
+func logRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 		start := time.Now()
 		next.ServeHTTP(rw, r)
-		logger.InfoContext(r.Context(), "request",
+		loggerFrom(r.Context()).InfoContext(r.Context(), "request",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.Int("status", rw.status),

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,22 +12,31 @@ import (
 	. "github.com/starquake/topbanana/internal/server"
 )
 
+// withReqLogger wraps next so requests carry a request-scoped logger drawn
+// from logger, exactly as the production chain does. logRequests and
+// recoverPanic pull that logger off the context with loggerFrom, so a test
+// can assert the lines they emit by reading buf - and the requestLogger
+// wrapper means every line also carries the generated requestId.
+func withReqLogger(logger *slog.Logger, next http.Handler) http.Handler {
+	return ExportRequestLogger(logger, next)
+}
+
 func TestLogRequests_LogsMethodPathStatus(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := ExportLogRequests(logger, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportLogRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test-path", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	log := buf.String()
-	for _, want := range []string{"method=GET", "path=/test-path", "status=201", "duration="} {
+	for _, want := range []string{"method=GET", "path=/test-path", "status=201", "duration=", "requestId="} {
 		if !strings.Contains(log, want) {
 			t.Errorf("log output %q missing %q", log, want)
 		}
@@ -39,9 +49,9 @@ func TestLogRequests_DefaultsTo200WhenWriteHeaderNotCalled(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := ExportLogRequests(logger, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportLogRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/ping", nil)
 	rec := httptest.NewRecorder()
@@ -58,9 +68,9 @@ func TestLogRequests_LogsErrorStatus(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := ExportLogRequests(logger, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportLogRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad request", http.StatusBadRequest)
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/bad", nil)
 	rec := httptest.NewRecorder()
@@ -77,9 +87,9 @@ func TestRecoverPanic_LogsAndReturns500(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := ExportRecoverPanic(logger, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportRecoverPanic(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("kaboom - synthetic test panic")
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/boom", nil)
 	rec := httptest.NewRecorder()
@@ -89,7 +99,7 @@ func TestRecoverPanic_LogsAndReturns500(t *testing.T) {
 		t.Errorf("status = %d, want %d", got, want)
 	}
 	log := buf.String()
-	for _, want := range []string{"handler panic recovered", "kaboom", "path=/boom", "method=GET", "stack="} {
+	for _, want := range []string{"handler panic recovered", "kaboom", "path=/boom", "method=GET", "stack=", "requestId="} {
 		if !strings.Contains(log, want) {
 			t.Errorf("log output missing %q\nfull log:\n%s", want, log)
 		}
@@ -108,9 +118,9 @@ func TestRecoverPanic_IgnoresErrAbortHandler(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	handler := ExportRecoverPanic(logger, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportRecoverPanic(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic(http.ErrAbortHandler)
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/abort", nil)
 	rec := httptest.NewRecorder()
@@ -132,12 +142,12 @@ func TestLogRequests_UnwrapAllowsFlush(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 
-	handler := ExportLogRequests(logger, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := withReqLogger(logger, ExportLogRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		rc := http.NewResponseController(w)
 		if err := rc.Flush(); err != nil {
 			t.Errorf("Flush() via Unwrap error: %v", err)
 		}
-	}))
+	})))
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/flush", nil)
 	rec := httptest.NewRecorder()
@@ -145,5 +155,69 @@ func TestLogRequests_UnwrapAllowsFlush(t *testing.T) {
 
 	if !rec.Flushed {
 		t.Error("expected recorder to have been flushed via Unwrap")
+	}
+}
+
+// TestRequestLogger_BindsRequestIDOnContextLogger pins that the handler can
+// pull a logger off the request context whose lines carry the bound request
+// id, so any handler line inherits the id without restating it. The capturing
+// handler honours WithAttrs, so the With-bound requestId surfaces on the
+// record.
+func TestRequestLogger_BindsRequestIDOnContextLogger(t *testing.T) {
+	t.Parallel()
+
+	logs := newCaptureHandler()
+
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		ExportLoggerFrom(r.Context()).InfoContext(r.Context(), "handler line")
+	})
+	handler := withReqLogger(slog.New(logs), inner)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/scoped", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	attrs := logs.attrsFor(t, "handler line")
+	if got := attrs["requestId"].String(); got == "" {
+		t.Errorf("handler line missing a non-empty requestId attr (attrs: %v)", attrs)
+	}
+}
+
+// TestRequestLogger_DistinctIDsPerRequest pins that two requests through the
+// same wrapped handler get different request ids, so lines from concurrent
+// requests can be told apart.
+func TestRequestLogger_DistinctIDsPerRequest(t *testing.T) {
+	t.Parallel()
+
+	logs := newCaptureHandler()
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		ExportLoggerFrom(r.Context()).InfoContext(r.Context(), "tick")
+	})
+	handler := withReqLogger(slog.New(logs), inner)
+
+	for range 2 {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/scoped", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	ids := logs.attrValuesFor("tick", "requestId")
+	if got, want := len(ids), 2; got != want {
+		t.Fatalf("captured %d %q lines, want %d", got, "tick", want)
+	}
+	if ids[0] == "" || ids[1] == "" {
+		t.Errorf("requestId attrs = %q, %q, want both non-empty", ids[0], ids[1])
+	}
+	if ids[0] == ids[1] {
+		t.Errorf("requestId attrs = %q, %q, want distinct", ids[0], ids[1])
+	}
+}
+
+// TestLoggerFrom_FallsBackToDefault pins that loggerFrom on a context with no
+// request-scoped logger returns a usable logger rather than nil, so a handler
+// invoked outside the middleware chain still logs.
+func TestLoggerFrom_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := ExportLoggerFrom(context.Background()); got == nil {
+		t.Error("loggerFrom on a bare context = nil, want a usable logger")
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -860,7 +860,7 @@ func addAPIRoutes(
 	)
 	mux.Handle("GET /api/games/{gameID}/results", ensurePlayer(clientapi.HandleGameResults(logger, gameService)))
 
-	addSessionRoutes(mux, logger, realtime.SessionService, realtime.SessionHub, ensurePlayer)
+	addSessionRoutes(mux, realtime.SessionService, realtime.SessionHub, ensurePlayer)
 }
 
 // addSessionRoutes registers the hosted live-session API (MP-1 / #678,
@@ -874,29 +874,28 @@ func addAPIRoutes(
 // gate and participant gates live in the handlers and service.
 func addSessionRoutes(
 	mux *http.ServeMux,
-	logger *slog.Logger,
 	sessionService *livesession.Service,
 	sessionHub *livesession.Hub,
 	ensurePlayer func(http.Handler) http.Handler,
 ) {
-	mux.Handle("POST /api/sessions", ensurePlayer(clientapi.HandleSessionCreate(logger, sessionService)))
-	mux.Handle("POST /api/sessions/{code}/join", ensurePlayer(clientapi.HandleSessionJoin(logger, sessionService)))
-	mux.Handle("POST /api/sessions/{code}/ready", ensurePlayer(clientapi.HandleSessionReady(logger, sessionService)))
-	mux.Handle("POST /api/sessions/{code}/start", ensurePlayer(clientapi.HandleSessionStart(logger, sessionService)))
+	mux.Handle("POST /api/sessions", ensurePlayer(clientapi.HandleSessionCreate(sessionService)))
+	mux.Handle("POST /api/sessions/{code}/join", ensurePlayer(clientapi.HandleSessionJoin(sessionService)))
+	mux.Handle("POST /api/sessions/{code}/ready", ensurePlayer(clientapi.HandleSessionReady(sessionService)))
+	mux.Handle("POST /api/sessions/{code}/start", ensurePlayer(clientapi.HandleSessionStart(sessionService)))
 	mux.Handle(
 		"POST /api/sessions/{code}/arm-start",
-		ensurePlayer(clientapi.HandleSessionArmStart(logger, sessionService)),
+		ensurePlayer(clientapi.HandleSessionArmStart(sessionService)),
 	)
 	mux.Handle(
 		"POST /api/sessions/{code}/cancel-start",
-		ensurePlayer(clientapi.HandleSessionCancelStart(logger, sessionService)),
+		ensurePlayer(clientapi.HandleSessionCancelStart(sessionService)),
 	)
-	mux.Handle("POST /api/sessions/{code}/answer", ensurePlayer(clientapi.HandleSessionAnswer(logger, sessionService)))
-	mux.Handle("POST /api/sessions/{code}/leave", ensurePlayer(clientapi.HandleSessionLeave(logger, sessionService)))
-	mux.Handle("GET /api/sessions/{code}/state", ensurePlayer(clientapi.HandleSessionState(logger, sessionService)))
+	mux.Handle("POST /api/sessions/{code}/answer", ensurePlayer(clientapi.HandleSessionAnswer(sessionService)))
+	mux.Handle("POST /api/sessions/{code}/leave", ensurePlayer(clientapi.HandleSessionLeave(sessionService)))
+	mux.Handle("GET /api/sessions/{code}/state", ensurePlayer(clientapi.HandleSessionState(sessionService)))
 	mux.Handle(
 		"GET /api/sessions/{code}/events",
-		ensurePlayer(clientapi.HandleSessionEvents(logger, sessionService, sessionHub)),
+		ensurePlayer(clientapi.HandleSessionEvents(sessionService, sessionHub)),
 	)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,12 +55,15 @@ func New(
 	mux := http.NewServeMux()
 	addRoutes(mux, logger, stores, gameService, realtime, cfg, mail)
 	var handler http.Handler = mux
-	handler = logRequests(logger, handler)
-	// recoverPanic is the OUTERMOST wrapper so a handler panic still
-	// captures the request fields logRequests would have recorded and
-	// the 500 reaches the client cleanly instead of leaking a half-
-	// written response (#346).
-	handler = recoverPanic(logger, handler)
+	handler = logRequests(handler)
+	// recoverPanic wraps logRequests so a handler panic still captures the
+	// request fields logRequests would have recorded and the 500 reaches the
+	// client cleanly instead of leaking a half-written response (#346).
+	handler = recoverPanic(handler)
+	// requestLogger is the OUTERMOST wrapper so the request-scoped logger
+	// (carrying a generated request id) is bound on the context before
+	// recoverPanic and logRequests draw their lines from it.
+	handler = requestLogger(logger, handler)
 
 	return handler
 }


### PR DESCRIPTION
Closes #874

Introduces a request-scoped logger: a middleware binds a generated request id once via `slog.With` and stashes the derived logger in the request context, so the access log, the panic log, and the adopting handlers inherit the id without restating it.

## What changed
- `internal/handlers`: `WithLogger` / `LoggerFromContext` carry the request-scoped logger on the context (unexported key type). This is the shared home both the server middleware (setter) and the client API handlers (reader) import without a cycle.
- `internal/server/middleware.go`: new `requestLogger` middleware (outermost wrapper) generates a hex request id from `crypto/rand`, binds it with `slog.With`, and stores the logger on the context. `logRequests` and `recoverPanic` now draw their lines from that logger (via `loggerFrom`), so the access log and panic log carry the request id. Their `logger` parameter is dropped; the base logger flows through `requestLogger`.
- `internal/clientapi/sessions.go`: the live-session handlers pull the request-scoped logger from the context and bind the player id once, so their lines inherit `requestId` + `player` automatically.
- Test capture handlers in `internal/auth/logging_test.go` and `internal/livesession/logging_test.go` now honour `WithAttrs` (accumulate the bound attrs and merge them onto each captured record) instead of returning the receiver unchanged, which silently dropped `slog.With`-bound fields. Each file gains a test proving a `With`-bound attr now surfaces.

## How the request id is generated
8 random bytes from `crypto/rand.Read`, hex-encoded (16 chars). No new dependency. On the documented-impossible read failure it yields an empty id (an unscoped but still usable log line) rather than failing the request.

## Tests
- Middleware chain test: a request through `requestLogger` -> `logRequests`/`recoverPanic` logs with a `requestId` present, and a logger pulled from the context carries the bound fields (asserted via a capturing handler that honours `WithAttrs`); plus distinct ids per request and the `loggerFrom` default fallback.
- `internal/clientapi`: a session handler line inherits both `requestId` and `player` end to end (router-less, real store, forced 500).
- `internal/handlers`: `WithLogger` / `LoggerFromContext` round-trip + default fallback.
- The fixed capture handlers each get a `With`-bound-attr surfacing test.

## Follow-up (not in this slice)
Adopt the context logger in the remaining handler surfaces: auth, admin, profile, host, and the rest of the client API (`clientapi.go`). The plumbing is in place; this PR converts only the live-session client handlers as the first high-value demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
