### PR TITLE
Add a times-played counter on the admin quiz list

### DIFF
--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -386,14 +386,15 @@ func finishGame(ctx context.Context, games game.Store, playerID int64, q *quiz.Q
 		return fmt.Errorf("create participant: %w", err)
 	}
 	now := time.Now()
-	for _, qs := range q.Questions {
+	for i, qs := range q.Questions {
 		gq := &game.Question{
 			GameID:     g.ID,
 			QuestionID: qs.ID,
 			StartedAt:  now,
 			ExpiredAt:  now.Add(answerWindowSeconds * time.Second),
 		}
-		if err := games.CreateQuestion(ctx, gq); err != nil {
+		completesGame := i == len(q.Questions)-1
+		if err := games.CreateQuestion(ctx, gq, completesGame); err != nil {
 			return fmt.Errorf("create question: %w", err)
 		}
 	}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -184,7 +184,10 @@ type QuizData struct {
 	// ModeOptions feeds the admin form's play-mode selector (MP-0 /
 	// #677) - pulled straight from the domain constants.
 	ModeOptions []string
-	Questions   []*QuestionData
+	// PlayCount is the durable "times played" counter surfaced on the
+	// admin quiz list footer (#891).
+	PlayCount int64
+	Questions []*QuestionData
 }
 
 // QuestionData is the data for a question. TimeLimitSecondsValue is the
@@ -305,6 +308,7 @@ func quizDataFromQuiz(qz *quiz.Quiz) *QuizData {
 		VisibilityOptions:    quiz.VisibilityValues(),
 		Mode:                 mode,
 		ModeOptions:          quiz.ModeValues(),
+		PlayCount:            qz.PlayCount,
 		Questions:            questionDataFromQuestions(qz.Questions),
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -135,6 +135,7 @@ type Quiz struct {
 	TimeLimitSeconds  int64
 	Visibility        string
 	Mode              string
+	PlayCount         int64
 }
 
 type Round struct {

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -12,6 +12,35 @@ import (
 	"time"
 )
 
+const bumpQuizPlayCountForGame = `-- name: BumpQuizPlayCountForGame :exec
+UPDATE quizzes
+SET play_count = play_count + 1
+WHERE quizzes.id = (SELECT quiz_id FROM games WHERE games.id = ?)
+`
+
+// Increments the durable hit counter (#891) for the quiz that owns this solo
+// game. Resolves the quiz from the game id so the caller only signals "this
+// play completed" without threading the quiz id. Never decremented; the CHECK
+// on quizzes.play_count keeps it non-negative.
+func (q *Queries) BumpQuizPlayCountForGame(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, bumpQuizPlayCountForGame, id)
+	return err
+}
+
+const bumpQuizPlayCountForSession = `-- name: BumpQuizPlayCountForSession :exec
+UPDATE quizzes
+SET play_count = play_count + 1
+WHERE quizzes.id = (SELECT quiz_id FROM sessions WHERE sessions.id = ?)
+`
+
+// Increments the durable hit counter (#891) for the quiz a live session is
+// playing. Resolves the quiz from the session id. A session with a NULL
+// quiz_id (a quiz-less room) matches no quiz row, so the bump is a safe no-op.
+func (q *Queries) BumpQuizPlayCountForSession(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, bumpQuizPlayCountForSession, id)
+	return err
+}
+
 const createOption = `-- name: CreateOption :one
 INSERT INTO options (question_id, text, is_correct)
 VALUES (?, ?, ?)
@@ -76,7 +105,7 @@ func (q *Queries) CreateQuestion(ctx context.Context, arg CreateQuestionParams) 
 const createQuiz = `-- name: CreateQuiz :one
 INSERT INTO quizzes (title, slug, description, created_by_player_id, time_limit_seconds, visibility, mode, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-RETURNING id, title, slug, description, created_at, updated_at, created_by_player_id, time_limit_seconds, visibility, mode
+RETURNING id, title, slug, description, created_at, updated_at, created_by_player_id, time_limit_seconds, visibility, mode, play_count
 `
 
 type CreateQuizParams struct {
@@ -115,6 +144,7 @@ func (q *Queries) CreateQuiz(ctx context.Context, arg CreateQuizParams) (Quiz, e
 		&i.TimeLimitSeconds,
 		&i.Visibility,
 		&i.Mode,
+		&i.PlayCount,
 	)
 	return i, err
 }
@@ -243,6 +273,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -261,6 +292,7 @@ type GetQuizRow struct {
 	TimeLimitSeconds     int64
 	Visibility           string
 	Mode                 string
+	PlayCount            int64
 	CreatedByDisplayName string
 }
 
@@ -281,6 +313,7 @@ func (q *Queries) GetQuiz(ctx context.Context, id int64) (GetQuizRow, error) {
 		&i.TimeLimitSeconds,
 		&i.Visibility,
 		&i.Mode,
+		&i.PlayCount,
 		&i.CreatedByDisplayName,
 	)
 	return i, err
@@ -314,6 +347,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -332,6 +366,7 @@ type ListLiveQuizzesRow struct {
 	TimeLimitSeconds     int64
 	Visibility           string
 	Mode                 string
+	PlayCount            int64
 	CreatedByDisplayName string
 }
 
@@ -359,6 +394,7 @@ func (q *Queries) ListLiveQuizzes(ctx context.Context) ([]ListLiveQuizzesRow, er
 			&i.TimeLimitSeconds,
 			&i.Visibility,
 			&i.Mode,
+			&i.PlayCount,
 			&i.CreatedByDisplayName,
 		); err != nil {
 			return nil, err
@@ -486,6 +522,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -505,6 +542,7 @@ type ListPublicQuizzesRow struct {
 	TimeLimitSeconds     int64
 	Visibility           string
 	Mode                 string
+	PlayCount            int64
 	CreatedByDisplayName string
 }
 
@@ -533,6 +571,7 @@ func (q *Queries) ListPublicQuizzes(ctx context.Context) ([]ListPublicQuizzesRow
 			&i.TimeLimitSeconds,
 			&i.Visibility,
 			&i.Mode,
+			&i.PlayCount,
 			&i.CreatedByDisplayName,
 		); err != nil {
 			return nil, err
@@ -662,6 +701,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -679,6 +719,7 @@ type ListQuizzesRow struct {
 	TimeLimitSeconds     int64
 	Visibility           string
 	Mode                 string
+	PlayCount            int64
 	CreatedByDisplayName string
 }
 
@@ -715,6 +756,7 @@ func (q *Queries) ListQuizzes(ctx context.Context) ([]ListQuizzesRow, error) {
 			&i.TimeLimitSeconds,
 			&i.Visibility,
 			&i.Mode,
+			&i.PlayCount,
 			&i.CreatedByDisplayName,
 		); err != nil {
 			return nil, err

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -840,7 +840,7 @@ func (q *Queries) SetSessionFinished(ctx context.Context, id string) error {
 	return err
 }
 
-const setSessionIntermission = `-- name: SetSessionIntermission :exec
+const setSessionIntermission = `-- name: SetSessionIntermission :execresult
 UPDATE sessions
 SET phase               = 'intermission',
     current_question_id = NULL,
@@ -848,16 +848,19 @@ SET phase               = 'intermission',
     question_expires_at = NULL,
     finished_at         = CURRENT_TIMESTAMP
 WHERE id = ?
+  AND phase NOT IN ('intermission', 'finished')
 `
 
 // Ends a game without closing the room (#836): marks it intermission (the
 // between-games screen showing the final standings while the host arms the next
 // quiz) and clears the per-question runner columns. finished_at is stamped so
 // the just-ended game has a finish time, but the room stays alive - distinct
-// from SetSessionFinished, which terminates the room.
-func (q *Queries) SetSessionIntermission(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, setSessionIntermission, id)
-	return err
+// from SetSessionFinished, which terminates the room. Scoped to a non-terminal
+// phase so a second invocation against an already-intermission or finished room
+// matches no row; the store layer keys the #891 play_count bump on rows
+// affected, so an accidental repeat call cannot double-bump the counter.
+func (q *Queries) SetSessionIntermission(ctx context.Context, id string) (sql.Result, error) {
+	return q.db.ExecContext(ctx, setSessionIntermission, id)
 }
 
 const setSessionPlayerReady = `-- name: SetSessionPlayerReady :execresult

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -318,7 +318,12 @@ type Store interface {
 	CreateGameAndParticipant(ctx context.Context, g *Game, p *Participant) error
 	StartGame(ctx context.Context, id string) error
 	CreateParticipant(ctx context.Context, p *Participant) error
-	CreateQuestion(ctx context.Context, gq *Question) error
+	// CreateQuestion records the issuance of a quiz question to a game.
+	// When completesGame is true, the same transaction bumps
+	// quizzes.play_count for the quiz that owns this game (#891), so the
+	// durable hit counter cannot drift from the games-become-completed
+	// transition that fires alongside the final question.
+	CreateQuestion(ctx context.Context, gq *Question, completesGame bool) error
 	CreateAnswer(ctx context.Context, a *Answer) error
 	// ListAnswersForQuizLeaderboard returns one row per game_answer for
 	// every game (finished or in-progress) of the given quiz, joined with
@@ -692,11 +697,19 @@ func (s *Service) GetNextQuestion(ctx context.Context, gameID string, playerID i
 		Position: len(g.Questions) + 1,
 		Total:    len(qz.Questions),
 	}
-	if err = s.store.CreateQuestion(ctx, gq); err != nil {
+	if err = s.store.CreateQuestion(ctx, gq, completesGame(gq)); err != nil {
 		return nil, fmt.Errorf("failed to record game question: %w", err)
 	}
 
 	return gq, nil
+}
+
+// completesGame reports whether gq is the question whose insertion flips
+// [Game.IsCompleted] to true - the last question of the quiz. The caller's
+// not-yet-asked gate guarantees one insert per completion, so the store's
+// play_count bump (#891) keyed on this fires exactly once per game.
+func completesGame(gq *Question) bool {
+	return gq.Total > 0 && gq.Position >= gq.Total
 }
 
 // GetNext returns the next item in the play sequence. The resume path
@@ -1343,7 +1356,7 @@ func (s *Service) issueQuestion(
 		Position:     askedCount + 1,
 		Total:        len(qz.Questions),
 	}
-	if err := s.store.CreateQuestion(ctx, gq); err != nil {
+	if err := s.store.CreateQuestion(ctx, gq, completesGame(gq)); err != nil {
 		return nil, fmt.Errorf("failed to record game question: %w", err)
 	}
 

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -55,10 +55,10 @@ func (stubStore) CreateGame(_ context.Context, _ *Game) error { return errStub }
 func (stubStore) CreateGameAndParticipant(_ context.Context, _ *Game, _ *Participant) error {
 	return errStub
 }
-func (stubStore) StartGame(_ context.Context, _ string) error               { return errStub }
-func (stubStore) CreateParticipant(_ context.Context, _ *Participant) error { return errStub }
-func (stubStore) CreateQuestion(_ context.Context, _ *Question) error       { return errStub }
-func (stubStore) CreateAnswer(_ context.Context, _ *Answer) error           { return errStub }
+func (stubStore) StartGame(_ context.Context, _ string) error                 { return errStub }
+func (stubStore) CreateParticipant(_ context.Context, _ *Participant) error   { return errStub }
+func (stubStore) CreateQuestion(_ context.Context, _ *Question, _ bool) error { return errStub }
+func (stubStore) CreateAnswer(_ context.Context, _ *Answer) error             { return errStub }
 
 func (s stubStore) ListAnswersForQuizLeaderboard(
 	ctx context.Context, quizID int64,

--- a/internal/game/service_test.go
+++ b/internal/game/service_test.go
@@ -674,7 +674,7 @@ func TestService_GetNextQuestion(t *testing.T) {
 			t.Fatalf("failed to create participant: %v", err)
 		}
 
-		err = gameStore.CreateQuestion(ctx, &Question{GameID: testGame.ID, QuestionID: testQuiz.Questions[0].ID})
+		err = gameStore.CreateQuestion(ctx, &Question{GameID: testGame.ID, QuestionID: testQuiz.Questions[0].ID}, false)
 		if err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
@@ -846,7 +846,7 @@ func TestService_GetNextQuestion(t *testing.T) {
 			StartedAt:  past,
 			ExpiredAt:  past.Add(10 * time.Second),
 		}
-		if err := gameStore.CreateQuestion(ctx, expired); err != nil {
+		if err := gameStore.CreateQuestion(ctx, expired, false); err != nil {
 			t.Fatalf("CreateQuestion err = %v, want nil", err)
 		}
 
@@ -1007,7 +1007,7 @@ func TestService_GetNext(t *testing.T) {
 		// remaining item is the round's results boundary.
 		for _, q := range testQuiz.Questions {
 			if err := gameStore.CreateQuestion(
-				ctx, &Question{GameID: testGame.ID, QuestionID: q.ID},
+				ctx, &Question{GameID: testGame.ID, QuestionID: q.ID}, false,
 			); err != nil {
 				t.Fatalf("CreateQuestion err = %v, want nil", err)
 			}
@@ -1111,7 +1111,7 @@ func TestService_GetNext(t *testing.T) {
 		}
 		for _, q := range testQuiz.Questions {
 			if err := gameStore.CreateQuestion(
-				ctx, &Question{GameID: testGame.ID, QuestionID: q.ID},
+				ctx, &Question{GameID: testGame.ID, QuestionID: q.ID}, false,
 			); err != nil {
 				t.Fatalf("CreateQuestion err = %v, want nil", err)
 			}

--- a/internal/home/home_test.go
+++ b/internal/home/home_test.go
@@ -102,7 +102,7 @@ func finishGameFor(t *testing.T, games game.Store, playerID int64, qz *quiz.Quiz
 			QuestionID: qs.ID,
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
-		}); err != nil {
+		}, false); err != nil {
 			t.Fatalf("CreateQuestion err = %v, want nil", err)
 		}
 	}

--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -343,8 +343,12 @@ type Store interface {
 	Finish(ctx context.Context, sessionID string) error
 	// Intermission ends a game without closing the room (#836): marks it
 	// intermission (the between-games screen) and clears the per-question runner
-	// columns, leaving the room alive so the host can arm the next quiz.
-	Intermission(ctx context.Context, sessionID string) error
+	// columns, leaving the room alive so the host can arm the next quiz. When
+	// bumpPlayCount is true, the same transaction also bumps
+	// quizzes.play_count for the quiz this session is playing (#891), so the
+	// durable "times played" counter cannot drift from the natural game-end
+	// transition.
+	Intermission(ctx context.Context, sessionID string, bumpPlayCount bool) error
 	// RearmSession arms a quiz to play in a room whenever no game is running
 	// (#836): the first game from an empty lobby (a room created with no quiz)
 	// and every later game from the between-games intermission share this path.

--- a/internal/livesession/livesession_test.go
+++ b/internal/livesession/livesession_test.go
@@ -187,7 +187,9 @@ func (*fakeStore) EnterRoundResults(context.Context, string) error { return erro
 
 func (*fakeStore) Finish(context.Context, string) error { return errors.ErrUnsupported }
 
-func (*fakeStore) Intermission(context.Context, string) error { return errors.ErrUnsupported }
+func (*fakeStore) Intermission(context.Context, string, bool) error {
+	return errors.ErrUnsupported
+}
 
 func (*fakeStore) RearmSession(context.Context, string, int64) error { return errors.ErrUnsupported }
 

--- a/internal/livesession/restart_hosting_test.go
+++ b/internal/livesession/restart_hosting_test.go
@@ -82,7 +82,7 @@ func TestService_HostHasRunningGame_FalseWhenStaging(t *testing.T) {
 		if err = h.service.StartQuiz(ctx, sess.JoinCode, hostID, qz.ID); err != nil {
 			t.Fatalf("StartQuiz err = %v, want nil", err)
 		}
-		if err = h.store.Intermission(ctx, sess.ID); err != nil {
+		if err = h.store.Intermission(ctx, sess.ID, false); err != nil {
 			t.Fatalf("Intermission err = %v, want nil", err)
 		}
 		if got, want := runningGame(t, h), false; got != want {

--- a/internal/livesession/runner.go
+++ b/internal/livesession/runner.go
@@ -431,7 +431,10 @@ func (r *Runner) enterFirstRound(ctx context.Context, sess *Session, now time.Ti
 	if !ok {
 		// A quiz with no questions has nothing to run: end the game immediately
 		// (into intermission), so the room stays alive for the host to re-arm.
-		r.endGame(ctx, sess)
+		// Passing bumpQuizPlayCount=0 here keeps the durable "times played"
+		// counter honest: this path runs before any question ever appears, so
+		// the quiz was not actually played and must not score a hit (#891).
+		r.endEmptyGame(ctx, sess)
 
 		return
 	}
@@ -567,7 +570,34 @@ func (*Runner) hostLastSeen(sess *Session) time.Time {
 // game-end paths (the last reveal of the last round, or a quiz with no
 // questions).
 func (r *Runner) endGame(ctx context.Context, sess *Session) {
-	if err := r.store.Intermission(ctx, sess.ID); err != nil {
+	// endGame is the natural-completion path (last reveal of the last
+	// round), so this is the moment a play of the room's current quiz
+	// counts for the durable "times played" counter (#891). A quiz-less
+	// room cannot reach endGame, but the nil-check keeps the store API
+	// honest if a future caller hits this from an unusual phase. The
+	// empty-quiz "play" that runs no questions goes through endEmptyGame
+	// instead so the counter is not bumped for a never-played game.
+	if err := r.store.Intermission(ctx, sess.ID, sess.QuizID != nil); err != nil {
+		r.logger.WarnContext(
+			ctx,
+			"runner failed to move session to intermission",
+			slog.String(logSessionKey, sess.ID),
+			slog.Any("err", err),
+		)
+
+		return
+	}
+	r.forget(sess.ID)
+	r.publish(sess.JoinCode, PhaseIntermission)
+}
+
+// endEmptyGame is the empty-quiz variant of [endGame]: the room is armed at a
+// quiz with no questions, so it transitions straight to intermission without
+// ever issuing a question. The "times played" counter (#891) deliberately
+// skips this case - no game was actually played here - so the bump argument
+// stays false.
+func (r *Runner) endEmptyGame(ctx context.Context, sess *Session) {
+	if err := r.store.Intermission(ctx, sess.ID, false); err != nil {
 		r.logger.WarnContext(
 			ctx,
 			"runner failed to move session to intermission",

--- a/internal/migrations/20260614120000_add_quiz_play_count.sql
+++ b/internal/migrations/20260614120000_add_quiz_play_count.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+-- play_count is a durable hit counter on the quiz row (#891): bumped once when
+-- a play of the quiz completes, never decremented. A separate counter (rather
+-- than a JOIN-derived COUNT) survives the retention sweep that hard-deletes old
+-- games, so the visible play total never silently shrinks. A nullable,
+-- constant-default-free ADD COLUMN needs no table rebuild, so there is no
+-- FK-rebuild dance here even though quizzes is a parent table.
+ALTER TABLE quizzes ADD COLUMN play_count INTEGER NOT NULL DEFAULT 0
+    CHECK (play_count >= 0);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Backfill from the solo history in `games`: one bump per completed game,
+-- where "completed" matches the finisher predicate used everywhere else
+-- (ListPopularQuizzes, Game.IsCompleted) - every quiz question was issued.
+-- The historical live-session plays cannot be reconstructed here (sessions
+-- only retain their current quiz_id; earlier game_seq plays are lost), so
+-- the seed is solo-only. New plays from both modes increment forward.
+UPDATE quizzes
+SET play_count = (
+    SELECT COUNT(*)
+    FROM games g
+    WHERE g.quiz_id = quizzes.id
+      AND (SELECT COUNT(*) FROM questions q WHERE q.quiz_id = quizzes.id) > 0
+      AND (SELECT COUNT(*) FROM game_questions gq WHERE gq.game_id = g.id) >=
+          (SELECT COUNT(*) FROM questions q WHERE q.quiz_id = quizzes.id)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE quizzes DROP COLUMN play_count;
+-- +goose StatementEnd

--- a/internal/migrations/quiz_play_count_test.go
+++ b/internal/migrations/quiz_play_count_test.go
@@ -1,0 +1,170 @@
+package migrations_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// quizPlayCountVersion is the #891 ADD COLUMN + backfill migration. Down-to one
+// version below, seed games, re-Up to exercise the backfill against populated
+// data the way dbtest.Open's fresh-DB run cannot.
+const quizPlayCountVersion = 20260614120000
+
+// TestQuizPlayCountMigration_BackfillsFromCompletedSoloGames pins the #891 seed:
+// the migration sets quizzes.play_count to the count of "completed" games per
+// quiz (every quiz question issued via game_questions), matching the finisher
+// predicate ListPopularQuizzes uses. An in-progress game with fewer issued
+// questions than the quiz holds is not counted; a quiz with no completed games
+// lands at zero.
+func TestQuizPlayCountMigration_BackfillsFromCompletedSoloGames(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	if err := goose.DownTo(db, ".", quizPlayCountVersion-1); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+
+	popularID := seedQuiz(t, db, "Popular", "popular-pc-mig")
+	loneID := seedQuiz(t, db, "Lone", "lone-pc-mig")
+	emptyID := seedQuiz(t, db, "Empty", "empty-pc-mig")
+
+	popularRoundID := seedRound(t, db, popularID)
+	popularQ1 := seedQuestion(t, db, popularID, popularRoundID, 1)
+	popularQ2 := seedQuestion(t, db, popularID, popularRoundID, 2)
+	loneRoundID := seedRound(t, db, loneID)
+	loneQ1 := seedQuestion(t, db, loneID, loneRoundID, 1)
+
+	// Two completed games on the popular quiz (every quiz question issued).
+	seedCompletedGame(t, db, "game-pop-1", popularID, []int64{popularQ1, popularQ2})
+	seedCompletedGame(t, db, "game-pop-2", popularID, []int64{popularQ1, popularQ2})
+	// An in-progress game on the popular quiz (only one of two questions issued)
+	// must NOT count.
+	seedCompletedGame(t, db, "game-pop-3", popularID, []int64{popularQ1})
+	// One completed game on the lone quiz; the empty quiz gets none.
+	seedCompletedGame(t, db, "game-lone-1", loneID, []int64{loneQ1})
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+
+	if got, want := readPlayCount(t, db, popularID), int64(2); got != want {
+		t.Errorf("popular quiz play_count = %d, want %d (two completed games)", got, want)
+	}
+	if got, want := readPlayCount(t, db, loneID), int64(1); got != want {
+		t.Errorf("lone quiz play_count = %d, want %d (one completed game)", got, want)
+	}
+	if got, want := readPlayCount(t, db, emptyID), int64(0); got != want {
+		t.Errorf("empty quiz play_count = %d, want %d (no games)", got, want)
+	}
+}
+
+// TestQuizPlayCountMigration_CheckConstraintRejectsNegative pins the CHECK on
+// play_count: the column refuses a write that would push the counter negative,
+// so a mis-written UPDATE cannot poison the durable hit counter.
+func TestQuizPlayCountMigration_CheckConstraintRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Check", "check-pc-mig")
+
+	_, err := db.ExecContext(
+		context.Background(), "UPDATE quizzes SET play_count = -1 WHERE id = ?", quizID,
+	)
+	if err == nil {
+		t.Error("UPDATE to -1 err = nil, want a CHECK violation")
+	}
+}
+
+func seedQuiz(t *testing.T, db *sql.DB, title, slug string) int64 {
+	t.Helper()
+	var quizID int64
+	if err := db.QueryRowContext(
+		context.Background(),
+		`INSERT INTO quizzes (title, slug, description, created_by_player_id)
+		 VALUES (?, ?, 'd', 1) RETURNING id`,
+		title, slug,
+	).Scan(&quizID); err != nil {
+		t.Fatalf("seed quiz %q err = %v, want nil", slug, err)
+	}
+
+	return quizID
+}
+
+func seedRound(t *testing.T, db *sql.DB, quizID int64) int64 {
+	t.Helper()
+	var roundID int64
+	if err := db.QueryRowContext(
+		context.Background(),
+		`INSERT INTO rounds (quiz_id, position, title) VALUES (?, 1, 'R') RETURNING id`, quizID,
+	).Scan(&roundID); err != nil {
+		t.Fatalf("seed round err = %v, want nil", err)
+	}
+
+	return roundID
+}
+
+func seedQuestion(t *testing.T, db *sql.DB, quizID, roundID int64, position int) int64 {
+	t.Helper()
+	var qID int64
+	if err := db.QueryRowContext(
+		context.Background(),
+		`INSERT INTO questions (quiz_id, round_id, text, position) VALUES (?, ?, 'Q', ?) RETURNING id`,
+		quizID, roundID, position,
+	).Scan(&qID); err != nil {
+		t.Fatalf("seed question err = %v, want nil", err)
+	}
+
+	return qID
+}
+
+// seedCompletedGame inserts a games row plus one game_questions per supplied
+// question id, so the finisher predicate (game_questions count >= questions
+// count) treats the game as completed iff every quiz question is in the slice.
+func seedCompletedGame(t *testing.T, db *sql.DB, gameID string, quizID int64, questionIDs []int64) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(
+		ctx, `INSERT INTO games (id, quiz_id) VALUES (?, ?)`, gameID, quizID,
+	); err != nil {
+		t.Fatalf("seed game %q err = %v, want nil", gameID, err)
+	}
+	for _, qid := range questionIDs {
+		if _, err := db.ExecContext(
+			ctx,
+			`INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
+			 VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			gameID, qid,
+		); err != nil {
+			t.Fatalf("seed game_question for game %q err = %v, want nil", gameID, err)
+		}
+	}
+}
+
+func readPlayCount(t *testing.T, db *sql.DB, quizID int64) int64 {
+	t.Helper()
+	var n int64
+	if err := db.QueryRowContext(
+		context.Background(), "SELECT play_count FROM quizzes WHERE id = ?", quizID,
+	).Scan(&n); err != nil {
+		t.Fatalf("read play_count err = %v, want nil", err)
+	}
+
+	return n
+}

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -22,6 +22,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -43,6 +44,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -65,6 +67,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -94,6 +97,7 @@ SELECT q.id,
        q.time_limit_seconds,
        q.visibility,
        q.mode,
