### PR TITLE
Retry e2e tests once on local runs too

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -260,15 +260,18 @@ export default defineConfig({
   // longer cross-contend.
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  // One retry in CI absorbs the post-registration flakes (e.g. the
-  // URL race after question Save tracked in #384, or any slow-runner
-  // browser nav). Registration steps are still single-shot: a retry
-  // hits ErrDisplayNameTaken from the prior attempt and fails again,
-  // but the affected specs are a small subset and the upside on the
-  // larger pool of timing-sensitive UI assertions is worth the
-  // trade. Local runs keep retries=0 so flakes surface loudly during
-  // development (#350).
-  retries: process.env.CI ? 1 : 0,
+  // One retry, in CI and locally. In CI it absorbs post-registration
+  // flakes (the URL race after question Save, #384) and slow-runner nav.
+  // Locally it absorbs the Playwright worker-teardown race under load
+  // (#1009): a worker's browser is closed gracefully during wind-down just
+  // as a tail-scheduled test calls browser.newContext, which fails on any
+  // spec - even single-page ones, since the default page fixture also opens
+  // a context. Local used to be retries=0 to surface flakes loudly (#350);
+  // that mostly holds because a passed-on-retry test still prints as "flaky"
+  // in the run summary, it just no longer hard-fails the run. Registration
+  // steps stay single-shot: a retry re-hits ErrDisplayNameTaken and fails
+  // again, but those are few.
+  retries: 1,
   workers: WORKER_COUNT,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {


### PR DESCRIPTION
Makes the e2e suite retry once on local runs as well as in CI (`retries` was CI-only before).

This absorbs the Playwright worker-teardown race under load (#1009): under parallelism a worker's browser is closed gracefully during wind-down just as a tail-scheduled test calls `browser.newContext`, which then fails with "Target page, context or browser has been closed". It hits any spec -- including single-page ones, because the default `page` fixture also opens a context -- so it can't be scoped to a subset. CI already absorbed it with `retries: 1`; local was `retries: 0` (#350), which is why it surfaced there.

The underlying race is not eliminated, just retried past (exactly as CI already does). A passed-on-retry test still prints as "flaky" in the local summary, so #350's "surface flakes loudly" intent mostly holds. Validated by running the chromium suite under heavy 4-worker load 3x: it previously failed 2-3/3 with this signature, and now passes 3/3 (races show as flaky, exit 0).

Closes #1009