### PR TITLE
Extract the quiz list card into a shared partial

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -187,7 +187,12 @@ type QuizData struct {
 	// PlayCount is the durable "times played" counter surfaced on the
 	// admin quiz list footer (#891).
 	PlayCount int64
-	Questions []*QuestionData
+	// ActionVariant selects which action cluster the shared quiz_card
+	// partial renders ("admin" Edit/Delete vs. a future host variant);
+	// html/template has no block/yield, so the card picks a named
+	// sub-template by this discriminator (#889).
+	ActionVariant string
+	Questions     []*QuestionData
 }
 
 // QuestionData is the data for a question. TimeLimitSecondsValue is the
@@ -255,6 +260,10 @@ const (
 	maxFormSize = 1 << 20 // 1 MB
 )
 
+// actionVariantAdmin selects the Edit/Delete action cluster in the shared
+// quiz_card partial. The host variant lands with the host UI work (#889).
+const actionVariantAdmin = "admin"
+
 // canEditQuiz is the single source of truth for the creator-or-Admin edit rule
 // (#281/#538): the session player must be present and must either be the quiz's
 // creator OR an Admin (who may edit, delete, and reset scores on any quiz). A
@@ -309,6 +318,7 @@ func quizDataFromQuiz(qz *quiz.Quiz) *QuizData {
 		Mode:                 mode,
 		ModeOptions:          quiz.ModeValues(),
 		PlayCount:            qz.PlayCount,
+		ActionVariant:        actionVariantAdmin,
 		Questions:            questionDataFromQuestions(qz.Questions),
 	}
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1031,6 +1031,9 @@ func newTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, page string
 			return fmt.Sprintf("Must be %d-%d characters.", MinPasswordLength, MaxPasswordLength)
 		},
 		"passwordMinLength": func() int { return MinPasswordLength },
+		// Placeholder so the shared components glob parses; this surface
+		// does not render quiz_card, which is the only user (#889).
+		"humanizeTime": func(time.Time) string { return "" },
 	}
 	layouts := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "components/*.gohtml", "auth/layouts/*.gohtml"),

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/starquake/topbanana/internal/absurl"
 	"github.com/starquake/topbanana/internal/envtag"
@@ -317,6 +318,9 @@ func parseTemplate(page string) *template.Template {
 		"navSection":     func() string { return "" },
 		"logoHref":       func() string { return "/" },
 		"profileHref":    func() string { return "/profile" },
+		// Placeholder so the shared components glob parses; this surface
+		// does not render quiz_card, which is the only user (#889).
+		"humanizeTime": func(time.Time) string { return "" },
 	}
 	base := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmplFS(), "components/*.gohtml", "home/layouts/*.gohtml"),

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/starquake/topbanana/internal/absurl"
 	"github.com/starquake/topbanana/internal/auth"
@@ -270,6 +271,9 @@ func newTemplateRenderer(logger *slog.Logger, csrfMgr *csrf.Manager, page string
 			return fmt.Sprintf("Must be %d-%d characters.", auth.MinPasswordLength, auth.MaxPasswordLength)
 		},
 		"passwordMinLength": func() int { return auth.MinPasswordLength },
