### PR TITLE
Share one restart-modal partial between admin and host

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -182,13 +182,13 @@ func parseTemplate(path string) *template.Template {
 	return render.Parse(tmpl.FS, funcs, path, "host/layouts/*.gohtml")
 }
 
-// parsePickerTemplate parses the host layouts plus the shared quiz-card and
-// modal-manager partials and the named page. It registers the same funcs as
-// parseTemplate (the shared quiz_card partial calls humanizeTime). Only the
-// quiz_card and modal_manager partials are parsed (not the whole components/
-// glob): the footer and topbar partials reference funcs (isSignedIn, isAdmin)
-// this page does not provide. modal_manager references no funcs, so it is safe
-// to add to the narrowed list.
+// parsePickerTemplate parses the host layouts plus the shared quiz-card,
+// modal-manager, and restart-modal partials and the named page. It registers
+// the same funcs as parseTemplate (the shared quiz_card partial calls
+// humanizeTime). Only those three partials are parsed (not the whole
+// components/ glob): the footer and topbar partials reference funcs
+// (isSignedIn, isAdmin) this page does not provide; the three listed here use
+// only csrfToken/humanizeTime, so they are safe to add to the narrowed list.
 func parsePickerTemplate(path string) *template.Template {
 	funcs := template.FuncMap{
 		"envTitleTag":  envtag.Get,
@@ -197,5 +197,6 @@ func parsePickerTemplate(path string) *template.Template {
 	}
 
 	return render.Parse(tmpl.FS, funcs, path,
-		"host/layouts/*.gohtml", "components/quiz_card.gohtml", "components/modal_manager.gohtml")
+		"host/layouts/*.gohtml", "components/quiz_card.gohtml",
+		"components/modal_manager.gohtml", "components/restart_modal.gohtml")
 }

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -152,36 +152,11 @@
             </div>
         </div>
 
-        {{/* Confirm-and-restart modal (#853). Mounted only when the host already
-             has a game in flight; the "Host live" button above opens it. Confirm
-             ends the running session and opens a fresh room hosting this quiz. */}}
-        {{if .HostHasRunningGame}}
-        <div id="modal-restart-host-{{.Quiz.ID}}" data-testid="restart-modal" role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
-            <div class="absolute inset-0" onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"></div>
-            <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">
-                <header class="flex items-center justify-between px-6 py-5 border-b border-border-soft">
-                    <p id="modal-restart-host-{{.Quiz.ID}}-title" class="font-display text-sm font-semibold uppercase tracking-[0.14em]">End the current session and start a new one?</p>
-                    <button type="button" aria-label="close"
-                            onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"
-                            class="w-6 h-6 inline-flex items-center justify-center rounded-full bg-border-soft text-text-dim border-0 hover:bg-border hover:text-text cursor-pointer">&times;</button>
-                </header>
-                <section class="px-6 py-5 text-[0.95rem]">
-                    A live session is already running. End it and start hosting this quiz instead?
-                </section>
-                <footer class="flex justify-end gap-2 px-6 py-4 border-t border-border-soft">
-                    <button type="button"
-                            onclick="closeModal('modal-restart-host-{{.Quiz.ID}}')"
-                            class="btn-ghost">Cancel</button>
-                    <form method="post" action="/host" class="inline-flex">
-                        <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-                        <input type="hidden" name="quiz_id" value="{{.Quiz.ID}}">
-                        <input type="hidden" name="restart" value="true">
-                        <button type="submit" class="btn-primary">End and start</button>
-                    </form>
-                </footer>
-            </div>
-        </div>
-        {{end}}
+        {{/* Confirm-and-restart modal (#853, shared partial #916). Mounted only
+             when the host already has a game in flight; the "Host live" button
+             above opens it. Confirm ends the running session and opens a fresh
+             room hosting this quiz. */}}
+        {{if .HostHasRunningGame}}{{template "restart_modal" .Quiz.ID}}{{end}}
 
         {{/* Delete-quiz modal */}}
         <div id="modal-delete-quiz-{{.Quiz.ID}}" role="dialog" aria-modal="true" aria-labelledby="modal-delete-quiz-{{.Quiz.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">

