### PR TITLE
Persist uploaded media on the data volume

### DIFF
--- a/deployments/demo/docker-compose.production.yml
+++ b/deployments/demo/docker-compose.production.yml
@@ -10,6 +10,10 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
+      # Uploaded media (#936) must live on the persistent volume: the
+      # distroless image's app filesystem is ephemeral, so the default
+      # ./media would be lost on every redeploy. Shares the data volume.
+      - MEDIA_DIR=/home/nonroot/data/media
       # REGISTRATION_ENABLED is now env-driven so the operator can
       # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
       # without a redeploy. Defaults true when unset so a fresh stack

--- a/deployments/demo/docker-compose.staging.yml
+++ b/deployments/demo/docker-compose.staging.yml
@@ -10,6 +10,10 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
+      # Uploaded media (#936) must live on the persistent volume: the
+      # distroless image's app filesystem is ephemeral, so the default
+      # ./media would be lost on every redeploy. Shares the data volume.
+      - MEDIA_DIR=/home/nonroot/data/media
       # REGISTRATION_ENABLED is now env-driven so the operator can
       # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
       # without a redeploy. Defaults true when unset so a fresh stack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
       - DB_URI=file:/home/nonroot/data/topbanana.sqlite?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_txlock=immediate
+      # Keep uploaded media on the named volume so it survives rebuilds,
+      # mirroring staging/production. The default ./media writes to the
+      # container's ephemeral filesystem and is lost on every restart.
+      - MEDIA_DIR=/home/nonroot/data/media
       - REGISTRATION_ENABLED=true
       - ADMIN_EMAILS=admin@example.test
       # Uncomment to wire the app to the mailpit sibling service for


### PR DESCRIPTION
I opened this to fix #1081: uploaded media was written to the container's ephemeral filesystem, so every image/audio clip was lost on each restart, redeploy, or image update.

## Cause

`MEDIA_DIR` defaults to `./media`, which in the runtime image (`WORKDIR /home/nonroot`) resolves to `/home/nonroot/media`. The only persistent volume is mounted at `/home/nonroot/data` (the SQLite DB), so media sat on the throwaway container layer. `MEDIA_DIR` was set in none of the compose files. `.env.example` already documents that staging/production must point it at a persistent volume; the deploy configs did not.

## Fix

Set `MEDIA_DIR=/home/nonroot/data/media` in all three compose files — dev, staging, and production — so uploads land under the already-mounted data volume. No new volume is needed: it shares the existing one, and the app creates the directory on startup (`os.MkdirAll`).

- `docker-compose.yml`
- `deployments/demo/docker-compose.staging.yml`
- `deployments/demo/docker-compose.production.yml`

## Verification

Config-only change; no Go/frontend/SQL touched, so the Go and frontend suites have nothing to exercise here. Validated each file parses as valid YAML (`yq`) and resolves `MEDIA_DIR` to the data-volume path.

Note: this persists media from the next deploy forward; clips uploaded before the fix were already lost and cannot be recovered.

Closes #1081

_— Claude Code, for @starquake_