+		// Placeholder so the shared components glob parses; this surface
+		// does not render quiz_card, which is the only user (#889).
+		"humanizeTime": func(time.Time) string { return "" },
 	}
 	layouts := template.Must(
 		template.New("").Funcs(funcs).ParseFS(tmpl.FS, "components/*.gohtml", "auth/layouts/*.gohtml"),

--- a/internal/web/tmpl/admin/pages/quizlist.gohtml
+++ b/internal/web/tmpl/admin/pages/quizlist.gohtml
@@ -50,77 +50,7 @@
     {{if .Quizzes}}
         <section class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5" aria-label="Your quizzes">
             {{range .Quizzes}}
-                <article class="group relative flex flex-col h-full bg-surface border border-border-soft rounded-lg overflow-hidden transition-colors duration-200 hover:border-accent-line">
-                    <div class="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-border to-transparent transition-colors group-hover:via-accent"></div>
-                    <div class="flex-1 p-5 pb-2">
-                        <div class="flex items-center justify-between mb-3 text-[0.7rem] uppercase tracking-[0.16em] text-text-mute">
-                            <span class="text-text-dim">Quiz #{{.ID}}</span>
-                            <time title="{{.UpdatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .UpdatedAt}}</time>
-                        </div>
-                        <h3 class="mb-2 font-display text-lg leading-[1.25] font-semibold">
-                            {{/* Stretched link — the ::before pseudo covers the whole article so
-                                 clicking anywhere on the card navigates to the quiz view. Footer
-                                 action buttons sit on `relative z-10` to stay independently
-                                 clickable above the pseudo. */}}
-                            <a href="/admin/quizzes/{{.ID}}"
-                               class="text-text hover:text-accent before:absolute before:inset-0 before:content-['']">
-                                {{.Title}}
-                            </a>
-                        </h3>
-                        <code class="inline-block mb-3.5 px-2 py-0.5 rounded-sm font-mono text-[0.72rem] text-cyan bg-cyan-soft">/play/{{.Slug}}-{{.ID}}</code>
-                        <p class="mb-4 text-text-dim text-sm leading-relaxed line-clamp-2">{{.Description}}</p>
-                    </div>
-                    <footer class="flex items-center justify-between px-5 py-3.5 border-t border-border-soft text-text-dim text-sm">
-                        <div class="flex items-center gap-2.5">
-                            <span><strong class="text-text font-semibold mr-1">{{.QuestionCount}}</strong>&nbsp;questions</span>
-                            {{/* Times-played counter (#891): bumped once each time a
-                                 game of this quiz completes; never decremented. The
-                                 Lucide play-circle icon labels the figure without
-                                 needing a "plays" word. */}}
-                            <span class="inline-flex items-center gap-1" title="Times played">
-                                <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
-                                <strong class="text-text font-semibold">{{.PlayCount}}</strong>
-                                <span class="sr-only">times played</span>
-                            </span>
-                            {{/* Play-mode badge (#829, #890): a live quiz is hosted-only,
-                                 a solo quiz is self-paced. Inline Lucide icons
-                                 (users / user) replace the dot so the mode reads at
-                                 a glance without learning the colour code. */}}
-                            {{if eq .Mode "live"}}
-                                <span class="pill pill-live">
-                                    <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.87a4 4 0 0 1 0 7.75"/></svg>
-                                    Live
-                                </span>
-                            {{else}}
-                                <span class="pill pill-solo">
-                                    <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
-                                    Solo
-                                </span>
-                            {{end}}
-                        </div>
-                        {{/* CanEdit is resolved server-side from the
-                             session player + creator (see admin.go's
-                             attachCanEdit). Templates never compute
-                             the rule themselves so a future policy
-                             change is a one-line Go edit. */}}
-                        {{if .CanEdit}}
-                            <div class="relative z-10 flex items-center gap-1">
-                                <a href="/admin/quizzes/{{.ID}}/edit" aria-label="Edit quiz" title="Edit"
-                                   class="icon-btn">
-                                    <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
-                                </a>
-                                <button type="button"
-                                        onclick="openModal('modal-delete-quiz-{{.ID}}')"
-                                        aria-label="Delete quiz" title="Delete"
-                                        class="w-9 h-9 inline-flex items-center justify-center rounded-sm bg-transparent border-0 text-danger hover:bg-danger/10 focus-visible:outline-none focus-visible:shadow-focus transition-colors cursor-pointer">
-                                    <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
-                                </button>
-                            </div>
-                        {{else if .CreatedByDisplayName}}
-                            <span class="text-[0.7rem] uppercase tracking-[0.12em] text-text-mute">Created by {{.CreatedByDisplayName}}</span>
-                        {{end}}
-                    </footer>
-                </article>
+                {{template "quiz_card" .}}
             {{end}}
         </section>
 

--- a/internal/web/tmpl/components/quiz_card.gohtml
+++ b/internal/web/tmpl/components/quiz_card.gohtml
@@ -1,0 +1,89 @@
+{{/* quiz_card renders one quiz tile. The dot is a QuizData item, so any
+     field the card needs (PlayCount, Mode, QuestionCount, CanEdit,
+     ActionVariant, ...) must live on QuizData. The footer action cluster is
+     parameterised by ActionVariant so other surfaces (the host UI, #889) can
+     reuse the same card with their own actions; html/template has no
+     block/yield, so the variant selects a named sub-template. */}}
+{{define "quiz_card"}}
+    <article class="group relative flex flex-col h-full bg-surface border border-border-soft rounded-lg overflow-hidden transition-colors duration-200 hover:border-accent-line">
+        <div class="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-border to-transparent transition-colors group-hover:via-accent"></div>
+        <div class="flex-1 p-5 pb-2">
+            <div class="flex items-center justify-between mb-3 text-[0.7rem] uppercase tracking-[0.16em] text-text-mute">
+                <span class="text-text-dim">Quiz #{{.ID}}</span>
+                <time title="{{.UpdatedAt.Format "2006-01-02 15:04"}}">{{humanizeTime .UpdatedAt}}</time>
+            </div>
+            <h3 class="mb-2 font-display text-lg leading-[1.25] font-semibold">
+                {{/* Stretched link — the ::before pseudo covers the whole article so
+                     clicking anywhere on the card navigates to the quiz view. Footer
+                     action buttons sit on `relative z-10` to stay independently
+                     clickable above the pseudo. */}}
+                <a href="/admin/quizzes/{{.ID}}"
+                   class="text-text hover:text-accent before:absolute before:inset-0 before:content-['']">
+                    {{.Title}}
+                </a>
+            </h3>
+            <code class="inline-block mb-3.5 px-2 py-0.5 rounded-sm font-mono text-[0.72rem] text-cyan bg-cyan-soft">/play/{{.Slug}}-{{.ID}}</code>
+            <p class="mb-4 text-text-dim text-sm leading-relaxed line-clamp-2">{{.Description}}</p>
+        </div>
+        <footer class="flex items-center justify-between px-5 py-3.5 border-t border-border-soft text-text-dim text-sm">
+            <div class="flex items-center gap-2.5">
+                <span><strong class="text-text font-semibold mr-1">{{.QuestionCount}}</strong>&nbsp;questions</span>
+                {{/* Times-played counter (#891): bumped once each time a
+                     game of this quiz completes; never decremented. The
+                     Lucide play-circle icon labels the figure without
+                     needing a "plays" word. */}}
+                <span class="inline-flex items-center gap-1" title="Times played">
+                    <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                    <strong class="text-text font-semibold">{{.PlayCount}}</strong>
+                    <span class="sr-only">times played</span>
+                </span>
+                {{/* Play-mode badge (#829, #890): a live quiz is hosted-only,
+                     a solo quiz is self-paced. Inline Lucide icons
+                     (users / user) replace the dot so the mode reads at
+                     a glance without learning the colour code. */}}
+                {{if eq .Mode "live"}}
+                    <span class="pill pill-live">
+                        <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.87a4 4 0 0 1 0 7.75"/></svg>
+                        Live
+                    </span>
+                {{else}}
+                    <span class="pill pill-solo">
+                        <svg viewBox="0 0 24 24" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                        Solo
+                    </span>
+                {{end}}
+            </div>
+            {{if eq .ActionVariant "host"}}{{template "quiz_card_actions_host" .}}{{else}}{{template "quiz_card_actions_admin" .}}{{end}}
+        </footer>
+    </article>
+{{end}}
+
+{{/* quiz_card_actions_admin is the Edit/Delete cluster for the admin surface.
+     CanEdit is resolved server-side from the session player + creator (see
+     admin.go's attachCanEdit); templates never compute the rule themselves so
+     a future policy change is a one-line Go edit. */}}
+{{define "quiz_card_actions_admin"}}
+    {{if .CanEdit}}
+        <div class="relative z-10 flex items-center gap-1">
+            <a href="/admin/quizzes/{{.ID}}/edit" aria-label="Edit quiz" title="Edit"
+               class="icon-btn">
+                <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
+            </a>
+            <button type="button"
+                    onclick="openModal('modal-delete-quiz-{{.ID}}')"
+                    aria-label="Delete quiz" title="Delete"
+                    class="w-9 h-9 inline-flex items-center justify-center rounded-sm bg-transparent border-0 text-danger hover:bg-danger/10 focus-visible:outline-none focus-visible:shadow-focus transition-colors cursor-pointer">
+                <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5zM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1H11z"/></svg>
+            </button>
+        </div>
+    {{else if .CreatedByDisplayName}}
+        <span class="text-[0.7rem] uppercase tracking-[0.12em] text-text-mute">Created by {{.CreatedByDisplayName}}</span>
+    {{end}}
+{{end}}
+
+{{/* quiz_card_actions_host is a placeholder for the host surface's action
+     cluster, filled in with the host UI work (#889, slice 2). html/template
+     resolves every {{template}} reference at parse time, including the
+     unreachable branch in quiz_card, so this define must exist now even though
+     no surface sets ActionVariant "host" yet. */}}
+{{define "quiz_card_actions_host"}}{{end}}


### PR DESCRIPTION
## Summary
- Extract the admin quiz-list card into `internal/web/tmpl/components/quiz_card.gohtml` with a parameterised action slot (`ActionVariant` discriminator on the card view model).
- Admin rendering is unchanged; the #891 play-count cell and the solo/live play-mode badge move into the partial intact.
- Register the placeholder funcs/templates the shared partial references (`humanizeTime`, the `quiz_card_actions_host` define) on every surface that globs `components/*.gohtml` so the partial parses everywhere; only admin renders it for now.

Part of #889 (slice 1 of 4: shared quiz-card partial). No behaviour change.

## Decisions
- Action slot uses an `ActionVariant` string discriminator (`"admin"` today) selecting a `quiz_card_actions_*` sub-template, rather than a block/yield (which Go `html/template` lacks). This PR defines only the `admin` variant; the host variant arrives in slice 2.
- Because `quiz_card.gohtml` lands in the shared `components/*.gohtml` glob, it is parsed by every surface that includes that glob (admin, auth, home, profile). Those surfaces get parse-only placeholders for `humanizeTime` and an empty `quiz_card_actions_host` define so parsing succeeds; they never render the card.

## Test plan
- [x] make lint-fix / make check / make smoke
- [x] make test-e2e (213 passed, 4 skipped)
- [x] Existing admin quiz-list tests pass unchanged (play-mode badge + #891 play-count cell rendering preserved through the extraction)