### PR TITLE
Add the media upload and serving endpoints

### DIFF
--- a/internal/mediahttp/mediahttp.go
+++ b/internal/mediahttp/mediahttp.go
@@ -1,0 +1,48 @@
+// Package mediahttp holds the HTTP handlers for the media slice (#936): the
+// host/admin upload endpoint and the public-entry serving endpoints. The image
+// pipeline, store, and filesystem persistence live in internal/media; this
+// package is only the HTTP edge - request parsing, authorization, and
+// streaming - so internal/media stays free of net/http.
+package mediahttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/media"
+)
+
+// Viewer resolves the authenticated (registered, non-anonymous) player from the
+// request session, or (nil, false) when the request is anonymous or cookieless.
+// The serving handlers use it for the private-quiz gate WITHOUT minting a player
+// row or setting a session cookie: a media response is cacheable (public images
+// carry Cache-Control: public, immutable), so it must not attach a Set-Cookie or
+// create a row the way EnsurePlayer would - the same reason the static asset
+// routes are not EnsurePlayer-wrapped.
+type Viewer func(r *http.Request) (*auth.Player, bool)
+
+// MediaService is the slice of *media.Service the handlers use. Defined here
+// (the consumer) so a test can substitute a fault-injection double, and so the
+// HTTP layer depends on the narrow surface it calls rather than the whole
+// service.
+type MediaService interface {
+	// Store processes an uploaded image through the pipeline, writes the webp
+	// full + thumbnail under the quiz directory, records a row, and returns it.
+	Store(ctx context.Context, quizID, createdBy int64, r io.Reader) (*media.Media, error)
+	// Get returns the media row for id, or media.ErrMediaNotFound.
+	Get(ctx context.Context, id int64) (*media.Media, error)
+	// Open opens a stored media file for reading by its root-relative path. The
+	// caller closes the returned file.
+	Open(relPath string) (*os.File, error)
+}
+
+// QuizVisibilityLookup is the slice of the quiz store the serving handlers use
+// to mirror the owning quiz's access rule onto its media.
+type QuizVisibilityLookup interface {
+	// GetQuizVisibility returns just the visibility of a quiz by ID. Returns
+	// quiz.ErrQuizNotFound when the quiz does not exist.
+	GetQuizVisibility(ctx context.Context, id int64) (string, error)
+}