+       q.play_count,
        p.display_name AS created_by_display_name
 FROM quizzes q
          JOIN players p ON p.id = q.created_by_player_id
@@ -265,3 +269,20 @@ WHERE id = ?;
 -- name: DeleteOption :execresult
 DELETE FROM options
 WHERE id = ?;
+
+-- name: BumpQuizPlayCountForGame :exec
+-- Increments the durable hit counter (#891) for the quiz that owns this solo
+-- game. Resolves the quiz from the game id so the caller only signals "this
+-- play completed" without threading the quiz id. Never decremented; the CHECK
+-- on quizzes.play_count keeps it non-negative.
+UPDATE quizzes
+SET play_count = play_count + 1
+WHERE quizzes.id = (SELECT quiz_id FROM games WHERE games.id = ?);
+
+-- name: BumpQuizPlayCountForSession :exec
+-- Increments the durable hit counter (#891) for the quiz a live session is
+-- playing. Resolves the quiz from the session id. A session with a NULL
+-- quiz_id (a quiz-less room) matches no quiz row, so the bump is a safe no-op.
+UPDATE quizzes
+SET play_count = play_count + 1
+WHERE quizzes.id = (SELECT quiz_id FROM sessions WHERE sessions.id = ?);

--- a/internal/queries/sessions.sql
+++ b/internal/queries/sessions.sql
@@ -212,19 +212,23 @@ SET phase               = 'finished',
     finished_at         = CURRENT_TIMESTAMP
 WHERE id = ?;
 
--- name: SetSessionIntermission :exec
+-- name: SetSessionIntermission :execresult
 -- Ends a game without closing the room (#836): marks it intermission (the
 -- between-games screen showing the final standings while the host arms the next
 -- quiz) and clears the per-question runner columns. finished_at is stamped so
 -- the just-ended game has a finish time, but the room stays alive - distinct
--- from SetSessionFinished, which terminates the room.
+-- from SetSessionFinished, which terminates the room. Scoped to a non-terminal
+-- phase so a second invocation against an already-intermission or finished room
+-- matches no row; the store layer keys the #891 play_count bump on rows
+-- affected, so an accidental repeat call cannot double-bump the counter.
 UPDATE sessions
 SET phase               = 'intermission',
     current_question_id = NULL,
     question_started_at = NULL,
     question_expires_at = NULL,
     finished_at         = CURRENT_TIMESTAMP
-WHERE id = ?;
+WHERE id = ?
+  AND phase NOT IN ('intermission', 'finished');
 
 -- name: RearmSession :execresult
 -- Arms a quiz to play in a room whenever no game is running (#836): the first

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -316,7 +316,14 @@ type Quiz struct {
 	// never solo-playable. A zero value (empty string) is treated as
 	// ModeSolo by the store layer so existing fixtures and the
 	// JSON-import path don't need to repeat the default.
-	Mode      string
+	Mode string
+	// PlayCount is the durable hit counter on the quiz row (#891): bumped
+	// once when a play of the quiz completes (the solo path bumps when the
+	// final game_questions row is issued, since that is the moment
+	// Game.IsCompleted flips true; the live path bumps when the runner moves
+	// the session to intermission) and never decremented, so the surfaced
+	// "times played" number survives any later retention sweep of old games.
+	PlayCount int64
 	Questions []*Question
 	// Rounds, when non-empty, tells the create path to author the quiz's
 	// rounds explicitly instead of dropping every question in the single

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -244,25 +244,41 @@ func execCreateGameAndParticipant(
 // provided Question object with generated values. started_at and expired_at are
 // formatted as UTC CURRENT_TIMESTAMP-format text so the stored column shares the
 // encoding the leaderboard staleness cutoff compares against (#789); see
-// [sqliteTimestampLayout].
-func (s *GameStore) CreateQuestion(ctx context.Context, gq *game.Question) error {
-	var err error
-	row, err := s.q.CreateGameQuestion(
-		ctx,
-		db.CreateGameQuestionParams{
-			GameID:     gq.GameID,
-			QuestionID: gq.QuestionID,
-			StartedAt:  gq.StartedAt.UTC().Format(sqliteTimestampLayout),
-			ExpiredAt:  gq.ExpiredAt.UTC().Format(sqliteTimestampLayout),
-		},
-	)
+// [sqliteTimestampLayout]. When completesGame is true, the same transaction
+// also bumps quizzes.play_count for the quiz that owns this game (#891), so the
+// counter cannot drift from the "game just became completed" transition that
+// fires alongside the final question.
+//
+//nolint:revive // completesGame signals whether this insert completes the game (a play-count bump input), not a behavioural mode switch.
+func (s *GameStore) CreateQuestion(ctx context.Context, gq *game.Question, completesGame bool) error {
+	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		row, qerr := q.CreateGameQuestion(
+			ctx,
+			db.CreateGameQuestionParams{
+				GameID:     gq.GameID,
+				QuestionID: gq.QuestionID,
+				StartedAt:  gq.StartedAt.UTC().Format(sqliteTimestampLayout),
+				ExpiredAt:  gq.ExpiredAt.UTC().Format(sqliteTimestampLayout),
+			},
+		)
+		if qerr != nil {
+			return fmt.Errorf("create game question: %w", qerr)
+		}
+		gq.ID = row.ID
+		gq.StartedAt = row.StartedAt
+		gq.ExpiredAt = row.ExpiredAt
+
+		if completesGame {
+			if berr := q.BumpQuizPlayCountForGame(ctx, gq.GameID); berr != nil {
+				return fmt.Errorf("bump quiz play count: %w", berr)
+			}
+		}
+
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create game question: %w", err)
 	}
-
-	gq.ID = row.ID
-	gq.StartedAt = row.StartedAt
-	gq.ExpiredAt = row.ExpiredAt
 
 	return nil
 }

--- a/internal/store/game_test.go
+++ b/internal/store/game_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"database/sql"
 	"errors"
 	"log/slog"
 	"strings"
@@ -265,11 +266,105 @@ func TestGameStore_CreateQuestion(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err := gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err := gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if gq.ID == 0 {
 			t.Error("gq.ID is 0, want non-zero")
+		}
+	})
+
+	t.Run("completesGame=false does not move the counter", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err := gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("CreateGame err = %v, want nil", err)
+		}
+
+		now := time.Now()
+		gq := &game.Question{
+			GameID:     g.ID,
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		if err := gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
+			t.Fatalf("CreateQuestion err = %v, want nil", err)
+		}
+
+		if got, want := readQuizPlayCount(t, db, testQuiz.ID), int64(0); got != want {
+			t.Errorf("play_count after no-bump call = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("completesGame on the final question moves the counter exactly once", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		g := &game.Game{QuizID: testQuiz.ID}
+		if err := gameStore.CreateGame(t.Context(), g); err != nil {
+			t.Fatalf("CreateGame err = %v, want nil", err)
+		}
+
+		now := time.Now()
+		for i, q := range testQuiz.Questions {
+			gq := &game.Question{
+				GameID:     g.ID,
+				QuestionID: q.ID,
+				StartedAt:  now,
+				ExpiredAt:  now.Add(10 * time.Second),
+			}
+			final := i == len(testQuiz.Questions)-1
+			if err := gameStore.CreateQuestion(t.Context(), gq, final); err != nil {
+				t.Fatalf("CreateQuestion err = %v, want nil", err)
+			}
+		}
+
+		if got, want := readQuizPlayCount(t, db, testQuiz.ID), int64(1); got != want {
+			t.Errorf("play_count after completed game = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("bump rolls back when the question insert fails", func(t *testing.T) {
+		t.Parallel()
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("CreateQuiz err = %v, want nil", err)
+		}
+
+		gameStore := NewGameStore(db, slog.Default())
+		// No CreateGame: the FK on game_questions.game_id will reject the
+		// insert, the bump rides the same transaction, so play_count must
+		// stay at zero.
+		now := time.Now()
+		gq := &game.Question{
+			GameID:     "missing-game-id",
+			QuestionID: testQuiz.Questions[0].ID,
+			StartedAt:  now,
+			ExpiredAt:  now.Add(10 * time.Second),
+		}
+		err := gameStore.CreateQuestion(t.Context(), gq, true)
+		if err == nil {
+			t.Fatal("CreateQuestion err = nil, want a FK violation")
+		}
+		if got, want := readQuizPlayCount(t, db, testQuiz.ID), int64(0); got != want {
+			t.Errorf("play_count after failed insert = %d, want %d (bump must roll back)", got, want)
 		}
 	})
 }
@@ -299,7 +394,7 @@ func TestGameStore_CreateAnswer(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err := gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err := gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 
@@ -349,7 +444,7 @@ func TestGameStore_CreateAnswer(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err := gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err := gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 
@@ -499,7 +594,7 @@ func TestGameStore_DeleteGamesForPlayerOnQuiz(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
@@ -650,7 +745,7 @@ func TestGameStore_DeleteGamesForPlayerOnQuiz(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
@@ -753,7 +848,7 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 				StartedAt:  now,
 				ExpiredAt:  now.Add(10 * time.Second),
 			}
-			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 				t.Fatalf("failed to create game question %d: %v", i, err)
 			}
 			gameQuestions[i] = gq
@@ -824,7 +919,7 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
@@ -901,7 +996,7 @@ func TestGameStore_ListAnswersForQuizLeaderboard(t *testing.T) {
 				StartedAt:  now,
 				ExpiredAt:  now.Add(10 * time.Second),
 			}
-			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 				t.Fatalf("failed to create question %d for game B: %v", i, err)
 			}
 			gameQuestionsB[i] = gq
@@ -1016,7 +1111,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 				StartedAt:  now,
 				ExpiredAt:  now.Add(10 * time.Second),
 			}
-			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 				t.Fatalf("failed to create game question: %v", err)
 			}
 		}
@@ -1122,7 +1217,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard(t *testing.T) {
 				StartedAt:  past.Add(-10 * time.Second),
 				ExpiredAt:  past,
 			}
-			if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+			if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 				t.Fatalf("failed to create game question: %v", err)
 			}
 
@@ -1192,7 +1287,7 @@ func TestGameStore_CreateQuestion_StoresUTCTimestampText(t *testing.T) {
 		StartedAt:  startedAt,
 		ExpiredAt:  expiredAt,
 	}
-	if err := gameStore.CreateQuestion(t.Context(), gq); err != nil {
+	if err := gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1258,7 +1353,7 @@ func TestGameStore_ListParticipantsForQuizLeaderboard_StaleBoundary(t *testing.T
 		StartedAt:  expiredAt.Add(-10 * time.Second),
 		ExpiredAt:  expiredAt,
 	}
-	if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+	if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 		t.Fatalf("failed to create game question: %v", err)
 	}
 
@@ -1430,4 +1525,18 @@ func TestGameStore_ListAnswersByGameQuestionID_UsesIndex(t *testing.T) {
 	if got, want := joined, "game_answers_game_question_id_idx"; !strings.Contains(got, want) {
 		t.Errorf("EXPLAIN QUERY PLAN output should contain %q; got:\n%s", want, got)
 	}
+}
+
+// readQuizPlayCount reads the durable hit counter off the quizzes row so the
+// bump tests pin behaviour against the column the admin list reads.
+func readQuizPlayCount(t *testing.T, db *sql.DB, quizID int64) int64 {
+	t.Helper()
+	var n int64
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT play_count FROM quizzes WHERE id = ?", quizID,
+	).Scan(&n); err != nil {
+		t.Fatalf("read play_count err = %v, want nil", err)
+	}
+
+	return n
 }