--- a/internal/web/tmpl/components/restart_modal.gohtml
+++ b/internal/web/tmpl/components/restart_modal.gohtml
@@ -1,0 +1,31 @@
+{{/* restart_modal is the confirm-and-restart dialog (#853, #889) shared by the
+     admin quiz-view and the host picker. The dot is the quiz id; the partial
+     pairs with an openModal('modal-restart-host-<id>') trigger and the shared
+     modal_manager script. csrfToken is bound per render. */}}
+{{define "restart_modal"}}
+<div id="modal-restart-host-{{.}}" data-testid="restart-modal" role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
+    <div class="absolute inset-0" onclick="closeModal('modal-restart-host-{{.}}')"></div>
+    <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">
+        <header class="flex items-center justify-between px-6 py-5 border-b border-border-soft">
+            <p id="modal-restart-host-{{.}}-title" class="font-display text-sm font-semibold uppercase tracking-[0.14em]">End the current session and start a new one?</p>
+            <button type="button" aria-label="close"
+                    onclick="closeModal('modal-restart-host-{{.}}')"
+                    class="w-6 h-6 inline-flex items-center justify-center rounded-full bg-border-soft text-text-dim border-0 hover:bg-border hover:text-text cursor-pointer">&times;</button>
+        </header>
+        <section class="px-6 py-5 text-[0.95rem]">
+            A live session is already running. End it and start hosting this quiz instead?
+        </section>
+        <footer class="flex justify-end gap-2 px-6 py-4 border-t border-border-soft">
+            <button type="button"
+                    onclick="closeModal('modal-restart-host-{{.}}')"
+                    class="btn-ghost">Cancel</button>
+            <form method="post" action="/host" class="inline-flex">
+                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
+                <input type="hidden" name="quiz_id" value="{{.}}">
+                <input type="hidden" name="restart" value="true">
+                <button type="submit" class="btn-primary">End and start</button>
+            </form>
+        </footer>
+    </div>
+</div>
+{{end}}

--- a/internal/web/tmpl/host/pages/picker.gohtml
+++ b/internal/web/tmpl/host/pages/picker.gohtml
@@ -19,33 +19,7 @@
                  page dot is hostPickerData, so .HostHasRunningGame is a
                  page-level field; inside the range .ID is the card's. */}}
             {{if .HostHasRunningGame}}
-                {{range .Quizzes}}
-                <div id="modal-restart-host-{{.ID}}" data-testid="restart-modal" role="dialog" aria-modal="true" aria-labelledby="modal-restart-host-{{.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
-                    <div class="absolute inset-0" onclick="closeModal('modal-restart-host-{{.ID}}')"></div>
-                    <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">
-                        <header class="flex items-center justify-between px-6 py-5 border-b border-border-soft">
-                            <p id="modal-restart-host-{{.ID}}-title" class="font-display text-sm font-semibold uppercase tracking-[0.14em]">End the current session and start a new one?</p>
-                            <button type="button" aria-label="close"
-                                    onclick="closeModal('modal-restart-host-{{.ID}}')"
-                                    class="w-6 h-6 inline-flex items-center justify-center rounded-full bg-border-soft text-text-dim border-0 hover:bg-border hover:text-text cursor-pointer">&times;</button>
-                        </header>
-                        <section class="px-6 py-5 text-[0.95rem]">
-                            A live session is already running. End it and start hosting this quiz instead?
-                        </section>
-                        <footer class="flex justify-end gap-2 px-6 py-4 border-t border-border-soft">
-                            <button type="button"
-                                    onclick="closeModal('modal-restart-host-{{.ID}}')"
-                                    class="btn-ghost">Cancel</button>
-                            <form method="post" action="/host" class="inline-flex">
-                                <input type="hidden" name="csrf_token" value="{{csrfToken}}">
-                                <input type="hidden" name="quiz_id" value="{{.ID}}">
-                                <input type="hidden" name="restart" value="true">
-                                <button type="submit" class="btn-primary">End and start</button>
-                            </form>
-                        </footer>
-                    </div>
-                </div>
-                {{end}}
+                {{range .Quizzes}}{{template "restart_modal" .ID}}{{end}}
             {{end}}
         {{else}}
             <div class="border border-dashed border-border rounded-xl p-12 text-center">


### PR DESCRIPTION
Closes #916

## Summary
The confirm-and-restart modal markup (#853/#889) was mirrored between the admin quiz-view and the host picker - only the modal *script* was shared (`modal_manager.gohtml`). This extracts the markup into a shared `components/restart_modal.gohtml` partial too. The two blocks were byte-identical except `{{.Quiz.ID}}` vs `{{.ID}}`, so the partial takes the quiz id as its dot.

- New `internal/web/tmpl/components/restart_modal.gohtml` (`{{define "restart_modal"}}`, dot = quiz id, binds `{{csrfToken}}`).
- `admin/pages/quizview.gohtml`: the inline modal becomes `{{template "restart_modal" .Quiz.ID}}`.
- `host/pages/picker.gohtml`: the per-quiz inline modal becomes `{{template "restart_modal" .ID}}`.
- `parsePickerTemplate` parses the new partial (admin already globs `components/*`).

Net ~-30 lines; the rendered HTML is unchanged on both surfaces.

## Test plan
- [x] No new test needed - this is a behaviour-preserving extraction pinned by existing tests that assert the rendered modal on **both** surfaces: `TestHostRestart_QuizViewGatesModal` (admin) and `TestHostQuizList_ChangeQuizWhenRunning` (host) - both pass.
- [x] `make check` (cold golangci cache) - green; `make tailwind-check` - no drift (no new classes).
- [x] `confirm-restart.spec.ts` (drives the admin restart modal) passes.