### PR TITLE
Shuffle live answer options per session

### DIFF
--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -934,7 +934,7 @@ func writeQuestionItem(
 	for i, o := range gq.QuizQuestion.Options {
 		resOptions[i] = nextOptionResponse{ID: o.ID, Text: o.Text}
 	}
-	shuffleByGame(gameID, gq.QuestionID, len(resOptions), func(i, j int) {
+	shuffleBySeed(gameID, gq.QuestionID, len(resOptions), func(i, j int) {
 		resOptions[i], resOptions[j] = resOptions[j], resOptions[i]
 	})
 

--- a/internal/clientapi/export_test.go
+++ b/internal/clientapi/export_test.go
@@ -1,6 +1,6 @@
 package clientapi
 
-// ExportShuffleByGame exposes the unexported shuffleByGame helper so
+// ExportShuffleBySeed exposes the unexported shuffleBySeed helper so
 // the external clientapi_test package can pin its determinism and
 // permutation contracts without becoming a whitebox test.
-var ExportShuffleByGame = shuffleByGame
+var ExportShuffleBySeed = shuffleBySeed

--- a/internal/clientapi/sessions.go
+++ b/internal/clientapi/sessions.go
@@ -616,6 +616,24 @@ func questionPosition(qz *quiz.Quiz, questionID int64) int {
 	return 0
 }
 
+// shuffledSessionOptions projects a question's options onto the wire shape in a
+// stable per (session, question) order (#1074): every player in the same
+// session sees the same order across reconnects, two sessions of the same quiz
+// differ, and a maker who lists the answer first cannot game the layout.
+// Scoring and reveal key off option id, not position, so reordering the display
+// set here leaves them untouched.
+func shuffledSessionOptions(sessionID string, q *quiz.Question) []sessionOptionResponse {
+	options := make([]sessionOptionResponse, 0, len(q.Options))
+	for _, o := range q.Options {
+		options = append(options, sessionOptionResponse{ID: o.ID, Text: o.Text})
+	}
+	shuffleBySeed(sessionID, q.ID, len(options), func(i, j int) {
+		options[i], options[j] = options[j], options[i]
+	})
+
+	return options
+}
+
 // newSessionQuestionResponse projects the live question view onto the wire
 // shape, enforcing the no-spoiler guarantee: correctness (per-option and
 // per-answer) is included only when state.Revealed is true.
@@ -625,10 +643,7 @@ func newSessionQuestionResponse(state *livesession.SessionState) *sessionQuestio
 	}
 	q := state.CurrentQuestion
 
-	options := make([]sessionOptionResponse, 0, len(q.Options))
-	for _, o := range q.Options {
-		options = append(options, sessionOptionResponse{ID: o.ID, Text: o.Text})
-	}
+	options := shuffledSessionOptions(state.Session.ID, q)
 
 	// The roster already excludes players who have left, so a left player's
 	// pick drops out of the answered-order badges here (MP-10) without

--- a/internal/clientapi/shuffle.go
+++ b/internal/clientapi/shuffle.go
@@ -6,20 +6,25 @@ import (
 	"math/rand/v2"
 )
 
-// shuffleOptionsSeed derives a deterministic uint64 seed from a game ID
+// shuffleOptionsSeed derives a deterministic uint64 seed from a scope ID
 // and question ID. The shuffle of the option buttons (#297) is stable
-// per (game, question) so a player who reloads mid-question sees the
+// per (scope, question) so a player who reloads mid-question sees the
 // same order they did before - preventing both confusion and a
-// deliberate "re-roll the layout" by refreshing. Different games on
-// the same question see different orders because the gameID dominates
-// the hash, so position-memorisation across players doesn't help
-// either. FNV-64a is fast, deterministic, and well-distributed enough
-// for a 4-element shuffle; no cryptographic strength is needed because
-// the order is observable anyway once the question is rendered.
-func shuffleOptionsSeed(gameID string, questionID int64) uint64 {
+// deliberate "re-roll the layout" by refreshing. Different scopes on the
+// same question see different orders because the scope ID dominates the
+// hash, so position-memorisation across players doesn't help either.
+// FNV-64a is fast, deterministic, and well-distributed enough for a small
+// shuffle; no cryptographic strength is needed because the order is
+// observable anyway once the question is rendered.
+//
+// The scope is the per-play identity that should pin the order: the solo
+// game id (#297) or the live session id (#1074), so every player in one
+// live session sees the same order while two sessions of the same quiz
+// differ.
+func shuffleOptionsSeed(scopeID string, questionID int64) uint64 {
 	h := fnv.New64a()
 	// hash.Hash.Write never returns an error.
-	_, _ = h.Write([]byte(gameID))
+	_, _ = h.Write([]byte(scopeID))
 	_, _ = h.Write([]byte{'/'})
 	// binary.Write into a hash.Hash never errors either; fixed byte
 	// order keeps the seed identical across hosts, and the value is
@@ -29,14 +34,15 @@ func shuffleOptionsSeed(gameID string, questionID int64) uint64 {
 	return h.Sum64()
 }
 
-// shuffleByGame shuffles n items in place using a PCG RNG seeded by
-// [shuffleOptionsSeed]. Two seed words derived from one hash give the
-// PCG enough entropy for the small permutation space (4!=24 here)
-// without pulling in a SHA family hash for what is essentially a UI
-// concern. swap mirrors the signature [rand.Rand.Shuffle] expects.
-func shuffleByGame(gameID string, questionID int64, n int, swap func(i, j int)) {
-	seed := shuffleOptionsSeed(gameID, questionID)
-	// G404: deterministic-by-design - we need the same (gameID,
+// shuffleBySeed shuffles n items in place using a PCG RNG seeded by
+// [shuffleOptionsSeed] over (scopeID, questionID). Two seed words derived
+// from one hash give the PCG enough entropy for the small permutation
+// space (4!=24 for the usual four options) without pulling in a SHA
+// family hash for what is essentially a UI concern. swap mirrors the
+// signature [rand.Rand.Shuffle] expects.
+func shuffleBySeed(scopeID string, questionID int64, n int, swap func(i, j int)) {
+	seed := shuffleOptionsSeed(scopeID, questionID)
+	// G404: deterministic-by-design - we need the same (scopeID,
 	// questionID) to always yield the same permutation across reloads
 	// and process restarts. crypto/rand cannot do that because it
 	// doesn't accept a seed. No secret protection is at stake; the

--- a/internal/clientapi/shuffle_test.go
+++ b/internal/clientapi/shuffle_test.go
@@ -8,66 +8,67 @@ import (
 	. "github.com/starquake/topbanana/internal/clientapi"
 )
 
-// TestShuffleByGame_Deterministic pins the contract the player client
-// relies on (#297): a reload of the same question in the same game
-// must produce the same option layout. The test calls the helper
-// twice with the same inputs and asserts byte-equal output orders.
-func TestShuffleByGame_Deterministic(t *testing.T) {
+// TestShuffleBySeed_Deterministic pins the contract both play surfaces
+// rely on (#297, #1074): a reload of the same question in the same scope
+// (solo game or live session) must produce the same option layout. The
+// test calls the helper twice with the same inputs and asserts byte-equal
+// output orders.
+func TestShuffleBySeed_Deterministic(t *testing.T) {
 	t.Parallel()
 
 	first := []int{1, 2, 3, 4}
-	ExportShuffleByGame("game-abc", 42, len(first), func(i, j int) {
+	ExportShuffleBySeed("scope-abc", 42, len(first), func(i, j int) {
 		first[i], first[j] = first[j], first[i]
 	})
 
 	second := []int{1, 2, 3, 4}
-	ExportShuffleByGame("game-abc", 42, len(second), func(i, j int) {
+	ExportShuffleBySeed("scope-abc", 42, len(second), func(i, j int) {
 		second[i], second[j] = second[j], second[i]
 	})
 
 	if !slices.Equal(first, second) {
-		t.Errorf("shuffleByGame(\"game-abc\", 42) produced %v then %v - want stable order", first, second)
+		t.Errorf("shuffleBySeed(\"scope-abc\", 42) produced %v then %v - want stable order", first, second)
 	}
 }
 
-// TestShuffleByGame_PreservesElements guards against the swap function
+// TestShuffleBySeed_PreservesElements guards against the swap function
 // dropping or duplicating items. Returns a permutation, not a sample.
-func TestShuffleByGame_PreservesElements(t *testing.T) {
+func TestShuffleBySeed_PreservesElements(t *testing.T) {
 	t.Parallel()
 
 	got := []int{1, 2, 3, 4, 5, 6, 7, 8}
-	ExportShuffleByGame("any-game", 1, len(got), func(i, j int) {
+	ExportShuffleBySeed("any-scope", 1, len(got), func(i, j int) {
 		got[i], got[j] = got[j], got[i]
 	})
 
 	slices.Sort(got)
 	want := []int{1, 2, 3, 4, 5, 6, 7, 8}
 	if !slices.Equal(got, want) {
-		t.Errorf("sorted shuffleByGame output = %v, want %v", got, want)
+		t.Errorf("sorted shuffleBySeed output = %v, want %v", got, want)
 	}
 }
 
-// TestShuffleByGame_DifferentGamesDiffer is the headline anti-cheat
-// property the ticket asks for: a screenshot from one player's game
-// doesn't tell another player where the right answer sits. Calls the
-// helper across N distinct gameIDs on the same question and asserts
-// at least two of them produce different orders. With 4 options
-// (24 permutations) and 8 trials the false-fail probability is below
-// 1e-9.
-func TestShuffleByGame_DifferentGamesDiffer(t *testing.T) {
+// TestShuffleBySeed_DifferentScopesDiffer is the headline anti-cheat
+// property the tickets ask for: a screenshot from one player's game (or
+// one live session) doesn't tell another player where the right answer
+// sits. Calls the helper across N distinct scope IDs on the same question
+// and asserts at least two of them produce different orders. With 4
+// options (24 permutations) and 8 trials the false-fail probability is
+// below 1e-9.
+func TestShuffleBySeed_DifferentScopesDiffer(t *testing.T) {
 	t.Parallel()
 
 	const trials = 8
 	seen := make(map[string]struct{}, trials)
 	for i := range trials {
 		opts := []int{1, 2, 3, 4}
-		gameID := "game-" + string(rune('a'+i))
-		ExportShuffleByGame(gameID, 1, len(opts), func(a, b int) {
+		scopeID := "scope-" + string(rune('a'+i))
+		ExportShuffleBySeed(scopeID, 1, len(opts), func(a, b int) {
 			opts[a], opts[b] = opts[b], opts[a]
 		})
 		seen[fmt.Sprintf("%v", opts)] = struct{}{}
 	}
 	if len(seen) < 2 {
-		t.Errorf("shuffleByGame across %d gameIDs produced only %d distinct orders, want >= 2", trials, len(seen))
+		t.Errorf("shuffleBySeed across %d scope IDs produced only %d distinct orders, want >= 2", trials, len(seen))
 	}
 }

--- a/test/integration/session_answer_shuffle_test.go
+++ b/test/integration/session_answer_shuffle_test.go
@@ -1,0 +1,220 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// seedShuffleLiveQuiz seeds a one-question live quiz with eight options so the
+// per-session answer shuffle (#1074) has a wide permutation space (8! = 40320).
+// The correct option is deliberately NOT first, so the test can confirm scoring
+// and reveal key off the option id, not its display position. Returns the quiz
+// with option ids populated, in DB order.
+func seedShuffleLiveQuiz(ctx context.Context, t *testing.T, quizzes quiz.Store, slug string) *quiz.Quiz {
+	t.Helper()
+	options := make([]*quiz.Option, 0, 8)
+	for i := range 8 {
+		// The fifth option (index 4) is the correct one.
+		options = append(options, &quiz.Option{Text: fmt.Sprintf("opt-%d", i), Correct: i == 4})
+	}
+	qz := &quiz.Quiz{
+		Title:             "Shuffle " + slug,
+		Slug:              slug,
+		Description:       "per-session shuffle fixture",
+		CreatedByPlayerID: seededAdminID,
+		Visibility:        quiz.VisibilityPublic,
+		Mode:              quiz.ModeLive,
+		Questions: []*quiz.Question{
+			{Text: "Q1", Position: 1, Options: options},
+		},
+	}
+	if err := quizzes.CreateQuiz(ctx, qz); err != nil {
+		t.Fatalf("CreateQuiz shuffle live err = %v, want nil", err)
+	}
+
+	return qz
+}
+
+// startShuffleSession registers a fresh host, promotes it so it may open a
+// room, opens a session for quizID, joins the given players, and starts the
+// runner, returning the join code. Each session gets its own host because a
+// host may hold only one running game at a time, and the test needs several
+// concurrent sessions to compare orders. It mints the host session cookie
+// (registerVerifyAndMint) rather than logging in so several back-to-back host
+// sign-ins from one IP don't trip the per-IP login cooldown.
+func startShuffleSession(
+	ctx context.Context, t *testing.T, setup integrationSetup, quizID int64, hostSlug string, players ...*http.Client,
+) string {
+	t.Helper()
+	baseURL := setup.BaseURL
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndMint(ctx, t, host, baseURL, setup.DBURI, hostSlug, hostSlug+"-pass-123")
+	makeHost(ctx, t, setup.DBURI, hostSlug)
+	code := createSession(ctx, t, host, baseURL, quizID)
+	for i, p := range players {
+		joinSession(ctx, t, p, baseURL, code, fmt.Sprintf("%s-p%d", hostSlug, i))
+	}
+	startSession(ctx, t, host, baseURL, code)
+
+	return code
+}
+
+// questionOptionIDs waits for the question phase and returns the option ids in
+// the order the server serves them to client.
+func questionOptionIDs(
+	ctx context.Context, t *testing.T, client *http.Client, baseURL, code string,
+) []int64 {
+	t.Helper()
+	state := waitForPhase(ctx, t, client, baseURL, code, "question")
+	if state.Question == nil {
+		t.Fatal("question phase has no question in state")
+	}
+	ids := make([]int64, 0, len(state.Question.Options))
+	for _, o := range state.Question.Options {
+		ids = append(ids, o.ID)
+	}
+
+	return ids
+}
+
+// TestSessionAnswer_OptionsShuffledPerSession pins the #1074 contract end to
+// end: the live answer options are served in a per-session order that is the
+// same for every player in one session, stable across reads, different across
+// sessions, and not the raw DB order - while scoring and reveal still key off
+// the option id. Three sessions of an eight-option quiz make the "different
+// sessions differ" check effectively non-flaky (false-fail below 1e-9).
+func TestSessionAnswer_OptionsShuffledPerSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	qz := seedShuffleLiveQuiz(ctx, t, setup.Stores.Quizzes, "answer-shuffle")
+	dbOrder := make([]int64, 0, len(qz.Questions[0].Options))
+	for _, o := range qz.Questions[0].Options {
+		dbOrder = append(dbOrder, o.ID)
+	}
+	wantSet := slices.Clone(dbOrder)
+	slices.Sort(wantSet)
+
+	const sessionCount = 3
+	orders := make([][]int64, 0, sessionCount)
+	for s := range sessionCount {
+		// Two players per session so the same-session-agreement check has two
+		// independent reads.
+		one := newAnonClient(t)
+		two := newAnonClient(t)
+		code := startShuffleSession(ctx, t, setup, qz.ID, fmt.Sprintf("sh-host-%d", s), one, two)
+
+		first := questionOptionIDs(ctx, t, one, baseURL, code)
+		second := questionOptionIDs(ctx, t, two, baseURL, code)
+
+		// Every player in the same session sees the identical order.
+		if !slices.Equal(first, second) {
+			t.Errorf("session %d players saw different orders: %v vs %v", s, first, second)
+		}
+		// The served set is a permutation of the DB option ids - nothing dropped
+		// or duplicated.
+		gotSet := slices.Clone(first)
+		slices.Sort(gotSet)
+		if !slices.Equal(gotSet, wantSet) {
+			t.Errorf("session %d option id set = %v, want %v", s, gotSet, wantSet)
+		}
+		orders = append(orders, first)
+	}
+
+	// At least one session's order differs from raw DB order, proving the
+	// shuffle is applied rather than the options being passed through.
+	shuffledSomewhere := slices.ContainsFunc(orders, func(o []int64) bool {
+		return !slices.Equal(o, dbOrder)
+	})
+	if !shuffledSomewhere {
+		t.Errorf("no session shuffled the options; all matched DB order %v", dbOrder)
+	}
+
+	// Different sessions get different orders (the anti-cheat property): across
+	// three sessions of an eight-option quiz, at least two distinct orders.
+	distinct := make(map[string]struct{}, sessionCount)
+	for _, o := range orders {
+		distinct[fmt.Sprintf("%v", o)] = struct{}{}
+	}
+	if len(distinct) < 2 {
+		t.Errorf("3 sessions produced only %d distinct orders, want >= 2", len(distinct))
+	}
+}
+
+// TestSessionAnswer_ScoringByOptionID confirms the shuffle leaves scoring and
+// reveal untouched: a player who picks the seeded-correct option (found by id,
+// wherever the shuffle placed it) is scored correct with a positive score and
+// reveal names that same id, while a wrong picker stays at zero.
+func TestSessionAnswer_ScoringByOptionID(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegrationWithEnv(t, map[string]string{
+		"SESSION_RUNNER_BEAT": "250ms",
+		"REVEAL_DELAY":        "200ms",
+	})
+	baseURL := setup.BaseURL
+
+	qz := seedShuffleLiveQuiz(ctx, t, setup.Stores.Quizzes, "answer-shuffle-score")
+	correctID, wrongID := correctAndWrongOptionID(t, qz, qz.Questions[0].ID)
+
+	ace := newAnonClient(t)
+	bee := newAnonClient(t)
+	code := startShuffleSession(ctx, t, setup, qz.ID, "sh-score-host", ace, bee)
+
+	aceID := playerIDFromState(ctx, t, ace, baseURL, code, "sh-score-host-p0")
+	beeID := playerIDFromState(ctx, t, bee, baseURL, code, "sh-score-host-p1")
+
+	// Wait for the answer window, then pick by option id regardless of the
+	// shuffled display position.
+	waitForAnswersOpen(ctx, t, ace, baseURL, code)
+	answerSession(ctx, t, ace, baseURL, code, correctID, http.StatusNoContent)
+	answerSession(ctx, t, bee, baseURL, code, wrongID, http.StatusNoContent)
+
+	reveal := waitForPhase(ctx, t, ace, baseURL, code, "reveal")
+	if reveal.Question == nil {
+		t.Fatal("reveal phase has no question in state")
+	}
+	// Reveal names the correct option by id, whatever position the shuffle gave
+	// it.
+	if got, want := reveal.Question.CorrectOptionIDs, []int64{correctID}; !slices.Equal(got, want) {
+		t.Errorf("correctOptionIds = %v, want %v", got, want)
+	}
+
+	aceAns := findAnswer(t, reveal.Question.Answers, aceID)
+	if aceAns.Correct == nil || !*aceAns.Correct {
+		t.Errorf("Ace answer Correct = %v, want true", aceAns.Correct)
+	}
+	if aceAns.Score == nil || *aceAns.Score <= 0 {
+		t.Errorf("Ace answer Score = %v, want a positive score", aceAns.Score)
+	}
+	beeAns := findAnswer(t, reveal.Question.Answers, beeID)
+	if beeAns.Correct == nil || *beeAns.Correct {
+		t.Errorf("Bee answer Correct = %v, want false", beeAns.Correct)
+	}
+}
+
+// findAnswer returns the recorded answer for playerID, failing if absent.
+func findAnswer(t *testing.T, answers []sessionRunnerAns, playerID int64) sessionRunnerAns {
+	t.Helper()
+	for _, a := range answers {
+		if a.PlayerID == playerID {
+			return a
+		}
+	}
+	t.Fatalf("answers missing player %d", playerID)
+
+	return sessionRunnerAns{}
+}

--- a/test/integration/session_hud_test.go
+++ b/test/integration/session_hud_test.go
@@ -134,7 +134,7 @@ func TestSessionState_HUDPositionTotalAndSelfScore(t *testing.T) {
 
 	// Both answer the same question (Ace correct, Bee wrong); all-answered closes
 	// it early and the runner scores it.
-	playQuestion(ctx, t, ace, bee, baseURL, code)
+	playQuestion(ctx, t, ace, bee, baseURL, code, qz)
 
 	// After the question is scored, Ace's self.score reflects the points earned;
 	// Bee, who picked wrong, stays at 0.
@@ -153,7 +153,7 @@ func TestSessionState_HUDPositionTotalAndSelfScore(t *testing.T) {
 	// Finish round 1's second question so the round_results board appears, then
 	// confirm Ace's self.score equals their standings total - the HUD reads the
 	// same per-game aggregation the board does.
-	playQuestion(ctx, t, ace, bee, baseURL, code)
+	playQuestion(ctx, t, ace, bee, baseURL, code, qz)
 	rr := waitForResultsPhase(ctx, t, ace, baseURL, code, "round_results")
 	aceID := playerIDFromState(ctx, t, ace, baseURL, code, "Ace")
 	aceStanding := findStanding(t, rr.Standings, aceID)

--- a/test/integration/session_round_intro_test.go
+++ b/test/integration/session_round_intro_test.go
@@ -116,7 +116,7 @@ func TestSessionRoundIntro_TitleSummaryAndPosition(t *testing.T) {
 	}
 
 	// Play round 1's single question so the runner advances into round 2.
-	playQuestion(ctx, t, ace, bee, baseURL, code)
+	playQuestion(ctx, t, ace, bee, baseURL, code, qz)
 
 	// Second round_intro: the second round's title, and a position past the
 	// first round so a surface knows it is not the first round.

--- a/test/integration/session_round_results_test.go
+++ b/test/integration/session_round_results_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -105,12 +106,14 @@ func waitForResultsAnswersOpen(
 }
 
 // playQuestion drives one question to close: it waits for the question phase,
-// has the winner pick the correct option (index 0) and the loser the wrong one
-// (index 1) on the SAME question, then waits until that question leaves the
-// question phase (early close on all-answered). Returns the question id so the
-// caller can confirm each call advanced to a distinct question.
+// has the winner pick the seeded-correct option and the loser a wrong one on
+// the SAME question, then waits until that question leaves the question phase
+// (early close on all-answered). Returns the question id so the caller can
+// confirm each call advanced to a distinct question. The correct option is
+// resolved from the seeded quiz by id, not by display position, because the
+// live answer set is shuffled per session (#1074).
 func playQuestion(
-	ctx context.Context, t *testing.T, winner, loser *http.Client, baseURL, code string,
+	ctx context.Context, t *testing.T, winner, loser *http.Client, baseURL, code string, qz *quiz.Quiz,
 ) int64 {
 	t.Helper()
 	state := waitForResultsPhase(ctx, t, winner, baseURL, code, "question")
@@ -118,12 +121,13 @@ func playQuestion(
 		t.Fatal("question phase missing a two-option question")
 	}
 	qID := state.Question.ID
+	correctID, wrongID := correctAndWrongOptionID(t, qz, qID)
 
 	// Answers open after the read beat, so wait until the window opens before
 	// submitting; a pick during the read beat would 409.
 	state = waitForResultsAnswersOpen(ctx, t, winner, baseURL, code, qID)
-	answerSession(ctx, t, winner, baseURL, code, state.Question.Options[0].ID, http.StatusNoContent)
-	answerSession(ctx, t, loser, baseURL, code, state.Question.Options[1].ID, http.StatusNoContent)
+	answerSession(ctx, t, winner, baseURL, code, correctID, http.StatusNoContent)
+	answerSession(ctx, t, loser, baseURL, code, wrongID, http.StatusNoContent)
 
 	// Wait for the question to close so the next call targets the next question
 	// rather than re-answering this one.
@@ -138,6 +142,41 @@ func playQuestion(
 	t.Fatalf("question %d never closed", qID)
 
 	return qID
+}
+
+// correctAndWrongOptionID resolves, from the seeded quiz fixture, one correct
+// and one wrong option id for the question with questionID. It scans both the
+// flat questions and the per-round questions so it works for either fixture
+// shape. The fixture's Correct flags are the ground truth the live shuffle
+// (#1074) cannot reorder, so a test can pick the right option by id no matter
+// where the shuffle placed it on the wire.
+func correctAndWrongOptionID(t *testing.T, qz *quiz.Quiz, questionID int64) (int64, int64) {
+	t.Helper()
+	questions := slices.Clone(qz.Questions)
+	for _, r := range qz.Rounds {
+		questions = append(questions, r.Questions...)
+	}
+	for _, q := range questions {
+		if q.ID != questionID {
+			continue
+		}
+		var correctID, wrongID int64
+		for _, o := range q.Options {
+			if o.Correct {
+				correctID = o.ID
+			} else {
+				wrongID = o.ID
+			}
+		}
+		if correctID == 0 || wrongID == 0 {
+			t.Fatalf("question %d fixture lacks a correct and a wrong option", questionID)
+		}
+
+		return correctID, wrongID
+	}
+	t.Fatalf("quiz fixture has no question with id %d", questionID)
+
+	return 0, 0
 }
 
 // findStanding returns the standing for playerID, failing if absent.
@@ -194,8 +233,8 @@ func TestSessionRoundResults_DeltasTotalsAndStandings(t *testing.T) {
 	// Round 1 has two questions. Ace picks the correct option, Bee the wrong
 	// one; both answering closes each question early. Distinct ids confirm the
 	// runner advanced from q1 to q2.
-	q1 := playQuestion(ctx, t, ace, bee, baseURL, code)
-	q2 := playQuestion(ctx, t, ace, bee, baseURL, code)
+	q1 := playQuestion(ctx, t, ace, bee, baseURL, code, qz)
+	q2 := playQuestion(ctx, t, ace, bee, baseURL, code, qz)
 	if q1 == q2 {
 		t.Fatalf("round 1 played the same question twice (id %d)", q1)
 	}
@@ -225,7 +264,7 @@ func TestSessionRoundResults_DeltasTotalsAndStandings(t *testing.T) {
 	// Round 2 is the final round; same picks. Its closing reveal ends the game
 	// directly into intermission (the between-games screen, #836), skipping
 	// round_results, so the game ends on a single final-standings screen (#749).
-	playQuestion(ctx, t, ace, bee, baseURL, code)
+	playQuestion(ctx, t, ace, bee, baseURL, code, qz)
 
 	// intermission: final standings carry the full cumulative totals, Ace first.
 	// The final standings carry the last round's score as RoundScore so the bar

--- a/test/integration/session_round_results_test.go
+++ b/test/integration/session_round_results_test.go
@@ -125,7 +125,7 @@ func playQuestion(
 
 	// Answers open after the read beat, so wait until the window opens before
 	// submitting; a pick during the read beat would 409.
-	state = waitForResultsAnswersOpen(ctx, t, winner, baseURL, code, qID)
+	waitForResultsAnswersOpen(ctx, t, winner, baseURL, code, qID)
 	answerSession(ctx, t, winner, baseURL, code, correctID, http.StatusNoContent)
 	answerSession(ctx, t, loser, baseURL, code, wrongID, http.StatusNoContent)
 
@@ -150,7 +150,7 @@ func playQuestion(
 // shape. The fixture's Correct flags are the ground truth the live shuffle
 // (#1074) cannot reorder, so a test can pick the right option by id no matter
 // where the shuffle placed it on the wire.
-func correctAndWrongOptionID(t *testing.T, qz *quiz.Quiz, questionID int64) (int64, int64) {
+func correctAndWrongOptionID(t *testing.T, qz *quiz.Quiz, questionID int64) (correctID, wrongID int64) {
 	t.Helper()
 	questions := slices.Clone(qz.Questions)
 	for _, r := range qz.Rounds {
@@ -160,7 +160,6 @@ func correctAndWrongOptionID(t *testing.T, qz *quiz.Quiz, questionID int64) (int
 		if q.ID != questionID {
 			continue
 		}
-		var correctID, wrongID int64
 		for _, o := range q.Options {
 			if o.Correct {
 				correctID = o.ID

--- a/test/integration/session_runner_test.go
+++ b/test/integration/session_runner_test.go
@@ -175,15 +175,17 @@ func TestSessionRunner_HostStartQuestionAnswerReveal(t *testing.T) {
 	}
 
 	// During the read beat the answer window has not opened yet: a pick lands as
-	// 409, so a client cannot pre-submit before the options open.
-	pick := state.Question.Options[0].ID
+	// 409, so a client cannot pre-submit before the options open. The correct
+	// option is resolved from the fixture by id, not display position, because
+	// the live answer set is shuffled per session (#1074).
+	pick, _ := correctAndWrongOptionID(t, qz, state.Question.ID)
 	if state.ServerNow.Before(*state.Question.StartedAt) {
 		answerSession(ctx, t, player, baseURL, code, pick, http.StatusConflict)
 	}
 
-	// Once the read beat elapses the window opens; the player answers the FIRST
-	// option (seeded correct). The state read before reveal still must not say
-	// which pick was right.
+	// Once the read beat elapses the window opens; the player answers the seeded
+	// correct option. The state read before reveal still must not say which pick
+	// was right.
 	waitForAnswersOpen(ctx, t, player, baseURL, code)
 	answerSession(ctx, t, player, baseURL, code, pick, http.StatusNoContent)
 


### PR DESCRIPTION
Closes #1074

Live answer options are now served in a deterministic order seeded by the live session id plus the question id, so every player in a session sees the same option order (stable across reconnects and on the big screen, which renders the same payload), two sessions of the same quiz differ, and the order differs from DB order - a maker who lists the correct answer first can no longer be gamed. The existing solo-only shuffle helper was generalized from `shuffleByGame(gameID, questionID, ...)` to a seed-scoped `shuffleBySeed(scopeID, questionID, ...)` and is now used by both the solo (`scope = game id`) and live (`scope = session id`) paths; the seed derivation is byte-for-byte identical to before, so existing solo games keep their current layout. Scoring and reveal already key off option id rather than position, so they are unaffected (covered by a new test).

Followed the plan's recommended answers (seed = session id + question id; big screen automatic; no re-arm special case).

Non-critical review notes: none. (`/code-review` flagged one cleanup - a hand-rolled correct/wrong-option loop in the new scoring test duplicating the new `correctAndWrongOptionID` helper - which I applied; `/go-style-review` was clean.)

_- Claude Code, for @starquake_
