### PR TITLE
Add audio media storage and the question audio reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ lint-cross-refs:
 lint-migrations:
 	@hits=$$(grep -lE 'PRAGMA[[:space:]]+foreign_keys[[:space:]]*=[[:space:]]*OFF' \
 	    internal/migrations/*.sql 2>/dev/null \
-	    | grep -vE '20260506000000_add_player_auth_columns\.sql|20260520200000_quiz_creator\.sql|20260528100000_require_email_for_credentialled_players\.sql|20260529160000_roles_player_host_admin\.sql|20260530000000_add_rounds\.sql|20260606120000_session_runner\.sql|20260607120000_session_round_results\.sql|20260611120000_persistent_rooms\.sql|20260612120000_session_quiz_nullable\.sql|20260616180000_media_id_autoincrement\.sql' \
+	    | grep -vE '20260506000000_add_player_auth_columns\.sql|20260520200000_quiz_creator\.sql|20260528100000_require_email_for_credentialled_players\.sql|20260529160000_roles_player_host_admin\.sql|20260530000000_add_rounds\.sql|20260606120000_session_runner\.sql|20260607120000_session_round_results\.sql|20260611120000_persistent_rooms\.sql|20260612120000_session_quiz_nullable\.sql|20260616180000_media_id_autoincrement\.sql|20260619120000_media_type_audio\.sql' \
 	    || true); \
 	if [ -n "$$hits" ]; then \
 	    echo "lint-migrations: the following migrations use PRAGMA foreign_keys = OFF;"; \

--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -371,7 +371,7 @@ func runRetentionSweep(ctx context.Context, logger *slog.Logger, retention reten
 // not-ready row is the residue of a cancelled upload, hidden from the library
 // until it is dropped, so it is bounded but not urgent (#992, #472).
 func startSweeps(ctx context.Context, cfg *config.Config, logger *slog.Logger, stores *store.Stores) {
-	mediaSweep := media.NewService(stores.Media, cfg.MediaDir, logger)
+	mediaSweep := media.NewService(stores.Media, cfg.MediaDir, cfg.MediaImageMaxBytes, cfg.MediaAudioMaxBytes, logger)
 	sweepExpiredAtStartup(ctx, logger, stores, mediaSweep)
 	go runTokenSweep(
 		ctx, logger,

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -125,10 +125,10 @@ type QuestionData struct {
 	QuizID  int64
 	RoundID int64
 	Text    string
-	// MediaID is the id of the attached library image, or 0 when none is
+	// ImageMediaID is the id of the attached library image, or 0 when none is
 	// attached (#937). The picker pre-checks the radio whose value equals
 	// it; 0 leaves the "None" radio checked.
-	MediaID               int64
+	ImageMediaID          int64
 	Position              int
 	TimeLimitSecondsValue string
 	Options               []*OptionData
@@ -247,8 +247,8 @@ func questionDataFromQuestion(q *quiz.Question) *QuestionData {
 	}
 
 	var mediaID int64
-	if q.MediaID != nil {
-		mediaID = *q.MediaID
+	if q.ImageMediaID != nil {
+		mediaID = *q.ImageMediaID
 	}
 
 	return &QuestionData{
@@ -256,7 +256,7 @@ func questionDataFromQuestion(q *quiz.Question) *QuestionData {
 		QuizID:                q.QuizID,
 		RoundID:               q.RoundID,
 		Text:                  q.Text,
-		MediaID:               mediaID,
+		ImageMediaID:          mediaID,
 		Position:              q.Position,
 		TimeLimitSecondsValue: timeLimit,
 		Options:               optionDataFromOptions(q.Options),
@@ -617,14 +617,14 @@ const (
 	errMediaVerifyFailed = "Could not verify the selected image. Try again."
 )
 
-// resolveQuestionMedia interprets the optional media_id picker input (#937).
-// Blank or "0" -> (nil, "") meaning "no image attached" (NULL). A non-empty
-// value must parse and must name an image in quizID's own library; a missing,
-// foreign, or unparseable id yields a field-error message so the save handler
-// re-renders the form rather than persisting a cross-quiz reference. A store
-// failure also surfaces as a message so the caller never silently drops the
-// attachment.
-func resolveQuestionMedia(
+// resolveQuestionImage interprets the optional image_media_id picker input
+// (#937). Blank or "0" -> (nil, "") meaning "no image attached" (NULL). A
+// non-empty value must parse and must name an image in quizID's own library; a
+// missing, foreign, or unparseable id yields a field-error message so the save
+// handler re-renders the form rather than persisting a cross-quiz reference. A
+// store failure also surfaces as a message so the caller never silently drops
+// the attachment.
+func resolveQuestionImage(
 	ctx context.Context, mediaStore QuestionMediaStore, quizID int64, raw string,
 ) (*int64, string) {
 	raw = strings.TrimSpace(raw)
@@ -676,14 +676,14 @@ func fillQuestionFromForm(
 	}
 
 	qs.Text = r.PostFormValue("text")
-	// Image picker (#937). An empty/absent media_id means "no image"
+	// Image picker (#937). An empty/absent image_media_id means "no image"
 	// (NULL); a non-empty value must name an image in this question's own
 	// quiz library, validated below.
-	mediaID, mediaErr := resolveQuestionMedia(r.Context(), mediaStore, qs.QuizID, r.PostFormValue("media_id"))
+	mediaID, mediaErr := resolveQuestionImage(r.Context(), mediaStore, qs.QuizID, r.PostFormValue("image_media_id"))
 	if mediaErr != "" {
 		return map[string]string{"media": mediaErr}, true
 	}
-	qs.MediaID = mediaID
+	qs.ImageMediaID = mediaID
 	// Optional per-question override (#99). Blank input clears any
 	// previous override (NULL -> inherit the quiz default); a parse
 	// failure lands a zero, which Question.Valid rejects with an

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1383,9 +1383,9 @@ func TestHandleQuestionSave(t *testing.T) {
 		handler := HandleQuestionSave(logger, nil, env.quizzes, env.media)
 
 		form := url.Values{
-			"text":     {"Question Four"},
-			"media_id": {strconv.FormatInt(mediaID, 10)},
-			"round_id": {strconv.FormatInt(roundID, 10)},
+			"text":           {"Question Four"},
+			"image_media_id": {strconv.FormatInt(mediaID, 10)},
+			"round_id":       {strconv.FormatInt(roundID, 10)},
 		}
 		options := []struct {
 			text    string
@@ -1434,10 +1434,10 @@ func TestHandleQuestionSave(t *testing.T) {
 		if got, want := created.Text, "Question Four"; got != want {
 			t.Errorf("created question text = %q, want %q", got, want)
 		}
-		if created.MediaID == nil {
-			t.Errorf("created question MediaID = nil, want %d", mediaID)
-		} else if got, want := *created.MediaID, mediaID; got != want {
-			t.Errorf("created question MediaID = %d, want %d", got, want)
+		if created.ImageMediaID == nil {
+			t.Errorf("created question ImageMediaID = nil, want %d", mediaID)
+		} else if got, want := *created.ImageMediaID, mediaID; got != want {
+			t.Errorf("created question ImageMediaID = %d, want %d", got, want)
 		}
 		if got, want := created.RoundID, roundID; got != want {
 			t.Errorf("created question RoundID = %d, want %d", got, want)
@@ -1478,8 +1478,8 @@ func TestHandleQuestionSave(t *testing.T) {
 		// Update the text and attach an image, keep the two existing options
 		// (by id) with their text changed, and append a brand-new option.
 		form := url.Values{
-			"text":     {question.Text + " Updated"},
-			"media_id": {strconv.FormatInt(mediaID, 10)},
+			"text":           {question.Text + " Updated"},
+			"image_media_id": {strconv.FormatInt(mediaID, 10)},
 		}
 		form.Add("option[0].id", strconv.FormatInt(question.Options[0].ID, 10))
 		form.Add("option[0].text", question.Options[0].Text+" Updated")
@@ -1515,10 +1515,10 @@ func TestHandleQuestionSave(t *testing.T) {
 		if got, want := stored.Text, question.Text+" Updated"; got != want {
 			t.Errorf("stored text = %q, want %q", got, want)
 		}
-		if stored.MediaID == nil {
-			t.Errorf("stored MediaID = nil, want %d", mediaID)
-		} else if got, want := *stored.MediaID, mediaID; got != want {
-			t.Errorf("stored MediaID = %d, want %d", got, want)
+		if stored.ImageMediaID == nil {
+			t.Errorf("stored ImageMediaID = nil, want %d", mediaID)
+		} else if got, want := *stored.ImageMediaID, mediaID; got != want {
+			t.Errorf("stored ImageMediaID = %d, want %d", got, want)
 		}
 		// Position is no longer driven by the form (#16); it stays put.
 		if got, want := stored.Position, question.Position; got != want {
@@ -1532,7 +1532,7 @@ func TestHandleQuestionSave(t *testing.T) {
 
 // TestHandleQuestionSave_Media covers the image-picker save paths (#937):
 // a same-quiz image attaches, a foreign image is rejected with a field error,
-// and an empty media_id detaches (NULL).
+// and an empty image_media_id detaches (NULL).
 func TestHandleQuestionSave_Media(t *testing.T) {
 	t.Parallel()
 
@@ -1553,8 +1553,8 @@ func TestHandleQuestionSave_Media(t *testing.T) {
 		handler := HandleQuestionSave(logger, nil, env.quizzes, env.media)
 
 		form := url.Values{
-			"text":     {question.Text},
-			"media_id": {strconv.FormatInt(foreignMediaID, 10)},
+			"text":           {question.Text},
+			"image_media_id": {strconv.FormatInt(foreignMediaID, 10)},
 		}
 		form.Add("option[0].id", strconv.FormatInt(question.Options[0].ID, 10))
 		form.Add("option[0].text", question.Options[0].Text)
@@ -1585,8 +1585,8 @@ func TestHandleQuestionSave_Media(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetQuestion err = %v, want nil", err)
 		}
-		if stored.MediaID != nil {
-			t.Errorf("stored MediaID = %d, want nil (foreign media rejected)", *stored.MediaID)
+		if stored.ImageMediaID != nil {
+			t.Errorf("stored ImageMediaID = %d, want nil (foreign media rejected)", *stored.ImageMediaID)
 		}
 	})
 
@@ -1600,7 +1600,7 @@ func TestHandleQuestionSave_Media(t *testing.T) {
 		question := qz.Questions[0]
 
 		// Pre-attach an image so the detach is observable.
-		question.MediaID = &mediaID
+		question.ImageMediaID = &mediaID
 		if err := env.quizzes.UpdateQuestion(t.Context(), question); err != nil {
 			t.Fatalf("seed attach err = %v, want nil", err)
 		}
@@ -1608,8 +1608,8 @@ func TestHandleQuestionSave_Media(t *testing.T) {
 		handler := HandleQuestionSave(logger, nil, env.quizzes, env.media)
 
 		form := url.Values{
-			"text":     {question.Text},
-			"media_id": {""},
+			"text":           {question.Text},
+			"image_media_id": {""},
 		}
 		form.Add("option[0].id", strconv.FormatInt(question.Options[0].ID, 10))
 		form.Add("option[0].text", question.Options[0].Text)
@@ -1636,8 +1636,8 @@ func TestHandleQuestionSave_Media(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetQuestion err = %v, want nil", err)
 		}
-		if stored.MediaID != nil {
-			t.Errorf("stored MediaID = %d, want nil after detach", *stored.MediaID)
+		if stored.ImageMediaID != nil {
+			t.Errorf("stored ImageMediaID = %d, want nil after detach", *stored.ImageMediaID)
 		}
 	})
 }
@@ -1656,7 +1656,7 @@ func TestHandleQuestionEdit_Picker(t *testing.T) {
 		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz One", "quiz-one"))
 		mediaID := env.seedMedia(t, qz.ID)
 		question := qz.Questions[0]
-		question.MediaID = &mediaID
+		question.ImageMediaID = &mediaID
 		if err := env.quizzes.UpdateQuestion(t.Context(), question); err != nil {
 			t.Fatalf("seed attach err = %v, want nil", err)
 		}

--- a/internal/admin/quizimport.go
+++ b/internal/admin/quizimport.go
@@ -400,7 +400,7 @@ func fillQuizFromRounds(qz *quiz.Quiz, rounds []quizImportRoundPayload) error {
 // questionFromImportPayload maps one import question onto the domain
 // type at the given quiz-wide position. Imported questions never carry an
 // image: the JSON import cannot reference uploaded media (which is keyed by a
-// per-quiz media id, not a URL), so MediaID stays nil (#937).
+// per-quiz media id, not a URL), so ImageMediaID stays nil (#937).
 func questionFromImportPayload(qIn quizImportQuestionPayload, position int) *quiz.Question {
 	qs := &quiz.Question{
 		Text:     qIn.Text,

--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -233,7 +233,7 @@ func quizGetQuestions(qz *quiz.Quiz) []quizGetQuestionResponse {
 			ID:       qs.ID,
 			Text:     qs.Text,
 			Position: qs.Position,
-			ImageURL: mediaURL(qs.MediaID),
+			ImageURL: mediaURL(qs.ImageMediaID),
 			Options:  opts,
 		})
 	}
@@ -939,7 +939,7 @@ func writeQuestionItem(
 		Type:           string(game.ItemTypeQuestion),
 		ID:             gq.QuizQuestion.ID,
 		Text:           gq.QuizQuestion.Text,
-		ImageURL:       mediaURL(gq.QuizQuestion.MediaID),
+		ImageURL:       mediaURL(gq.QuizQuestion.ImageMediaID),
 		Options:        resOptions,
 		StartedAt:      gq.StartedAt,
 		ExpiredAt:      gq.ExpiredAt,

--- a/internal/clientapi/sessions.go
+++ b/internal/clientapi/sessions.go
@@ -667,7 +667,7 @@ func newSessionQuestionResponse(state *livesession.SessionState) *sessionQuestio
 		ID:                q.ID,
 		RoundID:           q.RoundID,
 		Text:              q.Text,
-		ImageURL:          mediaURL(q.MediaID),
+		ImageURL:          mediaURL(q.ImageMediaID),
 		Position:          questionPosition(state.Quiz, q.ID),
 		Total:             len(state.Quiz.Questions),
 		RoundNumber:       round.RoundNumber,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,16 @@ var ErrMediaUploadBudgetWindowNegative = errors.New("MEDIA_UPLOAD_BUDGET_WINDOW 
 // value is meaningless; zero is allowed and disables the cap.
 var ErrMediaQuizImageLimitNegative = errors.New("MEDIA_QUIZ_IMAGE_LIMIT must not be negative")
 
+// ErrMediaAudioMaxBytesNegative is returned when MEDIA_AUDIO_MAX_BYTES parses to
+// a negative integer. It caps a stored audio upload's raw size, so a negative
+// value is meaningless; zero is allowed and disables the cap.
+var ErrMediaAudioMaxBytesNegative = errors.New("MEDIA_AUDIO_MAX_BYTES must not be negative")
+
+// ErrMediaImageMaxBytesNegative is returned when MEDIA_IMAGE_MAX_BYTES parses to
+// a negative integer. It caps a stored image upload's raw size, so a negative
+// value is meaningless; zero is allowed and disables the cap.
+var ErrMediaImageMaxBytesNegative = errors.New("MEDIA_IMAGE_MAX_BYTES must not be negative")
+
 // ErrSMTPConfigIncomplete is returned when SMTP env vars are partially
 // populated. SMTP is opt-in (an unconfigured instance still boots and
 // the no-op mailer kicks in), but a partial configuration is almost
@@ -174,6 +184,18 @@ const (
 	// while bounding the disk and row growth one host can drive on a single
 	// quiz.
 	MediaQuizImageLimitDefault = 200
+
+	// MediaAudioMaxBytesDefault is the default cap on a stored audio upload's raw
+	// size (~20 MB, #1059). Audio is stored as-is (no transcoding), so the cap
+	// bounds the bytes one clip can occupy; 20 MB comfortably holds a typical
+	// short question sound while rejecting an oversized file.
+	MediaAudioMaxBytesDefault int64 = 20 << 20
+
+	// MediaImageMaxBytesDefault is the default cap on a stored image upload's raw
+	// size (~10 MB, #1059). It mirrors media.MaxUploadBytes; the literal is
+	// repeated here rather than imported so config does not depend on the media
+	// package.
+	MediaImageMaxBytesDefault int64 = 10 << 20
 
 	// sessionKeyByteLength is the length in bytes of an ephemeral session key generated for development.
 	sessionKeyByteLength = 32
@@ -293,6 +315,16 @@ type Config struct {
 	// Defaults to 200. Parsed from MEDIA_QUIZ_IMAGE_LIMIT; the e2e/integration
 	// suites shrink it to exercise the 409 path. Zero disables the cap.
 	MediaQuizImageLimit int
+
+	// MediaAudioMaxBytes caps a stored audio upload's raw size in bytes (#1059).
+	// Defaults to MediaAudioMaxBytesDefault (~20 MB). Parsed from
+	// MEDIA_AUDIO_MAX_BYTES; zero disables the cap.
+	MediaAudioMaxBytes int64
+
+	// MediaImageMaxBytes caps a stored image upload's raw size in bytes (#1059).
+	// Defaults to MediaImageMaxBytesDefault (~10 MB). Parsed from
+	// MEDIA_IMAGE_MAX_BYTES; zero disables the cap.
+	MediaImageMaxBytes int64
 
 	// GoogleClientID, GoogleClientSecret, and GoogleRedirectURL are the
 	// Google OAuth 2.0 credentials issued in the Google Cloud Console.
@@ -495,6 +527,8 @@ func defaultConfig() Config {
 		MediaUploadBudget:       MediaUploadBudgetDefault,
 		MediaUploadBudgetWindow: MediaUploadBudgetWindowDefault,
 		MediaQuizImageLimit:     MediaQuizImageLimitDefault,
+		MediaAudioMaxBytes:      MediaAudioMaxBytesDefault,
+		MediaImageMaxBytes:      MediaImageMaxBytesDefault,
 	}
 }
 
@@ -647,8 +681,20 @@ func parseMediaUploadLimits(getenv func(string) string, c *Config) error {
 		return err
 	}
 
-	return parseNonNegativeInt(
+	if err := parseNonNegativeInt(
 		getenv, "MEDIA_QUIZ_IMAGE_LIMIT", ErrMediaQuizImageLimitNegative, &c.MediaQuizImageLimit,
+	); err != nil {
+		return err
+	}
+
+	if err := parseNonNegativeInt64(
+		getenv, "MEDIA_AUDIO_MAX_BYTES", ErrMediaAudioMaxBytesNegative, &c.MediaAudioMaxBytes,
+	); err != nil {
+		return err
+	}
+
+	return parseNonNegativeInt64(
+		getenv, "MEDIA_IMAGE_MAX_BYTES", ErrMediaImageMaxBytesNegative, &c.MediaImageMaxBytes,
 	)
 }
 
@@ -690,11 +736,46 @@ func parseNonNegativeInt(getenv func(string) string, name string, negativeErr er
 		return fmt.Errorf("invalid %s: %q, err: %w", name, val, err)
 	}
 	if n < 0 {
-		return fmt.Errorf("%w: %q", negativeErr, val)
+		return negativeValueErr(negativeErr, val)
 	}
 	*dst = n
 
 	return nil
+}
+
+// parseNonNegativeInt64 is parseNonNegativeInt for an int64 destination, used by
+// the byte-sized caps that can exceed an int's guaranteed range. An unparseable
+// value returns a wrapped error naming the var; a negative value returns the
+// supplied sentinel so callers can match it with [errors.Is]. Zero is accepted
+// (the media caps treat zero as "disabled").
+func parseNonNegativeInt64(getenv func(string) string, name string, negativeErr error, dst *int64) error {
+	val := getenv(name)
+	if val == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(val, decimalBase, bitSize64)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %q, err: %w", name, val, err)
+	}
+	if n < 0 {
+		return negativeValueErr(negativeErr, val)
+	}
+	*dst = n
+
+	return nil
+}
+
+// decimalBase and bitSize64 are the base and bit width for parsing an int64 env
+// var with [strconv.ParseInt].
+const (
+	decimalBase = 10
+	bitSize64   = 64
+)
+
+// negativeValueErr wraps sentinel with the offending value so callers can match
+// it with [errors.Is] while still seeing the parsed string.
+func negativeValueErr(sentinel error, val string) error {
+	return fmt.Errorf("%w: %q", sentinel, val)
 }
 
 // parseSMTPConfig reads the SMTP_* env vars into c. SMTP defaults to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -875,6 +875,132 @@ func TestParse_LoginCooldown(t *testing.T) {
 	})
 }
 
+func TestParse_MediaAudioMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid values", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			value string
+			want  int64
+		}{
+			{"unset defaults", "", MediaAudioMaxBytesDefault},
+			{"explicit zero disables", "0", 0},
+			{"parses a value", "1048576", 1048576},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				getenv := func(key string) string {
+					if key == "MEDIA_AUDIO_MAX_BYTES" {
+						return tt.value
+					}
+					if key == "APP_ENV" {
+						return "development"
+					}
+
+					return ""
+				}
+
+				c, err := Parse(getenv)
+				if err != nil {
+					t.Fatalf("Parse() err = %v, want nil", err)
+				}
+				if got, want := c.MediaAudioMaxBytes, tt.want; got != want {
+					t.Errorf("MediaAudioMaxBytes = %d, want %d", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("unparseable value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("MEDIA_AUDIO_MAX_BYTES", "huge"))
+		if err == nil {
+			t.Fatal("Parse() with invalid MEDIA_AUDIO_MAX_BYTES: err = nil, want non-nil")
+		}
+		if got, want := err.Error(), "invalid MEDIA_AUDIO_MAX_BYTES"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("MEDIA_AUDIO_MAX_BYTES", "-1"))
+		if got, want := err, ErrMediaAudioMaxBytesNegative; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestParse_MediaImageMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid values", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			value string
+			want  int64
+		}{
+			{"unset defaults", "", MediaImageMaxBytesDefault},
+			{"explicit zero disables", "0", 0},
+			{"parses a value", "1048576", 1048576},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				getenv := func(key string) string {
+					if key == "MEDIA_IMAGE_MAX_BYTES" {
+						return tt.value
+					}
+					if key == "APP_ENV" {
+						return "development"
+					}
+
+					return ""
+				}
+
+				c, err := Parse(getenv)
+				if err != nil {
+					t.Fatalf("Parse() err = %v, want nil", err)
+				}
+				if got, want := c.MediaImageMaxBytes, tt.want; got != want {
+					t.Errorf("MediaImageMaxBytes = %d, want %d", got, want)
+				}
+			})
+		}
+	})
+
+	t.Run("unparseable value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("MEDIA_IMAGE_MAX_BYTES", "huge"))
+		if err == nil {
+			t.Fatal("Parse() with invalid MEDIA_IMAGE_MAX_BYTES: err = nil, want non-nil")
+		}
+		if got, want := err.Error(), "invalid MEDIA_IMAGE_MAX_BYTES"; !strings.Contains(got, want) {
+			t.Errorf("err.Error() = %q, should contain %q", got, want)
+		}
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(getenvFailure("MEDIA_IMAGE_MAX_BYTES", "-1"))
+		if got, want := err, ErrMediaImageMaxBytesNegative; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestParse_AdminEmails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/media.sql.go
+++ b/internal/db/media.sql.go
@@ -30,7 +30,7 @@ func (q *Queries) CountMediaByQuiz(ctx context.Context, quizID int64) (int64, er
 const createMedia = `-- name: CreateMedia :one
 INSERT INTO media (
     quiz_id, type, mime, path, thumb_path,
-    width, height, size_bytes, sha256, created_by_player_id, ready
+    width, height, size_bytes, sha256, duration_ms, created_by_player_id, ready
 )
 VALUES (
     ?1,
@@ -43,9 +43,10 @@ VALUES (
     ?8,
     ?9,
     ?10,
+    ?11,
     0
 )
-RETURNING id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready
+RETURNING id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
 `
 
 type CreateMediaParams struct {
@@ -58,6 +59,7 @@ type CreateMediaParams struct {
 	Height            sql.NullInt64
 	SizeBytes         int64
 	Sha256            string
+	DurationMs        sql.NullInt64
 	CreatedByPlayerID int64
 }
 
@@ -82,6 +84,7 @@ func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (Mediu
 		arg.Height,
 		arg.SizeBytes,
 		arg.Sha256,
+		arg.DurationMs,
 		arg.CreatedByPlayerID,
 	)
 	var i Medium
@@ -99,6 +102,7 @@ func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (Mediu
 		&i.CreatedByPlayerID,
 		&i.CreatedAt,
 		&i.Ready,
+		&i.DurationMs,
 	)
 	return i, err
 }
@@ -117,7 +121,7 @@ func (q *Queries) DeleteMedia(ctx context.Context, id int64) (sql.Result, error)
 }
 
 const getMedia = `-- name: GetMedia :one
-SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready
+SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
 FROM media
 WHERE id = ?1
 `
@@ -141,12 +145,13 @@ func (q *Queries) GetMedia(ctx context.Context, id int64) (Medium, error) {
 		&i.CreatedByPlayerID,
 		&i.CreatedAt,
 		&i.Ready,
+		&i.DurationMs,
 	)
 	return i, err
 }
 
 const listMediaByQuiz = `-- name: ListMediaByQuiz :many
-SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready
+SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
 FROM media
 WHERE quiz_id = ?1
   AND ready = 1
@@ -182,6 +187,7 @@ func (q *Queries) ListMediaByQuiz(ctx context.Context, quizID int64) ([]Medium, 
 			&i.CreatedByPlayerID,
 			&i.CreatedAt,
 			&i.Ready,
+			&i.DurationMs,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -92,6 +92,7 @@ type Medium struct {
 	CreatedByPlayerID int64
 	CreatedAt         time.Time
 	Ready             int64
+	DurationMs        sql.NullInt64
 }
 
 type Option struct {
@@ -137,7 +138,8 @@ type Question struct {
 	Text             string
 	Position         int64
 	TimeLimitSeconds sql.NullInt64
-	MediaID          sql.NullInt64
+	ImageMediaID     sql.NullInt64
+	AudioMediaID     sql.NullInt64
 }
 
 type Quiz struct {

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -66,9 +66,9 @@ func (q *Queries) CreateOption(ctx context.Context, arg CreateOptionParams) (Opt
 }
 
 const createQuestion = `-- name: CreateQuestion :one
-INSERT INTO questions (quiz_id, round_id, text, position, media_id, time_limit_seconds)
-VALUES (?, ?, ?, ?, ?, ?)
-RETURNING id, quiz_id, round_id, text, position, time_limit_seconds, media_id
+INSERT INTO questions (quiz_id, round_id, text, position, image_media_id, audio_media_id, time_limit_seconds)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING id, quiz_id, round_id, text, position, time_limit_seconds, image_media_id, audio_media_id
 `
 
 type CreateQuestionParams struct {
@@ -76,7 +76,8 @@ type CreateQuestionParams struct {
 	RoundID          int64
 	Text             string
 	Position         int64
-	MediaID          sql.NullInt64
+	ImageMediaID     sql.NullInt64
+	AudioMediaID     sql.NullInt64
 	TimeLimitSeconds sql.NullInt64
 }
 
@@ -86,7 +87,8 @@ func (q *Queries) CreateQuestion(ctx context.Context, arg CreateQuestionParams) 
 		arg.RoundID,
 		arg.Text,
 		arg.Position,
-		arg.MediaID,
+		arg.ImageMediaID,
+		arg.AudioMediaID,
 		arg.TimeLimitSeconds,
 	)
 	var i Question
@@ -97,7 +99,8 @@ func (q *Queries) CreateQuestion(ctx context.Context, arg CreateQuestionParams) 
 		&i.Text,
 		&i.Position,
 		&i.TimeLimitSeconds,
-		&i.MediaID,
+		&i.ImageMediaID,
+		&i.AudioMediaID,
 	)
 	return i, err
 }
@@ -241,7 +244,7 @@ func (q *Queries) GetOptionsByIDs(ctx context.Context, ids []int64) ([]Option, e
 }
 
 const getQuestion = `-- name: GetQuestion :one
-SELECT id, quiz_id, round_id, text, position, time_limit_seconds, media_id
+SELECT id, quiz_id, round_id, text, position, time_limit_seconds, image_media_id, audio_media_id
 FROM questions
 WHERE id = ?
 LIMIT 1
@@ -257,7 +260,8 @@ func (q *Queries) GetQuestion(ctx context.Context, id int64) (Question, error) {
 		&i.Text,
 		&i.Position,
 		&i.TimeLimitSeconds,
-		&i.MediaID,
+		&i.ImageMediaID,
+		&i.AudioMediaID,
 	)
 	return i, err
 }
@@ -653,7 +657,7 @@ func (q *Queries) ListQuestionIDsByRoundID(ctx context.Context, roundID int64) (
 }
 
 const listQuestionsByQuizID = `-- name: ListQuestionsByQuizID :many
-SELECT id, quiz_id, round_id, text, position, time_limit_seconds, media_id
+SELECT id, quiz_id, round_id, text, position, time_limit_seconds, image_media_id, audio_media_id
 FROM questions
 WHERE quiz_id = ?
 ORDER BY position
@@ -675,7 +679,8 @@ func (q *Queries) ListQuestionsByQuizID(ctx context.Context, quizID int64) ([]Qu
 			&i.Text,
 			&i.Position,
 			&i.TimeLimitSeconds,
-			&i.MediaID,
+			&i.ImageMediaID,
+			&i.AudioMediaID,
 		); err != nil {
 			return nil, err
 		}
@@ -881,7 +886,8 @@ const updateQuestion = `-- name: UpdateQuestion :execresult
 UPDATE questions
 SET text               = ?,
     position           = ?,
-    media_id           = ?,
+    image_media_id     = ?,
+    audio_media_id     = ?,
     time_limit_seconds = ?
 WHERE id = ?
 `
@@ -889,7 +895,8 @@ WHERE id = ?
 type UpdateQuestionParams struct {
 	Text             string
 	Position         int64
-	MediaID          sql.NullInt64
+	ImageMediaID     sql.NullInt64
+	AudioMediaID     sql.NullInt64
 	TimeLimitSeconds sql.NullInt64
 	ID               int64
 }
@@ -898,7 +905,8 @@ func (q *Queries) UpdateQuestion(ctx context.Context, arg UpdateQuestionParams) 
 	return q.db.ExecContext(ctx, updateQuestion,
 		arg.Text,
 		arg.Position,
-		arg.MediaID,
+		arg.ImageMediaID,
+		arg.AudioMediaID,
 		arg.TimeLimitSeconds,
 		arg.ID,
 	)

--- a/internal/media/audio.go
+++ b/internal/media/audio.go
@@ -1,0 +1,226 @@
+package media
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"strconv"
+)
+
+// ErrUnsupportedAudio is returned when an audio upload's magic bytes do not
+// match one of the accepted, already-browser-playable formats. Audio is not
+// transcoded server-side, so an unrecognised container is rejected rather than
+// converted.
+var ErrUnsupportedAudio = errors.New("unsupported or unrecognised audio format")
+
+// ErrAudioTooLarge is returned when an audio upload exceeds the configured cap.
+var ErrAudioTooLarge = errors.New("audio upload exceeds maximum size")
+
+// Canonical audio MIME types for the accepted formats. The stored MIME is
+// derived from the sniffed magic bytes, not the client-declared type.
+const (
+	mimeMP3 = "audio/mpeg"
+	mimeMP4 = "audio/mp4"
+	mimeOGG = "audio/ogg"
+	mimeWAV = "audio/wav"
+)
+
+// File extensions for the accepted audio formats.
+const (
+	extMP3 = ".mp3"
+	extMP4 = ".m4a"
+	extOGG = ".ogg"
+	extWAV = ".wav"
+)
+
+// Magic-byte offsets and the byte length the longest signature check needs. The
+// WAV check reads the "RIFF" tag at 0..3 and the "WAVE" form type at 8..11, so
+// the sniffer needs at least audioSniffLen bytes for a full match. The ISO-BMFF
+// "ftyp" check reads the four-byte major_brand at ftypBrandOffset.
+const (
+	ftypOffset      = 4
+	ftypBrandOffset = 8
+	wavFormOffset   = 8
+	audioSniffLen   = 12
+
+	// mp3FrameSyncByte is the first byte of an MPEG frame sync; the second byte
+	// has its top three bits set, tested with mp3FrameSyncMask.
+	mp3FrameSyncByte = 0xFF
+	mp3FrameSyncMask = 0xE0
+)
+
+// Audio major_brand values an ISO-BMFF "ftyp" box must carry to be accepted as
+// audio/mp4. The trailing space is part of the four-byte brand. A video brand
+// (e.g. "isom", "mp42", "avc1") is rejected so an MP4 video is not stored as a
+// sound.
+const (
+	ftypBrandM4A = "M4A "
+	ftypBrandM4B = "M4B "
+)
+
+// StoreAudio persists an already-browser-playable audio upload as-is under
+// <root>/<quizID>/<id><ext>, recording a media row with the sniffed MIME, byte
+// size, sha256, and the caller-supplied duration. Audio is not decoded or
+// transcoded server-side: the format is detected by sniffing magic bytes, and
+// an unrecognised container is rejected with ErrUnsupportedAudio rather than
+// converted. durationMs is advisory (read in-browser by the caller); a value of
+// zero or less stores NULL.
+//
+// Like Store, the row is inserted not-ready, the file is written, the path
+// recorded, and only then the row is flipped ready (a two-phase commit). A
+// failure at any post-insert step tears the row and file back down under a
+// cancel-immune context so a failed upload leaves no orphans. Returns
+// ErrEmptyUpload for a zero-byte upload and ErrAudioTooLarge when the bytes
+// exceed the configured cap.
+func (s *Service) StoreAudio(
+	ctx context.Context, quizID, createdBy int64, durationMs int, r io.Reader,
+) (*Media, error) {
+	raw, err := s.readAudioCapped(r)
+	if err != nil {
+		return nil, err
+	}
+
+	mime, ext, ok := sniffAudio(raw)
+	if !ok {
+		return nil, ErrUnsupportedAudio
+	}
+
+	sum := sha256.Sum256(raw)
+
+	row, err := s.store.CreateMedia(ctx, &Media{
+		QuizID:            quizID,
+		Type:              TypeAudio,
+		MIME:              mime,
+		SizeBytes:         int64(len(raw)),
+		SHA256:            hex.EncodeToString(sum[:]),
+		DurationMs:        durationToPtr(durationMs),
+		CreatedByPlayerID: createdBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating audio media row: %w", err)
+	}
+
+	quizDir := strconv.FormatInt(quizID, decimalBase)
+	relPath := filepath.Join(quizDir, strconv.FormatInt(row.ID, decimalBase)+ext)
+	// Audio has no thumbnail, so a single blob is committed and ThumbPath stays
+	// empty (NULL).
+	if err = s.writeAndCommit(ctx, row.ID, quizDir, []fileBlob{{relPath: relPath, data: raw}}); err != nil {
+		return nil, err
+	}
+
+	row.Path = relPath
+
+	return row, nil
+}
+
+// readAudioCapped reads the upload, capping it at audioMaxBytes (plus one byte
+// to detect an over-cap upload). A zero or negative cap disables the limit. An
+// empty upload is rejected.
+func (s *Service) readAudioCapped(r io.Reader) ([]byte, error) {
+	reader := r
+	if s.audioMaxBytes > 0 {
+		// Saturate the read limit rather than computing audioMaxBytes+1: a cap
+		// at math.MaxInt64 would overflow to a negative limit, which LimitReader
+		// treats as "read nothing" and would fail every upload as empty. At the
+		// saturated limit the over-cap check below is unreachable, but a cap that
+		// high is effectively no cap.
+		limit := int64(math.MaxInt64)
+		if s.audioMaxBytes < math.MaxInt64 {
+			limit = s.audioMaxBytes + 1
+		}
+		reader = io.LimitReader(r, limit)
+	}
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading audio upload: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, ErrEmptyUpload
+	}
+	if s.audioMaxBytes > 0 && int64(len(raw)) > s.audioMaxBytes {
+		return nil, ErrAudioTooLarge
+	}
+
+	return raw, nil
+}
+
+// durationToPtr maps a caller-supplied duration in milliseconds to the *int the
+// media row stores: a value of zero or less (unknown / not measured) becomes
+// nil so it is stored NULL rather than as a real zero-length clip.
+func durationToPtr(durationMs int) *int {
+	if durationMs <= 0 {
+		return nil
+	}
+
+	return &durationMs
+}
+
+// sniffAudio detects an accepted, already-browser-playable audio format from the
+// upload's leading bytes and returns its canonical stored MIME and file
+// extension. ok is false for an unrecognised format. Detection is by magic
+// bytes, not the client-declared type:
+//
+//   - MP3: "ID3" tag, or an MPEG frame sync (0xFF followed by a byte with its
+//     top three bits set).
+//   - M4A: an ISO-BMFF "ftyp" box at offset 4 carrying an audio major_brand
+//     ("M4A " or "M4B ") at offset 8 (stored as audio/mp4). An MP4 *video*
+//     shares the "ftyp" box but carries a video brand, so it is rejected.
+//   - OGG: "OggS" header.
+//   - WAV: "RIFF" header with the "WAVE" form type at offset 8.
+func sniffAudio(b []byte) (mime, ext string, ok bool) {
+	switch {
+	case isMP3(b):
+		return mimeMP3, extMP3, true
+	case isAudioMP4(b):
+		return mimeMP4, extMP4, true
+	case hasPrefixAt(b, 0, "OggS"):
+		return mimeOGG, extOGG, true
+	case isWAV(b):
+		return mimeWAV, extWAV, true
+	default:
+		return "", "", false
+	}
+}
+
+// isAudioMP4 reports whether b is an ISO-BMFF "ftyp" container carrying an audio
+// major_brand. The "ftyp" box alone is shared by MP4 video, so the major_brand
+// at ftypBrandOffset is checked and only audio brands ("M4A " / "M4B ") are
+// accepted; a video brand falls through to rejection.
+func isAudioMP4(b []byte) bool {
+	if !hasPrefixAt(b, ftypOffset, "ftyp") {
+		return false
+	}
+
+	return hasPrefixAt(b, ftypBrandOffset, ftypBrandM4A) || hasPrefixAt(b, ftypBrandOffset, ftypBrandM4B)
+}
+
+// isMP3 reports whether b starts with an MP3 signature: an "ID3" tag or an MPEG
+// frame sync (0xFF followed by a byte with its top three bits set).
+func isMP3(b []byte) bool {
+	if hasPrefixAt(b, 0, "ID3") {
+		return true
+	}
+
+	return len(b) >= 2 && b[0] == mp3FrameSyncByte && b[1]&mp3FrameSyncMask == mp3FrameSyncMask
+}
+
+// isWAV reports whether b is a RIFF/WAVE container: "RIFF" at the start and
+// "WAVE" at wavFormOffset.
+func isWAV(b []byte) bool {
+	return len(b) >= audioSniffLen && hasPrefixAt(b, 0, "RIFF") && hasPrefixAt(b, wavFormOffset, "WAVE")
+}
+
+// hasPrefixAt reports whether the four-or-fewer ASCII bytes of sig appear in b
+// starting at offset.
+func hasPrefixAt(b []byte, offset int, sig string) bool {
+	if len(b) < offset+len(sig) {
+		return false
+	}
+
+	return string(b[offset:offset+len(sig)]) == sig
+}

--- a/internal/media/audio_test.go
+++ b/internal/media/audio_test.go
@@ -1,0 +1,331 @@
+package media_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+	. "github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// testAudioMaxBytes is a generous audio cap for the shared fixture so the
+// accept-path tests are never bounded by it; the over-cap test builds its own
+// Service with a tiny cap.
+const testAudioMaxBytes int64 = 20 << 20
+
+// mp3ID3 builds a minimal payload whose magic bytes sniff as MP3 via the "ID3"
+// tag. The trailing bytes are filler so the row has a non-trivial size.
+func mp3ID3() []byte {
+	return append([]byte("ID3"), bytes.Repeat([]byte{0x00}, 16)...)
+}
+
+// mp3FrameSync builds a minimal payload whose magic bytes sniff as MP3 via the
+// MPEG frame sync (0xFF followed by a byte with its top three bits set).
+func mp3FrameSync() []byte {
+	return append([]byte{0xFF, 0xFB}, bytes.Repeat([]byte{0x00}, 16)...)
+}
+
+// m4aFtyp builds a payload whose magic bytes sniff as MP4 audio via "ftyp" at
+// offset 4 with the "M4A " audio major_brand at offset 8.
+func m4aFtyp() []byte {
+	return append([]byte{0x00, 0x00, 0x00, 0x18}, []byte("ftypM4A ")...)
+}
+
+// m4bFtyp builds a payload sniffing as MP4 audio via the "M4B " audio brand.
+func m4bFtyp() []byte {
+	return append([]byte{0x00, 0x00, 0x00, 0x18}, []byte("ftypM4B ")...)
+}
+
+// mp4VideoFtyp builds an ISO-BMFF "ftyp" container carrying a video major_brand
+// (brand selectable, e.g. "isom"/"mp42"/"avc1"). It shares the "ftyp" box with
+// audio M4A but must be rejected so an MP4 video is not stored as a sound.
+func mp4VideoFtyp(brand string) []byte {
+	return append([]byte{0x00, 0x00, 0x00, 0x18}, []byte("ftyp"+brand)...)
+}
+
+// oggHeader builds a payload whose magic bytes sniff as OGG via "OggS".
+func oggHeader() []byte {
+	return append([]byte("OggS"), bytes.Repeat([]byte{0x00}, 16)...)
+}
+
+// wavHeader builds a payload whose magic bytes sniff as WAV via "RIFF" + "WAVE".
+func wavHeader() []byte {
+	b := make([]byte, 0, 32)
+	b = append(b, []byte("RIFF")...)
+	b = append(b, 0x24, 0x00, 0x00, 0x00)
+	b = append(b, []byte("WAVE")...)
+	b = append(b, bytes.Repeat([]byte{0x00}, 16)...)
+
+	return b
+}
+
+// TestSniffAudio pins the magic-byte format detection: each accepted format maps
+// to its canonical MIME and extension, and an unrecognised payload is rejected.
+func TestSniffAudio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		wantMIME string
+		wantExt  string
+		wantOK   bool
+	}{
+		{"mp3 id3", mp3ID3(), "audio/mpeg", ".mp3", true},
+		{"mp3 frame sync", mp3FrameSync(), "audio/mpeg", ".mp3", true},
+		{"m4a ftyp", m4aFtyp(), "audio/mp4", ".m4a", true},
+		{"m4b ftyp", m4bFtyp(), "audio/mp4", ".m4a", true},
+		{"ogg", oggHeader(), "audio/ogg", ".ogg", true},
+		{"wav", wavHeader(), "audio/wav", ".wav", true},
+		{"mp4 video isom rejected", mp4VideoFtyp("isom"), "", "", false},
+		{"mp4 video mp42 rejected", mp4VideoFtyp("mp42"), "", "", false},
+		{"mp4 video avc1 rejected", mp4VideoFtyp("avc1"), "", "", false},
+		{"ftyp without brand rejected", []byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p'}, "", "", false},
+		{"png is not audio", []byte("\x89PNG\r\n\x1a\n"), "", "", false},
+		{"random bytes", []byte("not audio at all here"), "", "", false},
+		{"too short", []byte{0xFF}, "", "", false},
+		{"empty", nil, "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotMIME, gotExt, gotOK := ExportSniffAudio(tt.input)
+			if gotOK != tt.wantOK {
+				t.Fatalf("sniffAudio ok = %t, want %t", gotOK, tt.wantOK)
+			}
+			if gotMIME != tt.wantMIME {
+				t.Errorf("sniffAudio mime = %q, want %q", gotMIME, tt.wantMIME)
+			}
+			if gotExt != tt.wantExt {
+				t.Errorf("sniffAudio ext = %q, want %q", gotExt, tt.wantExt)
+			}
+		})
+	}
+}
+
+// TestServiceStoreAudioAcceptsFormats pins the accept path for every supported
+// format: StoreAudio records a sound row with the sniffed MIME, writes the
+// single file at the returned path, and computes a sha256.
+func TestServiceStoreAudioAcceptsFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		payload  []byte
+		wantMIME string
+		wantExt  string
+	}{
+		{"mp3 id3", mp3ID3(), "audio/mpeg", ".mp3"},
+		{"mp3 frame sync", mp3FrameSync(), "audio/mpeg", ".mp3"},
+		{"m4a ftyp", m4aFtyp(), "audio/mp4", ".m4a"},
+		{"ogg", oggHeader(), "audio/ogg", ".ogg"},
+		{"wav", wavHeader(), "audio/wav", ".wav"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fx := newServiceWithQuiz(t)
+
+			m, err := fx.svc.StoreAudio(
+				t.Context(), fx.quizID, seededAdminID, 5000, bytes.NewReader(tt.payload),
+			)
+			if err != nil {
+				t.Fatalf("StoreAudio err = %v, want nil", err)
+			}
+
+			if got, want := m.Type, TypeAudio; got != want {
+				t.Errorf("Type = %q, want %q", got, want)
+			}
+			if got, want := m.MIME, tt.wantMIME; got != want {
+				t.Errorf("MIME = %q, want %q", got, want)
+			}
+			if got, want := filepath.Ext(m.Path), tt.wantExt; got != want {
+				t.Errorf("path ext = %q, want %q", got, want)
+			}
+			if got, want := m.SizeBytes, int64(len(tt.payload)); got != want {
+				t.Errorf("SizeBytes = %d, want %d", got, want)
+			}
+			if len(m.SHA256) != 64 {
+				t.Errorf("len(SHA256) = %d, want 64 hex chars", len(m.SHA256))
+			}
+			if m.DurationMs == nil {
+				t.Fatal("DurationMs = nil, want 5000")
+			}
+			if got, want := *m.DurationMs, 5000; got != want {
+				t.Errorf("DurationMs = %d, want %d", got, want)
+			}
+
+			stat, err := os.Stat(filepath.Join(fx.root, m.Path))
+			if err != nil {
+				t.Fatalf("stat audio file err = %v, want nil", err)
+			}
+			if got, want := stat.Size(), m.SizeBytes; got != want {
+				t.Errorf("file size = %d, want %d (SizeBytes)", got, want)
+			}
+		})
+	}
+}
+
+// TestServiceStoreAudioPersistsDuration pins that the stored duration round-trips
+// through the DB (not just the in-memory return), and that a non-positive
+// duration stores NULL.
+func TestServiceStoreAudioPersistsDuration(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	withDuration, err := fx.svc.StoreAudio(
+		t.Context(), fx.quizID, seededAdminID, 3200, bytes.NewReader(mp3ID3()),
+	)
+	if err != nil {
+		t.Fatalf("StoreAudio err = %v, want nil", err)
+	}
+	stored, err := fx.svc.Get(t.Context(), withDuration.ID)
+	if err != nil {
+		t.Fatalf("Get err = %v, want nil", err)
+	}
+	if stored.DurationMs == nil {
+		t.Fatal("stored DurationMs = nil, want 3200")
+	}
+	if got, want := *stored.DurationMs, 3200; got != want {
+		t.Errorf("stored DurationMs = %d, want %d", got, want)
+	}
+
+	noDuration, err := fx.svc.StoreAudio(
+		t.Context(), fx.quizID, seededAdminID, 0, bytes.NewReader(oggHeader()),
+	)
+	if err != nil {
+		t.Fatalf("StoreAudio (no duration) err = %v, want nil", err)
+	}
+	if noDuration.DurationMs != nil {
+		t.Errorf("DurationMs = %d, want nil for a non-positive duration", *noDuration.DurationMs)
+	}
+	storedNone, err := fx.svc.Get(t.Context(), noDuration.ID)
+	if err != nil {
+		t.Fatalf("Get (no duration) err = %v, want nil", err)
+	}
+	if storedNone.DurationMs != nil {
+		t.Errorf("stored DurationMs = %d, want nil (NULL)", *storedNone.DurationMs)
+	}
+}
+
+// TestServiceStoreAudioRejectsUnsupported pins that an unrecognised format is
+// rejected with ErrUnsupportedAudio and leaves no row behind.
+func TestServiceStoreAudioRejectsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	_, err := fx.svc.StoreAudio(
+		t.Context(), fx.quizID, seededAdminID, 1000,
+		bytes.NewReader([]byte("\x89PNG\r\n\x1a\n not audio")),
+	)
+	if got, want := err, ErrUnsupportedAudio; !errors.Is(got, want) {
+		t.Fatalf("StoreAudio err = %v, want %v", got, want)
+	}
+
+	rows, err := fx.svc.ListByQuiz(t.Context(), fx.quizID)
+	if err != nil {
+		t.Fatalf("ListByQuiz err = %v, want nil", err)
+	}
+	if got, want := len(rows), 0; got != want {
+		t.Errorf("rows after rejected upload = %d, want %d", got, want)
+	}
+}
+
+// TestServiceStoreAudioRejectsVideoMP4 pins that an MP4 *video* (an ISO-BMFF
+// "ftyp" container with a video major_brand) is rejected with
+// ErrUnsupportedAudio rather than stored as a sound, and leaves no row behind.
+func TestServiceStoreAudioRejectsVideoMP4(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	_, err := fx.svc.StoreAudio(
+		t.Context(), fx.quizID, seededAdminID, 1000, bytes.NewReader(mp4VideoFtyp("isom")),
+	)
+	if got, want := err, ErrUnsupportedAudio; !errors.Is(got, want) {
+		t.Fatalf("StoreAudio err = %v, want %v", got, want)
+	}
+
+	rows, err := fx.svc.ListByQuiz(t.Context(), fx.quizID)
+	if err != nil {
+		t.Fatalf("ListByQuiz err = %v, want nil", err)
+	}
+	if got, want := len(rows), 0; got != want {
+		t.Errorf("rows after rejected video upload = %d, want %d", got, want)
+	}
+}
+
+// TestServiceStoreAudioRejectsEmpty pins that a zero-byte upload is rejected with
+// ErrEmptyUpload.
+func TestServiceStoreAudioRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	_, err := fx.svc.StoreAudio(t.Context(), fx.quizID, seededAdminID, 0, bytes.NewReader(nil))
+	if got, want := err, ErrEmptyUpload; !errors.Is(got, want) {
+		t.Errorf("StoreAudio err = %v, want %v", got, want)
+	}
+}
+
+// TestServiceStoreAudioRejectsOverCap pins that an upload exceeding the
+// configured cap is rejected with ErrAudioTooLarge. The Service is built with a
+// tiny cap and fed a valid-magic payload longer than it.
+func TestServiceStoreAudioRejectsOverCap(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "media-svc-audio-overcap")
+	root := t.TempDir()
+	const tinyCap int64 = 8
+	svc := NewService(store.NewMediaStore(db, slog.Default()), root, testImageMaxBytes, tinyCap, slog.Default())
+
+	payload := append([]byte("ID3"), bytes.Repeat([]byte{0x00}, 64)...)
+	_, err := svc.StoreAudio(t.Context(), quizID, seededAdminID, 1000, bytes.NewReader(payload))
+	if got, want := err, ErrAudioTooLarge; !errors.Is(got, want) {
+		t.Errorf("StoreAudio err = %v, want %v", got, want)
+	}
+}
+
+// TestServiceStoreAudioHugeCap pins that a cap near math.MaxInt64 does not
+// overflow the LimitReader bound: the +1 would wrap negative and make
+// LimitReader report EOF immediately, failing every upload as empty. The store
+// must still accept a normal payload at such a cap.
+func TestServiceStoreAudioHugeCap(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "media-svc-audio-hugecap")
+	root := t.TempDir()
+	svc := NewService(store.NewMediaStore(db, slog.Default()), root, testImageMaxBytes, math.MaxInt64, slog.Default())
+
+	m, err := svc.StoreAudio(t.Context(), quizID, seededAdminID, 1000, bytes.NewReader(mp3ID3()))
+	if err != nil {
+		t.Fatalf("StoreAudio err = %v, want nil", err)
+	}
+	if got, want := m.SizeBytes, int64(len(mp3ID3())); got != want {
+		t.Errorf("SizeBytes = %d, want %d", got, want)
+	}
+}

--- a/internal/media/export_test.go
+++ b/internal/media/export_test.go
@@ -15,3 +15,6 @@ func DecodeJPEGForTest(r io.Reader) (image.Image, error) {
 func DecodeJPEGConfigForTest(r io.Reader) (image.Config, error) {
 	return jpeg.DecodeConfig(r)
 }
+
+// ExportSniffAudio re-exports the unexported audio format sniffer for tests.
+var ExportSniffAudio = sniffAudio

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -7,10 +7,14 @@ import (
 )
 
 // TypeImage is the media.type value for an image row. The column is
-// type-discriminated (image|video|sound) so the same table and per-quiz
-// directory carry sound and video later without a schema change; only image
-// is produced today.
+// type-discriminated (image|video|audio) so the same table and per-quiz
+// directory carry audio and video without a schema change.
 const TypeImage = "image"
+
+// TypeAudio is the media.type value for an audio row (#1059). Audio is stored
+// as-is (no server-side transcoding); only already-browser-playable formats are
+// accepted.
+const TypeAudio = "audio"
 
 // ErrMediaNotFound is returned when a media id does not name a row.
 var ErrMediaNotFound = errors.New("media not found")
@@ -25,16 +29,20 @@ var ErrPathEscapesRoot = errors.New("media path escapes root")
 // resolves them against that root rather than trusting an absolute path from
 // the DB.
 type Media struct {
-	ID                int64
-	QuizID            int64
-	Type              string
-	MIME              string
-	Path              string
-	ThumbPath         string
-	Width             int
-	Height            int
-	SizeBytes         int64
-	SHA256            string
+	ID        int64
+	QuizID    int64
+	Type      string
+	MIME      string
+	Path      string
+	ThumbPath string
+	Width     int
+	Height    int
+	SizeBytes int64
+	SHA256    string
+	// DurationMs is the playback length of an audio row in milliseconds, or nil
+	// when unknown (#1059). It is advisory and supplied by the caller, since
+	// audio is not decoded server-side; an image row leaves it nil.
+	DurationMs        *int
 	CreatedByPlayerID int64
 	CreatedAt         time.Time
 }
@@ -56,7 +64,8 @@ type Store interface {
 	// assigned id and created_at populated. The row's Path and ThumbPath may be
 	// empty at insert time; they are filled in via UpdateMediaPaths once the
 	// assigned id names the on-disk files. MarkMediaReady flips it ready once
-	// the files are written and the paths recorded.
+	// the files are written and the paths recorded. DurationMs is persisted as
+	// supplied (nil stores NULL) for audio rows.
 	CreateMedia(ctx context.Context, m *Media) (*Media, error)
 	// UpdateMediaPaths sets the on-disk paths of a media row after its files are
 	// written. Returns ErrMediaNotFound when no row matched.

--- a/internal/media/pipeline.go
+++ b/internal/media/pipeline.go
@@ -17,14 +17,18 @@ import (
 	"image/jpeg"
 	_ "image/png" // register the png decoder with image.Decode
 	"io"
+	"math"
 
 	"golang.org/x/image/draw"
 )
 
 const (
-	// MaxUploadBytes caps the raw upload size (~10 MB). A larger upload is
-	// rejected before decode so a hostile or accidental huge file cannot make
-	// the decoder allocate unbounded memory.
+	// MaxUploadBytes is the documented default cap on the raw upload size
+	// (~10 MB). The runtime cap is configurable (MEDIA_IMAGE_MAX_BYTES, threaded
+	// through Service into Process); this constant remains the default value and
+	// the basis for the multipart request envelope in internal/mediahttp. A
+	// larger upload is rejected before decode so a hostile or accidental huge
+	// file cannot make the decoder allocate unbounded memory.
 	MaxUploadBytes = 10 << 20
 
 	// MaxPixels caps the decoded pixel area (~50 megapixels). The byte cap does
@@ -55,7 +59,7 @@ const (
 	MIMEJPEG = "image/jpeg"
 )
 
-// ErrUploadTooLarge is returned when the raw upload exceeds MaxUploadBytes.
+// ErrUploadTooLarge is returned when the raw upload exceeds the configured cap.
 var ErrUploadTooLarge = errors.New("upload exceeds maximum size")
 
 // ErrEmptyUpload is returned when the upload contains no bytes.
@@ -93,13 +97,14 @@ type Processed struct {
 // Process decodes the upload (jpeg or png), downscales it so its long edge is
 // at most MaxLongEdge, re-encodes it as lossy jpeg, and derives a
 // ThumbLongEdge jpeg thumbnail from the same decoded source. It is pure: no
-// disk or network. The reader is fully consumed.
+// disk or network. The reader is fully consumed. maxBytes caps the raw upload
+// size; zero or negative disables the cap.
 //
-// Returns ErrUploadTooLarge when the raw bytes exceed MaxUploadBytes,
-// ErrEmptyUpload for a zero-byte upload, and ErrUnsupportedImage when the
-// bytes are not a decodable jpeg or png.
-func Process(r io.Reader) (*Processed, error) {
-	raw, err := readCapped(r)
+// Returns ErrUploadTooLarge when the raw bytes exceed maxBytes, ErrEmptyUpload
+// for a zero-byte upload, and ErrUnsupportedImage when the bytes are not a
+// decodable jpeg or png.
+func Process(r io.Reader, maxBytes int64) (*Processed, error) {
+	raw, err := readCapped(r, maxBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -157,18 +162,31 @@ func decodeGuarded(raw []byte) (image.Image, error) {
 	return src, nil
 }
 
-// readCapped reads at most MaxUploadBytes+1 from r so the result both holds the
-// whole upload (when within the cap) and detects an over-cap upload by the
-// extra byte. An empty upload is rejected.
-func readCapped(r io.Reader) ([]byte, error) {
-	raw, err := io.ReadAll(io.LimitReader(r, MaxUploadBytes+1))
+// readCapped reads the upload, capping it at maxBytes (plus one byte to detect
+// an over-cap upload). A zero or negative cap disables the limit. An empty
+// upload is rejected.
+func readCapped(r io.Reader, maxBytes int64) ([]byte, error) {
+	reader := r
+	if maxBytes > 0 {
+		// Saturate the read limit rather than computing maxBytes+1: a cap at
+		// math.MaxInt64 would overflow to a negative limit, which LimitReader
+		// treats as "read nothing" and would fail every upload as empty. At the
+		// saturated limit the over-cap check below is unreachable, but a cap that
+		// high is effectively no cap.
+		limit := int64(math.MaxInt64)
+		if maxBytes < math.MaxInt64 {
+			limit = maxBytes + 1
+		}
+		reader = io.LimitReader(r, limit)
+	}
+	raw, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("reading upload: %w", err)
 	}
 	if len(raw) == 0 {
 		return nil, ErrEmptyUpload
 	}
-	if len(raw) > MaxUploadBytes {
+	if maxBytes > 0 && int64(len(raw)) > maxBytes {
 		return nil, ErrUploadTooLarge
 	}
 

--- a/internal/media/pipeline_test.go
+++ b/internal/media/pipeline_test.go
@@ -69,7 +69,7 @@ func TestProcessAcceptedFormats(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := Process(bytes.NewReader(raw))
+			got, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 			if err != nil {
 				t.Fatalf("Process(%s) err = %v, want nil", name, err)
 			}
@@ -93,7 +93,7 @@ func TestProcessRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	raw := encodePNG(t, gradient(800, 600))
-	got, err := Process(bytes.NewReader(raw))
+	got, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 	if err != nil {
 		t.Fatalf("Process err = %v, want nil", err)
 	}
@@ -132,7 +132,7 @@ func TestProcessDownscalesLongEdge(t *testing.T) {
 
 	// 3200x1600: long edge double MaxLongEdge, 2:1 aspect ratio.
 	raw := encodePNG(t, gradient(3200, 1600))
-	got, err := Process(bytes.NewReader(raw))
+	got, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 	if err != nil {
 		t.Fatalf("Process err = %v, want nil", err)
 	}
@@ -162,7 +162,7 @@ func TestProcessNeverUpscales(t *testing.T) {
 	t.Parallel()
 
 	raw := encodePNG(t, gradient(100, 60))
-	got, err := Process(bytes.NewReader(raw))
+	got, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 	if err != nil {
 		t.Fatalf("Process err = %v, want nil", err)
 	}
@@ -180,11 +180,11 @@ func TestProcessSHA256Deterministic(t *testing.T) {
 
 	raw := encodePNG(t, gradient(640, 480))
 
-	first, err := Process(bytes.NewReader(raw))
+	first, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 	if err != nil {
 		t.Fatalf("Process #1 err = %v, want nil", err)
 	}
-	second, err := Process(bytes.NewReader(raw))
+	second, err := Process(bytes.NewReader(raw), MaxUploadBytes)
 	if err != nil {
 		t.Fatalf("Process #2 err = %v, want nil", err)
 	}
@@ -200,15 +200,36 @@ func TestProcessSHA256Deterministic(t *testing.T) {
 	}
 }
 
-// TestProcessRejectsOversize pins the raw-size guard: an upload past
-// MaxUploadBytes is rejected before decode.
+// TestProcessRejectsOversize pins the raw-size guard: an upload past the cap is
+// rejected before decode.
 func TestProcessRejectsOversize(t *testing.T) {
 	t.Parallel()
 
 	oversize := bytes.Repeat([]byte{0xff}, MaxUploadBytes+1)
-	_, err := Process(bytes.NewReader(oversize))
+	_, err := Process(bytes.NewReader(oversize), MaxUploadBytes)
 	if got, want := err, ErrUploadTooLarge; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+// TestProcessHonorsCustomCap pins that the cap is the maxBytes argument, not a
+// fixed constant: an image the default cap accepts is rejected under a tiny cap.
+func TestProcessHonorsCustomCap(t *testing.T) {
+	t.Parallel()
+
+	raw := encodePNG(t, gradient(200, 120))
+	if int64(len(raw)) > MaxUploadBytes {
+		t.Fatalf("test input %d bytes exceeds the default cap %d", len(raw), MaxUploadBytes)
+	}
+
+	if _, err := Process(bytes.NewReader(raw), MaxUploadBytes); err != nil {
+		t.Fatalf("Process under default cap err = %v, want nil", err)
+	}
+
+	tinyCap := int64(len(raw) - 1)
+	_, err := Process(bytes.NewReader(raw), tinyCap)
+	if got, want := err, ErrUploadTooLarge; !errors.Is(got, want) {
+		t.Errorf("err under tiny cap = %v, want %v", got, want)
 	}
 }
 
@@ -216,7 +237,7 @@ func TestProcessRejectsOversize(t *testing.T) {
 func TestProcessRejectsEmpty(t *testing.T) {
 	t.Parallel()
 
-	_, err := Process(bytes.NewReader(nil))
+	_, err := Process(bytes.NewReader(nil), MaxUploadBytes)
 	if got, want := err, ErrEmptyUpload; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -228,7 +249,7 @@ func TestProcessRejectsEmpty(t *testing.T) {
 func TestProcessRejectsNonImage(t *testing.T) {
 	t.Parallel()
 
-	_, err := Process(bytes.NewReader([]byte("this is plainly not an image at all")))
+	_, err := Process(bytes.NewReader([]byte("this is plainly not an image at all")), MaxUploadBytes)
 	if got, want := err, ErrUnsupportedImage; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v", got, want)
 	}
@@ -254,7 +275,7 @@ func TestProcess_Concurrent(t *testing.T) {
 	for range workers {
 		go func() {
 			defer wg.Done()
-			if _, err := Process(bytes.NewReader(inputPNG)); err != nil {
+			if _, err := Process(bytes.NewReader(inputPNG), MaxUploadBytes); err != nil {
 				t.Errorf("Process err = %v, want nil", err)
 			}
 		}()
@@ -300,7 +321,7 @@ func TestProcess_RejectsDecodeBomb(t *testing.T) {
 		t.Fatalf("bomb header = %d bytes, want a tiny file", got)
 	}
 
-	_, err := Process(bytes.NewReader(bomb))
+	_, err := Process(bytes.NewReader(bomb), MaxUploadBytes)
 	if got, want := err, ErrImageTooLarge; !errors.Is(got, want) {
 		t.Errorf("Process(decode bomb) err = %v, want %v", got, want)
 	}

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -43,16 +43,26 @@ const (
 // files under a per-quiz directory below root, and records a media row. It is
 // the single place that ties the pure pipeline to the filesystem and the store.
 type Service struct {
-	store  Store
-	root   string
-	logger *slog.Logger
+	store         Store
+	root          string
+	imageMaxBytes int64
+	audioMaxBytes int64
+	logger        *slog.Logger
 }
 
 // NewService returns a media Service writing files under root and recording
 // rows through store. root is the configured media directory; the caller
-// ensures it exists at startup.
-func NewService(store Store, root string, logger *slog.Logger) *Service {
-	return &Service{store: store, root: root, logger: logger}
+// ensures it exists at startup. imageMaxBytes caps a stored image upload's raw
+// size and audioMaxBytes caps a stored audio upload's raw size; zero or negative
+// means no cap.
+func NewService(store Store, root string, imageMaxBytes, audioMaxBytes int64, logger *slog.Logger) *Service {
+	return &Service{
+		store:         store,
+		root:          root,
+		imageMaxBytes: imageMaxBytes,
+		audioMaxBytes: audioMaxBytes,
+		logger:        logger,
+	}
 }
 
 // Store processes the upload into a normalised jpeg full image plus thumbnail,
@@ -76,7 +86,7 @@ func (s *Service) Store(ctx context.Context, quizID, createdBy int64, r io.Reade
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, fmt.Errorf("upload cancelled before processing: %w", ctxErr)
 	}
-	processed, err := Process(r)
+	processed, err := Process(r, s.imageMaxBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +112,12 @@ func (s *Service) Store(ctx context.Context, quizID, createdBy int64, r io.Reade
 		return nil, fmt.Errorf("creating media row: %w", err)
 	}
 
-	relFull, relThumb, err := s.writeAndCommit(ctx, row.ID, quizDir, processed)
-	if err != nil {
+	relFull := filepath.Join(quizDir, strconv.FormatInt(row.ID, decimalBase)+fullSuffix)
+	relThumb := filepath.Join(quizDir, strconv.FormatInt(row.ID, decimalBase)+thumbSuffix)
+	if err = s.writeAndCommit(ctx, row.ID, quizDir, []fileBlob{
+		{relPath: relFull, data: processed.Full},
+		{relPath: relThumb, data: processed.Thumb},
+	}); err != nil {
 		return nil, err
 	}
 
@@ -223,100 +237,108 @@ func (s *Service) Open(relPath string) (*os.File, error) {
 	return f, nil
 }
 
-// writeAndCommit creates the per-quiz directory, writes the full + thumb files,
-// records their paths on the row, and flips the row ready -- the two-phase
-// commit's file + DB work after the not-ready insert. It returns the
-// root-relative paths it wrote. A failure at any step tears the just-written
-// files and the still-hidden row back down so a failed upload leaves nothing
-// behind (#992, #998).
-func (s *Service) writeAndCommit(
-	ctx context.Context, id int64, quizDir string, processed *Processed,
-) (relFull, relThumb string, err error) {
+// fileBlob is one root-relative file the two-phase commit writes: an image
+// passes a full + thumb pair, audio passes a single file.
+type fileBlob struct {
+	relPath string
+	data    []byte
+}
+
+// writeAndCommit creates the per-quiz directory, writes every file in blobs,
+// records the resulting paths on the row, and flips the row ready -- the
+// two-phase commit's file + DB work after the not-ready insert. blobs[0] is the
+// primary file (recorded as Path); blobs[1], when present, is the thumbnail
+// (recorded as ThumbPath). A failure at any step tears the just-written files
+// and the still-hidden row back down so a failed upload leaves nothing behind
+// (#992, #998).
+func (s *Service) writeAndCommit(ctx context.Context, id int64, quizDir string, blobs []fileBlob) error {
 	// Create the per-quiz directory only after the insert succeeds, so a quiz
 	// whose first upload fails at the insert is not left with a stray empty dir
 	// (#998).
 	if mkErr := os.MkdirAll(filepath.Join(s.root, quizDir), dirPerm); mkErr != nil {
 		s.cleanupRow(context.WithoutCancel(ctx), id)
 
-		return "", "", fmt.Errorf("creating quiz media directory: %w", mkErr)
+		return fmt.Errorf("creating quiz media directory: %w", mkErr)
 	}
 
-	relFull = filepath.Join(quizDir, strconv.FormatInt(id, decimalBase)+fullSuffix)
-	relThumb = filepath.Join(quizDir, strconv.FormatInt(id, decimalBase)+thumbSuffix)
-
-	if err = s.writeFiles(processed, relFull, relThumb); err != nil {
+	if err := s.writeFiles(blobs); err != nil {
 		s.cleanupRow(context.WithoutCancel(ctx), id)
 
-		return "", "", err
+		return err
+	}
+
+	relPath := blobs[0].relPath
+	relThumb := ""
+	if len(blobs) > 1 {
+		relThumb = blobs[1].relPath
 	}
 
 	// Cleanup on the post-write failures runs under a cancel-immune context so a
 	// cancelled upload's row + files actually get removed instead of orphaning
 	// when ctx is the cause of the failure (#951).
-	if err = s.store.UpdateMediaPaths(ctx, id, relFull, relThumb); err != nil {
-		s.cleanupRowAndFiles(ctx, id, relFull, relThumb)
+	if err := s.store.UpdateMediaPaths(ctx, id, relPath, relThumb); err != nil {
+		s.cleanupRowAndFiles(ctx, id, blobs)
 
-		return "", "", fmt.Errorf("recording media paths: %w", err)
+		return fmt.Errorf("recording media paths: %w", err)
 	}
 
 	// Flip the row ready last, so a cancel arriving after the paths commit but
 	// before this flip leaves a hidden (not-ready) row the sweep drops rather
 	// than a file the host sees in their library (#992).
-	if err = s.store.MarkMediaReady(ctx, id); err != nil {
-		s.cleanupRowAndFiles(ctx, id, relFull, relThumb)
+	if err := s.store.MarkMediaReady(ctx, id); err != nil {
+		s.cleanupRowAndFiles(ctx, id, blobs)
 
-		return "", "", fmt.Errorf("marking media ready: %w", err)
-	}
-
-	return relFull, relThumb, nil
-}
-
-// writeFiles writes the full and thumb jpeg bytes to the given root-relative
-// paths using a temp-then-rename pattern so a SIGKILL or crash between the
-// two writes can't leave a row pointing at a half-written or missing file.
-// Both files are written under <name>.tmp, then atomically renamed into
-// place. A failure at any step cleans up whatever has been written so a
-// failed upload leaves nothing behind.
-func (s *Service) writeFiles(processed *Processed, relFull, relThumb string) error {
-	fullTmp := relFull + ".tmp"
-	thumbTmp := relThumb + ".tmp"
-
-	if err := os.WriteFile(filepath.Join(s.root, fullTmp), processed.Full, filePerm); err != nil {
-		return fmt.Errorf("writing full image: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(s.root, thumbTmp), processed.Thumb, filePerm); err != nil {
-		s.removeFile(fullTmp)
-
-		return fmt.Errorf("writing thumbnail: %w", err)
-	}
-
-	if err := os.Rename(filepath.Join(s.root, fullTmp), filepath.Join(s.root, relFull)); err != nil {
-		s.removeFile(fullTmp)
-		s.removeFile(thumbTmp)
-
-		return fmt.Errorf("publishing full image: %w", err)
-	}
-	if err := os.Rename(filepath.Join(s.root, thumbTmp), filepath.Join(s.root, relThumb)); err != nil {
-		// The full file already landed at its final name; tear it back down
-		// so the upload's invariant ("either both files exist or neither
-		// does") is preserved.
-		s.removeFile(relFull)
-		s.removeFile(thumbTmp)
-
-		return fmt.Errorf("publishing thumbnail: %w", err)
+		return fmt.Errorf("marking media ready: %w", err)
 	}
 
 	return nil
 }
 
-// cleanupRowAndFiles removes both written files and the media row after a
+// writeFiles writes every blob to its root-relative path using a
+// temp-then-rename pattern so a SIGKILL or crash mid-write can't leave a row
+// pointing at a half-written or missing file. Each blob is written under
+// <name>.tmp, then atomically renamed into place. A failure at any step removes
+// every file written so far so the upload's invariant ("all files exist or
+// none do") holds and a failed upload leaves nothing behind.
+func (s *Service) writeFiles(blobs []fileBlob) error {
+	written := make([]string, 0, len(blobs))
+
+	for _, b := range blobs {
+		tmp := b.relPath + ".tmp"
+		if err := os.WriteFile(filepath.Join(s.root, tmp), b.data, filePerm); err != nil {
+			s.removeFiles(written)
+			s.removeFile(tmp)
+
+			return fmt.Errorf("writing media file %q: %w", b.relPath, err)
+		}
+		if err := os.Rename(filepath.Join(s.root, tmp), filepath.Join(s.root, b.relPath)); err != nil {
+			s.removeFiles(written)
+			s.removeFile(tmp)
+
+			return fmt.Errorf("publishing media file %q: %w", b.relPath, err)
+		}
+		written = append(written, b.relPath)
+	}
+
+	return nil
+}
+
+// removeFiles unlinks every root-relative path best-effort.
+func (s *Service) removeFiles(relPaths []string) {
+	for _, p := range relPaths {
+		s.removeFile(p)
+	}
+}
+
+// cleanupRowAndFiles removes every written file and the media row after a
 // post-write failure, under a cancel-immune context derived from ctx so a
 // cancelled upload (the common cause of the failure) still gets fully torn down
 // rather than orphaning a row or files (#951).
-func (s *Service) cleanupRowAndFiles(ctx context.Context, id int64, relFull, relThumb string) {
+func (s *Service) cleanupRowAndFiles(ctx context.Context, id int64, blobs []fileBlob) {
 	cleanup := context.WithoutCancel(ctx)
-	s.removeFile(relFull)
-	s.removeFile(relThumb)
+	for _, b := range blobs {
+		s.removeFile(b.relPath)
+	}
 	s.cleanupRow(cleanup, id)
 }
 

--- a/internal/media/service_test.go
+++ b/internal/media/service_test.go
@@ -23,6 +23,11 @@ import (
 // FK created_by_player_id to it.
 const seededAdminID int64 = 1
 
+// testImageMaxBytes is a generous image cap for the shared fixture so the
+// accept-path tests are never bounded by it; the over-cap test builds its own
+// Service with a tiny cap.
+const testImageMaxBytes int64 = 10 << 20
+
 // fixture bundles a media Service with the DB, quiz id, and temp root it was
 // built over so tests can reach whichever it needs without unpacking a wide
 // tuple. The DB is exposed so a test can seed a second quiz in the same DB to
@@ -49,7 +54,13 @@ func newServiceWithQuiz(t *testing.T) fixture {
 
 	quizID := seedQuiz(t, db, "media-svc")
 	root := t.TempDir()
-	svc := NewService(store.NewMediaStore(db, slog.Default()), root, slog.Default())
+	svc := NewService(
+		store.NewMediaStore(db, slog.Default()),
+		root,
+		testImageMaxBytes,
+		testAudioMaxBytes,
+		slog.Default(),
+	)
 
 	return fixture{svc: svc, db: db, quizID: quizID, root: root}
 }
@@ -146,6 +157,29 @@ func TestServiceStoreRoundTrip(t *testing.T) {
 	}
 }
 
+// TestServiceStoreImageOverCap pins that an image upload over the configured
+// imageMaxBytes is rejected with ErrUploadTooLarge before it is stored.
+func TestServiceStoreImageOverCap(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "media-svc-image-overcap")
+	root := t.TempDir()
+	const tinyCap int64 = 8
+	svc := NewService(store.NewMediaStore(db, slog.Default()), root, tinyCap, testAudioMaxBytes, slog.Default())
+
+	_, err := svc.Store(t.Context(), quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	if got, want := err, ErrUploadTooLarge; !errors.Is(got, want) {
+		t.Errorf("Store err = %v, want %v", got, want)
+	}
+}
+
 // TestServiceStoreCancelledBeforeProcessing pins the ctx-cancelled short-
 // circuit: a cancel that reaches the handler before Process runs returns the
 // cancel error AND leaves no row + no files behind, so the host's apparent
@@ -235,7 +269,7 @@ func TestServiceStoreCancelledMidFlightCleansUp(t *testing.T) {
 	innerStore := store.NewMediaStore(db, slog.Default())
 	ctx, cancel := context.WithCancel(t.Context())
 	wrapped := &cancelOnUpdatePathsStore{Store: innerStore, cancel: cancel}
-	svc := NewService(wrapped, root, slog.Default())
+	svc := NewService(wrapped, root, testImageMaxBytes, testAudioMaxBytes, slog.Default())
 
 	_, err := svc.Store(ctx, quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
 	if err == nil {
@@ -293,7 +327,7 @@ func TestServiceStoreCancelledAfterPathsLeavesNothing(t *testing.T) {
 	innerStore := store.NewMediaStore(db, slog.Default())
 	ctx, cancel := context.WithCancel(t.Context())
 	wrapped := &cancelAfterPathsStore{Store: innerStore, cancel: cancel}
-	svc := NewService(wrapped, root, slog.Default())
+	svc := NewService(wrapped, root, testImageMaxBytes, testAudioMaxBytes, slog.Default())
 
 	_, err := svc.Store(ctx, quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
 	if err == nil {
@@ -348,7 +382,13 @@ func TestServiceStoreCreateMediaFailureLeavesNoDir(t *testing.T) {
 	db := dbtest.Open(t)
 	quizID := seedQuiz(t, db, "media-svc-insert-fail")
 	root := t.TempDir()
-	svc := NewService(store.NewMediaStore(db, slog.Default()), root, slog.Default())
+	svc := NewService(
+		store.NewMediaStore(db, slog.Default()),
+		root,
+		testImageMaxBytes,
+		testAudioMaxBytes,
+		slog.Default(),
+	)
 
 	// Close the DB so the CreateMedia insert fails; Process runs first and
 	// does not touch the DB, so the failure lands exactly at the insert.

--- a/internal/migrations/20260618120000_audio_media.sql
+++ b/internal/migrations/20260618120000_audio_media.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- Adds the storage foundation for question sounds (#1059), mirroring the image
+-- media feature. A media row can now record an audio clip's playback length,
+-- and a question can reference an uploaded sound separately from its image.
+--
+-- duration_ms is nullable (NULL = unknown length): audio is not decoded
+-- server-side, so the value is supplied by the caller (read in-browser) and may
+-- be absent. ADD COLUMN is an in-place change in SQLite (no table rebuild), so
+-- even though media is a parent table (questions references it) this needs no
+-- foreign-key dance: a plain ALTER inside goose's default transaction is fine,
+-- exactly as 20260617120000 added the ready column.
+-- +goose StatementBegin
+ALTER TABLE media ADD COLUMN duration_ms INTEGER;
+-- +goose StatementEnd
+
+-- audio_media_id is a second media reference on questions, kept separate from
+-- media_id so a question can carry both an image and a sound. It is nullable
+-- (NULL = no sound). ON DELETE SET NULL clears it when the sound is deleted, so
+-- moderating a sound leaves the question intact minus its audio - the same rule
+-- 20260616120000 gave media_id. SQLite permits ADD COLUMN with an FK only when
+-- the column default is NULL, which it is, so no table rebuild is needed.
+-- +goose StatementBegin
+ALTER TABLE questions ADD COLUMN audio_media_id INTEGER REFERENCES media (id) ON DELETE SET NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE questions DROP COLUMN audio_media_id;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE media DROP COLUMN duration_ms;
+-- +goose StatementEnd

--- a/internal/migrations/20260619120000_media_type_audio.sql
+++ b/internal/migrations/20260619120000_media_type_audio.sql
@@ -1,0 +1,183 @@
+-- NO TRANSACTION required: SQLite ignores PRAGMA foreign_keys inside a
+-- transaction, and this migration rebuilds the media table (the parent of
+-- questions.media_id and questions.audio_media_id) to widen its type CHECK from
+-- ('image', 'video', 'sound') to ('image', 'video', 'audio'), unifying the
+-- audio kind on 'audio' (#1059). A CHECK change needs a table rebuild in SQLite.
+-- PRAGMA defer_foreign_keys is not enough on a parent rebuild: DROP TABLE on the
+-- parent invalidates the child rows' references in a way the deferred check at
+-- COMMIT still trips on (see 20260616180000 for the same pattern).
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA foreign_keys = OFF;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+BEGIN TRANSACTION;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE media_new
+(
+    id                   INTEGER  PRIMARY KEY AUTOINCREMENT,
+    quiz_id              INTEGER  NOT NULL REFERENCES quizzes (id) ON DELETE CASCADE,
+    type                 TEXT     NOT NULL DEFAULT 'image'
+                                  CHECK (type IN ('image', 'video', 'audio')),
+    mime                 TEXT     NOT NULL,
+    path                 TEXT     NOT NULL,
+    thumb_path           TEXT,
+    width                INTEGER,
+    height               INTEGER,
+    size_bytes           INTEGER  NOT NULL,
+    sha256               TEXT     NOT NULL,
+    created_by_player_id INTEGER  NOT NULL REFERENCES players (id),
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ready                INTEGER  NOT NULL DEFAULT 1 CHECK (ready IN (0, 1)),
+    duration_ms          INTEGER
+);
+-- +goose StatementEnd
+
+-- Translate any legacy 'sound' row to 'audio' DURING the copy: media_new's CHECK
+-- is already the new set, so a literal copy of a 'sound' row would fail the
+-- CHECK. The CASE folds the data migration into the INSERT so no later UPDATE is
+-- needed. Explicit ids advance sqlite_sequence's seq for media_new to MAX(id).
+-- +goose StatementBegin
+INSERT INTO media_new (
+    id, quiz_id, type, mime, path, thumb_path, width, height,
+    size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
+)
+SELECT id, quiz_id,
+       CASE WHEN type = 'sound' THEN 'audio' ELSE type END,
+       mime, path, thumb_path, width, height,
+       size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
+FROM media;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE media;
+-- +goose StatementEnd
+
+-- ALTER TABLE RENAME auto-renames the sqlite_sequence entry, so the cursor
+-- carries across the rename without explicit handling.
+-- +goose StatementBegin
+ALTER TABLE media_new RENAME TO media;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX media_quiz_id_idx ON media (quiz_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX media_not_ready_idx ON media (created_at) WHERE ready = 0;
+-- +goose StatementEnd
+
+-- The fk-violation guard from 20260529160000: pragma_foreign_key_check returns
+-- the violating rows, goose discards them, so on its own it cannot stop a
+-- broken rebuild from committing. Convert "a violation exists" into a failing
+-- CHECK so the whole transaction aborts.
+-- +goose StatementBegin
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+COMMIT;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA foreign_keys = OFF;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+BEGIN TRANSACTION;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE media_old
+(
+    id                   INTEGER  PRIMARY KEY AUTOINCREMENT,
+    quiz_id              INTEGER  NOT NULL REFERENCES quizzes (id) ON DELETE CASCADE,
+    type                 TEXT     NOT NULL DEFAULT 'image'
+                                  CHECK (type IN ('image', 'video', 'sound')),
+    mime                 TEXT     NOT NULL,
+    path                 TEXT     NOT NULL,
+    thumb_path           TEXT,
+    width                INTEGER,
+    height               INTEGER,
+    size_bytes           INTEGER  NOT NULL,
+    sha256               TEXT     NOT NULL,
+    created_by_player_id INTEGER  NOT NULL REFERENCES players (id),
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ready                INTEGER  NOT NULL DEFAULT 1 CHECK (ready IN (0, 1)),
+    duration_ms          INTEGER
+);
+-- +goose StatementEnd
+
+-- Reverse the kind unification: translate 'audio' back to 'sound' during the
+-- copy so the legacy CHECK accepts every row.
+-- +goose StatementBegin
+INSERT INTO media_old (
+    id, quiz_id, type, mime, path, thumb_path, width, height,
+    size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
+)
+SELECT id, quiz_id,
+       CASE WHEN type = 'audio' THEN 'sound' ELSE type END,
+       mime, path, thumb_path, width, height,
+       size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms
+FROM media;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DELETE FROM sqlite_sequence WHERE name = 'media';
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE media;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE media_old RENAME TO media;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX media_quiz_id_idx ON media (quiz_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX media_not_ready_idx ON media (created_at) WHERE ready = 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+COMMIT;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd

--- a/internal/migrations/20260619130000_question_image_media_id.sql
+++ b/internal/migrations/20260619130000_question_image_media_id.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Rename questions.media_id to image_media_id for symmetry with the audio
+-- reference added in 20260618120000 (#1059): a question now names its image and
+-- its sound with parallel image_media_id / audio_media_id columns. SQLite's
+-- RENAME COLUMN is an in-place metadata change that works on a foreign-key
+-- column, so no table rebuild is needed.
+-- +goose StatementBegin
+ALTER TABLE questions RENAME COLUMN media_id TO image_media_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE questions RENAME COLUMN image_media_id TO media_id;
+-- +goose StatementEnd

--- a/internal/migrations/audio_media_test.go
+++ b/internal/migrations/audio_media_test.go
@@ -1,0 +1,199 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// audioMediaVersion is the #1059 migration adding media.duration_ms and
+// questions.audio_media_id.
+const audioMediaVersion = 20260618120000
+
+// TestAudioMediaMigration_Columns pins the #1059 schema additions: media gains a
+// duration_ms column and questions gains an audio_media_id column with a foreign
+// key to media (now in addition to media_id).
+func TestAudioMediaMigration_Columns(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	if !tableColumns(t, db, "media")["duration_ms"] {
+		t.Error("media is missing the duration_ms column")
+	}
+
+	if !tableColumns(t, db, "questions")["audio_media_id"] {
+		t.Error("questions is missing the audio_media_id column")
+	}
+	// questions already FK-references media via image_media_id, so a target-set
+	// check cannot prove audio_media_id specifically got its own FK; assert the
+	// FK keyed on the new column directly.
+	if !foreignKeyOnColumn(t, db, "questions", "audio_media_id", "media") {
+		t.Error("questions.audio_media_id is missing its foreign key to media")
+	}
+}
+
+// TestAudioMediaMigration_DownUpRoundTrips pins that the #1059 migration both
+// directions cleanly: Down drops media.duration_ms and questions.audio_media_id
+// (the latter being the source side of an FK), and Up re-adds them. Exercising
+// Down-then-Up against a populated DB catches a broken rebuild the fresh-DB
+// dbtest.Open run cannot.
+func TestAudioMediaMigration_DownUpRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	// Seed a quiz + media row so Down/Up runs against populated tables, not an
+	// empty schema.
+	quizID := seedQuiz(t, db, "Audio roundtrip", "audio-down-up-roundtrip")
+	seedMedia(t, db, quizID)
+
+	if err := goose.DownTo(db, ".", audioMediaVersion-1); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+	if tableColumns(t, db, "media")["duration_ms"] {
+		t.Error("media still has duration_ms after Down, want it dropped")
+	}
+	if tableColumns(t, db, "questions")["audio_media_id"] {
+		t.Error("questions still has audio_media_id after Down, want it dropped")
+	}
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+	if !tableColumns(t, db, "media")["duration_ms"] {
+		t.Error("media is missing duration_ms after re-Up")
+	}
+	if !tableColumns(t, db, "questions")["audio_media_id"] {
+		t.Error("questions is missing audio_media_id after re-Up")
+	}
+	if !foreignKeyOnColumn(t, db, "questions", "audio_media_id", "media") {
+		t.Error("questions.audio_media_id is missing its foreign key after re-Up")
+	}
+}
+
+// foreignKeyOnColumn reports whether the named table has a foreign key whose
+// source column is fromCol targeting toTable.
+func foreignKeyOnColumn(t *testing.T, db *sql.DB, table, fromCol, toTable string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(
+		t.Context(),
+		`SELECT count(*) FROM pragma_foreign_key_list(?) WHERE "from" = ? AND "table" = ?`,
+		table, fromCol, toTable,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_foreign_key_list err = %v, want nil", err)
+	}
+
+	return n > 0
+}
+
+// TestAudioMediaMigration_DurationRoundTrips pins that duration_ms stores and
+// reads back an explicit value, and stays NULL when omitted.
+func TestAudioMediaMigration_DurationRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Audio duration", "audio-duration-roundtrip")
+	withDuration := seedMedia(t, db, quizID)
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET duration_ms = ? WHERE id = ?", 5000, withDuration,
+	); err != nil {
+		t.Fatalf("set duration_ms err = %v, want nil", err)
+	}
+
+	var got sql.NullInt64
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT duration_ms FROM media WHERE id = ?", withDuration,
+	).Scan(&got); err != nil {
+		t.Fatalf("read duration_ms err = %v, want nil", err)
+	}
+	if !got.Valid {
+		t.Fatal("duration_ms = NULL, want a stored value")
+	}
+	if want := int64(5000); got.Int64 != want {
+		t.Errorf("duration_ms = %d, want %d", got.Int64, want)
+	}
+
+	withoutDuration := seedMedia(t, db, quizID)
+	var none sql.NullInt64
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT duration_ms FROM media WHERE id = ?", withoutDuration,
+	).Scan(&none); err != nil {
+		t.Fatalf("read default duration_ms err = %v, want nil", err)
+	}
+	if none.Valid {
+		t.Errorf("duration_ms = %d, want NULL when unset", none.Int64)
+	}
+}
+
+// TestAudioMediaMigration_DeleteSetsNull pins the ON DELETE SET NULL rule on
+// audio_media_id (#1059): deleting a sound clears it off any question
+// referencing it - the question survives, just loses its audio_media_id.
+func TestAudioMediaMigration_DeleteSetsNull(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Audio question", "audio-media-setnull")
+	roundID := seedRound(t, db, quizID)
+	mediaID := seedMedia(t, db, quizID)
+	questionID := seedQuestionWithAudioMedia(t, db, quizID, roundID, mediaID)
+
+	if _, err := db.ExecContext(
+		t.Context(), "DELETE FROM media WHERE id = ?", mediaID,
+	); err != nil {
+		t.Fatalf("delete media err = %v, want nil", err)
+	}
+
+	var got sql.NullInt64
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT audio_media_id FROM questions WHERE id = ?", questionID,
+	).Scan(&got); err != nil {
+		t.Fatalf("read question audio_media_id err = %v, want nil (question must survive)", err)
+	}
+	if got.Valid {
+		t.Errorf("question audio_media_id = %d after sound delete, want NULL (ON DELETE SET NULL)", got.Int64)
+	}
+}
+
+// seedQuestionWithAudioMedia inserts a question attached to mediaID via
+// audio_media_id and returns its id.
+func seedQuestionWithAudioMedia(t *testing.T, db *sql.DB, quizID, roundID, mediaID int64) int64 {
+	t.Helper()
+	var id int64
+	if err := db.QueryRowContext(
+		t.Context(),
+		`INSERT INTO questions (quiz_id, round_id, text, position, audio_media_id)
+		 VALUES (?, ?, 'Q', 1, ?) RETURNING id`,
+		quizID, roundID, mediaID,
+	).Scan(&id); err != nil {
+		t.Fatalf("seed question err = %v, want nil", err)
+	}
+
+	return id
+}

--- a/internal/migrations/media_type_audio_test.go
+++ b/internal/migrations/media_type_audio_test.go
@@ -1,0 +1,150 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// mediaTypeAudioPrevVersion is the migration just below the type-unification
+// rebuild; DownTo it to land on a schema whose media CHECK still accepts
+// 'sound', the legacy value the data migration translates.
+const mediaTypeAudioPrevVersion = 20260618120000
+
+// TestMediaTypeAudioMigration_CheckAndShape pins the #1059 kind unification:
+// after the rebuild the media type CHECK accepts 'audio' and rejects 'sound',
+// both indexes survive, and all 14 columns remain.
+func TestMediaTypeAudioMigration_CheckAndShape(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Audio kind", "media-type-audio-check")
+	id := seedMedia(t, db, quizID)
+
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET type = 'audio' WHERE id = ?", id,
+	); err != nil {
+		t.Errorf("UPDATE type = 'audio' err = %v, want nil", err)
+	}
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET type = 'sound' WHERE id = ?", id,
+	); err == nil {
+		t.Error("UPDATE type = 'sound' err = nil, want a CHECK constraint violation")
+	}
+
+	if !indexExists(t, db, "media_quiz_id_idx") {
+		t.Error("media_quiz_id_idx index is missing after rebuild")
+	}
+	if !indexExists(t, db, "media_not_ready_idx") {
+		t.Error("media_not_ready_idx index is missing after rebuild")
+	}
+
+	wantCols := []string{
+		"id", "quiz_id", "type", "mime", "path", "thumb_path", "width",
+		"height", "size_bytes", "sha256", "created_by_player_id", "created_at",
+		"ready", "duration_ms",
+	}
+	gotCols := tableColumns(t, db, "media")
+	for _, col := range wantCols {
+		if !gotCols[col] {
+			t.Errorf("media is missing column %q after rebuild", col)
+		}
+	}
+	if got, want := len(gotCols), len(wantCols); got != want {
+		t.Errorf("media column count = %d, want %d (rebuild must not add or drop columns)", got, want)
+	}
+}
+
+// TestMediaTypeAudioMigration_DataMigration pins that a pre-existing 'sound' row
+// is translated to 'audio' by Up. DownTo a schema whose CHECK still allows
+// 'sound', insert one, then Up and assert it is now 'audio'.
+func TestMediaTypeAudioMigration_DataMigration(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Audio data", "media-type-audio-data")
+
+	if err := goose.DownTo(db, ".", mediaTypeAudioPrevVersion); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+
+	var id int64
+	if err := db.QueryRowContext(
+		t.Context(),
+		`INSERT INTO media (quiz_id, type, mime, path, size_bytes, sha256, created_by_player_id)
+		 VALUES (?, 'sound', 'audio/mpeg', 'clip.mp3', 10, 'deadbeef', 1) RETURNING id`,
+		quizID,
+	).Scan(&id); err != nil {
+		t.Fatalf("seed sound media err = %v, want nil", err)
+	}
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+
+	var got string
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT type FROM media WHERE id = ?", id,
+	).Scan(&got); err != nil {
+		t.Fatalf("read media type err = %v, want nil", err)
+	}
+	if want := "audio"; got != want {
+		t.Errorf("media type = %q after Up, want %q", got, want)
+	}
+}
+
+// TestMediaTypeAudioMigration_DownReverts pins the reverse: Down restores the
+// legacy CHECK (so 'sound' is accepted again) and translates the canonical
+// 'audio' row back to 'sound'.
+func TestMediaTypeAudioMigration_DownReverts(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Audio revert", "media-type-audio-revert")
+	id := seedMedia(t, db, quizID)
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET type = 'audio' WHERE id = ?", id,
+	); err != nil {
+		t.Fatalf("set type = 'audio' err = %v, want nil", err)
+	}
+
+	if err := goose.DownTo(db, ".", mediaTypeAudioPrevVersion); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+
+	var got string
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT type FROM media WHERE id = ?", id,
+	).Scan(&got); err != nil {
+		t.Fatalf("read media type err = %v, want nil", err)
+	}
+	if want := "sound"; got != want {
+		t.Errorf("media type = %q after Down, want %q", got, want)
+	}
+
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET type = 'sound' WHERE id = ?", id,
+	); err != nil {
+		t.Errorf("UPDATE type = 'sound' after Down err = %v, want nil (legacy CHECK)", err)
+	}
+}

--- a/internal/migrations/question_media_id_test.go
+++ b/internal/migrations/question_media_id_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestQuestionMediaIDMigration_ColumnSwap pins the #937 schema swap: questions
-// gains a nullable media_id with a foreign key to media, and the legacy
+// gains a nullable image_media_id with a foreign key to media, and the legacy
 // image_url column is gone.
 func TestQuestionMediaIDMigration_ColumnSwap(t *testing.T) {
 	t.Parallel()
@@ -21,8 +21,8 @@ func TestQuestionMediaIDMigration_ColumnSwap(t *testing.T) {
 	})
 
 	cols := tableColumns(t, db, "questions")
-	if !cols["media_id"] {
-		t.Error("questions is missing the media_id column")
+	if !cols["image_media_id"] {
+		t.Error("questions is missing the image_media_id column")
 	}
 	if cols["image_url"] {
 		t.Error("questions still has the image_url column, want it dropped")
@@ -35,7 +35,7 @@ func TestQuestionMediaIDMigration_ColumnSwap(t *testing.T) {
 
 // TestQuestionMediaIDMigration_DeleteSetsNull pins the ON DELETE SET NULL rule
 // (#936 moderation): deleting an image clears it off any question referencing
-// it - the question survives, just loses its media_id.
+// it - the question survives, just loses its image_media_id.
 func TestQuestionMediaIDMigration_DeleteSetsNull(t *testing.T) {
 	t.Parallel()
 
@@ -57,15 +57,15 @@ func TestQuestionMediaIDMigration_DeleteSetsNull(t *testing.T) {
 		t.Fatalf("delete media err = %v, want nil", err)
 	}
 
-	// The question must survive the image delete, with a NULL media_id.
+	// The question must survive the image delete, with a NULL image_media_id.
 	var got sql.NullInt64
 	if err := db.QueryRowContext(
-		t.Context(), "SELECT media_id FROM questions WHERE id = ?", questionID,
+		t.Context(), "SELECT image_media_id FROM questions WHERE id = ?", questionID,
 	).Scan(&got); err != nil {
-		t.Fatalf("read question media_id err = %v, want nil (question must survive)", err)
+		t.Fatalf("read question image_media_id err = %v, want nil (question must survive)", err)
 	}
 	if got.Valid {
-		t.Errorf("question media_id = %d after image delete, want NULL (ON DELETE SET NULL)", got.Int64)
+		t.Errorf("question image_media_id = %d after image delete, want NULL (ON DELETE SET NULL)", got.Int64)
 	}
 }
 
@@ -76,7 +76,7 @@ func seedQuestionWithMedia(t *testing.T, db *sql.DB, quizID, roundID, mediaID in
 	var id int64
 	if err := db.QueryRowContext(
 		t.Context(),
-		`INSERT INTO questions (quiz_id, round_id, text, position, media_id)
+		`INSERT INTO questions (quiz_id, round_id, text, position, image_media_id)
 		 VALUES (?, ?, 'Q', 1, ?) RETURNING id`,
 		quizID, roundID, mediaID,
 	).Scan(&id); err != nil {

--- a/internal/queries/media.sql
+++ b/internal/queries/media.sql
@@ -11,7 +11,7 @@
 -- and the not-ready sweep drops the stranded row plus its files.
 INSERT INTO media (
     quiz_id, type, mime, path, thumb_path,
-    width, height, size_bytes, sha256, created_by_player_id, ready
+    width, height, size_bytes, sha256, duration_ms, created_by_player_id, ready
 )
 VALUES (
     sqlc.arg('quiz_id'),
@@ -23,6 +23,7 @@ VALUES (
     sqlc.arg('height'),
     sqlc.arg('size_bytes'),
     sqlc.arg('sha256'),
+    sqlc.arg('duration_ms'),
     sqlc.arg('created_by_player_id'),
     0
 )

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -184,15 +184,16 @@ WHERE round_id = ?
 ORDER BY position;
 
 -- name: CreateQuestion :one
-INSERT INTO questions (quiz_id, round_id, text, position, media_id, time_limit_seconds)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO questions (quiz_id, round_id, text, position, image_media_id, audio_media_id, time_limit_seconds)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: UpdateQuestion :execresult
 UPDATE questions
 SET text               = ?,
     position           = ?,
-    media_id           = ?,
+    image_media_id     = ?,
+    audio_media_id     = ?,
     time_limit_seconds = ?
 WHERE id = ?;
 

--- a/internal/quiz/quiz.go
+++ b/internal/quiz/quiz.go
@@ -355,13 +355,19 @@ type Question struct {
 	// the caller leaves it zero.
 	RoundID int64
 	Text    string
-	// MediaID references an uploaded image in the question's own quiz
+	// ImageMediaID references an uploaded image in the question's own quiz
 	// library (#937). Nil means no image attached. The referenced media
 	// row is quiz-scoped; the admin save handler validates same-quiz
-	// ownership before persisting. media.media_id ON DELETE SET NULL clears
-	// this when the image is deleted, so a moderated image leaves the
+	// ownership before persisting. The questions.image_media_id foreign key is
+	// ON DELETE SET NULL, so deleting the image clears this and leaves the
 	// question intact minus its picture (#936).
-	MediaID          *int64
+	ImageMediaID *int64
+	// AudioMediaID references an uploaded sound in the question's own quiz
+	// library (#1059). Nil means no sound attached. It is separate from
+	// ImageMediaID so a question can carry both an image and a sound. The
+	// questions.audio_media_id foreign key is ON DELETE SET NULL, so deleting
+	// the sound clears this and leaves the question intact minus its audio.
+	AudioMediaID     *int64
 	Position         int
 	TimeLimitSeconds *int
 	Options          []*Option

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -64,7 +64,15 @@ func addRoutes(
 
 	addAuthRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	addAdminRoutes(mux, logger, stores, gameDeps, sessions, csrfMgr, emailDeps, playerDeps)
-	addMediaRoutes(mux, logger, stores, sessions, csrfMgr, media.NewService(stores.Media, cfg.MediaDir, logger), cfg)
+	addMediaRoutes(
+		mux,
+		logger,
+		stores,
+		sessions,
+		csrfMgr,
+		media.NewService(stores.Media, cfg.MediaDir, cfg.MediaImageMaxBytes, cfg.MediaAudioMaxBytes, logger),
+		cfg,
+	)
 	addProfileRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	addAPIRoutes(mux, logger, stores, gameService, realtime, sessions, cfg)
 	addHostRoutes(mux, logger, stores, sessions, csrfMgr, realtime.SessionService, cfg.BaseURL)

--- a/internal/store/media.go
+++ b/internal/store/media.go
@@ -38,6 +38,7 @@ func (s *MediaStore) CreateMedia(ctx context.Context, m *media.Media) (*media.Me
 		Height:            sql.NullInt64{Int64: int64(m.Height), Valid: m.Height != 0},
 		SizeBytes:         m.SizeBytes,
 		Sha256:            m.SHA256,
+		DurationMs:        nullableInt(m.DurationMs),
 		CreatedByPlayerID: m.CreatedByPlayerID,
 	})
 	if err != nil {
@@ -169,7 +170,8 @@ func (s *MediaStore) CountMediaByQuiz(ctx context.Context, quizID int64) (int64,
 }
 
 // mediaFromRow maps a generated db.Medium row to the media.Media domain type.
-// A NULL thumb_path / width / height surfaces as the Go zero value.
+// A NULL thumb_path / width / height surfaces as the Go zero value; a NULL
+// duration_ms surfaces as a nil *int so "unknown" stays distinct from zero.
 func mediaFromRow(row db.Medium) *media.Media {
 	return &media.Media{
 		ID:                row.ID,
@@ -182,6 +184,7 @@ func mediaFromRow(row db.Medium) *media.Media {
 		Height:            int(row.Height.Int64),
 		SizeBytes:         row.SizeBytes,
 		SHA256:            row.Sha256,
+		DurationMs:        nullableIntToPtr(row.DurationMs),
 		CreatedByPlayerID: row.CreatedByPlayerID,
 		CreatedAt:         row.CreatedAt,
 	}

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -283,8 +283,9 @@ func (s *QuizStore) ListQuestions(ctx context.Context, quizID int64) ([]*quiz.Qu
 			RoundID:          r.RoundID,
 			Text:             r.Text,
 			Position:         int(r.Position),
-			MediaID:          nullableInt64ToPtr(r.MediaID),
-			TimeLimitSeconds: nullableTimeLimitToPtr(r.TimeLimitSeconds),
+			ImageMediaID:     nullableInt64ToPtr(r.ImageMediaID),
+			AudioMediaID:     nullableInt64ToPtr(r.AudioMediaID),
+			TimeLimitSeconds: nullableIntToPtr(r.TimeLimitSeconds),
 		}
 
 		options := optionsByQuestion[qs.ID]
@@ -316,8 +317,9 @@ func (s *QuizStore) GetQuestion(ctx context.Context, id int64) (*quiz.Question, 
 		RoundID:          row.RoundID,
 		Text:             row.Text,
 		Position:         int(row.Position),
-		MediaID:          nullableInt64ToPtr(row.MediaID),
-		TimeLimitSeconds: nullableTimeLimitToPtr(row.TimeLimitSeconds),
+		ImageMediaID:     nullableInt64ToPtr(row.ImageMediaID),
+		AudioMediaID:     nullableInt64ToPtr(row.AudioMediaID),
+		TimeLimitSeconds: nullableIntToPtr(row.TimeLimitSeconds),
 	}
 
 	options, err := s.listOptions(ctx, qs.ID)
@@ -798,7 +800,7 @@ func (s *QuizStore) createAuthoredRounds(ctx context.Context, q *db.Queries, qz 
 				Title:                   round.Title,
 				Summary:                 round.Summary,
 				Position:                defaultRound.Position,
-				BoundaryDurationSeconds: nullableTimeLimit(round.BoundaryDurationSeconds),
+				BoundaryDurationSeconds: nullableInt(round.BoundaryDurationSeconds),
 				ID:                      defaultRound.ID,
 			}); err != nil {
 				return fmt.Errorf("failed to rename default round: %w", err)
@@ -809,7 +811,7 @@ func (s *QuizStore) createAuthoredRounds(ctx context.Context, q *db.Queries, qz 
 				Position:                int64(i),
 				Title:                   round.Title,
 				Summary:                 round.Summary,
-				BoundaryDurationSeconds: nullableTimeLimit(round.BoundaryDurationSeconds),
+				BoundaryDurationSeconds: nullableInt(round.BoundaryDurationSeconds),
 			})
 			if createErr != nil {
 				return fmt.Errorf("failed to create round %q: %w", round.Title, createErr)
@@ -940,8 +942,9 @@ func (s *QuizStore) execCreateQuestion(ctx context.Context, q *db.Queries, qs *q
 		RoundID:          qs.RoundID,
 		Text:             qs.Text,
 		Position:         int64(qs.Position),
-		MediaID:          nullableInt64(qs.MediaID),
-		TimeLimitSeconds: nullableTimeLimit(qs.TimeLimitSeconds),
+		ImageMediaID:     nullableInt64(qs.ImageMediaID),
+		AudioMediaID:     nullableInt64(qs.AudioMediaID),
+		TimeLimitSeconds: nullableInt(qs.TimeLimitSeconds),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create question: %w", err)
@@ -949,7 +952,7 @@ func (s *QuizStore) execCreateQuestion(ctx context.Context, q *db.Queries, qs *q
 
 	qs.ID = row.ID
 	qs.RoundID = row.RoundID
-	qs.TimeLimitSeconds = nullableTimeLimitToPtr(row.TimeLimitSeconds)
+	qs.TimeLimitSeconds = nullableIntToPtr(row.TimeLimitSeconds)
 	for _, o := range qs.Options {
 		o.ID = 0
 		o.QuestionID = qs.ID
@@ -971,8 +974,9 @@ func (s *QuizStore) execUpdateQuestion(ctx context.Context, q *db.Queries, qs *q
 	res, err := q.UpdateQuestion(ctx, db.UpdateQuestionParams{
 		Text:             qs.Text,
 		Position:         int64(qs.Position),
-		MediaID:          nullableInt64(qs.MediaID),
-		TimeLimitSeconds: nullableTimeLimit(qs.TimeLimitSeconds),
+		ImageMediaID:     nullableInt64(qs.ImageMediaID),
+		AudioMediaID:     nullableInt64(qs.AudioMediaID),
+		TimeLimitSeconds: nullableInt(qs.TimeLimitSeconds),
 		ID:               qs.ID,
 	})
 	if err != nil {
@@ -1212,10 +1216,11 @@ func (*QuizStore) deleteOption(ctx context.Context, q *db.Queries, id int64) err
 	return nil
 }
 
-// nullableTimeLimit packs a *int into the [sql.NullInt64] the sqlc-generated
-// params expect for questions.time_limit_seconds. nil -> NULL, which the
-// game service treats as "inherit the quiz default" (#99).
-func nullableTimeLimit(v *int) sql.NullInt64 {
+// nullableInt packs a *int into the [sql.NullInt64] the sqlc-generated params
+// expect for nullable integer columns such as questions.time_limit_seconds
+// (nil -> "inherit the quiz default", #99) and media.duration_ms (nil ->
+// "unknown length"). nil maps to NULL.
+func nullableInt(v *int) sql.NullInt64 {
 	if v == nil {
 		return sql.NullInt64{}
 	}
@@ -1223,9 +1228,10 @@ func nullableTimeLimit(v *int) sql.NullInt64 {
 	return sql.NullInt64{Int64: int64(*v), Valid: true}
 }
 
-// nullableTimeLimitToPtr is the inverse of nullableTimeLimit, used when
-// hydrating Question domain values from sqlc RETURNING / SELECT rows.
-func nullableTimeLimitToPtr(v sql.NullInt64) *int {
+// nullableIntToPtr is the inverse of nullableInt, used when hydrating domain
+// values from sqlc RETURNING / SELECT rows; NULL maps back to nil so "unset"
+// stays distinct from a real zero.
+func nullableIntToPtr(v sql.NullInt64) *int {
 	if !v.Valid {
 		return nil
 	}
@@ -1235,7 +1241,7 @@ func nullableTimeLimitToPtr(v sql.NullInt64) *int {
 }
 
 // nullableInt64 packs a *int64 into the [sql.NullInt64] the sqlc-generated
-// params expect for questions.media_id. nil -> NULL, which means "no image
+// params expect for questions.image_media_id. nil -> NULL, which means "no image
 // attached" (#937).
 func nullableInt64(v *int64) sql.NullInt64 {
 	if v == nil {
@@ -1246,7 +1252,7 @@ func nullableInt64(v *int64) sql.NullInt64 {
 }
 
 // nullableInt64ToPtr is the inverse of nullableInt64, used when hydrating
-// Question.MediaID from sqlc RETURNING / SELECT rows.
+// Question.ImageMediaID from sqlc RETURNING / SELECT rows.
 func nullableInt64ToPtr(v sql.NullInt64) *int64 {
 	if !v.Valid {
 		return nil

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -1658,10 +1658,10 @@ func seedQuizMedia(t *testing.T, db *sql.DB, quizID int64) int64 {
 	return created.ID
 }
 
-func TestQuizStore_MediaID(t *testing.T) {
+func TestQuizStore_ImageMediaID(t *testing.T) {
 	t.Parallel()
 
-	t.Run("create question persists media_id", func(t *testing.T) {
+	t.Run("create question persists image_media_id", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbtest.Open(t)
@@ -1674,11 +1674,11 @@ func TestQuizStore_MediaID(t *testing.T) {
 		mediaID := seedQuizMedia(t, db, testQuiz.ID)
 
 		q := &quiz.Question{
-			QuizID:   testQuiz.ID,
-			Text:     "What is shown in the image?",
-			Position: 99,
-			MediaID:  &mediaID,
-			Options:  []*quiz.Option{{Text: "A cat", Correct: true}},
+			QuizID:       testQuiz.ID,
+			Text:         "What is shown in the image?",
+			Position:     99,
+			ImageMediaID: &mediaID,
+			Options:      []*quiz.Option{{Text: "A cat", Correct: true}},
 		}
 		if err := quizStore.CreateQuestion(t.Context(), q); err != nil {
 			t.Fatalf("failed to create question: %v", err)
@@ -1688,15 +1688,15 @@ func TestQuizStore_MediaID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get question: %v", err)
 		}
-		if qs.MediaID == nil {
-			t.Fatalf("GetQuestion MediaID = nil, want %d", mediaID)
+		if qs.ImageMediaID == nil {
+			t.Fatalf("GetQuestion ImageMediaID = nil, want %d", mediaID)
 		}
-		if got, want := *qs.MediaID, mediaID; got != want {
-			t.Errorf("GetQuestion MediaID = %d, want %d", got, want)
+		if got, want := *qs.ImageMediaID, mediaID; got != want {
+			t.Errorf("GetQuestion ImageMediaID = %d, want %d", got, want)
 		}
 	})
 
-	t.Run("update question persists and clears media_id", func(t *testing.T) {
+	t.Run("update question persists and clears image_media_id", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbtest.Open(t)
@@ -1710,12 +1710,12 @@ func TestQuizStore_MediaID(t *testing.T) {
 
 		original := testQuiz.Questions[0]
 		attached := &quiz.Question{
-			ID:       original.ID,
-			QuizID:   testQuiz.ID,
-			Text:     original.Text,
-			Position: original.Position,
-			MediaID:  &mediaID,
-			Options:  original.Options,
+			ID:           original.ID,
+			QuizID:       testQuiz.ID,
+			Text:         original.Text,
+			Position:     original.Position,
+			ImageMediaID: &mediaID,
+			Options:      original.Options,
 		}
 		if err := quizStore.UpdateQuestion(t.Context(), attached); err != nil {
 			t.Fatalf("failed to update question: %v", err)
@@ -1725,18 +1725,18 @@ func TestQuizStore_MediaID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get question: %v", err)
 		}
-		if qs.MediaID == nil || *qs.MediaID != mediaID {
-			t.Fatalf("GetQuestion MediaID = %v, want %d", qs.MediaID, mediaID)
+		if qs.ImageMediaID == nil || *qs.ImageMediaID != mediaID {
+			t.Fatalf("GetQuestion ImageMediaID = %v, want %d", qs.ImageMediaID, mediaID)
 		}
 
-		// A nil MediaID on a later save clears the attachment (NULL).
+		// A nil ImageMediaID on a later save clears the attachment (NULL).
 		detached := &quiz.Question{
-			ID:       original.ID,
-			QuizID:   testQuiz.ID,
-			Text:     original.Text,
-			Position: original.Position,
-			MediaID:  nil,
-			Options:  original.Options,
+			ID:           original.ID,
+			QuizID:       testQuiz.ID,
+			Text:         original.Text,
+			Position:     original.Position,
+			ImageMediaID: nil,
+			Options:      original.Options,
 		}
 		if err = quizStore.UpdateQuestion(t.Context(), detached); err != nil {
 			t.Fatalf("failed to update question: %v", err)
@@ -1745,12 +1745,12 @@ func TestQuizStore_MediaID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get question: %v", err)
 		}
-		if qs.MediaID != nil {
-			t.Errorf("GetQuestion MediaID = %v, want nil after detach", *qs.MediaID)
+		if qs.ImageMediaID != nil {
+			t.Errorf("GetQuestion ImageMediaID = %v, want nil after detach", *qs.ImageMediaID)
 		}
 	})
 
-	t.Run("list questions includes media_id", func(t *testing.T) {
+	t.Run("list questions includes image_media_id", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbtest.Open(t)
@@ -1763,7 +1763,7 @@ func TestQuizStore_MediaID(t *testing.T) {
 		mediaID := seedQuizMedia(t, db, testQuiz.ID)
 
 		target := testQuiz.Questions[0]
-		target.MediaID = &mediaID
+		target.ImageMediaID = &mediaID
 		if err := quizStore.UpdateQuestion(t.Context(), target); err != nil {
 			t.Fatalf("failed to update question: %v", err)
 		}
@@ -1777,8 +1777,8 @@ func TestQuizStore_MediaID(t *testing.T) {
 		for _, q := range questions {
 			if q.ID == target.ID {
 				found = true
-				if q.MediaID == nil || *q.MediaID != mediaID {
-					t.Errorf("ListQuestions MediaID = %v, want %d", q.MediaID, mediaID)
+				if q.ImageMediaID == nil || *q.ImageMediaID != mediaID {
+					t.Errorf("ListQuestions ImageMediaID = %v, want %d", q.ImageMediaID, mediaID)
 				}
 			}
 		}
@@ -1787,7 +1787,7 @@ func TestQuizStore_MediaID(t *testing.T) {
 		}
 	})
 
-	t.Run("deleting attached media clears the question's media_id", func(t *testing.T) {
+	t.Run("deleting attached media clears the question's image_media_id", func(t *testing.T) {
 		t.Parallel()
 
 		db := dbtest.Open(t)
@@ -1801,7 +1801,7 @@ func TestQuizStore_MediaID(t *testing.T) {
 		mediaID := seedQuizMedia(t, db, testQuiz.ID)
 
 		target := testQuiz.Questions[0]
-		target.MediaID = &mediaID
+		target.ImageMediaID = &mediaID
 		if err := quizStore.UpdateQuestion(t.Context(), target); err != nil {
 			t.Fatalf("failed to update question: %v", err)
 		}
@@ -1814,8 +1814,181 @@ func TestQuizStore_MediaID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetQuestion err = %v, want nil (question must survive media delete)", err)
 		}
-		if qs.MediaID != nil {
-			t.Errorf("GetQuestion MediaID = %v, want nil after image delete (ON DELETE SET NULL)", *qs.MediaID)
+		if qs.ImageMediaID != nil {
+			t.Errorf(
+				"GetQuestion ImageMediaID = %v, want nil after image delete (ON DELETE SET NULL)",
+				*qs.ImageMediaID,
+			)
+		}
+	})
+}
+
+func TestQuizStore_AudioMediaID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create question persists audio_media_id alongside image_media_id", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+		imageID := seedQuizMedia(t, db, testQuiz.ID)
+		audioID := seedQuizMedia(t, db, testQuiz.ID)
+
+		q := &quiz.Question{
+			QuizID:       testQuiz.ID,
+			Text:         "What is this sound?",
+			Position:     99,
+			ImageMediaID: &imageID,
+			AudioMediaID: &audioID,
+			Options:      []*quiz.Option{{Text: "A bell", Correct: true}},
+		}
+		if err := quizStore.CreateQuestion(t.Context(), q); err != nil {
+			t.Fatalf("failed to create question: %v", err)
+		}
+
+		qs, err := quizStore.GetQuestion(t.Context(), q.ID)
+		if err != nil {
+			t.Fatalf("failed to get question: %v", err)
+		}
+		if qs.AudioMediaID == nil {
+			t.Fatalf("GetQuestion AudioMediaID = nil, want %d", audioID)
+		}
+		if got, want := *qs.AudioMediaID, audioID; got != want {
+			t.Errorf("GetQuestion AudioMediaID = %d, want %d", got, want)
+		}
+		// A question carries both an image and a sound independently.
+		if qs.ImageMediaID == nil || *qs.ImageMediaID != imageID {
+			t.Errorf("GetQuestion ImageMediaID = %v, want %d", qs.ImageMediaID, imageID)
+		}
+	})
+
+	t.Run("update question persists and clears audio_media_id", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+		audioID := seedQuizMedia(t, db, testQuiz.ID)
+
+		original := testQuiz.Questions[0]
+		attached := &quiz.Question{
+			ID:           original.ID,
+			QuizID:       testQuiz.ID,
+			Text:         original.Text,
+			Position:     original.Position,
+			AudioMediaID: &audioID,
+			Options:      original.Options,
+		}
+		if err := quizStore.UpdateQuestion(t.Context(), attached); err != nil {
+			t.Fatalf("failed to update question: %v", err)
+		}
+
+		qs, err := quizStore.GetQuestion(t.Context(), original.ID)
+		if err != nil {
+			t.Fatalf("failed to get question: %v", err)
+		}
+		if qs.AudioMediaID == nil || *qs.AudioMediaID != audioID {
+			t.Fatalf("GetQuestion AudioMediaID = %v, want %d", qs.AudioMediaID, audioID)
+		}
+
+		detached := &quiz.Question{
+			ID:           original.ID,
+			QuizID:       testQuiz.ID,
+			Text:         original.Text,
+			Position:     original.Position,
+			AudioMediaID: nil,
+			Options:      original.Options,
+		}
+		if err = quizStore.UpdateQuestion(t.Context(), detached); err != nil {
+			t.Fatalf("failed to update question: %v", err)
+		}
+		qs, err = quizStore.GetQuestion(t.Context(), original.ID)
+		if err != nil {
+			t.Fatalf("failed to get question: %v", err)
+		}
+		if qs.AudioMediaID != nil {
+			t.Errorf("GetQuestion AudioMediaID = %v, want nil after detach", *qs.AudioMediaID)
+		}
+	})
+
+	t.Run("list questions includes audio_media_id", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+		audioID := seedQuizMedia(t, db, testQuiz.ID)
+
+		target := testQuiz.Questions[0]
+		target.AudioMediaID = &audioID
+		if err := quizStore.UpdateQuestion(t.Context(), target); err != nil {
+			t.Fatalf("failed to update question: %v", err)
+		}
+
+		questions, err := quizStore.ListQuestions(t.Context(), testQuiz.ID)
+		if err != nil {
+			t.Fatalf("failed to list questions: %v", err)
+		}
+
+		var found bool
+		for _, q := range questions {
+			if q.ID == target.ID {
+				found = true
+				if q.AudioMediaID == nil || *q.AudioMediaID != audioID {
+					t.Errorf("ListQuestions AudioMediaID = %v, want %d", q.AudioMediaID, audioID)
+				}
+			}
+		}
+		if !found {
+			t.Error("question not found in ListQuestions result")
+		}
+	})
+
+	t.Run("deleting attached sound clears the question's audio_media_id", func(t *testing.T) {
+		t.Parallel()
+
+		db := dbtest.Open(t)
+		quizStore := NewQuizStore(db, slog.Default())
+		mediaStore := NewMediaStore(db, slog.Default())
+
+		testQuiz := newTestQuizzes()[0]
+		if err := quizStore.CreateQuiz(t.Context(), testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+		audioID := seedQuizMedia(t, db, testQuiz.ID)
+
+		target := testQuiz.Questions[0]
+		target.AudioMediaID = &audioID
+		if err := quizStore.UpdateQuestion(t.Context(), target); err != nil {
+			t.Fatalf("failed to update question: %v", err)
+		}
+
+		if err := mediaStore.DeleteMedia(t.Context(), audioID); err != nil {
+			t.Fatalf("DeleteMedia err = %v, want nil", err)
+		}
+
+		qs, err := quizStore.GetQuestion(t.Context(), target.ID)
+		if err != nil {
+			t.Fatalf("GetQuestion err = %v, want nil (question must survive sound delete)", err)
+		}
+		if qs.AudioMediaID != nil {
+			t.Errorf(
+				"GetQuestion AudioMediaID = %v, want nil after sound delete (ON DELETE SET NULL)",
+				*qs.AudioMediaID,
+			)
 		}
 	})
 }

--- a/internal/store/round.go
+++ b/internal/store/round.go
@@ -95,7 +95,7 @@ func (s *QuizStore) CreateRound(ctx context.Context, g *quiz.Round) error {
 		Position:                int64(g.Position),
 		Title:                   g.Title,
 		Summary:                 g.Summary,
-		BoundaryDurationSeconds: nullableTimeLimit(g.BoundaryDurationSeconds),
+		BoundaryDurationSeconds: nullableInt(g.BoundaryDurationSeconds),
 	})
 	if err != nil {
 		if isRoundUniqueViolation(err) {
@@ -107,7 +107,7 @@ func (s *QuizStore) CreateRound(ctx context.Context, g *quiz.Round) error {
 	g.ID = row.ID
 	g.CreatedAt = row.CreatedAt
 	g.UpdatedAt = row.UpdatedAt
-	g.BoundaryDurationSeconds = nullableTimeLimitToPtr(row.BoundaryDurationSeconds)
+	g.BoundaryDurationSeconds = nullableIntToPtr(row.BoundaryDurationSeconds)
 
 	return nil
 }
@@ -125,7 +125,7 @@ func (s *QuizStore) UpdateRound(ctx context.Context, g *quiz.Round) error {
 		Title:                   g.Title,
 		Summary:                 g.Summary,
 		Position:                int64(g.Position),
-		BoundaryDurationSeconds: nullableTimeLimit(g.BoundaryDurationSeconds),
+		BoundaryDurationSeconds: nullableInt(g.BoundaryDurationSeconds),
 		ID:                      g.ID,
 	})
 	if err != nil {
@@ -439,7 +439,7 @@ func roundFromRow(r db.Round) *quiz.Round {
 		Position:                int(r.Position),
 		Title:                   r.Title,
 		Summary:                 r.Summary,
-		BoundaryDurationSeconds: nullableTimeLimitToPtr(r.BoundaryDurationSeconds),
+		BoundaryDurationSeconds: nullableIntToPtr(r.BoundaryDurationSeconds),
 		CreatedAt:               r.CreatedAt,
 		UpdatedAt:               r.UpdatedAt,
 	}

--- a/internal/web/tmpl/admin/pages/questionform.gohtml
+++ b/internal/web/tmpl/admin/pages/questionform.gohtml
@@ -63,14 +63,14 @@
                      data-testid="question-image-picker"
                      {{if $mediaErr}}aria-describedby="media-error"{{end}}>
                     <label class="group relative flex aspect-square cursor-pointer items-center justify-center rounded-lg border border-border-soft bg-surface text-center text-xs text-text-dim has-[:checked]:border-accent has-[:checked]:text-text has-[:focus-visible]:shadow-focus">
-                        <input type="radio" name="media_id" value="" class="sr-only"
-                               {{if eq .Question.MediaID 0}}checked{{end}}>
+                        <input type="radio" name="image_media_id" value="" class="sr-only"
+                               {{if eq .Question.ImageMediaID 0}}checked{{end}}>
                         None
                     </label>
                     {{range .Library}}
                         <label class="group relative block aspect-square cursor-pointer overflow-hidden rounded-lg border border-border-soft bg-surface has-[:checked]:border-accent has-[:focus-visible]:shadow-focus">
-                            <input type="radio" name="media_id" value="{{.ID}}" class="sr-only peer"
-                                   {{if eq $.Question.MediaID .ID}}checked{{end}}>
+                            <input type="radio" name="image_media_id" value="{{.ID}}" class="sr-only peer"
+                                   {{if eq $.Question.ImageMediaID .ID}}checked{{end}}>
                             <img src="/media/{{.ID}}/thumb"
                                  alt="Quiz image {{.ID}}"
                                  loading="lazy"
@@ -87,7 +87,7 @@
                     {{end}}
                 </div>
             {{else}}
-                <input type="hidden" name="media_id" value="">
+                <input type="hidden" name="image_media_id" value="">
                 <p class="text-text-dim text-[0.95rem]">
                     No images in this quiz's library yet.
                     <a href="/admin/quizzes/{{.Quiz.ID}}" class="text-accent underline">Upload images on the quiz page first</a>

--- a/test/integration/admin_import_test.go
+++ b/test/integration/admin_import_test.go
@@ -331,7 +331,7 @@ func TestAdminImport_Integration(t *testing.T) {
 	t.Run("rejects a per-question imageUrl field", func(t *testing.T) {
 		t.Parallel()
 		// #937: questions now reference an uploaded library image by
-		// media_id, not a free-text URL, and the import cannot point at
+		// image_media_id, not a free-text URL, and the import cannot point at
 		// uploaded media. The legacy imageUrl field was dropped from the
 		// wire shape, so a payload still carrying it is rejected by
 		// DisallowUnknownFields rather than silently ignored.

--- a/test/integration/question_image_test.go
+++ b/test/integration/question_image_test.go
@@ -37,7 +37,7 @@ type sessionImageRes struct {
 }
 
 // attachMediaToQuestion seeds a media row for the question's quiz and points the
-// question at it via MediaID, returning the new media id. The row's files are
+// question at it via ImageMediaID, returning the new media id. The row's files are
 // not written: the play endpoints only project /media/<id> from the id, so the
 // wire-field assertions never fetch the bytes.
 func attachMediaToQuestion(
@@ -67,7 +67,7 @@ func attachMediaToQuestion(
 	if err != nil {
 		t.Fatalf("GetQuestion err = %v, want nil", err)
 	}
-	qs.MediaID = &row.ID
+	qs.ImageMediaID = &row.ID
 	if err := stores.Quizzes.UpdateQuestion(ctx, qs); err != nil {
 		t.Fatalf("UpdateQuestion err = %v, want nil", err)
 	}


### PR DESCRIPTION
Slice 1 of 3 for #1059 -- audio storage foundation (media duration, a question audio reference, and a validate-and-store audio path; no upload/UI/playback yet).