--- a/internal/mediahttp/serve.go
+++ b/internal/mediahttp/serve.go
@@ -1,0 +1,171 @@
+package mediahttp
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// publicCacheControl and privateCacheControl key the cache policy to the owning
+// quiz's visibility. A public image is shared and immutable: the URL embeds an
+// immutable id and the ETag carries the stored webp's sha256, so the bytes never
+// change under a stable id, and a one-week max-age plus immutable lets the
+// client skip even the revalidation round-trip. A private image must never land
+// in a shared cache, so it is private + no revalidation skip.
+const (
+	publicCacheControl  = "public, max-age=604800, immutable"
+	privateCacheControl = "private, no-cache"
+)
+
+// HandleMediaServe serves the full webp for GET /media/{id}. Authorization
+// mirrors the owning quiz's own access rule: a public quiz's image is served to
+// anyone (including anonymous players mid-game), a private quiz's image only to
+// an authenticated viewer resolved by viewer (no player row is minted - the
+// response is cacheable). The id is an integer path param; the file is streamed
+// via [http.ServeContent] so ETag / If-None-Match / range handling come for free.
+func HandleMediaServe(
+	logger *slog.Logger, svc MediaService, quizzes QuizVisibilityLookup, viewer Viewer,
+) http.Handler {
+	return serveMedia(logger, svc, quizzes, viewer, fullPath)
+}
+
+// HandleMediaThumb serves the 480px webp thumbnail for GET /media/{id}/thumb.
+// Same authorization and caching as HandleMediaServe; it differs only in which
+// of the row's two files it streams.
+func HandleMediaThumb(
+	logger *slog.Logger, svc MediaService, quizzes QuizVisibilityLookup, viewer Viewer,
+) http.Handler {
+	return serveMedia(logger, svc, quizzes, viewer, thumbPath)
+}
+
+// fullPath and thumbPath select which of a row's two files a serving handler
+// streams. Passing the selector (rather than a bool flag) keeps serveMedia free
+// of a control-flow flag parameter.
+func fullPath(m *media.Media) string  { return m.Path }
+func thumbPath(m *media.Media) string { return m.ThumbPath }
+
+// serveMedia is the shared body of the full / thumb serving handlers. pickPath
+// chooses the file to stream. It loads the row, gates on the owning quiz's
+// visibility, then streams the chosen file with a visibility-aware
+// Cache-Control and the sha256 ETag.
+func serveMedia(
+	logger *slog.Logger, svc MediaService, quizzes QuizVisibilityLookup,
+	viewer Viewer, pickPath func(*media.Media) string,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := handlers.ParseIDFromPath(w, r, logger, "id")
+		if !ok {
+			return
+		}
+
+		m, err := svc.Get(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, media.ErrMediaNotFound) {
+				http.NotFound(w, r)
+
+				return
+			}
+			logger.ErrorContext(r.Context(), "error loading media", slog.Any("err", err))
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		visibility, ok := authorizeMediaRead(w, r, logger, quizzes, viewer, m.QuizID)
+		if !ok {
+			return
+		}
+
+		relPath := pickPath(m)
+		if relPath == "" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		streamMedia(w, r, logger, svc, m, relPath, visibility)
+	})
+}
+
+// authorizeMediaRead resolves the owning quiz's visibility and applies the
+// play-surface read rule (mirrors clientapi.canReadQuiz): public/unlisted are
+// reachable by anyone, private requires an authenticated (registered,
+// non-anonymous) viewer. The viewer is resolved from the session without minting
+// a player row, so a cacheable image response carries no Set-Cookie. A missing
+// quiz or an unauthorized viewer is answered with a 404 so the gate is
+// indistinguishable from a genuinely missing item, matching the play surface.
+// Returns the visibility (for the cache policy) and whether to proceed.
+func authorizeMediaRead(
+	w http.ResponseWriter, r *http.Request,
+	logger *slog.Logger, quizzes QuizVisibilityLookup, viewer Viewer, quizID int64,
+) (string, bool) {
+	visibility, err := quizzes.GetQuizVisibility(r.Context(), quizID)
+	if err != nil {
+		if errors.Is(err, quiz.ErrQuizNotFound) {
+			http.NotFound(w, r)
+
+			return "", false
+		}
+		logger.ErrorContext(r.Context(), "error loading quiz visibility for media gate", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return "", false
+	}
+
+	if visibility == quiz.VisibilityPrivate {
+		if _, ok := viewer(r); !ok {
+			http.NotFound(w, r)
+
+			return "", false
+		}
+	}
+
+	return visibility, true
+}
+
+// streamMedia opens and streams the chosen file via [http.ServeContent], which
+// handles the ETag / If-None-Match / Range dance. The Content-Type is the row's
+// stored mime, the ETag is the stored webp's sha256 (quoted, a strong
+// validator), and Cache-Control is keyed to visibility.
+func streamMedia(
+	w http.ResponseWriter, r *http.Request,
+	logger *slog.Logger, svc MediaService, m *media.Media, relPath, visibility string,
+) {
+	ctx := r.Context()
+	f, err := svc.Open(relPath)
+	if err != nil {
+		if errors.Is(err, media.ErrPathEscapesRoot) {
+			http.NotFound(w, r)
+
+			return
+		}
+		logger.ErrorContext(ctx, "error opening media file", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			logger.ErrorContext(ctx, "error closing media file", slog.Any("err", cerr))
+		}
+	}()
+
+	w.Header().Set("Content-Type", m.MIME)
+	w.Header().Set("ETag", strconv.Quote(m.SHA256))
+	if visibility == quiz.VisibilityPublic {
+		w.Header().Set("Cache-Control", publicCacheControl)
+	} else {
+		w.Header().Set("Cache-Control", privateCacheControl)
+	}
+
+	// ServeContent reads the ETag from the header we set and answers a matching
+	// If-None-Match with 304, so the conditional-request handling is not
+	// reimplemented here. The name is only used for content-type sniffing, which
+	// our explicit Content-Type pre-empts; created_at is the modtime.
+	http.ServeContent(w, r, m.Path, m.CreatedAt, f)
+}

--- a/internal/mediahttp/upload.go
+++ b/internal/mediahttp/upload.go
@@ -1,0 +1,189 @@
+package mediahttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+const (
+	// uploadFormField is the multipart field the image arrives under.
+	uploadFormField = "image"
+
+	// maxUploadRequestBytes caps the whole multipart request body. It sits
+	// above media.MaxUploadBytes (the ~10 MB image cap the pipeline enforces on
+	// the file part) so the multipart envelope - boundaries, the csrf_token
+	// field, headers - fits without tripping the body cap before the pipeline
+	// can return the cleaner ErrUploadTooLarge for an oversized image. The
+	// pipeline still rejects an image part over MaxUploadBytes, so this is only
+	// a coarse outer guard, not the real image limit.
+	maxUploadRequestBytes = media.MaxUploadBytes + multipartEnvelopeHeadroom
+
+	// multipartEnvelopeHeadroom is the slack added over the image cap to cover
+	// the multipart envelope (boundaries, the csrf_token field, part headers).
+	multipartEnvelopeHeadroom = 2 << 20
+
+	// multipartMemoryBytes is how much of the parsed multipart form is buffered
+	// in memory before parts spill to temp files. Kept modest so a flood of
+	// concurrent uploads does not pin large buffers; the file part is streamed
+	// to the pipeline either way.
+	multipartMemoryBytes = 1 << 20
+)
+
+// QuizEditLookup is the slice of the quiz store the upload handler uses to
+// enforce the per-quiz edit gate: a host may upload only to a quiz they
+// created, an admin to any (mirrors admin.canEditQuiz / requireQuizOwner).
+type QuizEditLookup interface {
+	// GetQuiz returns a quiz (including CreatedByPlayerID). Returns
+	// quiz.ErrQuizNotFound when the quiz does not exist.
+	GetQuiz(ctx context.Context, id int64) (*quiz.Quiz, error)
+}
+
+// HandleMediaUpload accepts a multipart image upload for POST
+// /admin/quizzes/{quizID}/media and stores it through the media service. The
+// route is host/admin-gated upstream (requireGameHost); this handler adds the
+// per-quiz edit gate so a host may upload only to a quiz they created and an
+// admin to any (the same creator-or-admin rule the admin question/quiz
+// mutations apply via requireQuizOwner). A non-owner host gets a 403; a missing
+// quiz a 404. Pipeline rejections (too large, empty, unsupported) map to 400;
+// other failures to 500. On success it redirects 303 to the quiz view - the
+// library UI that would render the new image lands in a later slice (#936
+// slice 3).
+//
+// The caller is expected to front this handler with MaxMultipartFormMiddleware
+// so the body is capped and the multipart form is parsed before the CSRF
+// middleware validates the token, which for a multipart form lives in the
+// parsed PostForm.
+func HandleMediaUpload(logger *slog.Logger, svc MediaService, quizzes QuizEditLookup) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		quizID, ok := handlers.ParseIDFromPath(w, r, logger, "quizID")
+		if !ok {
+			return
+		}
+
+		player, ok := auth.PlayerFromContext(r.Context())
+		if !ok {
+			// The host gate upstream guarantees a player on the context; a
+			// missing one is a wiring bug, not a client error.
+			logger.ErrorContext(r.Context(), "media upload reached handler without a player on context")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		if !authorizeQuizEdit(w, r, logger, quizzes, quizID, player) {
+			return
+		}
+
+		ctx := r.Context()
+		file, _, err := r.FormFile(uploadFormField)
+		if err != nil {
+			http.Error(w, "missing image file", http.StatusBadRequest)
+
+			return
+		}
+		defer func() {
+			if cerr := file.Close(); cerr != nil {
+				logger.ErrorContext(ctx, "error closing uploaded file", slog.Any("err", cerr))
+			}
+		}()
+
+		if _, err = svc.Store(ctx, quizID, player.ID, file); err != nil {
+			writeUploadError(w, r, logger, err)
+
+			return
+		}
+
+		// quizID is an int64 parsed from the path, so the formatted target is a
+		// fixed-shape internal admin path with no caller-controlled segment.
+		dest := fmt.Sprintf("/admin/quizzes/%d", quizID)
+		http.Redirect(w, r, dest, http.StatusSeeOther) //nolint:gosec // dest is built from an int64 id, not user input
+	})
+}
+
+// authorizeQuizEdit loads the quiz and gates the request on the creator-or-admin
+// edit rule (mirrors admin.canEditQuiz): the player must be the quiz's creator
+// or an admin. A missing quiz yields 404, a non-owner non-admin a 403. Returns
+// whether to proceed.
+func authorizeQuizEdit(
+	w http.ResponseWriter, r *http.Request,
+	logger *slog.Logger, quizzes QuizEditLookup, quizID int64, player *auth.Player,
+) bool {
+	qz, err := quizzes.GetQuiz(r.Context(), quizID)
+	if err != nil {
+		if errors.Is(err, quiz.ErrQuizNotFound) {
+			http.NotFound(w, r)
+
+			return false
+		}
+		logger.ErrorContext(r.Context(), "error loading quiz for media upload gate", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+
+		return false
+	}
+
+	if !player.IsAdmin() && player.ID != qz.CreatedByPlayerID {
+		http.Error(w, "you do not have permission to upload media to this quiz", http.StatusForbidden)
+
+		return false
+	}
+
+	return true
+}
+
+// writeUploadError maps a media.Service.Store error to an HTTP response: the
+// pipeline's caller-fault sentinels become 400 with a short message, anything
+// else is logged and returned as 500.
+func writeUploadError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, err error) {
+	switch {
+	case errors.Is(err, media.ErrUploadTooLarge):
+		http.Error(w, "image exceeds the maximum upload size", http.StatusBadRequest)
+	case errors.Is(err, media.ErrImageTooLarge):
+		http.Error(w, "image dimensions exceed the maximum", http.StatusBadRequest)
+	case errors.Is(err, media.ErrEmptyUpload):
+		http.Error(w, "image file is empty", http.StatusBadRequest)
+	case errors.Is(err, media.ErrUnsupportedImage):
+		http.Error(w, "unsupported image format (use jpg, png, or webp)", http.StatusBadRequest)
+	default:
+		logger.ErrorContext(r.Context(), "error storing uploaded media", slog.Any("err", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}
+
+// MaxMultipartFormMiddleware caps the request body at maxUploadRequestBytes and
+// parses the multipart form before the next handler runs. It is mounted in
+// front of the CSRF middleware on the upload route: the CSRF validator reads the
+// token from PostForm, which for a multipart submission is only populated once
+// the multipart body has been parsed. Parsing here (with the large cap) makes
+// the token visible to the CSRF layer and leaves the parsed file part ready for
+// the handler's FormFile call. A body over the cap or a malformed form yields
+// 400 before the token check, so an oversized upload cannot slip past as a CSRF
+// failure.
+func MaxMultipartFormMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxUploadRequestBytes)
+		// MaxBytesReader above bounds the body, so the parse cannot exhaust
+		// memory despite gosec's G120 flag on the bare ParseMultipartForm call.
+		if err := r.ParseMultipartForm(multipartMemoryBytes); err != nil { //nolint:gosec // body capped above
+			http.Error(w, "invalid or oversized upload", http.StatusBadRequest)
+
+			return
+		}
+		// Parts larger than multipartMemoryBytes spill to temp files that
+		// net/http never removes on its own; clean them up once the handler is
+		// done reading the upload (best-effort).
+		defer func() {
+			if r.MultipartForm != nil {
+				_ = r.MultipartForm.RemoveAll()
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -20,6 +20,8 @@ import (
 	"github.com/starquake/topbanana/internal/host"
 	"github.com/starquake/topbanana/internal/livesession"
 	"github.com/starquake/topbanana/internal/mailer"
+	"github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/mediahttp"
 	"github.com/starquake/topbanana/internal/profile"
 	"github.com/starquake/topbanana/internal/session"
 	"github.com/starquake/topbanana/internal/store"
@@ -62,10 +64,25 @@ func addRoutes(
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	addAdminRoutes(mux, logger, stores, gameDeps, sessions, csrfMgr, emailDeps, playerDeps)
+	addMediaRoutes(mux, logger, stores, sessions, csrfMgr, media.NewService(stores.Media, cfg.MediaDir, logger))
 	addProfileRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	addAPIRoutes(mux, logger, stores, gameService, realtime, sessions, cfg)
 	addHostRoutes(mux, logger, stores, sessions, csrfMgr, realtime.SessionService)
+	addClientAndPublicRoutes(mux, logger, stores, sessions, csrfMgr, cfg)
+}
 
+// addClientAndPublicRoutes registers the player SPA shell, static assets, PWA
+// manifest + service worker, health/version probes, and the public home +
+// quizzes pages. Split out of addRoutes so that function stays under revive's
+// function-length cap as the route surface grows.
+func addClientAndPublicRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+	cfg *config.Config,
+) {
 	// Client
 	shell := client.NewShellHandlers(cfg, stores.Quizzes, logger)
 	// The SPA root and the per-quiz share URL both go through the shell
@@ -521,6 +538,56 @@ func addAdminRoutes(
 
 	addAdminQuestionRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)
 	addAdminRoundRoutes(mux, logger, stores, csrfMW, requireGameHost, csrfMgr)
+}
+
+// addMediaRoutes registers the media slice's HTTP surface (#936 slice 2): the
+// host/admin upload endpoint and the two public-entry serving endpoints.
+//
+// The upload route (POST /admin/quizzes/{quizID}/media) mirrors the admin
+// question POSTs but swaps MaxFormSizeMiddleware (1 MB, urlencoded) for
+// MaxMultipartFormMiddleware: the upload is multipart and its body must be
+// capped well above the 10 MB image limit. MaxMultipartFormMiddleware also
+// parses the multipart form so the CSRF token (a form field) is visible to
+// csrfMW, which reads it from PostForm; without that parse a multipart POST has
+// no PostForm token and would always 403. requireGameHost gates to Host/Admin;
+// the handler adds the per-quiz creator-or-admin edit gate.
+//
+// The serving routes (GET /media/{id} and GET /media/{id}/thumb) resolve the
+// viewer read-only via AuthenticatedSessionPlayer - NOT EnsurePlayer - so a
+// cacheable image response never mints a players row or attaches a Set-Cookie (a
+// Set-Cookie on a Cache-Control: public response is a shared-cache footgun). The
+// private-quiz gate only needs to know whether an authenticated viewer is
+// present. Authorization mirrors the owning quiz's own access rule, decided
+// inside the handler by the quiz's visibility: public/unlisted to anyone,
+// private to an authenticated viewer.
+func addMediaRoutes(
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	stores *store.Stores,
+	sessions *session.Manager,
+	csrfMgr *csrf.Manager,
+	svc *media.Service,
+) {
+	requireGameHost := func(h http.Handler) http.Handler {
+		return auth.RequireGameHost(auth.RequireVerifiedEmail(h), stores.Players, sessions, csrfMgr, logger)
+	}
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/media",
+		mediahttp.MaxMultipartFormMiddleware(csrfMgr.Middleware(requireGameHost(
+			mediahttp.HandleMediaUpload(logger, svc, stores.Quizzes),
+		))),
+	)
+
+	// The serve routes resolve the viewer from the session WITHOUT minting a
+	// player row or setting a cookie (unlike EnsurePlayer): a media response is
+	// cacheable, so it must not carry a Set-Cookie. The private-quiz gate only
+	// needs to know whether an authenticated viewer is present, which
+	// AuthenticatedSessionPlayer answers read-only.
+	viewer := func(r *http.Request) (*auth.Player, bool) {
+		return auth.AuthenticatedSessionPlayer(r, stores.Players, sessions)
+	}
+	mux.Handle("GET /media/{id}", mediahttp.HandleMediaServe(logger, svc, stores.Quizzes, viewer))
+	mux.Handle("GET /media/{id}/thumb", mediahttp.HandleMediaThumb(logger, svc, stores.Quizzes, viewer))
 }
 
 // addAdminQuestionRoutes registers the question CRUD + reorder routes

--- a/test/integration/media_test.go
+++ b/test/integration/media_test.go
@@ -1,0 +1,390 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"maps"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// TestMediaUpload_Integration covers the host/admin upload endpoint (#936
+// slice 2): an owner can upload an image to their editable quiz and the image
+// then serves back; a non-owner host is refused; and a malformed upload is
+// rejected with 400.
+func TestMediaUpload_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupMedia(t, map[string]string{
+		"ADMIN_EMAILS": "media-boss@example.test",
+	})
+	baseURL := setup.BaseURL
+
+	registerAdminClient(ctx, t, baseURL, setup.DBURI, "media-boss")
+	owner := registerAdminClient(ctx, t, baseURL, setup.DBURI, "media-owner")
+	other := registerAdminClient(ctx, t, baseURL, setup.DBURI, "media-other")
+	makeHost(ctx, t, setup.DBURI, "media-owner")
+	makeHost(ctx, t, setup.DBURI, "media-other")
+
+	quizID := createQuizAs(ctx, t, owner, baseURL, "Media Owner Quiz")
+
+	t.Run("owner uploads then serves back", func(t *testing.T) {
+		t.Parallel()
+		uploadImage(ctx, t, owner, baseURL, quizID, "pic.png", pngBytes(t, 200, 120))
+		mediaID := latestMediaID(ctx, t, setup.Stores, quizID)
+
+		resp := httpGet(ctx, t, owner, baseURL+fmt.Sprintf("/media/%d", mediaID))
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("serve status = %d, want %d", got, want)
+		}
+		if got, want := resp.Header.Get("Content-Type"), "image/webp"; got != want {
+			t.Errorf("Content-Type = %q, want %q", got, want)
+		}
+		if etag := resp.Header.Get("ETag"); etag == "" {
+			t.Error("ETag header is empty, want the stored sha256")
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body err = %v, want nil", err)
+		}
+		if len(body) == 0 {
+			t.Error("served image body is empty")
+		}
+	})
+
+	t.Run("non-owner host is refused", func(t *testing.T) {
+		t.Parallel()
+		token := fetchCSRFToken(ctx, t, other, baseURL+"/admin/quizzes")
+		body, contentType := multipartImage(t, "pic.png", pngBytes(t, 64, 64), token)
+		req := newMultipartReq(ctx, t, baseURL+fmt.Sprintf("/admin/quizzes/%d/media", quizID), body, contentType)
+		resp, err := other.Do(req)
+		if err != nil {
+			t.Fatalf("Do err = %v, want nil", err)
+		}
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusForbidden; got != want {
+			t.Errorf("non-owner upload status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("non-image upload is 400", func(t *testing.T) {
+		t.Parallel()
+		token := fetchCSRFToken(ctx, t, owner, baseURL+"/admin/quizzes")
+		body, contentType := multipartImage(t, "note.txt", []byte("not an image at all"), token)
+		req := newMultipartReq(ctx, t, baseURL+fmt.Sprintf("/admin/quizzes/%d/media", quizID), body, contentType)
+		resp, err := owner.Do(req)
+		if err != nil {
+			t.Fatalf("Do err = %v, want nil", err)
+		}
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusBadRequest; got != want {
+			t.Errorf("non-image upload status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("missing file part is 400", func(t *testing.T) {
+		t.Parallel()
+		token := fetchCSRFToken(ctx, t, owner, baseURL+"/admin/quizzes")
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		if err := mw.WriteField("csrf_token", token); err != nil {
+			t.Fatalf("WriteField err = %v, want nil", err)
+		}
+		if err := mw.Close(); err != nil {
+			t.Fatalf("multipart Close err = %v, want nil", err)
+		}
+		req := newMultipartReq(
+			ctx, t, baseURL+fmt.Sprintf("/admin/quizzes/%d/media", quizID), &buf, mw.FormDataContentType(),
+		)
+		resp, err := owner.Do(req)
+		if err != nil {
+			t.Fatalf("Do err = %v, want nil", err)
+		}
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusBadRequest; got != want {
+			t.Errorf("missing-file upload status = %d, want %d", got, want)
+		}
+	})
+}
+
+// TestMediaServe_Integration covers the serving endpoints (#936 slice 2):
+// conditional requests, the thumbnail variant, the unknown-id 404, a garbage
+// id, and the public-vs-private visibility gate.
+func TestMediaServe_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupMedia(t, map[string]string{
+		"ADMIN_EMAILS": "serve-boss@example.test",
+	})
+	baseURL := setup.BaseURL
+
+	registerAdminClient(ctx, t, baseURL, setup.DBURI, "serve-boss")
+	owner := registerAdminClient(ctx, t, baseURL, setup.DBURI, "serve-owner")
+	makeHost(ctx, t, setup.DBURI, "serve-owner")
+
+	publicQuiz := createQuizAs(ctx, t, owner, baseURL, "Public Serve Quiz")
+	privateQuiz := createQuizWithVisibility(ctx, t, owner, baseURL, "Private Serve Quiz", "private")
+
+	uploadImage(ctx, t, owner, baseURL, publicQuiz, "p.png", pngBytes(t, 240, 160))
+	publicMedia := latestMediaID(ctx, t, setup.Stores, publicQuiz)
+	uploadImage(ctx, t, owner, baseURL, privateQuiz, "s.png", pngBytes(t, 240, 160))
+	privateMedia := latestMediaID(ctx, t, setup.Stores, privateQuiz)
+
+	t.Run("public image then conditional 304", func(t *testing.T) {
+		t.Parallel()
+		etag := func() string {
+			resp := httpGet(ctx, t, owner, baseURL+fmt.Sprintf("/media/%d", publicMedia))
+			defer closeBody(t, resp.Body)
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Fatalf("public serve status = %d, want %d", got, want)
+			}
+			if got := resp.Header.Get("Cache-Control"); !strings.Contains(got, "public") {
+				t.Errorf("public Cache-Control = %q, want it to contain %q", got, "public")
+			}
+
+			return resp.Header.Get("ETag")
+		}()
+		if etag == "" {
+			t.Fatal("public serve ETag is empty")
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+fmt.Sprintf("/media/%d", publicMedia), nil)
+		if err != nil {
+			t.Fatalf("NewRequest err = %v, want nil", err)
+		}
+		req.Header.Set("If-None-Match", etag)
+		condResp, err := owner.Do(req)
+		if err != nil {
+			t.Fatalf("conditional Do err = %v, want nil", err)
+		}
+		defer closeBody(t, condResp.Body)
+		if got, want := condResp.StatusCode, http.StatusNotModified; got != want {
+			t.Errorf("conditional serve status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("public image to anonymous viewer mints no session cookie", func(t *testing.T) {
+		t.Parallel()
+		anon := newAnonClient(t)
+		resp := httpGet(ctx, t, anon, baseURL+fmt.Sprintf("/media/%d", publicMedia))
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("anonymous public serve status = %d, want %d", got, want)
+		}
+		// Serving a cacheable image must not mint a player row or set a session
+		// cookie (#936): a Set-Cookie on a Cache-Control: public response is a
+		// shared-cache footgun that can leak one visitor's session to others.
+		if got := resp.Header.Get("Set-Cookie"); got != "" {
+			t.Errorf("public serve set cookie %q, want none (no player mint on a cacheable response)", got)
+		}
+	})
+
+	t.Run("thumbnail serves", func(t *testing.T) {
+		t.Parallel()
+		resp := httpGet(ctx, t, owner, baseURL+fmt.Sprintf("/media/%d/thumb", publicMedia))
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("thumb status = %d, want %d", got, want)
+		}
+		if got, want := resp.Header.Get("Content-Type"), "image/webp"; got != want {
+			t.Errorf("thumb Content-Type = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown id is 404", func(t *testing.T) {
+		t.Parallel()
+		resp := httpGet(ctx, t, owner, baseURL+"/media/999999")
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+			t.Errorf("unknown-id status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("garbage id is 4xx", func(t *testing.T) {
+		t.Parallel()
+		resp := httpGet(ctx, t, owner, baseURL+"/media/not-a-number")
+		defer closeBody(t, resp.Body)
+		if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+			t.Errorf("garbage-id status = %d, want a 4xx", resp.StatusCode)
+		}
+	})
+
+	t.Run("private image refused to anonymous viewer", func(t *testing.T) {
+		t.Parallel()
+		anon := newAnonClient(t)
+		resp := httpGet(ctx, t, anon, baseURL+fmt.Sprintf("/media/%d", privateMedia))
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+			t.Errorf("anonymous private serve status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("private image allowed to owner", func(t *testing.T) {
+		t.Parallel()
+		resp := httpGet(ctx, t, owner, baseURL+fmt.Sprintf("/media/%d", privateMedia))
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("owner private serve status = %d, want %d", got, want)
+		}
+		if got := resp.Header.Get("Cache-Control"); !strings.Contains(got, "private") {
+			t.Errorf("private Cache-Control = %q, want it to contain %q", got, "private")
+		}
+	})
+}
+
+// setupMedia boots an integration server with a per-test MEDIA_DIR (a t.TempDir
+// the framework cleans up) and a store.Stores for resolving uploaded media ids
+// directly, rather than the default ./media under the package working dir.
+func setupMedia(t *testing.T, extra map[string]string) (context.Context, integrationSetup) {
+	t.Helper()
+	env := map[string]string{"MEDIA_DIR": t.TempDir()}
+	maps.Copy(env, extra)
+
+	return setupIntegrationWithEnv(t, env)
+}
+
+// latestMediaID returns the most recently created media id for a quiz, read
+// straight from the store. ListMediaByQuiz orders newest-first, so the first
+// row is the latest upload. Slice 2 exposes no list endpoint, so the test reads
+// the row through the same store the server writes.
+func latestMediaID(ctx context.Context, t *testing.T, stores *store.Stores, quizID int64) int64 {
+	t.Helper()
+	items, err := stores.Media.ListMediaByQuiz(ctx, quizID)
+	if err != nil {
+		t.Fatalf("ListMediaByQuiz err = %v, want nil", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("no media rows for quiz %d", quizID)
+	}
+
+	return items[0].ID
+}
+
+// uploadImage posts a multipart image to the quiz's media endpoint and asserts
+// the 303-to-quiz-view redirect (slice 2 has no library UI to land on).
+func uploadImage(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL string, quizID int64, name string, data []byte,
+) {
+	t.Helper()
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/admin/quizzes")
+	body, contentType := multipartImage(t, name, data, token)
+	req := newMultipartReq(ctx, t, baseURL+fmt.Sprintf("/admin/quizzes/%d/media", quizID), body, contentType)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("upload Do err = %v, want nil", err)
+	}
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		rb, _ := io.ReadAll(resp.Body)
+		t.Fatalf("upload status = %d, want %d; body=%q", got, want, rb)
+	}
+	if got, want := resp.Header.Get("Location"), fmt.Sprintf("/admin/quizzes/%d", quizID); got != want {
+		t.Errorf("upload redirect Location = %q, want %q", got, want)
+	}
+}
+
+// createQuizWithVisibility posts a quiz with the given visibility and returns
+// the id parsed from the redirect Location. Mirrors createQuizAs but adds the
+// visibility form field (#103) so a private quiz can be created for the serving
+// gate tests.
+func createQuizWithVisibility(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, title, visibility string,
+) int64 {
+	t.Helper()
+	token := fetchCSRFToken(ctx, t, client, baseURL+"/admin/quizzes/new")
+	form := url.Values{
+		"title":       {title},
+		"description": {"owned by test"},
+		"visibility":  {visibility},
+		"csrf_token":  {token},
+	}
+	req := newFormReq(ctx, t, baseURL+"/admin/quizzes", form)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("create quiz err = %v, want nil", err)
+	}
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create quiz status = %d, want %d; body=%q", got, want, body)
+	}
+	loc := resp.Header.Get("Location")
+	const prefix = "/admin/quizzes/"
+	if !strings.HasPrefix(loc, prefix) {
+		t.Fatalf("create quiz Location = %q, want prefix %q", loc, prefix)
+	}
+	var id int64
+	if _, err := fmt.Sscanf(loc[len(prefix):], "%d", &id); err != nil {
+		t.Fatalf("parse quiz id from Location %q err = %v", loc, err)
+	}
+
+	return id
+}
+
+// pngBytes renders a varied-colour PNG of the given size for use as upload
+// input. A real decodable image is required: the pipeline rejects anything it
+// cannot decode, so a byte blob would not exercise the success path.
+func pngBytes(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 128, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode err = %v, want nil", err)
+	}
+
+	return buf.Bytes()
+}
+
+// multipartImage builds a multipart body carrying the image under the "image"
+// field plus the csrf_token field, returning the body and its content type.
+func multipartImage(t *testing.T, filename string, data []byte, token string) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("image", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile err = %v, want nil", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		t.Fatalf("write image part err = %v, want nil", err)
+	}
+	if err := mw.WriteField("csrf_token", token); err != nil {
+		t.Fatalf("WriteField err = %v, want nil", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("multipart Close err = %v, want nil", err)
+	}
+
+	return &buf, mw.FormDataContentType()
+}
+
+// newMultipartReq builds a POST request carrying a multipart body with the
+// given content type.
+func newMultipartReq(
+	ctx context.Context, t *testing.T, target string, body io.Reader, contentType string,
+) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, body)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	return req
+}


