### PR TITLE
Add global security-header middleware

### DIFF
--- a/internal/auth/invite_handler.go
+++ b/internal/auth/invite_handler.go
@@ -32,9 +32,6 @@ func HandleAcceptInviteForm(logger *slog.Logger, csrfMgr *csrf.Manager, invites 
 	invalid := newTemplateRenderer(logger, csrfMgr, "auth/pages/accept_invite_invalid.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Strip the raw token from any cross-origin Referer the browser
-		// might leak (Google Fonts on base.gohtml is the notable case).
-		w.Header().Set("Referrer-Policy", "no-referrer")
 		raw := r.URL.Query().Get("token")
 		if !inviteLivePreflight(r, logger, invites, raw) {
 			invalid.Render(w, r, http.StatusGone, invitePageData{Title: "Invite"})

--- a/internal/auth/reset_handler.go
+++ b/internal/auth/reset_handler.go
@@ -31,9 +31,6 @@ func HandleResetForm(
 	invalid := newTemplateRenderer(logger, csrfMgr, "auth/pages/reset_password_invalid.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Strip raw token from any cross-origin Referer the browser
-		// might leak (Google Fonts on base.gohtml is the notable case).
-		w.Header().Set("Referrer-Policy", "no-referrer")
 		raw := r.URL.Query().Get("token")
 		if !resetTokenLivePreflight(r, logger, tokens, raw) {
 			invalid.Render(w, r, http.StatusGone, resetPageData{Title: "Reset link"})

--- a/internal/auth/verify_handler.go
+++ b/internal/auth/verify_handler.go
@@ -68,11 +68,6 @@ func HandleVerifyEmail(
 	renderer := newTemplateRenderer(logger, csrfMgr, "auth/pages/verify_email.gohtml")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Strip the raw token from any cross-origin Referer the browser
-		// would otherwise send (Google Fonts on base.gohtml is the
-		// notable case). Modern defaults strip the query already; the
-		// explicit no-referrer header pins the behaviour on older UAs.
-		w.Header().Set("Referrer-Policy", "no-referrer")
 		raw := r.URL.Query().Get("token")
 		if raw == "" {
 			renderer.Render(w, r, http.StatusBadRequest, verifyEmailPageData{

--- a/internal/server/securityheaders.go
+++ b/internal/server/securityheaders.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/starquake/topbanana/internal/config"
+)
+
+// contentSecurityPolicy is the sitewide CSP. It starts loose: script-src
+// allows 'unsafe-inline' (inline onclick/onsubmit handlers in admin templates,
+// inline SW-registration scripts, and Alpine attribute expressions) and
+// 'unsafe-eval' (Alpine.js v3 evaluates x-data/x-show/@click expressions via
+// new Function, which CSP gates on 'unsafe-eval' not 'unsafe-inline').
+// style-src allows 'unsafe-inline' because of two inline style attributes.
+// Tightening to a nonce-based strict CSP is a follow-up tracked separately.
+const contentSecurityPolicy = `default-src 'self'; ` +
+	`script-src 'self' 'unsafe-inline' 'unsafe-eval'; ` +
+	`style-src 'self' 'unsafe-inline'; ` +
+	`img-src 'self'; ` +
+	`font-src 'self'; ` +
+	`connect-src 'self'; ` +
+	`media-src 'self'; ` +
+	`worker-src 'self'; ` +
+	`object-src 'none'; ` +
+	`base-uri 'none'; ` +
+	`frame-ancestors 'none'`
+
+// strictTransportSecurity is the HSTS value applied only when cookies are
+// Secure (any non-development env). Browsers ignore HSTS over HTTP, so gating
+// avoids pinning a dev laptop that serves plain HTTP.
+const strictTransportSecurity = "max-age=31536000; includeSubDomains"
+
+// securityHeaders sets the sitewide security response headers. Wire it as the
+// innermost wrapper so the headers are on w.Header() before any handler writes
+// the response, including recoverPanic's 500 on a handler panic (the headers
+// stay on the header map across the unwind). HSTS is gated on SecureCookies so
+// a development server reachable over plain HTTP does not pin itself.
+func securityHeaders(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("Content-Security-Policy", contentSecurityPolicy)
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("Referrer-Policy", "no-referrer")
+			h.Set("X-Frame-Options", "DENY")
+			if cfg.SecureCookies() {
+				h.Set("Strict-Transport-Security", strictTransportSecurity)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/server/securityheaders.go
+++ b/internal/server/securityheaders.go
@@ -19,7 +19,7 @@ const contentSecurityPolicy = `default-src 'self'; ` +
 	`img-src 'self'; ` +
 	`font-src 'self'; ` +
 	`connect-src 'self'; ` +
-	`media-src 'self'; ` +
+	`media-src 'self' blob:; ` +
 	`worker-src 'self'; ` +
 	`object-src 'none'; ` +
 	`base-uri 'none'; ` +

--- a/internal/server/securityheaders_test.go
+++ b/internal/server/securityheaders_test.go
@@ -18,7 +18,7 @@ const cspExpected = `default-src 'self'; ` +
 	`img-src 'self'; ` +
 	`font-src 'self'; ` +
 	`connect-src 'self'; ` +
-	`media-src 'self'; ` +
+	`media-src 'self' blob:; ` +
 	`worker-src 'self'; ` +
 	`object-src 'none'; ` +
 	`base-uri 'none'; ` +

--- a/internal/server/securityheaders_test.go
+++ b/internal/server/securityheaders_test.go
@@ -1,0 +1,120 @@
+//nolint:testpackage // tests the unexported securityHeaders middleware directly
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/starquake/topbanana/internal/config"
+)
+
+// cspExpected is the exact CSP value securityHeaders must set. Pinned here so
+// a drift in the policy is caught alongside the integration test that asserts
+// the same value on live responses.
+const cspExpected = `default-src 'self'; ` +
+	`script-src 'self' 'unsafe-inline' 'unsafe-eval'; ` +
+	`style-src 'self' 'unsafe-inline'; ` +
+	`img-src 'self'; ` +
+	`font-src 'self'; ` +
+	`connect-src 'self'; ` +
+	`media-src 'self'; ` +
+	`worker-src 'self'; ` +
+	`object-src 'none'; ` +
+	`base-uri 'none'; ` +
+	`frame-ancestors 'none'`
+
+// TestSecurityHeaders_SetsAllHeaders pins that every sitewide header is
+// present on a normal response, the CSP matches the expected value, and the
+// wrapped handler still runs and controls the status. Uses production env so
+// HSTS is in scope.
+func TestSecurityHeaders_SetsAllHeaders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{AppEnvironment: config.AppEnvironmentProduction}
+	called := false
+	handler := securityHeaders(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+	if !called {
+		t.Fatal("wrapped handler was not called")
+	}
+	if got, want := rec.Code, http.StatusNoContent; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	wantHeaders := map[string]string{
+		"Content-Security-Policy":   cspExpected,
+		"X-Content-Type-Options":    "nosniff",
+		"Referrer-Policy":           "no-referrer",
+		"X-Frame-Options":           "DENY",
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+	}
+	for k, want := range wantHeaders {
+		if got := rec.Header().Get(k); got != want {
+			t.Errorf("header %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestSecurityHeaders_HSTSGatedOnSecureCookies pins that HSTS is only set when
+// cookies are Secure (any non-development env). The integration harness boots
+// APP_ENV=development, so a dev server reachable over plain HTTP must not pin
+// itself with HSTS.
+func TestSecurityHeaders_HSTSGatedOnSecureCookies(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		env      string
+		wantHSTS bool
+	}{
+		{name: "development omits HSTS", env: config.AppEnvironmentDefault, wantHSTS: false},
+		{name: "production sets HSTS", env: config.AppEnvironmentProduction, wantHSTS: true},
+		{name: "unstated env fails secure and sets HSTS", env: "staging", wantHSTS: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{AppEnvironment: tc.env}
+			handler := securityHeaders(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+			got := rec.Header().Get("Strict-Transport-Security")
+			if tc.wantHSTS && got == "" {
+				t.Errorf("AppEnvironment=%q: want an HSTS header, got empty", tc.env)
+			}
+			if !tc.wantHSTS && got != "" {
+				t.Errorf("AppEnvironment=%q: want no HSTS header, got %q", tc.env, got)
+			}
+		})
+	}
+}
+
+// TestSecurityHeaders_HeadersSetBeforeHandler pins that the headers are on the
+// response map before the wrapped handler runs, so a handler that writes its
+// own headers (e.g. a 500 from recoverPanic) still carries the security set.
+func TestSecurityHeaders_HeadersSetBeforeHandler(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{AppEnvironment: config.AppEnvironmentProduction}
+	var seenCSP string
+	handler := securityHeaders(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seenCSP = w.Header().Get("Content-Security-Policy")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+	if got, want := seenCSP, cspExpected; got != want {
+		t.Errorf("handler saw CSP %q, want %q (headers must be set before the handler runs)", got, want)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,6 +65,10 @@ func New(
 	mux := http.NewServeMux()
 	addRoutes(mux, logger, stores, gameService, realtime, cfg, mail)
 	var handler http.Handler = mux
+	// securityHeaders is the innermost wrapper so the security headers land on
+	// w.Header() before any handler writes the response, including the 500
+	// recoverPanic emits on a handler panic (the headers survive the unwind).
+	handler = securityHeaders(cfg)(handler)
 	handler = logRequests(handler)
 	// recoverPanic wraps logRequests so a handler panic still captures the
 	// request fields logRequests would have recorded and the 500 reaches the

--- a/test/integration/security_headers_test.go
+++ b/test/integration/security_headers_test.go
@@ -15,7 +15,7 @@ const cspExpected = `default-src 'self'; ` +
 	`img-src 'self'; ` +
 	`font-src 'self'; ` +
 	`connect-src 'self'; ` +
-	`media-src 'self'; ` +
+	`media-src 'self' blob:; ` +
 	`worker-src 'self'; ` +
 	`object-src 'none'; ` +
 	`base-uri 'none'; ` +

--- a/test/integration/security_headers_test.go
+++ b/test/integration/security_headers_test.go
@@ -1,0 +1,151 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// cspExpected pins the exact CSP the server emits; it must match the value in
+// internal/server/securityheaders.go. Duplicating it here keeps the
+// integration assertion self-describing and catches drift on the live
+// response (not just the middleware unit test).
+const cspExpected = `default-src 'self'; ` +
+	`script-src 'self' 'unsafe-inline' 'unsafe-eval'; ` +
+	`style-src 'self' 'unsafe-inline'; ` +
+	`img-src 'self'; ` +
+	`font-src 'self'; ` +
+	`connect-src 'self'; ` +
+	`media-src 'self'; ` +
+	`worker-src 'self'; ` +
+	`object-src 'none'; ` +
+	`base-uri 'none'; ` +
+	`frame-ancestors 'none'`
+
+// assertCommonSecurityHeaders checks the headers that are present on every
+// response regardless of environment. HSTS is asserted separately because it
+// is gated on SecureCookies (non-development).
+func assertCommonSecurityHeaders(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	want := map[string]string{
+		"Content-Security-Policy": cspExpected,
+		"X-Content-Type-Options":  "nosniff",
+		"Referrer-Policy":         "no-referrer",
+		"X-Frame-Options":         "DENY",
+	}
+	for k, v := range want {
+		if got := resp.Header.Get(k); got != v {
+			t.Errorf("header %q = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// assertHSTSPresent checks that Strict-Transport-Security is set (used in
+// the production-env case where SecureCookies is true).
+func assertHSTSPresent(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	if got := resp.Header.Get("Strict-Transport-Security"); got == "" {
+		t.Error("want Strict-Transport-Security header, got empty")
+	}
+}
+
+// assertHSTSAbsent checks that Strict-Transport-Security is NOT set (used in
+// the development-env case where a plain-HTTP dev server must not pin itself).
+func assertHSTSAbsent(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	if got := resp.Header.Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("want no Strict-Transport-Security header, got %q", got)
+	}
+}
+
+// TestSecurityHeaders_OnEverySurface pins that the security headers land on
+// every surface a visitor or player hits: the public home + auth pages, the
+// player SPA shell, the embedded static assets, the PWA manifest + service
+// worker, the JSON API, and the authed admin console. The integration harness
+// boots APP_ENV=development, so HSTS must be absent (a dev server reachable
+// over plain HTTP must not pin itself).
+func TestSecurityHeaders_OnEverySurface(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"REGISTRATION_ENABLED": "true",
+	})
+	baseURL := srv.BaseURL
+	client := &http.Client{}
+
+	publicCases := []struct {
+		name string
+		path string
+	}{
+		{"home", "/"},
+		{"login", "/login"},
+		{"player SPA", "/client/"},
+		{"static CSS", "/static/css/app.css"},
+		{"static vendored JS", "/static/js/vendor/alpine.min.js"},
+		{"manifest", "/manifest.webmanifest"},
+		{"service worker", "/sw.js"},
+		{"JSON API", "/api/players/me"},
+	}
+	for _, tc := range publicCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := httpGet(ctx, t, client, baseURL+tc.path)
+			defer closeBody(t, resp.Body)
+			assertCommonSecurityHeaders(t, resp)
+			assertHSTSAbsent(t, resp)
+		})
+	}
+
+	// The admin console is behind RequireGameHost; the first registrant is
+	// promoted to admin so an authed GET /admin reaches the page (200).
+	t.Run("admin console", func(t *testing.T) {
+		t.Parallel()
+
+		adminClient := authClient(t)
+		registerVerifyAndMint(
+			ctx,
+			t,
+			adminClient,
+			baseURL,
+			srv.DBURI,
+			"sec-headers-admin",
+			"sec-headers-admin-pass-123",
+		)
+		resp := httpGet(ctx, t, adminClient, baseURL+"/admin")
+		defer closeBody(t, resp.Body)
+		if got, want := resp.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("GET /admin status = %d, want %d", got, want)
+		}
+		assertCommonSecurityHeaders(t, resp)
+		assertHSTSAbsent(t, resp)
+	})
+}
+
+// TestSecurityHeaders_HSTSInProduction pins that HSTS is emitted once the env
+// is non-development (SecureCookies true). Boots a second server with
+// APP_ENV=production and asserts Strict-Transport-Security on the public
+// surfaces. Only public endpoints are checked: production cookies are Secure,
+// so the harness's no-TLS http.Client cannot carry a session to /admin.
+func TestSecurityHeaders_HSTSInProduction(t *testing.T) {
+	t.Parallel()
+
+	ctx, srv := startServer(t, map[string]string{
+		"APP_ENV": "production",
+	})
+	baseURL := srv.BaseURL
+	client := &http.Client{}
+
+	for _, path := range []string{"/", "/login", "/static/css/app.css", "/sw.js"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			resp := httpGet(ctx, t, client, baseURL+path)
+			defer closeBody(t, resp.Body)
+			assertCommonSecurityHeaders(t, resp)
+			assertHSTSPresent(t, resp)
+		})
+	}
+}


### PR DESCRIPTION
Opened this draft PR for #1100.

## Plan

Add a `securityHeaders` middleware wired innermost in `server.New` so the headers land on `w.Header()` before any handler writes the response — including `recoverPanic`'s 500 on a handler panic. Sets on every response:

- `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; worker-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: no-referrer` (absorbs the 3 ad-hoc sets on auth token handlers, whose comments were stale — cited Google Fonts on `base.gohtml`, removed in #599)
- `X-Frame-Options: DENY`
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — only when `cfg.SecureCookies()` (non-`development`); browsers ignore HSTS over HTTP anyway, gating avoids pinning a dev laptop

The CSP starts loose: `script-src` needs `'unsafe-inline'` for ~69 inline `onclick`/`onsubmit` handlers in admin templates, 4 inline SW-registration `<script>` blocks, and Alpine attribute expressions; `'unsafe-eval'` is required because Alpine.js v3 evaluates `x-data`/`x-show`/`@click` expressions via `new Function`, which CSP gates on `'unsafe-eval'` not `'unsafe-inline'`. `style-src` needs `'unsafe-inline'` for 2 inline `style="..."` attributes.

## Tests

- `internal/server/securityheaders_test.go` (unit): headers present; HSTS gated on `SecureCookies()`; CSP value pinned; headers set before the wrapped handler runs.
- `test/integration/security_headers_test.go`: headers on every surface (home, login, player SPA, static assets, manifest, SW, JSON API, authed admin console); HSTS absent under `APP_ENV=development`, present under `APP_ENV=production`.

## Out of scope

Tightening to a strict CSP (`script-src 'self' 'nonce-…'`) requires migrating the inline handlers to `addEventListener`, externalizing the SW-registration scripts, switching Alpine to its CSP-nonce build, and plumbing per-request nonces through `internal/render` + templates. Separate follow-up.

Closes #1100

_— glm-5.2, for @starquake_