### PR TITLE
Drop the runtime tdewolff/minify dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/rs/xid v1.6.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
-	github.com/tdewolff/minify/v2 v2.24.13
 	github.com/wneessen/go-mail v0.7.3
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
@@ -28,7 +27,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
-	github.com/tdewolff/parse/v2 v2.8.12 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,13 +38,6 @@ github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tdewolff/minify/v2 v2.24.13 h1:xrcF7gKDnUszseEY9WX9mUlZII2v2Go/QAcAwRASw58=
-github.com/tdewolff/minify/v2 v2.24.13/go.mod h1:emvwoYeIl8bfAKqRU5ww95LX9Gpggpqv/naal9a8Yq0=
-github.com/tdewolff/parse/v2 v2.8.12 h1:5BBjfaCv482v3nltlS0u6wH1xJaxjR6ofDrWttNvROg=
-github.com/tdewolff/parse/v2 v2.8.12/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
-github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
-github.com/tdewolff/test v1.0.12 h1:7F21DqIajswxuche0geHdrUZRCWE4oko4b7bcmkkrxk=
-github.com/tdewolff/test v1.0.12/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/wneessen/go-mail v0.7.3 h1:g3DravXC5SMlVdboFrQA8Jx95A8sOzoBeS5F+vzNRK0=
 github.com/wneessen/go-mail v0.7.3/go.mod h1:QGhBX0yNbc1J+Mkjcu7z2rpj4B4l+BmDY8gYznPC9sk=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,11 +7,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/tdewolff/minify/v2"
-	"github.com/tdewolff/minify/v2/css"
-	"github.com/tdewolff/minify/v2/html"
-	"github.com/tdewolff/minify/v2/js"
-
 	"github.com/starquake/topbanana/internal/config"
 )
 
@@ -20,7 +15,6 @@ var staticFS embed.FS
 
 // Handler returns an [http.Handler] that serves the client files.
 // If cfg.ClientDir is not empty, it serves files from that directory.
-// If cfg.isProduction is true, it minifies the files.
 func Handler(cfg *config.Config) http.Handler {
 	var fsys fs.FS
 	if cfg.ClientDir != "" {
@@ -33,17 +27,5 @@ func Handler(cfg *config.Config) http.Handler {
 		}
 	}
 
-	fileServer := http.FileServer(http.FS(fsys))
-
-	if cfg.IsProduction() {
-		m := minify.New()
-		m.AddFunc("text/html", html.Minify)
-		m.AddFunc("text/css", css.Minify)
-		m.AddFunc("application/javascript", js.Minify)
-		m.AddFunc("text/javascript", js.Minify)
-
-		return http.StripPrefix("/client", m.Middleware(fileServer))
-	}
-
-	return http.StripPrefix("/client", fileServer)
+	return http.StripPrefix("/client", http.FileServer(http.FS(fsys)))
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -15,10 +15,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/tdewolff/minify/v2"
-	"github.com/tdewolff/minify/v2/css"
-	"github.com/tdewolff/minify/v2/js"
-
 	"github.com/starquake/topbanana/internal/config"
 	"github.com/starquake/topbanana/internal/envtag"
 )
@@ -42,18 +38,7 @@ func Handler(cfg *config.Config) http.Handler {
 	// string, and "font/woff2" is a constant valid one.
 	_ = mime.AddExtensionType(".woff2", "font/woff2")
 
-	fileServer := http.FileServer(http.FS(resolveStaticFS(cfg)))
-
-	if cfg.IsProduction() {
-		m := minify.New()
-		m.AddFunc("text/css", css.Minify)
-		m.AddFunc("application/javascript", js.Minify)
-		m.AddFunc("text/javascript", js.Minify)
-
-		return http.StripPrefix("/assets", m.Middleware(fileServer))
-	}
-
-	return http.StripPrefix("/assets", fileServer)
+	return http.StripPrefix("/assets", http.FileServer(http.FS(resolveStaticFS(cfg))))
 }
 
 // ManifestHandler serves /manifest.webmanifest with the correct


### PR DESCRIPTION
## Summary
- Removed the css/js Minify middleware (no-op on already-minified Tailwind + esbuild output).
- Removed html.Minify on the SPA shells (measured ~7.9 KB gzipped/session, not worth a build-time toolchain).
- Dropped `github.com/tdewolff/minify/v2` from go.mod / go.sum.

Closes #896.

## Test plan
- [x] make lint-fix / make check / make smoke / make test-e2e