### PR DESCRIPTION
Slice 2 of 4 of #936 — the HTTP edge on top of slice 1's media foundation. No library UI yet (slice 3) and no admin moderation (slice 4).

- `POST /admin/quizzes/{quizID}/media` — host/admin upload. Gated host/admin upstream, then a per-quiz **creator-or-admin edit gate** (only the quiz's owner, or an admin, can upload). Multipart body capped above the 10 MB image cap and parsed before the CSRF check (the token lives in the parsed `PostForm`); pipeline rejections → 400.
- `GET /media/{id}` and `GET /media/{id}/thumb` — serving. Access **mirrors the owning quiz**: public/unlisted → anyone (incl. anonymous players mid-game), private → an authenticated viewer; missing/unauthorized → 404 (indistinguishable). sha256 `ETag` + `If-None-Match`/304 via `http.ServeContent`, visibility-keyed `Cache-Control`.

Two issues fixed during review (caught by the review loop, not in the original draft):
- The serve routes resolve the viewer **read-only** (`AuthenticatedSessionPlayer`), not `EnsurePlayer` — so a cacheable image response never mints a player row or attaches a `Set-Cookie` (a shared-cache session-leak footgun). Pinned by a "no cookie on public serve" test.
- The upload middleware now removes multipart temp files (`MultipartForm.RemoveAll`) — net/http leaves spilled >1 MB parts on disk otherwise.

Does not close #936 (partial).