### PR TITLE
Inject the SSE heartbeat interval

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/starquake/topbanana/internal/bgtasks"
+	"github.com/starquake/topbanana/internal/clientapi"
 	"github.com/starquake/topbanana/internal/config"
 	"github.com/starquake/topbanana/internal/database"
 	"github.com/starquake/topbanana/internal/envtag"
@@ -31,9 +32,9 @@ import (
 )
 
 const (
-	readHeaderTimeout = 5 * time.Second
-	readTimeout       = 10 * time.Second
-	writeTimeout      = 10 * time.Second
+	readHeaderTimeout   = 5 * time.Second
+	readTimeout         = 10 * time.Second
+	defaultWriteTimeout = 10 * time.Second
 	// idleTimeout caps how long a keep-alive connection can sit unused before the
 	// server closes it. Without this, idle connections behind a pooled proxy or
 	// CDN linger indefinitely and leak file descriptors. 120s is the conventional
@@ -51,13 +52,98 @@ const (
 	tokenSweepInterval = time.Hour
 )
 
+// Option configures a [Run] invocation. Used by integration tests to
+// override values that have no env-var hook (the HTTP server's write
+// timeout and the SSE handlers' heartbeat intervals, used by the SSE
+// heartbeat regression tests to keep the assertion inside a sub-second
+// window without leaning on the production 10s / 25s defaults). No
+// production caller passes options.
+type Option func(*options)
+
+type options struct {
+	writeTimeout                  time.Duration
+	leaderboardHeartbeatInterval  time.Duration
+	sessionEventHeartbeatInterval time.Duration
+}
+
+// WithWriteTimeout overrides the HTTP server's WriteTimeout. The SSE
+// heartbeat regression tests shrink it so the assertion that the stream
+// stays alive past WriteTimeout AND past one heartbeat tick runs in a
+// sub-second window. Zero or negative values are ignored.
+func WithWriteTimeout(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.writeTimeout = d
+		}
+	}
+}
+
+// WithLeaderboardHeartbeatInterval overrides the heartbeat interval for
+// the leaderboard SSE stream. The heartbeat regression test shrinks it so
+// the "at least one heartbeat fired" assertion runs in milliseconds. Zero
+// or negative values are ignored.
+func WithLeaderboardHeartbeatInterval(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.leaderboardHeartbeatInterval = d
+		}
+	}
+}
+
+// WithSessionEventHeartbeatInterval overrides the heartbeat interval for
+// the session-events SSE stream. The heartbeat regression test shrinks it
+// so the "at least one heartbeat fired" assertion runs in milliseconds.
+// Zero or negative values are ignored.
+func WithSessionEventHeartbeatInterval(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.sessionEventHeartbeatInterval = d
+		}
+	}
+}
+
+// newRealtime bundles the process-local pub/sub deps and the resolved
+// streaming-timer settings into a [server.Realtime] for [server.New].
+func newRealtime(
+	leaderboardHub *leaderboard.Hub,
+	sessionService *livesession.Service,
+	sessionHub *livesession.Hub,
+	o options,
+) server.Realtime {
+	return server.Realtime{
+		LeaderboardHub:                leaderboardHub,
+		SessionService:                sessionService,
+		SessionHub:                    sessionHub,
+		LeaderboardHeartbeatInterval:  o.leaderboardHeartbeatInterval,
+		SessionEventHeartbeatInterval: o.sessionEventHeartbeatInterval,
+	}
+}
+
+// resolveOptions builds the [Run] options struct from defaults plus any
+// caller-supplied overrides.
+func resolveOptions(opts []Option) options {
+	o := options{
+		writeTimeout:                  defaultWriteTimeout,
+		leaderboardHeartbeatInterval:  clientapi.DefaultLeaderboardHeartbeatInterval,
+		sessionEventHeartbeatInterval: clientapi.DefaultSessionEventHeartbeatInterval,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return o
+}
+
 // Run starts the application server, connects to the database, runs migrations, and listens for incoming requests.
 func Run(
 	ctx context.Context,
 	getenv func(string) string,
 	stdout io.Writer,
 	ln net.Listener,
+	opts ...Option,
 ) error {
+	o := resolveOptions(opts)
+
 	var err error
 	// SIGTERM is what Docker / k8s send on container stop; without it
 	// the graceful-shutdown path (httpServer.Shutdown + DB close) never
@@ -112,11 +198,7 @@ func Run(
 		<-runnerDone
 	}()
 
-	realtime := server.Realtime{
-		LeaderboardHub: leaderboardHub,
-		SessionService: sessionService,
-		SessionHub:     sessionHub,
-	}
+	realtime := newRealtime(leaderboardHub, sessionService, sessionHub, o)
 	srv, emailTasks, err := buildServer(signalCtx, cfg, logger, stores, gameService, realtime)
 	if err != nil {
 		return err
@@ -130,7 +212,7 @@ func Run(
 		logger.InfoContext(signalCtx, "listener overridden")
 	}
 
-	return runHTTPServer(ctx, signalCtx, ln, srv, emailTasks, logger)
+	return runHTTPServer(ctx, signalCtx, ln, srv, emailTasks, logger, o.writeTimeout)
 }
 
 // buildServer constructs the mailer, the background-task tracker, and the HTTP
@@ -345,6 +427,7 @@ func runHTTPServer(
 	srv http.Handler,
 	emailTasks *bgtasks.Tracker,
 	logger *slog.Logger,
+	writeTimeout time.Duration,
 ) error {
 	httpServer := &http.Server{
 		ReadHeaderTimeout: readHeaderTimeout,

--- a/cmd/server/app/shutdown_test.go
+++ b/cmd/server/app/shutdown_test.go
@@ -66,6 +66,7 @@ func TestRunHTTPServer_DrainsEmailTasksBeforeReturning(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
 			tasks,
 			slog.New(slog.DiscardHandler),
+			10*time.Second,
 		)
 	}()
 

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -418,12 +418,13 @@ func HandleQuizLeaderboard(logger *slog.Logger, service *game.Service) http.Hand
 // leaderboard stream. Methods on this type keep helper signatures
 // small instead of threading six parameters through each call.
 type leaderboardStreamer struct {
-	w        http.ResponseWriter
-	rc       *http.ResponseController
-	logger   *slog.Logger
-	service  *game.Service
-	quizID   int64
-	playerID int64
+	w                 http.ResponseWriter
+	rc                *http.ResponseController
+	logger            *slog.Logger
+	service           *game.Service
+	quizID            int64
+	playerID          int64
+	heartbeatInterval time.Duration
 }
 
 // writeEvent writes the given leaderboard response as a single SSE
@@ -465,24 +466,47 @@ func (s *leaderboardStreamer) writeHeartbeat() bool {
 	return true
 }
 
-// leaderboardHeartbeatInterval is how often the SSE handler emits a
-// no-op comment frame to keep the connection alive when the hub is
+// DefaultLeaderboardHeartbeatInterval is how often the SSE handler emits
+// a no-op comment frame to keep the connection alive when the hub is
 // quiet. The HTTP server's WriteTimeout no longer kills the response
 // (the handler clears its own write deadline), so this only exists as
 // insurance against intermediate proxy / NAT / mobile-carrier idle
 // timeouts that aren't visible during local-dev testing - nginx
 // defaults to 60s, HAProxy ~50s, mobile NATs sometimes 30s. 25s lands
 // comfortably inside all of those without the keep-alive cost of a
-// 10s tick.
-const leaderboardHeartbeatInterval = 25 * time.Second
+// 10s tick. Production wiring (internal/server/routes.go) passes this
+// value; the heartbeat regression tests pass a shorter interval.
+const DefaultLeaderboardHeartbeatInterval = 25 * time.Second
+
+// clampHeartbeat falls back to fallback when d is non-positive, so a
+// caller that builds the wiring struct without the field does not panic
+// at [time.NewTicker] inside the SSE handler.
+func clampHeartbeat(d, fallback time.Duration) time.Duration {
+	if d <= 0 {
+		return fallback
+	}
+
+	return d
+}
 
 // HandleQuizLeaderboardStream pushes leaderboard snapshots over SSE.
 // On every hub tick the handler re-fetches and emits one full snapshot,
 // not a delta - so a slow client coalesces multiple commits into one
 // repaint via the per-subscriber buffer of 1.
+//
+// heartbeatInterval is the gap between no-op SSE comment frames written
+// on an otherwise idle stream; production passes
+// [DefaultLeaderboardHeartbeatInterval] and the heartbeat regression
+// test shrinks it so the assertion runs in milliseconds, not seconds.
+// A zero or negative value falls back to the default so a caller that
+// constructs the wiring struct without the field does not panic at
+// [time.NewTicker].
 func HandleQuizLeaderboardStream(
 	logger *slog.Logger, service *game.Service, hub *leaderboard.Hub,
+	heartbeatInterval time.Duration,
 ) http.Handler {
+	heartbeatInterval = clampHeartbeat(heartbeatInterval, DefaultLeaderboardHeartbeatInterval)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -540,12 +564,13 @@ func HandleQuizLeaderboardStream(
 		}
 
 		streamer := &leaderboardStreamer{
-			w:        w,
-			rc:       rc,
-			logger:   logger,
-			service:  service,
-			quizID:   quizID,
-			playerID: player.ID,
+			w:                 w,
+			rc:                rc,
+			logger:            logger,
+			service:           service,
+			quizID:            quizID,
+			playerID:          player.ID,
+			heartbeatInterval: heartbeatInterval,
 		}
 
 		if !streamer.writeEvent(ctx, res) {
@@ -564,10 +589,10 @@ func HandleQuizLeaderboardStream(
 // initial-snapshot path, which can surface the error cleanly.
 //
 // The heartbeat ticker emits a no-op SSE comment frame every
-// leaderboardHeartbeatInterval to keep the connection warm; without
-// it Firefox closes idle streams after ~30s with NS_ERROR_PARTIAL_TRANSFER.
+// s.heartbeatInterval to keep the connection warm; without it Firefox
+// closes idle streams after ~30s with NS_ERROR_PARTIAL_TRANSFER.
 func (s *leaderboardStreamer) run(ctx context.Context, events <-chan struct{}) {
-	heartbeat := time.NewTicker(leaderboardHeartbeatInterval)
+	heartbeat := time.NewTicker(s.heartbeatInterval)
 	defer heartbeat.Stop()
 
 	for {

--- a/internal/clientapi/sessions.go
+++ b/internal/clientapi/sessions.go
@@ -639,21 +639,23 @@ type sessionEventResponse struct {
 	Phase   string `json:"phase"`
 }
 
-// sessionEventHeartbeatInterval is how often the session SSE handler emits
-// a no-op comment frame to keep the connection alive when the session is
-// quiet. Same value and rationale as the leaderboard stream
-// (leaderboardHeartbeatInterval): 25s lands inside common proxy / NAT /
-// mobile-carrier idle timeouts without the keep-alive cost of a faster
-// tick.
-const sessionEventHeartbeatInterval = 25 * time.Second
+// DefaultSessionEventHeartbeatInterval is how often the session SSE handler
+// emits a no-op comment frame to keep the connection alive when the session
+// is quiet. Same value and rationale as the leaderboard stream
+// ([DefaultLeaderboardHeartbeatInterval]): 25s lands inside common proxy /
+// NAT / mobile-carrier idle timeouts without the keep-alive cost of a
+// faster tick. Production wiring (internal/server/routes.go) passes this
+// value; the heartbeat regression test passes a shorter interval.
+const DefaultSessionEventHeartbeatInterval = 25 * time.Second
 
 // sessionEventStreamer bundles the per-request dependencies of the session
 // SSE stream. Mirrors leaderboardStreamer so the two share the same flush /
 // heartbeat / write-deadline handling.
 type sessionEventStreamer struct {
-	w      http.ResponseWriter
-	rc     *http.ResponseController
-	logger *slog.Logger
+	w                 http.ResponseWriter
+	rc                *http.ResponseController
+	logger            *slog.Logger
+	heartbeatInterval time.Duration
 }
 
 // writeTick writes one tick as a single SSE `data:` frame and flushes.
@@ -694,10 +696,10 @@ func (s *sessionEventStreamer) writeHeartbeat() bool {
 
 // run drains the hub channel and writes one SSE frame per tick until the
 // client disconnects or the channel closes. The heartbeat ticker emits a
-// no-op comment frame every sessionEventHeartbeatInterval to keep an idle
-// connection warm.
+// no-op comment frame every s.heartbeatInterval to keep an idle connection
+// warm.
 func (s *sessionEventStreamer) run(ctx context.Context, events <-chan livesession.Tick) {
-	heartbeat := time.NewTicker(sessionEventHeartbeatInterval)
+	heartbeat := time.NewTicker(s.heartbeatInterval)
 	defer heartbeat.Stop()
 
 	for {
@@ -757,7 +759,18 @@ func beatPresence(ctx context.Context, logger *slog.Logger, touch func(context.C
 // no game data - each tick is {version, phase}, a signal to re-GET
 // /api/sessions/{code}/state. A reconnect re-runs the gate and resends the
 // current version, which doubles as the resync path.
-func HandleSessionEvents(service *livesession.Service, hub *livesession.Hub) http.Handler {
+//
+// heartbeatInterval is the gap between no-op SSE comment frames written on
+// an otherwise idle stream; production passes
+// [DefaultSessionEventHeartbeatInterval] and the heartbeat regression test
+// shrinks it so the assertion runs in milliseconds, not seconds. A zero
+// or negative value falls back to the default so a caller that constructs
+// the wiring struct without the field does not panic at [time.NewTicker].
+func HandleSessionEvents(
+	service *livesession.Service, hub *livesession.Hub, heartbeatInterval time.Duration,
+) http.Handler {
+	heartbeatInterval = clampHeartbeat(heartbeatInterval, DefaultSessionEventHeartbeatInterval)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		logger := handlers.LoggerFromContext(ctx)
@@ -820,7 +833,7 @@ func HandleSessionEvents(service *livesession.Service, hub *livesession.Hub) htt
 			logger.WarnContext(ctx, "could not clear SSE write deadline", slog.Any("err", derr))
 		}
 
-		streamer := &sessionEventStreamer{w: w, rc: rc, logger: logger}
+		streamer := &sessionEventStreamer{w: w, rc: rc, logger: logger, heartbeatInterval: heartbeatInterval}
 
 		if !streamer.writeTick(ctx, livesession.Tick{Version: version, Phase: view.Phase}) {
 			return

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/starquake/topbanana/internal/admin"
 	"github.com/starquake/topbanana/internal/auth"
@@ -839,7 +840,10 @@ func addAPIRoutes(
 	)
 	mux.Handle(
 		"GET /api/quizzes/{slugID}/leaderboard/stream",
-		ensurePlayer(clientapi.HandleQuizLeaderboardStream(logger, gameService, realtime.LeaderboardHub)),
+		ensurePlayer(clientapi.HandleQuizLeaderboardStream(
+			logger, gameService, realtime.LeaderboardHub,
+			realtime.LeaderboardHeartbeatInterval,
+		)),
 	)
 	mux.Handle(
 		"GET /api/quizzes/{slugID}/my-game",
@@ -860,7 +864,10 @@ func addAPIRoutes(
 	)
 	mux.Handle("GET /api/games/{gameID}/results", ensurePlayer(clientapi.HandleGameResults(logger, gameService)))
 
-	addSessionRoutes(mux, realtime.SessionService, realtime.SessionHub, ensurePlayer)
+	addSessionRoutes(
+		mux, realtime.SessionService, realtime.SessionHub,
+		realtime.SessionEventHeartbeatInterval, ensurePlayer,
+	)
 }
 
 // addSessionRoutes registers the hosted live-session API (MP-1 / #678,
@@ -876,6 +883,7 @@ func addSessionRoutes(
 	mux *http.ServeMux,
 	sessionService *livesession.Service,
 	sessionHub *livesession.Hub,
+	heartbeatInterval time.Duration,
 	ensurePlayer func(http.Handler) http.Handler,
 ) {
 	mux.Handle("POST /api/sessions", ensurePlayer(clientapi.HandleSessionCreate(sessionService)))
@@ -895,7 +903,7 @@ func addSessionRoutes(
 	mux.Handle("GET /api/sessions/{code}/state", ensurePlayer(clientapi.HandleSessionState(sessionService)))
 	mux.Handle(
 		"GET /api/sessions/{code}/events",
-		ensurePlayer(clientapi.HandleSessionEvents(sessionService, sessionHub)),
+		ensurePlayer(clientapi.HandleSessionEvents(sessionService, sessionHub, heartbeatInterval)),
 	)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/starquake/topbanana/internal/bgtasks"
 	"github.com/starquake/topbanana/internal/config"
@@ -21,10 +22,19 @@ import (
 // service via SetLeaderboardPublisher). SessionService + SessionHub are the
 // hosted live-session service and its SSE tick hub; the same instances the
 // runner goroutine publishes through (MP-5 / #682).
+//
+// LeaderboardHeartbeatInterval and SessionEventHeartbeatInterval are how
+// often the two SSE handlers emit a no-op comment frame on an otherwise
+// idle stream. Production wiring passes
+// [clientapi.DefaultLeaderboardHeartbeatInterval] and
+// [clientapi.DefaultSessionEventHeartbeatInterval]; the heartbeat
+// regression tests shrink them so the assertion runs in milliseconds.
 type Realtime struct {
-	LeaderboardHub *leaderboard.Hub
-	SessionService *livesession.Service
-	SessionHub     *livesession.Hub
+	LeaderboardHub                *leaderboard.Hub
+	SessionService                *livesession.Service
+	SessionHub                    *livesession.Hub
+	LeaderboardHeartbeatInterval  time.Duration
+	SessionEventHeartbeatInterval time.Duration
 }
 
 // Mail bundles the mailer deps so they travel as one argument through

--- a/test/integration/gameplay_test.go
+++ b/test/integration/gameplay_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/starquake/topbanana/cmd/server/app"
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
@@ -241,13 +242,19 @@ func setupIntegration(t *testing.T) (context.Context, integrationSetup) {
 // same server (LOGIN_COOLDOWN=0 disables the per-IP login cooldown, the same
 // knob the e2e suite uses) or shrink the session runner beats
 // (SESSION_RUNNER_BEAT) while still getting a store.Stores for direct seeding.
-func setupIntegrationWithEnv(t *testing.T, extraEnv map[string]string) (context.Context, integrationSetup) {
+//
+// runOpts are forwarded to [app.Run] for values that have no env-var hook
+// (the HTTP server's WriteTimeout and the SSE handlers' heartbeat intervals,
+// used by the SSE heartbeat regression test).
+func setupIntegrationWithEnv(
+	t *testing.T, extraEnv map[string]string, runOpts ...app.Option,
+) (context.Context, integrationSetup) {
 	t.Helper()
 
 	env := map[string]string{"REGISTRATION_ENABLED": "true"}
 	maps.Copy(env, extraEnv)
 
-	ctx, srv := startServer(t, env)
+	ctx, srv := startServer(t, env, runOpts...)
 
 	db, err := sql.Open("sqlite", srv.DBURI)
 	if err != nil {

--- a/test/integration/leaderboard_stream_test.go
+++ b/test/integration/leaderboard_stream_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/starquake/topbanana/cmd/server/app"
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
 )
@@ -212,25 +213,34 @@ func TestLeaderboardStream_Integration(t *testing.T) {
 // TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout
 // pins the #244 follow-up that disables the per-request write deadline
 // on the SSE handler and emits a periodic comment heartbeat. Before the
-// fix, the HTTP server's 10s WriteTimeout would kill every leaderboard
-// stream at exactly 10.003s — silent (no error to the client beyond
-// NS_ERROR_PARTIAL_TRANSFER in the browser) but fatal to anything that
-// expected the stream to stay open while no answers were committing.
+// fix, the HTTP server's WriteTimeout would kill every leaderboard
+// stream as soon as the deadline elapsed — silent (no error to the client
+// beyond NS_ERROR_PARTIAL_TRANSFER in the browser) but fatal to anything
+// that expected the stream to stay open while no answers were committing.
 //
 // The test opens a stream against a fresh quiz with no players, waits
-// past the 10s WriteTimeout AND past one heartbeat tick (25s), and
-// asserts:
+// past the WriteTimeout AND past several heartbeat ticks, and asserts:
 //   - the connection is still alive at the end of the window (no
 //     premature EOF — proves the WriteTimeout fix),
 //   - at least one heartbeat comment (`:` line) arrived after the
 //     initial snapshot (proves the heartbeat is firing).
 //
-// 27s wall-clock makes this one of the slower integration tests, but
-// it runs in parallel so the suite's critical path doesn't grow.
+// The HTTP server's WriteTimeout and the SSE handler's heartbeat
+// interval are injected via [app.Option], so this regression runs in
+// milliseconds instead of leaning on the production 10s / 25s defaults.
 func TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, nil)
+	const (
+		heartbeatInterval = 100 * time.Millisecond
+		writeTimeout      = 200 * time.Millisecond
+		window            = 1500 * time.Millisecond
+	)
+
+	ctx, srv := startServer(t, nil,
+		app.WithWriteTimeout(writeTimeout),
+		app.WithLeaderboardHeartbeatInterval(heartbeatInterval),
+	)
 
 	db, err := sql.Open("sqlite", srv.DBURI)
 	if err != nil {
@@ -260,11 +270,6 @@ func TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout(t *test
 		t.Fatalf("CreateQuiz err = %v, want nil", cerr)
 	}
 
-	// 27s is past the 10s WriteTimeout AND past the 25s heartbeat
-	// interval, so a working server emits at least one heartbeat
-	// inside the window. The request context cancels at the end, which
-	// unblocks the scanner loop below.
-	const window = 27 * time.Second
 	streamCtx, streamCancel := context.WithTimeout(ctx, window)
 	defer streamCancel()
 
@@ -291,9 +296,9 @@ func TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout(t *test
 	}
 
 	// Drain lines as they arrive. heartbeatLines counts SSE comment
-	// frames (lines beginning with ":"); a single one past the 10s
-	// mark proves the WriteTimeout fix is in place AND the heartbeat
-	// is firing.
+	// frames (lines beginning with ":"); a single one past the
+	// WriteTimeout mark proves the WriteTimeout fix is in place AND the
+	// heartbeat is firing.
 	scanner := bufio.NewScanner(streamResp.Body)
 	var heartbeatLines int
 	var sawInitialData bool
@@ -313,11 +318,11 @@ func TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout(t *test
 	if !sawInitialData {
 		t.Fatal("never received the initial-snapshot SSE event")
 	}
-	// The scanner only exits when the context cancels (after `window`)
-	// or the server closes the body. If we got out in well under the
-	// window, the server closed early — WriteTimeout still bites.
-	if elapsed < window-2*time.Second {
-		t.Fatalf("stream closed after %v, want stream to stay open the full %v window", elapsed, window)
+	// Stream must stay open well past the WriteTimeout - if the handler
+	// did not clear the per-request deadline, the loop would exit at
+	// ~writeTimeout, far short of the window.
+	if elapsed < writeTimeout*4 {
+		t.Fatalf("stream closed after %v, want stream to stay open well past WriteTimeout (%v)", elapsed, writeTimeout)
 	}
 	if heartbeatLines == 0 {
 		t.Errorf("got 0 heartbeat (`:` ...) lines in %v, want at least 1", window)

--- a/test/integration/session_events_test.go
+++ b/test/integration/session_events_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/starquake/topbanana/cmd/server/app"
 )
 
 // sessionTickPayload mirrors the JSON shape of one SSE tick on the session
@@ -254,15 +256,29 @@ func TestSessionEvents_NonParticipantRejected(t *testing.T) {
 }
 
 // TestSessionEvents_HeartbeatOnIdleStream pins that an idle event stream
-// emits keep-alive comment frames past the HTTP server's 10s WriteTimeout,
-// the same fix the leaderboard stream relies on. It opens a stream against
-// a session with no further mutations, holds it past the 10s WriteTimeout
-// AND past one 25s heartbeat tick, and asserts the connection stayed open
-// and at least one heartbeat comment arrived.
+// emits keep-alive comment frames, the same fix the leaderboard stream
+// relies on. It opens a stream against a session with no further mutations,
+// holds it past several heartbeat ticks, and asserts the connection stayed
+// open and at least one heartbeat comment arrived.
+//
+// The SSE handler's heartbeat interval is injected via [app.Option] so this
+// regression runs in milliseconds instead of leaning on the production 25s
+// default. The HTTP-server-WriteTimeout half of the regression is pinned by
+// the leaderboard sister test (which has no auth dance and so can run with
+// a tight WriteTimeout); the session events handler uses the same
+// SetWriteDeadline(time.Time{}) pattern so a single tight-WriteTimeout
+// witness covers both handlers.
 func TestSessionEvents_HeartbeatOnIdleStream(t *testing.T) {
 	t.Parallel()
 
-	ctx, setup := setupIntegration(t)
+	const (
+		heartbeatInterval = 100 * time.Millisecond
+		window            = 500 * time.Millisecond
+	)
+
+	ctx, setup := setupIntegrationWithEnv(t, nil,
+		app.WithSessionEventHeartbeatInterval(heartbeatInterval),
+	)
 	baseURL := setup.BaseURL
 
 	qz := seedLiveQuiz(ctx, t, setup.Stores.Quizzes, "events-heartbeat")
@@ -277,9 +293,6 @@ func TestSessionEvents_HeartbeatOnIdleStream(t *testing.T) {
 	alice := newAnonClient(t)
 	joinSession(ctx, t, alice, baseURL, code, "Alice")
 
-	// 27s is past the 10s WriteTimeout AND past the 25s heartbeat interval,
-	// so a working server emits at least one heartbeat inside the window.
-	const window = 27 * time.Second
 	streamCtx, streamCancel := context.WithTimeout(ctx, window)
 	defer streamCancel()
 
@@ -307,7 +320,7 @@ func TestSessionEvents_HeartbeatOnIdleStream(t *testing.T) {
 	if !sawInitialData {
 		t.Fatal("never received the initial-tick SSE event")
 	}
-	if elapsed < window-2*time.Second {
+	if elapsed < window-100*time.Millisecond {
 		t.Fatalf("stream closed after %v, want it to stay open the full %v window", elapsed, window)
 	}
 	if heartbeatLines == 0 {

--- a/test/integration/testmain_test.go
+++ b/test/integration/testmain_test.go
@@ -46,7 +46,14 @@ type testServer struct {
 // extraEnv is merged on top of the default getenv (HOST=localhost,
 // PORT=0, DB_URI=<tmpdb>) so tests can opt in to flags like
 // REGISTRATION_ENABLED without redoing the rest of the boilerplate.
-func startServer(t *testing.T, extraEnv map[string]string) (context.Context, testServer) {
+//
+// runOpts are forwarded to [app.Run] for values that have no env-var
+// hook: the HTTP server's WriteTimeout and the SSE handlers' heartbeat
+// intervals, which the heartbeat regression tests shrink so the
+// assertion runs inside a sub-second window.
+func startServer(
+	t *testing.T, extraEnv map[string]string, runOpts ...app.Option,
+) (context.Context, testServer) {
 	t.Helper()
 
 	if testing.Short() {
@@ -97,7 +104,7 @@ func startServer(t *testing.T, extraEnv map[string]string) (context.Context, tes
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- app.Run(ctx, getenv, stdout, ln)
+		errCh <- app.Run(ctx, getenv, stdout, ln, runOpts...)
 	}()
 
 	// Coverage instrumentation (make test-coverage, the CI build job) plus


### PR DESCRIPTION
## Summary
- SSE heartbeat interval and HTTP WriteTimeout are now constructor parameters via functional options.
- Production defaults (25s heartbeat, existing WriteTimeout) pinned in named constants.
- The two heartbeat regression tests inject short intervals and shrink their windows; each drops from ~27s to <1s.

Closes #898.

## Decisions
- Functional options (`WithLeaderboardHeartbeatInterval`, `WithSessionEventHeartbeatInterval`, `WithWriteTimeout`) over direct struct fields so the production wiring stays a one-liner and tests opt into overrides explicitly.
- `clampHeartbeat` helper guards zero/negative durations (silently ignored, documented in godoc).
- Production defaults live as exported `Default*` constants near the handlers so future tweaks are one edit.

## Test plan
- [x] make lint-fix / make check / make smoke / make test-e2e
- [x] go test ./test/integration -run "TestSessionEvents_HeartbeatOnIdleStream|TestLeaderboardStream_HeartbeatKeepsConnectionAlivePastWriteTimeout" -count=3 -v -- both consistently <1s