### PR TITLE
Serialize webp codec calls to fix the concurrency data race

### DIFF
--- a/internal/media/export_test.go
+++ b/internal/media/export_test.go
@@ -1,0 +1,38 @@
+package media
+
+import (
+	"image"
+	"io"
+
+	"github.com/deepteams/webp"
+)
+
+// The *ForTest wrappers route the external media_test package's webp codec calls
+// through webpMu, so the tests serialize on the same lock production does. The
+// deepteams/webp codec shares unsynchronized package state, so a test that calls
+// webp.Encode/Decode directly would race a concurrent Process under -race even
+// though production is serialized. See webpMu.
+
+// EncodeWebPForTest encodes img at quality q under webpMu.
+func EncodeWebPForTest(w io.Writer, img image.Image, q float32) error {
+	webpMu.Lock()
+	defer webpMu.Unlock()
+
+	return webp.Encode(w, img, &webp.EncoderOptions{Quality: q})
+}
+
+// DecodeWebPForTest decodes a webp stream under webpMu.
+func DecodeWebPForTest(r io.Reader) (image.Image, error) {
+	webpMu.Lock()
+	defer webpMu.Unlock()
+
+	return webp.Decode(r)
+}
+
+// DecodeWebPConfigForTest reads a webp header under webpMu.
+func DecodeWebPConfigForTest(r io.Reader) (image.Config, error) {
+	webpMu.Lock()
+	defer webpMu.Unlock()
+
+	return webp.DecodeConfig(r)
+}

--- a/internal/media/pipeline.go
+++ b/internal/media/pipeline.go
@@ -17,10 +17,21 @@ import (
 	_ "image/jpeg" // register the jpeg decoder with image.Decode
 	_ "image/png"  // register the png decoder with image.Decode
 	"io"
+	"sync"
 
 	"github.com/deepteams/webp"
 	"golang.org/x/image/draw"
 )
+
+// webpMu serializes every deepteams/webp codec call. v1.2.4 shares
+// unsynchronized package state across Encode/Decode, so concurrent use
+// data-races: the -race detector trips it under the parallel media tests, and
+// it is a real corruption risk for two uploads encoding at once. Decoding and
+// encoding here are upload-time paths - never hot - so serializing them costs
+// nothing in practice. Remove once the upstream race is fixed.
+//
+//nolint:gochecknoglobals // process-wide lock guarding a non-thread-safe library; must be shared across all callers.
+var webpMu sync.Mutex
 
 const (
 	// MaxUploadBytes caps the raw upload size (~10 MB). A larger upload is
@@ -103,21 +114,9 @@ func Process(r io.Reader) (*Processed, error) {
 		return nil, err
 	}
 
-	// Reject a decode bomb before the full decode allocates the pixel buffer:
-	// DecodeConfig reads only the header, so checking the declared dimensions
-	// costs nothing. PNG's max declared edge (2^31) keeps the int64 product in
-	// range, so the area multiply cannot overflow.
-	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	src, err := decodeGuarded(raw)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrUnsupportedImage, err)
-	}
-	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width)*int64(cfg.Height) > MaxPixels {
-		return nil, ErrImageTooLarge
-	}
-
-	src, _, err := image.Decode(bytes.NewReader(raw))
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrUnsupportedImage, err)
+		return nil, err
 	}
 
 	full := resizeLongEdge(src, MaxLongEdge)
@@ -144,6 +143,32 @@ func Process(r io.Reader) (*Processed, error) {
 		SHA256:    hex.EncodeToString(sum[:]),
 		MIME:      MIMEWebP,
 	}, nil
+}
+
+// decodeGuarded decodes raw (jpeg, png, or webp) under webpMu so the webp
+// codec's shared state is never touched concurrently. It rejects a decode bomb
+// from the header first (DecodeConfig reads only the header; PNG's max declared
+// edge of 2^31 keeps the int64 area product in range, so it cannot overflow),
+// then decodes the full image. Returns ErrImageTooLarge for an oversized
+// declared area and ErrUnsupportedImage for undecodable bytes.
+func decodeGuarded(raw []byte) (image.Image, error) {
+	webpMu.Lock()
+	defer webpMu.Unlock()
+
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnsupportedImage, err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width)*int64(cfg.Height) > MaxPixels {
+		return nil, ErrImageTooLarge
+	}
+
+	src, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnsupportedImage, err)
+	}
+
+	return src, nil
 }
 
 // readCapped reads at most MaxUploadBytes+1 from r so the result both holds the
@@ -185,10 +210,15 @@ func resizeLongEdge(src image.Image, maxLongEdge int) image.Image {
 	return dst
 }
 
