### PR TITLE
Add missing index on game_id for game_questions and game_participants

### DIFF
--- a/internal/db/games.sql.go
+++ b/internal/db/games.sql.go
@@ -392,7 +392,8 @@ ORDER BY game_question_id
 // game_question_id so callers can partition rows per question in a
 // single pass. Replaces the N+1 pattern of calling
 // ListAnswersByGameQuestionID once per issued question (#356); the
-// game_id column is already covered by the FK's implicit index.
+// UNIQUE(game_id, player_id, game_question_id) constraint serves as
+// the index for the game_id filter.
 func (q *Queries) ListAnswersByGameID(ctx context.Context, gameID string) ([]GameAnswer, error) {
 	rows, err := q.db.QueryContext(ctx, listAnswersByGameID, gameID)
 	if err != nil {

--- a/internal/migrations/20260624130000_index_game_id.sql
+++ b/internal/migrations/20260624130000_index_game_id.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+-- SQLite creates no implicit index for a REFERENCES FK, so WHERE game_id = ?
+-- on game_questions and game_participants falls back to a full table scan.
+-- These queries run on every GetGame (ListGameQuestionsByGameID,
+-- ListParticipantsByGameID) and grow linearly with lifetime games played.
+-- game_answers is already covered by the UNIQUE(game_id, player_id,
+-- game_question_id) constraint whose leftmost column is game_id.
+CREATE INDEX game_questions_game_id_idx ON game_questions(game_id);
+CREATE INDEX game_participants_game_id_idx ON game_participants(game_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX game_questions_game_id_idx;
+DROP INDEX game_participants_game_id_idx;
+-- +goose StatementEnd

--- a/internal/migrations/index_game_id_test.go
+++ b/internal/migrations/index_game_id_test.go
@@ -1,0 +1,65 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// indexGameIDVersion is the migration that adds indexes on game_id for
+// game_questions and game_participants.
+const indexGameIDVersion = 20260624130000
+
+// TestIndexGameID_UpCreatesIndexes pins that the Up migration creates both
+// indexes. Each is verified by querying sqlite_master for the index name.
+func TestIndexGameID_UpCreatesIndexes(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	for _, idx := range []string{
+		"game_questions_game_id_idx",
+		"game_participants_game_id_idx",
+	} {
+		if !indexExists(t, db, idx) {
+			t.Errorf("index %q does not exist after migration, want it to", idx)
+		}
+	}
+}
+
+// TestIndexGameID_DownDropsIndexes pins that the Down migration removes both
+// indexes so the schema returns to its pre-migration shape.
+func TestIndexGameID_DownDropsIndexes(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v, want nil", cerr)
+		}
+	})
+
+	if err := goose.DownTo(db, ".", indexGameIDVersion-1); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+
+	for _, idx := range []string{
+		"game_questions_game_id_idx",
+		"game_participants_game_id_idx",
+	} {
+		if indexExists(t, db, idx) {
+			t.Errorf("index %q still exists after Down, want it dropped", idx)
+		}
+	}
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+}

--- a/internal/queries/games.sql
+++ b/internal/queries/games.sql
@@ -62,7 +62,8 @@ WHERE game_question_id = ?;
 -- game_question_id so callers can partition rows per question in a
 -- single pass. Replaces the N+1 pattern of calling
 -- ListAnswersByGameQuestionID once per issued question (#356); the
--- game_id column is already covered by the FK's implicit index.
+-- UNIQUE(game_id, player_id, game_question_id) constraint serves as
+-- the index for the game_id filter.
 SELECT *
 FROM game_answers
 WHERE game_id = ?


### PR DESCRIPTION
Opened this draft PR for #1105.

## Plan

SQLite creates no implicit index for a `REFERENCES games(id)` FK. Two `WHERE game_id = ?` queries (`ListGameQuestionsByGameID`, `ListParticipantsByGameID`) run on every `GetGame` and fall back to a full table scan growing linearly with lifetime games played.

`game_answers` is already covered by the `UNIQUE(game_id, player_id, game_question_id)` constraint whose leftmost column is `game_id`, so no new index is needed there.

## Changes

1. **Migration** (`20260624130000_index_game_id.sql`): `CREATE INDEX game_questions_game_id_idx ON game_questions(game_id)` + `CREATE INDEX game_participants_game_id_idx ON game_participants(game_id)`.
2. **Query comment fix** (`internal/queries/games.sql`): the `ListAnswersByGameID` comment claimed "the game_id column is already covered by the FK's implicit index" — SQLite has no such implicit index. Corrected to reference the actual `UNIQUE` constraint that serves as the index.
3. **sqlc regeneration**: the comment change touched a sqlc-tracked query, so `internal/db/games.sql.go` was regenerated.

## Tests

`internal/migrations/index_game_id_test.go`: both indexes exist after Up, dropped after Down.

## Verification

`make lint-fix`, `make check` (83.2% coverage), `make smoke`, `make test-e2e` (271 passed, 0 failed).

Closes #1105

_— glm-5.2, for @starquake_