### PR TITLE
Retrofit older parent-rebuild migrations with _fk_guard CHECK pattern

### DIFF
--- a/internal/migrations/20260506000000_add_player_auth_columns.sql
+++ b/internal/migrations/20260506000000_add_player_auth_columns.sql
@@ -42,8 +42,22 @@ DROP TABLE players;
 ALTER TABLE players_new RENAME TO players;
 -- +goose StatementEnd
 
+-- A bare PRAGMA foreign_key_check only RETURNS the violating rows; goose
+-- discards that result set, so on its own it cannot stop a broken rebuild from
+-- committing. This guard turns "a FK violation exists" into a failed INSERT
+-- that aborts the whole transaction (and the migration): the CHECK (ok = 1)
+-- rejects the 0 produced when pragma_foreign_key_check returns any row.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
@@ -90,8 +104,19 @@ DROP TABLE players;
 ALTER TABLE players_new RENAME TO players;
 -- +goose StatementEnd
 
+-- Same enforcing FK guard as the Up: abort the transaction if the rebuild
+-- left any dangling reference, rather than silently committing it.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/internal/migrations/20260520200000_quiz_creator.sql
+++ b/internal/migrations/20260520200000_quiz_creator.sql
@@ -137,8 +137,22 @@ BEGIN
 END;
 -- +goose StatementEnd
 
+-- A bare PRAGMA foreign_key_check only RETURNS the violating rows; goose
+-- discards that result set, so on its own it cannot stop a broken rebuild from
+-- committing. This guard turns "a FK violation exists" into a failed INSERT
+-- that aborts the migration: the CHECK (ok = 1) rejects the 0 produced when
+-- pragma_foreign_key_check returns any row.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
@@ -241,8 +255,19 @@ BEGIN
 END;
 -- +goose StatementEnd
 
+-- Same enforcing FK guard as the Up: abort the migration if the rebuild
+-- left any dangling reference, rather than silently re-enabling FKs.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin

--- a/internal/migrations/20260528100000_require_email_for_credentialled_players.sql
+++ b/internal/migrations/20260528100000_require_email_for_credentialled_players.sql
@@ -65,8 +65,22 @@ DROP TABLE players;
 ALTER TABLE players_new RENAME TO players;
 -- +goose StatementEnd
 
+-- A bare PRAGMA foreign_key_check only RETURNS the violating rows; goose
+-- discards that result set, so on its own it cannot stop a broken rebuild from
+-- committing. This guard turns "a FK violation exists" into a failed INSERT
+-- that aborts the whole transaction (and the migration): the CHECK (ok = 1)
+-- rejects the 0 produced when pragma_foreign_key_check returns any row.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
@@ -119,8 +133,19 @@ DROP TABLE players;
 ALTER TABLE players_old RENAME TO players;
 -- +goose StatementEnd
 
+-- Same enforcing FK guard as the Up: abort the transaction if the rebuild
+-- left any dangling reference, rather than silently committing it.
 -- +goose StatementBegin
-PRAGMA foreign_key_check;
+CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO _fk_guard (ok)
+SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE _fk_guard;
 -- +goose StatementEnd
 
 -- +goose StatementBegin


### PR DESCRIPTION
Opened this draft PR for #1107.

## Plan

Three older parent-rebuild migrations used bare `PRAGMA foreign_key_check`, which goose discards — not a guard. A rebuild that left a dangling child reference would commit silently. Newer migrations use the `_fk_guard` CHECK-constraint pattern (canonical: `20260529160000_roles_player_host_admin.sql:75-86`).

## Changes

Retrofitted all three with the same `_fk_guard` block (both Up and Down):

- `20260506000000_add_player_auth_columns.sql`
- `20260528100000_require_email_for_credentialled_players.sql`
- `20260520200000_quiz_creator.sql`

The guard replaces bare `PRAGMA foreign_key_check` with:
1. `CREATE TEMP TABLE _fk_guard (ok INTEGER CHECK (ok = 1));`
2. `INSERT INTO _fk_guard (ok) SELECT CASE WHEN (SELECT count(*) FROM pragma_foreign_key_check) = 0 THEN 1 ELSE 0 END;`
3. `DROP TABLE _fk_guard;`

The INSERT fails (CHECK constraint) when any FK violation exists, aborting the migration before `PRAGMA foreign_keys = ON` re-enables enforcement with dangling references.

These migrations have already run on production; the retrofit only changes the migration SQL text — the DB schema after re-up is identical. The latent risk is only realised if ever replayed (`goose down` then `up`).

## Verification

`make lint-fix`, `make check` (83.2% coverage), `make smoke`, `make test-e2e` (271 passed, 0 failed).

Closes #1107

_— glm-5.2, for @starquake_