### PR TITLE
Prevent solo /next from double-issuing the same quiz question

### DIFF
--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -78,6 +78,7 @@ func (q *Queries) CreateGame(ctx context.Context, arg CreateGameParams) (Game, e
 const createGameQuestion = `-- name: CreateGameQuestion :one
 INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
 VALUES (?, ?, CAST(?3 AS TEXT), CAST(?4 AS TEXT))
+ON CONFLICT (game_id, question_id) DO NOTHING
 RETURNING id, game_id, question_id, started_at, expired_at
 `
 
@@ -96,6 +97,11 @@ type CreateGameQuestionParams struct {
 // suffix makes the lexical compare invert across a DST boundary and flip the
 // in-progress dot (#789). The store binds value.UTC().Format(...) so both the
 // stored column and the bound cutoff share one encoding.
+// ON CONFLICT DO NOTHING: the UNIQUE INDEX on (game_id, question_id) prevents
+// double-issuance when two concurrent /next calls race. A conflict yields
+// sql.ErrNoRows; the store fetches the existing row via
+// GetGameQuestionByGameAndQuestion and returns ErrQuestionAlreadyIssued so the
+// service treats it as a resume.
 func (q *Queries) CreateGameQuestion(ctx context.Context, arg CreateGameQuestionParams) (GameQuestion, error) {
 	row := q.db.QueryRowContext(ctx, createGameQuestion,
 		arg.GameID,
@@ -320,6 +326,33 @@ func (q *Queries) GetGameByPlayerAndQuiz(ctx context.Context, arg GetGameByPlaye
 		&i.QuizID,
 		&i.CreatedAt,
 		&i.StartedAt,
+	)
+	return i, err
+}
+
+const getGameQuestionByGameAndQuestion = `-- name: GetGameQuestionByGameAndQuestion :one
+SELECT id, game_id, question_id, started_at, expired_at
+FROM game_questions
+WHERE game_id = ? AND question_id = ?
+`
+
+type GetGameQuestionByGameAndQuestionParams struct {
+	GameID     string
+	QuestionID int64
+}
+
+// Fetches an existing game_questions row by (game_id, question_id). Used by
+// the store's CreateQuestion to recover the winning row when ON CONFLICT DO
+// NOTHING yields no rows (a concurrent /next race).
+func (q *Queries) GetGameQuestionByGameAndQuestion(ctx context.Context, arg GetGameQuestionByGameAndQuestionParams) (GameQuestion, error) {
+	row := q.db.QueryRowContext(ctx, getGameQuestionByGameAndQuestion, arg.GameID, arg.QuestionID)
+	var i GameQuestion
+	err := row.Scan(
+		&i.ID,
+		&i.GameID,
+		&i.QuestionID,
+		&i.StartedAt,
+		&i.ExpiredAt,
 	)
 	return i, err
 }

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -32,6 +32,13 @@ var (
 	// HandleAnswerPost for the recovery path (#353).
 	ErrAnswerAlreadyRecorded = errors.New("answer already recorded for this question")
 
+	// ErrQuestionAlreadyIssued is returned by [GameStore.CreateQuestion]
+	// when a concurrent /next call already inserted the same
+	// (game_id, question_id) row. The store populates the Question with
+	// the winning row's ID and timestamps before returning so the
+	// service can hand it back as a resume rather than a duplicate.
+	ErrQuestionAlreadyIssued = errors.New("question already issued for this game")
+
 	// ErrNoMoreQuestions is returned by [Service.GetNextQuestion] when
 	// every quiz question has already been issued for the game.
 	ErrNoMoreQuestions = errors.New("no more questions")

--- a/internal/game/service.go
+++ b/internal/game/service.go
@@ -285,14 +285,12 @@ func (s *Service) GetNextQuestion(ctx context.Context, gameID string, playerID i
 		return gq, nil
 	}
 
-	// Create a lookup map for questions already asked in this game
 	askedQuestions := make(map[int64]bool)
 	for _, gqs := range g.Questions {
 		askedQuestions[gqs.QuestionID] = true
 	}
 
 	var nextQuestion *quiz.Question
-	// Find the first question in the quiz that hasn't been asked yet
 	for _, q := range qz.Questions {
 		if !askedQuestions[q.ID] {
 			nextQuestion = q
@@ -305,12 +303,9 @@ func (s *Service) GetNextQuestion(ctx context.Context, gameID string, playerID i
 		return nil, ErrNoMoreQuestions
 	}
 
-	// Register the chosen quiz question as a GameQuestion. The answer
-	// window (StartedAt -> ExpiredAt) is anchored at now + revealDelay,
-	// not "now" - the reveal delay gives the player a brief beat to
-	// read the question before the option buttons appear (#247).
-	// Submissions before StartedAt are scored as if they arrived AT
-	// StartedAt (see CalculateScore's clamp).
+	// The answer window (StartedAt -> ExpiredAt) is anchored at now +
+	// revealDelay, not "now" - the reveal delay gives the player a brief
+	// beat to read the question before the option buttons appear (#247).
 	revealAt := time.Now().Add(s.revealDelay)
 	gq := &Question{
 		GameID:       gameID,
@@ -326,6 +321,10 @@ func (s *Service) GetNextQuestion(ctx context.Context, gameID string, playerID i
 	}
 	applyRoundProgress(gq, qz)
 	if err = s.store.CreateQuestion(ctx, gq, completesGame(gq)); err != nil {
+		if errors.Is(err, ErrQuestionAlreadyIssued) {
+			return gq, nil
+		}
+
 		return nil, fmt.Errorf("failed to record game question: %w", err)
 	}
 
@@ -647,6 +646,10 @@ func (s *Service) issueQuestion(
 	}
 	applyRoundProgress(gq, qz)
 	if err := s.store.CreateQuestion(ctx, gq, completesGame(gq)); err != nil {
+		if errors.Is(err, ErrQuestionAlreadyIssued) {
+			return gq, nil
+		}
+
 		return nil, fmt.Errorf("failed to record game question: %w", err)
 	}
 

--- a/internal/game/service_test.go
+++ b/internal/game/service_test.go
@@ -1569,3 +1569,103 @@ func countParticipantRows(ctx context.Context, t *testing.T, db *sql.DB, playerI
 
 	return n
 }
+
+// TestService_GetNextQuestion_Race pins the UNIQUE INDEX on
+// game_questions(game_id, question_id): N concurrent /next calls on the same
+// game must produce exactly one game_questions row, not N. Without the index +
+// ON CONFLICT handling, a double-tap on "Next" would insert duplicate rows,
+// re-serving the same question and inflating play_count.
+func TestService_GetNextQuestion_Race(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	db := dbtest.Open(t)
+
+	qz := &quiz.Quiz{
+		Title:             "Next Race Quiz",
+		Slug:              "next-race-quiz",
+		Description:       "for the concurrent /next race test",
+		CreatedByPlayerID: seededAdminID,
+		Questions: []*quiz.Question{
+			{
+				Text:     "Q1",
+				Position: 1,
+				Options: []*quiz.Option{
+					{Text: "A", Correct: true},
+					{Text: "B"},
+				},
+			},
+		},
+	}
+	stores := store.New(db, slog.Default())
+	if cerr := stores.Quizzes.CreateQuiz(ctx, qz); cerr != nil {
+		t.Fatalf("CreateQuiz err = %v, want nil", cerr)
+	}
+
+	player, err := stores.Players.CreateAnonymousPlayer(ctx, "anon-next-race")
+	if err != nil {
+		t.Fatalf("CreateAnonymousPlayer err = %v, want nil", err)
+	}
+
+	svc := NewService(stores.Games, stores.Quizzes, slog.Default())
+	svc.SetLeaderboardPublisher(leaderboard.NewHub())
+
+	game, err := svc.CreateGame(ctx, qz.ID, player.ID)
+	if err != nil {
+		t.Fatalf("CreateGame err = %v, want nil", err)
+	}
+
+	const parallel = 4
+	var wg sync.WaitGroup
+	wg.Add(parallel)
+	results := make([]*Question, parallel)
+	errs := make([]error, parallel)
+
+	for i := range parallel {
+		go func(idx int) {
+			defer wg.Done()
+			gq, gerr := svc.GetNextQuestion(context.Background(), game.ID, player.ID)
+			results[idx] = gq
+			errs[idx] = gerr
+		}(i)
+	}
+	wg.Wait()
+
+	for i, gerr := range errs {
+		if gerr != nil {
+			t.Errorf("goroutine %d err = %v, want nil", i, gerr)
+		}
+		if results[i] == nil {
+			t.Errorf("goroutine %d returned nil question", i)
+
+			continue
+		}
+		if got, want := results[i].QuestionID, qz.Questions[0].ID; got != want {
+			t.Errorf("goroutine %d QuestionID = %d, want %d", i, got, want)
+		}
+	}
+
+	// The core assertion: exactly one game_questions row for (game, question).
+	// Without the UNIQUE index, the race would produce up to `parallel` rows.
+	rowCount := countGameQuestionRows(ctx, t, db, game.ID, qz.Questions[0].ID)
+	if got, want := rowCount, 1; got != want {
+		t.Errorf("game_questions rows for (game=%s, question=%d) = %d, want %d",
+			game.ID, qz.Questions[0].ID, got, want)
+	}
+}
+
+// countGameQuestionRows pulls the row count for a (game_id, question_id) pair
+// directly from the DB. The UNIQUE INDEX should make this either 0 or 1.
+func countGameQuestionRows(ctx context.Context, t *testing.T, db *sql.DB, gameID string, questionID int64) int {
+	t.Helper()
+	row := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM game_questions WHERE game_id = ? AND question_id = ?`,
+		gameID, questionID,
+	)
+	var n int
+	if err := row.Scan(&n); err != nil {
+		t.Fatalf("QueryRow.Scan err = %v, want nil", err)
+	}
+
+	return n
+}

--- a/internal/migrations/20260624120000_unique_game_question_per_game.sql
+++ b/internal/migrations/20260624120000_unique_game_question_per_game.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Enforce one game_questions row per (game_id, question_id) so two
+-- concurrent /next calls cannot double-issue the same quiz question.
+-- Without this, the read-then-insert advance path races: both callers
+-- compute the same nextQuestion and both inserts succeed, producing a
+-- duplicate that inflates Position and can double-bump play_count.
+CREATE UNIQUE INDEX game_questions_game_question_idx ON game_questions(game_id, question_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX game_questions_game_question_idx;
+-- +goose StatementEnd

--- a/internal/migrations/unique_game_question_test.go
+++ b/internal/migrations/unique_game_question_test.go
@@ -1,0 +1,120 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// uniqueGameQuestionVersion is the migration that adds the UNIQUE INDEX on
+// game_questions(game_id, question_id) to prevent double-issuance.
+const uniqueGameQuestionVersion = 20260624120000
+
+// TestUniqueGameQuestionMigration_RejectsDuplicate pins that the unique index
+// prevents two game_questions rows for the same (game_id, question_id) pair,
+// which is the core invariant the migration enforces. A second insert with the
+// same pair must fail with a constraint violation.
+func TestUniqueGameQuestionMigration_RejectsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Unique GQ", "unique-gq-mig")
+	roundID := seedRound(t, db, quizID)
+	qID := seedQuestion(t, db, quizID, roundID, 1)
+
+	ctx := t.Context()
+	if _, err := db.ExecContext(
+		ctx, `INSERT INTO games (id, quiz_id) VALUES ('gq-dup-game', ?)`, quizID,
+	); err != nil {
+		t.Fatalf("seed game err = %v, want nil", err)
+	}
+
+	insertGameQuestion := func() error {
+		_, err := db.ExecContext(
+			ctx,
+			`INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
+			 VALUES ('gq-dup-game', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			qID,
+		)
+
+		return err
+	}
+
+	if err := insertGameQuestion(); err != nil {
+		t.Fatalf("first insert err = %v, want nil", err)
+	}
+
+	if err := insertGameQuestion(); err == nil {
+		t.Error("second insert err = nil, want a UNIQUE constraint violation")
+	}
+}
+
+// TestUniqueGameQuestionMigration_DownDropsIndex pins that the Down migration
+// removes the unique index so duplicates are again tolerated (the schema
+// returns to its pre-migration shape).
+func TestUniqueGameQuestionMigration_DownDropsIndex(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Unique GQ Down", "unique-gq-down-mig")
+	roundID := seedRound(t, db, quizID)
+	qID := seedQuestion(t, db, quizID, roundID, 1)
+
+	ctx := t.Context()
+	if _, err := db.ExecContext(
+		ctx, `INSERT INTO games (id, quiz_id) VALUES ('gq-down-game', ?)`, quizID,
+	); err != nil {
+		t.Fatalf("seed game err = %v, want nil", err)
+	}
+
+	insertGameQuestion := func() error {
+		_, err := db.ExecContext(
+			ctx,
+			`INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
+			 VALUES ('gq-down-game', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			qID,
+		)
+
+		return err
+	}
+
+	if err := insertGameQuestion(); err != nil {
+		t.Fatalf("first insert err = %v, want nil", err)
+	}
+
+	if err := goose.DownTo(db, ".", uniqueGameQuestionVersion-1); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+
+	if err := insertGameQuestion(); err != nil {
+		t.Errorf("post-down duplicate insert err = %v, want nil (index dropped)", err)
+	}
+
+	// Remove the duplicate row so goose.Up can re-create the unique index
+	// without a pre-existing conflict.
+	if _, err := db.ExecContext(
+		ctx,
+		`DELETE FROM game_questions WHERE game_id = 'gq-down-game' AND question_id = ?`,
+		qID,
+	); err != nil {
+		t.Fatalf("cleanup delete err = %v, want nil", err)
+	}
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+}

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -77,9 +77,23 @@ ORDER BY game_question_id;
 -- suffix makes the lexical compare invert across a DST boundary and flip the
 -- in-progress dot (#789). The store binds value.UTC().Format(...) so both the
 -- stored column and the bound cutoff share one encoding.
+-- ON CONFLICT DO NOTHING: the UNIQUE INDEX on (game_id, question_id) prevents
+-- double-issuance when two concurrent /next calls race. A conflict yields
+-- sql.ErrNoRows; the store fetches the existing row via
+-- GetGameQuestionByGameAndQuestion and returns ErrQuestionAlreadyIssued so the
+-- service treats it as a resume.
 INSERT INTO game_questions (game_id, question_id, started_at, expired_at)
 VALUES (?, ?, CAST(sqlc.arg('started_at') AS TEXT), CAST(sqlc.arg('expired_at') AS TEXT))
+ON CONFLICT (game_id, question_id) DO NOTHING
 RETURNING *;
+
+-- name: GetGameQuestionByGameAndQuestion :one
+-- Fetches an existing game_questions row by (game_id, question_id). Used by
+-- the store's CreateQuestion to recover the winning row when ON CONFLICT DO
+-- NOTHING yields no rows (a concurrent /next race).
+SELECT *
+FROM game_questions
+WHERE game_id = ? AND question_id = ?;
 
 -- name: ListAnswersForQuizLeaderboard :many
 -- Selects the per-answer scoring inputs for every game of the given

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -298,6 +298,10 @@ func (s *GameStore) CreateQuestion(ctx context.Context, gq *game.Question, compl
 		return nil
 	})
 	if err != nil {
+		if errors.Is(err, game.ErrQuestionAlreadyIssued) {
+			return game.ErrQuestionAlreadyIssued
+		}
+
 		return fmt.Errorf("failed to create game question: %w", err)
 	}
 

--- a/internal/store/game.go
+++ b/internal/store/game.go
@@ -249,6 +249,12 @@ func execCreateGameAndParticipant(
 // counter cannot drift from the "game just became completed" transition that
 // fires alongside the final question.
 //
+// Returns [game.ErrQuestionAlreadyIssued] when a concurrent /next call already
+// inserted the same (game_id, question_id) row. The Question is populated with
+// the winning row's ID and timestamps so the caller can return it as a resume
+// rather than a duplicate. The play_count bump is skipped in this case because
+// the winning caller already handled it.
+//
 //nolint:revive // completesGame signals whether this insert completes the game (a play-count bump input), not a behavioural mode switch.
 func (s *GameStore) CreateQuestion(ctx context.Context, gq *game.Question, completesGame bool) error {
 	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
@@ -262,6 +268,21 @@ func (s *GameStore) CreateQuestion(ctx context.Context, gq *game.Question, compl
 			},
 		)
 		if qerr != nil {
+			if errors.Is(qerr, sql.ErrNoRows) {
+				existing, gerr := q.GetGameQuestionByGameAndQuestion(ctx, db.GetGameQuestionByGameAndQuestionParams{
+					GameID:     gq.GameID,
+					QuestionID: gq.QuestionID,
+				})
+				if gerr != nil {
+					return fmt.Errorf("fetch existing game question after conflict: %w", gerr)
+				}
+				gq.ID = existing.ID
+				gq.StartedAt = existing.StartedAt
+				gq.ExpiredAt = existing.ExpiredAt
+
+				return game.ErrQuestionAlreadyIssued
+			}
+
 			return fmt.Errorf("create game question: %w", qerr)
 		}
 		gq.ID = row.ID


### PR DESCRIPTION
Opened this draft PR for #1103.

## Plan

`game_questions` had no UNIQUE constraint on `(game_id, question_id)`, and the solo advance path was read-then-insert with no lock. Two concurrent `/next` calls both computed the same `nextQuestion` and both inserts succeeded, producing duplicate rows that re-served the question and inflated `play_count`.

## Changes

1. **Migration** (`20260624120000_unique_game_question_per_game.sql`): `CREATE UNIQUE INDEX game_questions_game_question_idx ON game_questions(game_id, question_id)`.
2. **Query** (`internal/queries/games.sql`): `CreateGameQuestion` now uses `ON CONFLICT (game_id, question_id) DO NOTHING RETURNING *`. Added `GetGameQuestionByGameAndQuestion` to fetch the winning row on conflict.
3. **Store** (`internal/store/game.go`): `CreateQuestion` handles `sql.ErrNoRows` from the conflict by fetching the existing row, populating the `Question` with its ID/timestamps, and returning `game.ErrQuestionAlreadyIssued`. The `play_count` bump is skipped in the conflict case (the winning caller handles it).
4. **Service** (`internal/game/service.go`): `GetNextQuestion` and `issueQuestion` catch `ErrQuestionAlreadyIssued` and return the `gq` as a resume — the question is the same, the client sees it without error.
5. **Sentinel** (`internal/game/game.go`): `ErrQuestionAlreadyIssued`.

## Tests

- `internal/migrations/unique_game_question_test.go`: the unique index rejects a duplicate `(game_id, question_id)` insert; the Down migration drops the index so duplicates are tolerated again.
- `internal/game/service_test.go` (`TestService_GetNextQuestion_Race`): 4 concurrent `GetNextQuestion` goroutines on the same game all succeed (return the same question), and the DB has exactly 1 `game_questions` row. Run with `-count=5` for confidence.

## Verification

`make lint-fix`, `make check` (83.1% coverage), `make smoke`, `make test-e2e` (271 passed, 0 failed).

Closes #1103

_— glm-5.2, for @starquake_