### PR TITLE
Make the api-error e2e seed titles unique so retries do not 409

### DIFF
--- a/test/e2e/tests/api-error-handling.spec.ts
+++ b/test/e2e/tests/api-error-handling.spec.ts
@@ -21,7 +21,10 @@ test.use({ storageState: adminStatePath() });
 test('400 on answer POST does not show the retry banner', async ({ page, browserName }) => {
   test.setTimeout(45_000);
 
-  const quizTitle = `E2E 287 ${browserName}`;
+  // Date.now() keeps the title unique per attempt: a Playwright retry reuses
+  // the same per-worker DB, so a fixed title would 409 on re-import (the failed
+  // attempt already seeded it) and doom the retry (#908).
+  const quizTitle = `E2E 287 ${browserName} ${Date.now()}`;
 
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();
@@ -87,7 +90,8 @@ test('400 on answer POST does not show the retry banner', async ({ page, browser
 test('409 on startGame recovers via getMyGameForQuiz', async ({ page, browserName }) => {
   test.setTimeout(30_000);
 
-  const quizTitle = `E2E 287 conflict ${browserName}`;
+  // Unique per attempt so a retry does not 409 on the seed (#908).
+  const quizTitle = `E2E 287 conflict ${browserName} ${Date.now()}`;
 
   await seedQuiz(page, quizTitle);
   await page.context().clearCookies();


### PR DESCRIPTION
Closes #908

## Root cause (confirmed from the failed CI trace)

`api-error-handling.spec.ts` seeded its quizzes with **fixed** titles (`E2E 287 ${browserName}`, no timestamp). Playwright retries reuse the **same per-worker DB**, so:

1. Attempt 1 imports the quiz, then flakes later (an intermittent virtual-clock timing miss - the option button not mounting in time under full-suite load).
2. The retry re-imports the **same title** into the DB that still holds attempt 1's quiz -> `POST /admin/quizzes/import` returns **409** -> the retry is doomed and can never pass.

That is why #908 "flaked twice" and red-failed the run despite `retries: 1`. The downloaded `playwright-report-firefox` artifact from the failing run shows exactly this: attempt 1 = button-not-visible timeout, attempt 2 = `import failed: 409`.

## Fix

Give the two seeded titles a `${Date.now()}` suffix so each attempt is unique - matching the convention the other host-session specs already use (`Armed Fire ${Date.now()}`, etc.). A retry now seeds a fresh quiz and re-runs cleanly, so a transient attempt-1 timing miss is caught by the retry instead of red-failing the run.

## Validated

- `npx playwright test api-error-handling.spec.ts --repeat-each=2 --project=chromium` - both repeats pass (repeat-each reuses the worker DB, exactly the cross-attempt persistence that 409'd before; the old fixed title would collide on the 2nd repeat).
- The spec passes on chromium and firefox.

## Notes / not in scope

- #909 (`host-armed-start`) and #912 (`confirm-restart`) use `Date.now()` titles already, so they are retry-safe - their "Target page closed" symptom is a **separate** cause still to characterise (their own traces needed).
- ~27 other specs use fixed `${browserName}` titles; they only hit this 409 trap if they flake *after* seeding (which they currently don't). Worth a follow-up sweep to make seed titles unique suite-wide, but out of scope here.