### PR TITLE
Stop the persistent-rooms spec racing the answered-waiting hint

### DIFF
--- a/test/e2e/tests/persistent-rooms.spec.ts
+++ b/test/e2e/tests/persistent-rooms.spec.ts
@@ -103,12 +103,14 @@ test.describe('persistent live rooms', () => {
     await expect(page.getByTestId('question-view')).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId('question-text')).toHaveText('Game 1: what is 1+1?');
 
-    // The page player answers game 1's only question via the page UI. With
-    // the single active player in, the runner closes the question, reveals,
-    // and ends the game into intermission.
+    // The page player answers game 1's only question via the page UI. With the
+    // single active player in, the runner closes the question, reveals, and ends
+    // the game into intermission immediately - so fast the transient
+    // answered-waiting hint can be skipped before it paints, which is why the
+    // test asserts the stable intermission outcome below rather than that hint
+    // (#884).
     await expect(page.getByTestId('question-options')).toBeVisible({ timeout: 10_000 });
     await page.getByTestId('question-options').getByRole('button', { name: 'two' }).click();
-    await expect(page.getByTestId('answered-waiting')).toBeVisible();
 
     // Game 1 ends into intermission: the player sees the intermission view
     // (final standings + the waiting message), staying joined - no re-join,


### PR DESCRIPTION
Closes #884

The persistent-rooms spec asserted the transient `answered-waiting` ("you answered, waiting for others") hint after the single active player answered the only question. With one active player, the runner closes the question and advances the moment they answer, so on a loaded chromium runner the hint is skipped before it paints and the assertion fails with "element not found" (it passed on firefox / lighter runs - a race, not a regression).

Removed that transient assertion; the test proceeds straight to the stable `intermission-view` outcome that already follows, which is the real post-answer result. The game-2 `answered-waiting` `toBeHidden()` check (a stable absence assertion on the fresh question) is unchanged.

Verified: the spec passed 4x repeat on both chromium and firefox locally.