### PR TITLE
Bump the webp fork pin to the squashed fork-main commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/deepteams/webp => github.com/starquake/webp v0.0.0-20260615162507-8e999be13e87
+replace github.com/deepteams/webp => github.com/starquake/webp v0.0.0-20260615180040-7d874db6f3b8

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
-github.com/starquake/webp v0.0.0-20260615162507-8e999be13e87 h1:BUrHtivFJW5kf7J6Ei1+uldMatPU9aalLukJorbN+L4=
-github.com/starquake/webp v0.0.0-20260615162507-8e999be13e87/go.mod h1:J8Ap+HAixxpKKRN9IpEeSKlfvhsef1v43jKTO7m3f4c=
+github.com/starquake/webp v0.0.0-20260615180040-7d874db6f3b8 h1:xxZ4bEsIkgA6bJSf4zn8cYyzaJtFI0H9Ji2cqXF6mfE=
+github.com/starquake/webp v0.0.0-20260615180040-7d874db6f3b8/go.mod h1:J8Ap+HAixxpKKRN9IpEeSKlfvhsef1v43jKTO7m3f4c=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wneessen/go-mail v0.7.3 h1:g3DravXC5SMlVdboFrQA8Jx95A8sOzoBeS5F+vzNRK0=


### PR DESCRIPTION
Updates the `go.mod` `replace` pin to `github.com/starquake/webp@7d874db` - the fork's `main` HEAD after the gamma-table + `mbInfo` + `TLambdaSD` fixes were squashed together.

Re-pinned twice during this PR's lifetime as the fork settled. Lands on a stable `main` SHA now rather than a topic branch.

`go test ./internal/media -count=20 -race -run TestProcessSHA256Deterministic` and `go test ./internal/media -count=5 -race -run TestProcess_Concurrent` clean under the new pin.