### PR TITLE
Fix flaky host-reconnect spec: assert players by name, not count

### DIFF
--- a/test/e2e/tests/host-reconnect.spec.ts
+++ b/test/e2e/tests/host-reconnect.spec.ts
@@ -1,7 +1,17 @@
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
 
 import { test, expect } from './fixtures';
-import { importQuiz, setQuizMode, claimAndJoin } from './helpers';
+import { importQuiz, setQuizMode, claimAndJoin, playerRow } from './helpers';
+
+// standingsRow scopes to a between-games standings bar by player name. Like the
+// lobby roster, the host's one-room-per-host reuse can leave a stale prior-game
+// row in the standings, so specs assert a player's row is present by name rather
+// than a strict total count (#957, #1061).
+function standingsRow(page: Page, displayName: string): Locator {
+  return page
+    .locator('[data-testid="standings-bars"] [data-standings-row]')
+    .filter({ hasText: displayName });
+}
 
 // #876: the host big screen reconnecting mid-game. The TV is on a laptop/TV that
 // can sleep, lose wifi, or get refreshed. A reload must re-GET /state, re-subscribe
@@ -105,7 +115,10 @@ test.describe('host reconnect mid-game', () => {
     await joinAndReady(robinContext.request, joinCode, robin);
     await joinAndReady(quincyContext.request, joinCode, quincy);
 
-    await expect(host.locator('[data-player-row]')).toHaveCount(2, { timeout: 15_000 });
+    // Present-by-name, not a strict total: one-room-per-host reuse can leave a
+    // stale prior-test row in the roster (#957, #1061).
+    await expect(playerRow(host, robin)).toBeVisible({ timeout: 15_000 });
+    await expect(playerRow(host, quincy)).toBeVisible();
 
     // Host starts now; the runner drives round_intro -> question. The TV reaches
     // the live question phase.
@@ -143,7 +156,8 @@ test.describe('host reconnect mid-game', () => {
     // standings screen. The standings bars render on the reconnected host with
     // both players, proving the game ran to completion past the reconnect.
     await expect(host.locator('[data-phase-results]')).toBeVisible({ timeout: 20_000 });
-    await expect(host.locator('[data-testid="standings-bars"] [data-standings-row]')).toHaveCount(2, { timeout: 20_000 });
+    await expect(standingsRow(host, robin)).toBeVisible({ timeout: 20_000 });
+    await expect(standingsRow(host, quincy)).toBeVisible();
   });
 
   test('the host big screen reloaded on the standings screen resumes the standings', async ({ hostSessions }) => {
@@ -166,7 +180,10 @@ test.describe('host reconnect mid-game', () => {
     const quincyContext = await hostSessions.newPlayerContext();
     await joinAndReady(robinContext.request, joinCode, robin);
     await joinAndReady(quincyContext.request, joinCode, quincy);
-    await expect(host.locator('[data-player-row]')).toHaveCount(2, { timeout: 15_000 });
+    // Present-by-name, not a strict total: one-room-per-host reuse can leave a
+    // stale prior-test row in the roster (#957, #1061).
+    await expect(playerRow(host, robin)).toBeVisible({ timeout: 15_000 });
+    await expect(playerRow(host, quincy)).toBeVisible();
 
     await host.getByRole('button', { name: 'Start now' }).click();
     await expect(host.locator('[data-phase-question]')).toBeVisible({ timeout: 20_000 });
@@ -177,7 +194,8 @@ test.describe('host reconnect mid-game', () => {
     await answerOverApi(robinContext.request, joinCode, correct);
     await answerOverApi(quincyContext.request, joinCode, 'wrong-a');
     await expect(host.locator('[data-phase-results]')).toBeVisible({ timeout: 20_000 });
-    await expect(host.locator('[data-testid="standings-bars"] [data-standings-row]')).toHaveCount(2, { timeout: 20_000 });
+    await expect(standingsRow(host, robin)).toBeVisible({ timeout: 20_000 });
+    await expect(standingsRow(host, quincy)).toBeVisible();
 
     // The drop on a non-question phase: reload the host big screen on the
     // standings screen. The reloaded page must re-GET /state and resume on the
@@ -185,7 +203,8 @@ test.describe('host reconnect mid-game', () => {
     await host.reload();
 
     await expect(host.locator('[data-phase-results]')).toBeVisible({ timeout: 20_000 });
-    await expect(host.locator('[data-testid="standings-bars"] [data-standings-row]')).toHaveCount(2, { timeout: 20_000 });
+    await expect(standingsRow(host, robin)).toBeVisible({ timeout: 20_000 });
+    await expect(standingsRow(host, quincy)).toBeVisible();
     await expect(host.locator('[data-enter-code]')).toBeHidden();
   });
 });


### PR DESCRIPTION
Fixes the flaky `host-reconnect.spec.ts` (#1061).

## Root cause
The host TV specs host as the shared admin, and `StartHosting` is one-room-per-host: if the admin already has a non-finished room (an empty lobby or a between-games intermission), "Host live" **reuses** it rather than opening a fresh one. So a prior host-spec's room on the same worker — whose players' `left_at` hasn't been stamped yet when their contexts close — can leave **stale roster (and standings) rows** in the room this test inherits.

`host-reconnect.spec.ts` was the lone host spec still asserting a **strict total** `expect('[data-player-row]').toHaveCount(2)` (and the same on `[data-standings-row]`). With a stale row present it intermittently saw 3, failing then passing on retry. This is exactly the case the `playerRow` helper documents (#957): *"specs must assert a player is present by name, never with a strict total count."*

## Fix
Assert the joined players are present **by name** instead of an exact total:
- roster: use the existing `playerRow(host, name)` helper;
- standings: add a small `standingsRow(host, name)` helper (filters `[data-standings-row]` by `displayName`).

No product code changes — test-only, and it brings this spec in line with every other host spec's convention. A stale leftover row no longer fails the assertion, while the real intent (robin + quincy are present) is still verified.

## Verification
`npx playwright test tests/host-reconnect.spec.ts --repeat-each=2` green on chromium + firefox (9 passed, 0 flaky).

Closes #1061

_— Claude Code, for @starquake_