-// encodeWebP encodes img as lossy webp at webpQuality.
+// encodeWebP encodes img as lossy webp at webpQuality. The encode is serialized
+// on webpMu because the deepteams/webp codec is not safe for concurrent use.
 func encodeWebP(img image.Image) ([]byte, error) {
 	var buf bytes.Buffer
-	if err := webp.Encode(&buf, img, &webp.EncoderOptions{Quality: webpQuality}); err != nil {
+
+	webpMu.Lock()
+	err := webp.Encode(&buf, img, &webp.EncoderOptions{Quality: webpQuality})
+	webpMu.Unlock()
+	if err != nil {
 		return nil, fmt.Errorf("encoding webp: %w", err)
 	}
 

--- a/internal/media/pipeline_test.go
+++ b/internal/media/pipeline_test.go
@@ -9,9 +9,8 @@ import (
 	"image/color"
 	"image/jpeg"
 	"image/png"
+	"sync"
 	"testing"
-
-	"github.com/deepteams/webp"
 
 	. "github.com/starquake/topbanana/internal/media"
 )
@@ -58,8 +57,8 @@ func encodePNG(t *testing.T, img image.Image) []byte {
 func encodeWebP(t *testing.T, img image.Image) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := webp.Encode(&buf, img, &webp.EncoderOptions{Quality: 80}); err != nil {
-		t.Fatalf("webp.Encode err = %v, want nil", err)
+	if err := EncodeWebPForTest(&buf, img, 80); err != nil {
+		t.Fatalf("EncodeWebPForTest err = %v, want nil", err)
 	}
 
 	return buf.Bytes()
@@ -111,7 +110,7 @@ func TestProcessRoundTrip(t *testing.T) {
 		t.Fatalf("Process err = %v, want nil", err)
 	}
 
-	fullCfg, err := webp.DecodeConfig(bytes.NewReader(got.Full))
+	fullCfg, err := DecodeWebPConfigForTest(bytes.NewReader(got.Full))
 	if err != nil {
 		t.Fatalf("DecodeConfig(Full) err = %v, want nil", err)
 	}
@@ -120,7 +119,7 @@ func TestProcessRoundTrip(t *testing.T) {
 			fullCfg.Width, fullCfg.Height, got.Width, got.Height)
 	}
 
-	fullImg, err := webp.Decode(bytes.NewReader(got.Full))
+	fullImg, err := DecodeWebPForTest(bytes.NewReader(got.Full))
 	if err != nil {
 		t.Fatalf("Decode(Full) err = %v, want nil", err)
 	}
@@ -128,7 +127,7 @@ func TestProcessRoundTrip(t *testing.T) {
 		t.Errorf("decoded Full width = %d, want %d", got, want)
 	}
 
-	thumbImg, err := webp.Decode(bytes.NewReader(got.Thumb))
+	thumbImg, err := DecodeWebPForTest(bytes.NewReader(got.Thumb))
 	if err != nil {
 		t.Fatalf("Decode(Thumb) err = %v, want nil", err)
 	}
@@ -157,7 +156,7 @@ func TestProcessDownscalesLongEdge(t *testing.T) {
 		t.Errorf("Height = %d, want %d (2:1 aspect preserved)", got.Height, MaxLongEdge/2)
 	}
 
-	thumb, err := webp.DecodeConfig(bytes.NewReader(got.Thumb))
+	thumb, err := DecodeWebPConfigForTest(bytes.NewReader(got.Thumb))
 	if err != nil {
 		t.Fatalf("DecodeConfig(Thumb) err = %v, want nil", err)
 	}
@@ -250,6 +249,30 @@ func TestProcessRejectsNonImage(t *testing.T) {
 // longEdge returns the larger of a rectangle's two dimensions.
 func longEdge(r image.Rectangle) int {
 	return max(r.Dx(), r.Dy())
+}
+
+// TestProcess_Concurrent runs many Process calls at once. The deepteams/webp
+// codec is not safe for concurrent use, so without the webpMu serialization the
+// -race detector trips here (which is how this surfaced: CI's -race build caught
+// it under the parallel media tests). With the lock the run is clean. This pins
+// that concurrent uploads stay race-free.
+func TestProcess_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	inputPNG := encodePNG(t, gradient(200, 150))
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			if _, err := Process(bytes.NewReader(inputPNG)); err != nil {
+				t.Errorf("Process err = %v, want nil", err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // pngHeader builds a valid PNG signature + IHDR chunk declaring w x h, with no


### PR DESCRIPTION
Closes #944