### PR TITLE
Speed up Playwright via the page.clock API

### DIFF
--- a/test/e2e/tests/api-error-handling.spec.ts
+++ b/test/e2e/tests/api-error-handling.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, Route, Request } from './fixtures';
 import {
   seedQuiz,
   startQuizAsAnonymous,
+  installPlaythroughClock,
   QUIZ_QUESTIONS,
 } from './helpers';
 import { adminStatePath } from '../e2e-auth';
@@ -24,6 +25,12 @@ test('400 on answer POST does not show the retry banner', async ({ page, browser
 
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();
+  // Install the virtual clock so the post-400 synthesized feedback
+  // pause and the next question's reveal beat advance via
+  // page.clock.runFor instead of wall time. The spec's regression
+  // intent is that the catch path's setTimeout fires (so the game
+  // advances) - the timer is preserved, just driven by virtual time.
+  await installPlaythroughClock(page);
 
   // Fail the first answers POST with a 400 (mimicking the real server
   // path for ErrOptionNotInQuestion). The point is "no banner for
@@ -40,9 +47,13 @@ test('400 on answer POST does not show the retry banner', async ({ page, browser
 
   await startQuizAsAnonymous(page, quizTitle);
 
+  // Fast-forward the per-question reveal beat (#247) so the option
+  // button mounts under virtual time rather than wall time.
+  await page.clock.runFor(2_500);
   const firstChoice = QUIZ_QUESTIONS[0].options[0];
   const firstButton = page.getByRole('button', { name: firstChoice });
   await expect(firstButton).toBeVisible({ timeout: 10_000 });
+  await expect(firstButton).toBeEnabled({ timeout: 10_000 });
   await firstButton.click();
 
   // The retry banner uses role="alert". It must NOT appear for a
@@ -53,11 +64,17 @@ test('400 on answer POST does not show the retry banner', async ({ page, browser
   // The catch path synthesizes a timed-out feedback so the player
   // doesn't get stuck on a blank screen; the verdict eyebrow reads
   // "Time up" (#767).
-  await expect(page.getByTestId('reveal-verdict')).toHaveText('Time up', { timeout: 3_000 });
+  await expect(page.getByTestId('reveal-verdict')).toHaveText('Time up');
 
-  // The game must advance to the next question (resolveAndAdvance's
-  // pause runs the reveal beat first). Long timeout because the
-  // reveal is intentionally held briefly before the advance fires.
+  // Fast-forward past the synthesized feedback pause so
+  // resolveAndAdvance's setTimeout fires and the next question fetches.
+  await page.clock.runFor(3_500);
+
+  // The game must advance to the next question - the catch path's
+  // timer fires under virtual time. Long timeout because the
+  // reveal beat for question 2 then runs (real-time fetch + virtual
+  // setInterval ticks); the second runFor covers the new beat.
+  await page.clock.runFor(2_500);
   const secondChoice = QUIZ_QUESTIONS[1].options[0];
   await expect(page.getByRole('button', { name: secondChoice })).toBeVisible({ timeout: 15_000 });
 });

--- a/test/e2e/tests/claim.spec.ts
+++ b/test/e2e/tests/claim.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from './fixtures';
-import { registerForPending, login, markEmailVerified, seedQuiz, playThroughQuiz } from './helpers';
+import {
+  registerForPending,
+  login,
+  markEmailVerified,
+  seedQuiz,
+  playThroughQuiz,
+  installPlaythroughClock,
+} from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // Petname format: Title-cased Adjective-Adjective-Noun, e.g. "Steamy-Farty-Bear".
@@ -84,6 +91,10 @@ test.describe('claim modal over a played quiz', () => {
 
     await seedQuiz(page, quizTitle);
     await page.context().clearCookies();
+    // The playthrough fast-forwards per-question timers via the
+    // virtual clock; install before any navigation so the SPA's
+    // setInterval/setTimeout calls land on it from first paint.
+    await installPlaythroughClock(page);
 
     // Anonymous player walks the quiz. The pre-leaderboard claim card is
     // shown because the player is still on the auto-petname; once finished,
@@ -109,6 +120,10 @@ test.describe('claim modal over a played quiz', () => {
 
     await seedQuiz(page, quizTitle);
     await page.context().clearCookies();
+    // The later playthrough fast-forwards per-question timers via the
+    // virtual clock; install before any navigation so the SPA's
+    // setInterval/setTimeout calls land on it from first paint.
+    await installPlaythroughClock(page);
 
     // Visit /client/, claim a name via the start-screen modal, then play through.
     await page.goto('/client/');

--- a/test/e2e/tests/deeplink-flash.spec.ts
+++ b/test/e2e/tests/deeplink-flash.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { seedQuiz, playThroughQuiz } from './helpers';
+import { seedQuiz, playThroughQuiz, installPlaythroughClock } from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // Seed the quiz as the shared admin (via the JSON importer), then clear the
@@ -21,6 +21,10 @@ test('deep-link to an already-completed quiz never flashes the quiz header', asy
 
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();
+  // The playthrough fast-forwards per-question timers via the virtual
+  // clock; install before any navigation so the SPA's
+  // setInterval/setTimeout calls land on it from first paint.
+  await installPlaythroughClock(page);
 
   // Play the quiz to completion so the (player, quiz) pair is locked to the
   // already-completed state for the revisit below.

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -303,33 +303,79 @@ export async function startQuizAsAnonymous(page: Page, quizTitle: string): Promi
   await page.getByRole('button', { name: 'Start Game' }).click();
 }
 
+// FEEDBACK_PAUSE_WRONG_MS mirrors the larger arm of the per-question feedback
+// hold the solo client applies after a pick (#233): 2s after a correct pick,
+// 3s after a wrong one. Fast-forwarding by the wrong-arm value covers both.
+const FEEDBACK_PAUSE_WRONG_MS = 3_000;
+
+// CLOCK_BUFFER_MS gives a small margin over the exact beat so a tick that
+// lands fractionally short of its threshold still fires - runFor advances by
+// whole-ms increments and the client's serverTime() is derived from
+// Date.now() plus a clockOffset that's recomputed from each question's
+// serverNow, so a buffer absorbs the difference.
+const CLOCK_BUFFER_MS = 500;
+
+// playthroughClockInstall is the contract every spec calling
+// playThroughQuiz / answerRemainingQuestions must satisfy before page.goto.
+// It installs Playwright's virtual clock at the current real time so the
+// helper can fast-forward through the per-question reveal beat and feedback
+// pause without paying wall-clock time. Kept as a thin wrapper rather than
+// a hidden side-effect so the spec's clock contract is visible at its call
+// site.
+export async function installPlaythroughClock(page: Page): Promise<void> {
+  await page.clock.install();
+}
+
+// waitForOptionEnabled retries runFor + the toBeVisible / toBeEnabled
+// assertions in small chunks of virtual time until the option button is
+// visible AND enabled. The chunked retry absorbs three timing skews the
+// helper has no other way to align:
+//   1. The per-question /next fetch runs in real time, so the
+//      startRevealCountdown setInterval may not be registered yet when
+//      we first runFor.
+//   2. setInterval only ticks under virtual time, so once registered it
+//      needs a runFor to actually fire its 100ms ticks.
+//   3. resolveAndAdvance's setTimeout (the feedback pause) chains into
+//      nextQuestion -> fetch -> startRevealCountdown, all of which
+//      interleave real-time and virtual-time work.
+// Each retry pumps 500ms of virtual time and re-checks; the toPass
+// timeout caps total wall-clock at ~10s so a genuinely-stuck render
+// still fails loudly.
+async function waitForOptionEnabled(page: Page, choice: string): Promise<void> {
+  const optionButton = page.getByRole('button', { name: choice });
+  await expect(async () => {
+    await page.clock.runFor(500);
+    await expect(optionButton).toBeVisible({ timeout: 100 });
+    await expect(optionButton).toBeEnabled({ timeout: 100 });
+  }).toPass({ timeout: 10_000 });
+}
+
 // answerRemainingQuestions clicks the first option for each question starting
 // at fromIndex (default 0) and asserts the matching success/danger feedback.
 // Waits for the leaderboard at the end so the caller can pick up immediately
 // after the auto-advance from the final question. fromIndex lets timeout
 // specs skip the questions that have already been resolved (e.g. via the
 // timer-expired path).
+//
+// CONTRACT: the calling spec must call installPlaythroughClock(page) before
+// page.goto so the virtual clock is in place from the SPA's first paint. The
+// helper drives the per-question reveal-beat (#247) and feedback-pause (#233)
+// setInterval/setTimeout via page.clock.runFor instead of waiting in real
+// time, so the whole suite skips paying ~5s per question.
 export async function answerRemainingQuestions(page: Page, fromIndex = 0): Promise<void> {
   for (let i = fromIndex; i < QUIZ_QUESTIONS.length; i++) {
     const q = QUIZ_QUESTIONS[i];
     const choice = q.options[0];
     const wasCorrect = q.correctIndices.includes(0);
 
+    // Pump virtual time forward in 500ms chunks until the option
+    // button shows up and is no longer :disabled. The reveal beat
+    // (#247) only ticks under virtual time, and the per-question
+    // /next fetch is real-time, so a single runFor would race the
+    // fetch and pointlessly advance the clock before the setInterval
+    // is registered.
+    await waitForOptionEnabled(page, choice);
     const optionButton = page.getByRole('button', { name: choice });
-    // Per-question wait must cover the prior feedback pause (up to 3s
-    // on a wrong pick, #233) plus this question's reveal-countdown
-    // beat (3s, #247). The default 5s toBeVisible timeout isn't
-    // enough; 10s gives headroom for slow CI runners.
-    await expect(optionButton).toBeVisible({ timeout: 10_000 });
-    // toBeVisible passes during both the answer window AND the
-    // feedback pause (the buttons stay in DOM so the per-option
-    // reveal can paint correct/wrong/dim — #233). Under parallel
-    // load the click can land while a prior question's feedback is
-    // still active: `:disabled="!!feedback"` is truthy, the button
-    // carries btn-answer-dim, and the locator then detaches as the
-    // question advances (#432). Gate on toBeEnabled so the click
-    // happens within this question's answer window or fails fast.
-    await expect(optionButton).toBeEnabled({ timeout: 10_000 });
     await optionButton.click();
 
     // The quieter post-answer reveal (#767): a small verdict eyebrow
@@ -341,11 +387,18 @@ export async function answerRemainingQuestions(page: Page, fromIndex = 0): Promi
     } else {
       await expect(verdict).toHaveText('Not quite');
     }
+
+    // Feedback pause (#233): resolveAndAdvance schedules
+    // setTimeout(2s correct / 3s wrong) before nextQuestion. runFor
+    // fires the setTimeout under virtual time; the subsequent
+    // nextQuestion fetch is real-time, and the next iteration's
+    // waitForOptionEnabled picks up once the new question's
+    // setInterval is wired up.
+    await page.clock.runFor(FEEDBACK_PAUSE_WRONG_MS + CLOCK_BUFFER_MS);
   }
 
   // The leaderboard renders after the last answer's auto-advance hits 404
-  // on getNextQuestion. Generous timeout because the per-question feedback
-  // delay adds up.
+  // on getNextQuestion.
   await expect(page.getByRole('heading', { name: 'Game Finished!' })).toBeVisible({ timeout: 15_000 });
   await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
 }

--- a/test/e2e/tests/mobile-layout.spec.ts
+++ b/test/e2e/tests/mobile-layout.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from './fixtures';
 import { test, expect } from './fixtures';
-import { seedQuiz, playThroughQuiz } from './helpers';
+import { seedQuiz, playThroughQuiz, installPlaythroughClock } from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // #844 — a narrow iPhone (~320px CSS width) surfaced layout breaks: the
@@ -95,6 +95,10 @@ test.describe('solo leaderboard narrow-viewport layout (#844)', () => {
 
     await seedQuiz(page, quizTitle);
     await page.context().clearCookies();
+    // The later playthrough fast-forwards per-question timers via the
+    // virtual clock; install before any navigation so the SPA's
+    // setInterval/setTimeout calls land on it from first paint.
+    await installPlaythroughClock(page);
 
     // Claim the long name on the start screen, then play through so the
     // leaderboard row for the current player carries it.

--- a/test/e2e/tests/player.spec.ts
+++ b/test/e2e/tests/player.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { seedQuiz, QUIZ_QUESTIONS } from './helpers';
+import { seedQuiz, installPlaythroughClock, QUIZ_QUESTIONS } from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // Seed the quiz as the shared admin (via the JSON importer), then clear
@@ -19,6 +19,10 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
   // ---- Seed the quiz, then drop the admin cookie so play is anonymous.
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();
+  // Install Playwright's virtual clock before any navigation so the
+  // per-question reveal beat (#247) and feedback pause (#233) can be
+  // fast-forwarded by page.clock.runFor instead of paying wall time.
+  await installPlaythroughClock(page);
 
   // ---- Player flow: visit /quizzes (the public list, #284), click the
   // quiz card to land on /play/{slug-id}, then walk every question by
@@ -73,13 +77,17 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
     const choice = q.options[0];
     const wasCorrect = q.correctIndices.includes(0);
 
-    // Wait for the option button before reading the score chip so we
-    // don't sample stale state from the previous question's render. The
-    // timeout must span the prior question's feedback pause (up to 3s
-    // on a wrong pick, #233) plus this question's reveal-countdown
-    // (3s, #247) — 10s gives headroom for slow CI.
+    // Pump virtual time forward in small chunks until the option
+    // button shows up enabled. The reveal beat (#247) only ticks
+    // under virtual time, and the per-question /next fetch runs in
+    // real time, so a single fixed runFor would race the fetch -
+    // toPass retries while waiting on both.
     const optionButton = page.getByRole('button', { name: choice });
-    await expect(optionButton).toBeVisible({ timeout: 10_000 });
+    await expect(async () => {
+      await page.clock.runFor(500);
+      await expect(optionButton).toBeVisible({ timeout: 100 });
+      await expect(optionButton).toBeEnabled({ timeout: 100 });
+    }).toPass({ timeout: 10_000 });
 
     // #234 — before submitting, the running score chip must still
     // reflect only what's been scored so far. Pinning this here
@@ -119,6 +127,12 @@ test('admin sets up a multi-question quiz, then a player plays it through to the
       // chip to its prior value before the next question loads.
       await expect(scoreChipValue).toHaveText(String(prevScore));
     }
+
+    // Feedback pause (#233): resolveAndAdvance schedules
+    // setTimeout(2s correct / 3s wrong) before nextQuestion. runFor
+    // fires the setTimeout under virtual time so the next iteration's
+    // poll picks up once the new question is wired up.
+    await page.clock.runFor(3_500);
   }
 
   // After the auto-advance from the last answer, getNextQuestion() returns

--- a/test/e2e/tests/resume.spec.ts
+++ b/test/e2e/tests/resume.spec.ts
@@ -3,6 +3,7 @@ import {
   seedQuiz,
   startQuizAsAnonymous,
   answerRemainingQuestions,
+  installPlaythroughClock,
   QUIZ_QUESTIONS,
 } from './helpers';
 import { adminStatePath } from '../e2e-auth';
@@ -39,6 +40,13 @@ test('mid-game reload lands back on the question, not the start screen', async (
 
   await expect(page.getByRole('button', { name: firstChoice })).toBeVisible({ timeout: 10_000 });
   await expect(page.getByRole('button', { name: 'Start Game' })).toBeHidden();
+
+  // Install the virtual clock now (not before page.goto) so the
+  // pre-reload boot path keeps real timing - page.reload would
+  // otherwise re-paint Q1 against a frozen clock and the resumed
+  // reveal beat would stall. From here on the helper fast-forwards
+  // per-question timers via runFor.
+  await installPlaythroughClock(page);
 
   // The resumed game still walks through to completion — a regression
   // where the resume path left the client in a broken state would

--- a/test/e2e/tests/share.spec.ts
+++ b/test/e2e/tests/share.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from './fixtures';
-import { seedQuiz, startQuizAsAnonymous, answerRemainingQuestions } from './helpers';
+import {
+  seedQuiz,
+  startQuizAsAnonymous,
+  answerRemainingQuestions,
+  installPlaythroughClock,
+} from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // Seed each quiz as the shared admin via the JSON importer; the share
@@ -64,6 +69,9 @@ test('player client finish screen Copy writes title + score + URL', async ({ pag
   await seedQuiz(page, quizTitle);
 
   await page.context().clearCookies();
+  // Install the virtual clock before navigating so answerRemainingQuestions
+  // can fast-forward the per-question timers (page.clock contract).
+  await installPlaythroughClock(page);
   await page.addInitScript(() => {
     const w = window as unknown as { __copiedPayload?: string };
     w.__copiedPayload = undefined;
@@ -113,8 +121,11 @@ test('player client finish screen has a share button that includes the score', a
   await seedQuiz(page, quizTitle);
 
   // Play the quiz through as anonymous so the finish screen
-  // renders with a real `score` and `quizSlugId`.
+  // renders with a real `score` and `quizSlugId`. Install the
+  // virtual clock before navigating so the playthrough helper can
+  // fast-forward per-question timers.
   await page.context().clearCookies();
+  await installPlaythroughClock(page);
   await startQuizAsAnonymous(page, quizTitle);
   await answerRemainingQuestions(page);
 
@@ -156,8 +167,11 @@ test('share-result reads score from the leaderboard so a revisit still brags the
   await seedQuiz(page, quizTitle);
 
   // First play-through as anonymous so the score lands on the
-  // leaderboard against the auto-petname player row.
+  // leaderboard against the auto-petname player row. Install the
+  // virtual clock before navigating so the playthrough helper can
+  // fast-forward per-question timers.
   await page.context().clearCookies();
+  await installPlaythroughClock(page);
   await startQuizAsAnonymous(page, quizTitle);
   await answerRemainingQuestions(page);
 
@@ -213,9 +227,12 @@ test('home page popular-card share button opens the dialog with invitation text'
 
   // The home page only surfaces quizzes that have at least one
   // finished play in the last 30 days, so we need to seed the quiz
-  // AND play it through anonymously before the card appears.
+  // AND play it through anonymously before the card appears. Install
+  // the virtual clock before navigating so the playthrough helper can
+  // fast-forward per-question timers.
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();
+  await installPlaythroughClock(page);
   await startQuizAsAnonymous(page, quizTitle);
   await answerRemainingQuestions(page);
 

--- a/test/e2e/tests/timeout.spec.ts
+++ b/test/e2e/tests/timeout.spec.ts
@@ -3,6 +3,7 @@ import {
   seedQuiz,
   startQuizAsAnonymous,
   answerRemainingQuestions,
+  installPlaythroughClock,
   QUIZ_QUESTIONS,
 } from './helpers';
 import { adminStatePath } from '../e2e-auth';
@@ -81,6 +82,13 @@ test('timing out a question shows the Time up verdict and the rest of the quiz s
   await expect(page.getByRole('button', { name: secondQuestion.options[0] })).toBeVisible({
     timeout: SETTLE_MS,
   });
+
+  // Install the virtual clock now (not before page.goto) so the Q1
+  // countdown above ran against the real progress bar drain - the
+  // assertion at progress=0 only stays observable when the bar
+  // ticks in wall time. From here on the helper fast-forwards
+  // per-question timers via page.clock.runFor.
+  await installPlaythroughClock(page);
 
   // Play through the remaining questions. The point of this loop is not
   // to verify scoring but to prove the game progresses past the


### PR DESCRIPTION
## Summary
- Tests use Playwright's `page.clock` API to fast-forward past the per-question reveal beat and feedback pause after asserting the verdict element. Production timer (2s correct / 3s wrong) is unchanged.
- Each spec that played through a quiz now installs the clock before `page.goto`, asserts the verdict text, then `clock.runFor(...)` skips the timer.
- No server-side env var, no client-side `window.__topbananaConfig`, no test-only branches in the player JS.

Closes #899 (Lever A — fixture sharing still tracked separately).

## Decisions
- Rewrote the original timer-shrink approach (`FEEDBACK_DELAY` env var) after CI surfaced a race: at 50ms the verdict text empties before Playwright's polling catches it. User redirected to element-based; this PR uses `page.clock` (precedent: `cooldown.spec.ts`).
- Clock installed per-spec (not via fixture) so specs that watch a real countdown (`timeout.spec.ts` watches the per-question progress bar drain to 0) keep wall-clock timing for their first question; the helper installs the clock after that observation, then drives the remaining questions on virtual time.
- `resume.spec.ts` installs the clock AFTER the mid-game reload, not before — page reload would otherwise re-paint Q1 against a frozen clock and the resumed reveal beat would stall.
- `waitForOptionEnabled` polls `runFor(500ms)` + `toBeVisible` + `toBeEnabled` in a `toPass` retry: the per-question `/next` fetch runs in real time while the reveal-beat `setInterval` ticks under virtual time, and a fixed `runFor` would race the fetch and pointlessly advance the clock before the setInterval is registered.
- `standings-bargraph.spec.ts` (the third originally-failing spec) was untouched: it is a live-mode spec where the server's session runner beat drives advance, not the solo client's feedback pause. The original PR's `FEEDBACK_DELAY` knob never reached that path; its CI failure was unrelated.

## Test plan
- [x] `make lint-fix` / `make check` / `make smoke` / `make test-e2e` all clean locally
- [x] Wall-clock comparison vs the prior approach: full e2e suite ~5.1m locally (4 parallel workers, both browsers). The per-spec savings vs main on the modified specs are in the 17-20s range per playthrough; `player.spec.ts:9` drops from ~25s to 3.3s on both browsers, `share.spec.ts` finish/revisit/home each drop from ~20s to 2.4-3.3s.