--- a/internal/store/home_test.go
+++ b/internal/store/home_test.go
@@ -28,7 +28,7 @@ func finishGame(t *testing.T, gs *GameStore, g *game.Game, q *quiz.Quiz) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err := gs.CreateQuestion(t.Context(), gq); err != nil {
+		if err := gs.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("finishGame CreateQuestion err = %v, want nil", err)
 		}
 	}

--- a/internal/store/livesession.go
+++ b/internal/store/livesession.go
@@ -300,9 +300,31 @@ func (s *LiveSessionStore) Finish(ctx context.Context, sessionID string) error {
 }
 
 // Intermission ends a game without closing the room: marks it intermission and
-// clears the per-question runner columns, leaving the room alive (#836).
-func (s *LiveSessionStore) Intermission(ctx context.Context, sessionID string) error {
-	if err := s.q.SetSessionIntermission(ctx, sessionID); err != nil {
+// clears the per-question runner columns, leaving the room alive (#836). When
+// bumpPlayCount is true AND the session actually transitioned (it was
+// not already in intermission or finished), the same transaction also bumps
+// quizzes.play_count for the quiz this session is playing (#891), so the durable
+// "times played" counter rides the same commit as the natural game-end
+// transition and an accidental repeat call from a terminal phase cannot
+// double-bump.
+//
+//nolint:revive // bumpPlayCount signals whether this game-end should count as a play (a play-count bump input), not a behavioural mode switch.
+func (s *LiveSessionStore) Intermission(ctx context.Context, sessionID string, bumpPlayCount bool) error {
+	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
+		res, ierr := q.SetSessionIntermission(ctx, sessionID)
+		if ierr != nil {
+			return fmt.Errorf("set session intermission: %w", ierr)
+		}
+		transitioned := database.MustRowsAffected(res) > 0
+		if bumpPlayCount && transitioned {
+			if berr := q.BumpQuizPlayCountForSession(ctx, sessionID); berr != nil {
+				return fmt.Errorf("bump quiz play count: %w", berr)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
 		return fmt.Errorf("failed to move session to intermission: %w", err)
 	}
 

--- a/internal/store/livesession_test.go
+++ b/internal/store/livesession_test.go
@@ -1268,3 +1268,93 @@ func TestLiveSessionStore_MarkPlayerLeft_KeepsPlayedInStandings(t *testing.T) {
 		t.Fatalf("answers after leave = %d, want %d (both pickers, scoring read is unfiltered)", got, want)
 	}
 }
+
+// TestLiveSessionStore_Intermission_BumpsQuizPlayCount pins the #891 atomic
+// behaviour: passing bumpQuizPlayCount=quizID to Intermission both moves the
+// session to intermission and increments quizzes.play_count in the same
+// transaction.
+func TestLiveSessionStore_Intermission_BumpsQuizPlayCount(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+	sessionStore := NewLiveSessionStore(db, slog.Default())
+
+	qz := newLiveQuizWithQuestion(t, quizStore)
+	sess := &livesession.Session{QuizID: liveQuizIDPtr(qz.ID), HostPlayerID: seededAdminID, JoinCode: "INT001"}
+	if err := sessionStore.CreateSession(t.Context(), sess); err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+
+	if err := sessionStore.Intermission(t.Context(), sess.ID, true); err != nil {
+		t.Fatalf("Intermission err = %v, want nil", err)
+	}
+
+	sessAfter, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	if got, want := sessAfter.Phase, livesession.PhaseIntermission; got != want {
+		t.Errorf("phase = %q, want %q", got, want)
+	}
+	if got, want := readQuizPlayCount(t, db, qz.ID), int64(1); got != want {
+		t.Errorf("play_count = %d, want %d", got, want)
+	}
+}
+
+// TestLiveSessionStore_Intermission_SkipsBumpWhenFalse pins the #891 escape
+// hatch: passing bumpPlayCount=false (a runner that reached endGame without a
+// quiz id) moves the phase without touching the counter, so the column stays
+// honest on the "no game just played" path through the runner.
+func TestLiveSessionStore_Intermission_SkipsBumpWhenFalse(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+	sessionStore := NewLiveSessionStore(db, slog.Default())
+
+	qz := newLiveQuizWithQuestion(t, quizStore)
+	sess := &livesession.Session{QuizID: liveQuizIDPtr(qz.ID), HostPlayerID: seededAdminID, JoinCode: "INT002"}
+	if err := sessionStore.CreateSession(t.Context(), sess); err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+
+	if err := sessionStore.Intermission(t.Context(), sess.ID, false); err != nil {
+		t.Fatalf("Intermission err = %v, want nil", err)
+	}
+
+	if got, want := readQuizPlayCount(t, db, qz.ID), int64(0); got != want {
+		t.Errorf("play_count after no-bump intermission = %d, want %d", got, want)
+	}
+}
+
+// TestLiveSessionStore_Intermission_RepeatCallDoesNotDoubleBump pins the SQL
+// guard on SetSessionIntermission (#891): a second Intermission call against a
+// session already in intermission matches no row, so the counter does not
+// move a second time even if the caller forgets to gate on the phase. The
+// dispatcher already protects today's single call site, but the store-side
+// guard is the durable backstop.
+func TestLiveSessionStore_Intermission_RepeatCallDoesNotDoubleBump(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+	sessionStore := NewLiveSessionStore(db, slog.Default())
+
+	qz := newLiveQuizWithQuestion(t, quizStore)
+	sess := &livesession.Session{QuizID: liveQuizIDPtr(qz.ID), HostPlayerID: seededAdminID, JoinCode: "INT003"}
+	if err := sessionStore.CreateSession(t.Context(), sess); err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+
+	if err := sessionStore.Intermission(t.Context(), sess.ID, true); err != nil {
+		t.Fatalf("first Intermission err = %v, want nil", err)
+	}
+	if err := sessionStore.Intermission(t.Context(), sess.ID, true); err != nil {
+		t.Fatalf("second Intermission err = %v, want nil", err)
+	}
+
+	if got, want := readQuizPlayCount(t, db, qz.ID), int64(1); got != want {
+		t.Errorf("play_count after repeat intermission = %d, want %d (no double-bump)", got, want)
+	}
+}

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -60,6 +60,7 @@ func (s *QuizStore) ListQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 			TimeLimitSeconds:  int(r.TimeLimitSeconds),
 			Visibility:        r.Visibility,
 			Mode:              r.Mode,
+			PlayCount:         r.PlayCount,
 			// INNER JOIN on players makes this a plain string (#359);
 			// the FK guarantees a creator row exists.
 			CreatedByDisplayName: r.CreatedByDisplayName,
@@ -92,6 +93,7 @@ func (s *QuizStore) ListPublicQuizzes(ctx context.Context) ([]*quiz.Quiz, error)
 			TimeLimitSeconds:  int(r.TimeLimitSeconds),
 			Visibility:        r.Visibility,
 			Mode:              r.Mode,
+			PlayCount:         r.PlayCount,
 			// INNER JOIN, see ListQuizzes (#359).
 			CreatedByDisplayName: r.CreatedByDisplayName,
 		}
@@ -124,6 +126,7 @@ func (s *QuizStore) ListLiveQuizzes(ctx context.Context) ([]*quiz.Quiz, error) {
 			TimeLimitSeconds:  int(r.TimeLimitSeconds),
 			Visibility:        r.Visibility,
 			Mode:              r.Mode,
+			PlayCount:         r.PlayCount,
 			// INNER JOIN, see ListQuizzes (#359).
 			CreatedByDisplayName: r.CreatedByDisplayName,
 		}
@@ -187,6 +190,7 @@ func (s *QuizStore) GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error) {
 		TimeLimitSeconds:  int(row.TimeLimitSeconds),
 		Visibility:        row.Visibility,
 		Mode:              row.Mode,
+		PlayCount:         row.PlayCount,
 		// INNER JOIN, see ListQuizzes (#359).
 		CreatedByDisplayName: row.CreatedByDisplayName,
 	}
@@ -740,6 +744,7 @@ func (s *QuizStore) execCreateQuiz(ctx context.Context, q *db.Queries, qz *quiz.
 	qz.TimeLimitSeconds = int(row.TimeLimitSeconds)
 	qz.Visibility = row.Visibility
 	qz.Mode = row.Mode
+	qz.PlayCount = row.PlayCount
 
 	// Every quiz needs a default round (#444): questions.round_id is NOT
 	// NULL and execCreateQuestion resolves it via GetDefaultRound.

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -1823,7 +1823,7 @@ func TestQuizStore_DeleteQuiz(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("failed to create game question: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
@@ -1947,7 +1947,7 @@ func TestQuizStore_DeleteQuestion(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq0); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq0, false); err != nil {
 			t.Fatalf("failed to create game question 0: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{
@@ -1965,7 +1965,7 @@ func TestQuizStore_DeleteQuestion(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq1); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq1, false); err != nil {
 			t.Fatalf("failed to create game question 1: %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{

--- a/internal/store/round_test.go
+++ b/internal/store/round_test.go
@@ -557,7 +557,7 @@ func TestQuizStore_DeleteRound(t *testing.T) {
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err = gameStore.CreateQuestion(t.Context(), gq); err != nil {
+		if err = gameStore.CreateQuestion(t.Context(), gq, false); err != nil {
 			t.Fatalf("CreateQuestion (game) err = %v", err)
 		}
 		if err = gameStore.CreateAnswer(t.Context(), &game.Answer{

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -73,6 +73,15 @@
                     <footer class="flex items-center justify-between px-5 py-3.5 border-t border-border-soft text-text-dim text-sm">
                         <div class="flex items-center gap-2.5">
                             <span><strong class="text-text font-semibold mr-1">{{.QuestionCount}}</strong>&nbsp;questions</span>
+                            {{/* Times-played counter (#891): bumped once each time a
+                                 game of this quiz completes; never decremented. The
+                                 Lucide play-circle icon labels the figure without
+                                 needing a "plays" word. */}}
+                            <span class="inline-flex items-center gap-1" title="Times played">
+                                <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                                <strong class="text-text font-semibold">{{.PlayCount}}</strong>
+                                <span class="sr-only">times played</span>
+                            </span>
                             {{/* Play-mode badge (#829, #890): a live quiz is hosted-only,
                                  a solo quiz is self-paced. Inline Lucide icons
                                  (users / user) replace the dot so the mode reads at

--- a/test/integration/admin_quiz_play_count_test.go
+++ b/test/integration/admin_quiz_play_count_test.go
@@ -1,0 +1,56 @@
+package integration_test
+
+import (
+	"database/sql"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestAdminQuizList_RendersPlayCount pins the #891 admin-list footer: each
+// quiz row carries its play_count alongside the question count. Seeding the
+// quiz with the store starts the counter at 0; bumping it through the SQL
+// surface the migration added must surface as the rendered figure.
+func TestAdminQuizList_RendersPlayCount(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegration(t)
+	baseURL := setup.BaseURL
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "play-count-host", "play-count-pass-123")
+
+	qz := seedSoloQuiz(ctx, t, setup.Stores.Quizzes, "play-count-list")
+
+	db, err := sql.Open("sqlite", setup.DBURI)
+	if err != nil {
+		t.Fatalf("open db err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+	if _, err := db.ExecContext(
+		ctx, "UPDATE quizzes SET play_count = 7 WHERE id = ?", qz.ID,
+	); err != nil {
+		t.Fatalf("seed play_count err = %v, want nil", err)
+	}
+
+	body := readBody(ctx, t, host, baseURL+"/admin/quizzes")
+	if !strings.Contains(body, qz.Title) {
+		t.Fatalf("admin list body missing quiz title %q", qz.Title)
+	}
+	// The footer renders the counter as a bold number inside an
+	// inline-flex span tagged with the "Times played" tooltip; assert the
+	// figure and the label without coupling to the exact SVG markup.
+	if want := `>7</strong>`; !strings.Contains(body, want) {
+		t.Errorf("admin list body missing rendered play_count %q", want)
+	}
+	if want := `Times played`; !strings.Contains(body, want) {
+		t.Errorf("admin list body missing %q label", want)
+	}
+}

--- a/test/integration/home_test.go
+++ b/test/integration/home_test.go
@@ -466,7 +466,7 @@ func finishGameInt(t *testing.T, games game.Store, playerID int64, q *quiz.Quiz)
 			StartedAt:  now,
 			ExpiredAt:  now.Add(10 * time.Second),
 		}
-		if err := games.CreateQuestion(ctx, gq); err != nil {
+		if err := games.CreateQuestion(ctx, gq, false); err != nil {
 			t.Fatalf("CreateQuestion err = %v, want nil", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `quizzes.play_count` (NOT NULL, CHECK >= 0) plus a backfill from completed solo games on migration 20260614120000.
- Bump the counter in the same transaction as the state change: the solo path bumps inside `GameStore.CreateQuestion` when issuing the final question of a game (matching `Game.IsCompleted`'s "every quiz question issued" predicate); the live path bumps inside `LiveSessionStore.Intermission` when the runner's `endGame` natural-completion path moves the session to intermission.
- Render the counter on the admin quiz list card footer next to the existing question count and solo/live badge, using a Lucide play-circle icon.

Closes #891.

## Decisions
- **"Played" means a game that finished every question.** For solo, this is the moment the last `game_questions` row is inserted (same predicate the home page popular list and `Game.IsCompleted` already use). For live, it is the natural-completion path through `Runner.endGame` -> `Intermission`. A host explicitly ending mid-game (`finishTerminal`) does not bump - that is an abandoned play, not a completed one.
- **The bump signal is a plain `bool`.** `GameStore.CreateQuestion(..., completesGame bool)` and `LiveSessionStore.Intermission(..., bumpPlayCount bool)` take a bool rather than threading a quiz id. The quiz to bump is derived in SQL from the id the store already holds - `BumpQuizPlayCountForGame` resolves it from the game id, `BumpQuizPlayCountForSession` from the session id (a NULL session quiz_id is a safe no-op). No behaviour change versus the earlier id-or-zero form.
- **Backfill is solo-only.** The migration seeds `play_count` from the `games` table's completed games per quiz. Historical live-session plays cannot be reconstructed (sessions only retain their current `quiz_id` and a `game_seq` counter; earlier plays are lost), so the seed skips them. New live plays from this migration onward increment forward.
- **Idempotency lives in two places.** The solo "issue this question" path is naturally idempotent because `GetNextQuestion` only inserts a `game_questions` row when the chosen quiz question is not already in `askedQuestions`. The live path adds a SQL-level guard - `SetSessionIntermission` now scopes to `phase NOT IN ('intermission', 'finished')` and returns `:execresult` so the store only bumps when the row actually transitioned. A repeat call from an already-intermission room matches no row and does not double-bump.
- **Empty-quiz live plays do not count.** A live quiz with zero questions takes the `enterFirstRound` -> empty-rounds path. That now uses a new `endEmptyGame` runner method (passing `bumpPlayCount = false`) so the counter is not bumped for a game that never issued a question. The solo path already does not bump for empty quizzes (`GetNextQuestion` returns `ErrNoMoreQuestions` before `CreateQuestion` is called).
- **Bonus skipped on purpose.** No sortable column - per the issue, the sort affordance is a follow-up.

## Test plan
- [x] `make lint-fix`
- [x] `rm -rf ~/.cache/golangci-lint && make check` (coverage 83.0%, gate 80)
- [x] `make smoke` (the new migration runs cleanly against the dev DB)
- [x] `make test-e2e` (201 passed, 4 skipped)
- [x] Migration test (`TestQuizPlayCountMigration_BackfillsFromCompletedSoloGames`) pins the seed against a DB with seeded completed / in-progress / no games and asserts the CHECK constraint rejects negatives.
- [x] Solo layer tests pin the branches of `GameStore.CreateQuestion`: `completesGame=false` leaves the counter at zero; the bump on the final issued question moves it to one; a failing insert rolls the bump back.
- [x] Live layer tests pin `LiveSessionStore.Intermission`: the bump rides the transition, `bumpPlayCount=false` skips, and a repeat call from an already-intermission session does not double-bump.
- [x] Integration test (`TestAdminQuizList_RendersPlayCount`) pins the admin list rendering the figure and the Lucide play-circle label.