### PR TITLE
Replace multi-line larger-screen note with monitor icon on host picker

### DIFF
--- a/internal/web/tmpl/components/quiz_card.gohtml
+++ b/internal/web/tmpl/components/quiz_card.gohtml
@@ -98,10 +98,13 @@
      cluster sits on `relative z-10` to stay clickable above the card body. */}}
 {{define "quiz_card_actions_host"}}
     {{/* Hosting needs the big-screen lobby, which is unusable on a phone, so
-         below md the action is a plain note instead of a button that overflows
-         the card (#1050). */}}
+         below md the action is an icon with a tooltip instead of a button that
+         overflows the card (#1050). The monitor icon conveys "use a larger
+         screen" without the multi-line text wrap (#1058). */}}
     <div class="relative z-10 ml-auto flex items-center gap-1">
-        <span data-testid="host-needs-larger-screen-{{.ID}}" class="md:hidden text-[0.7rem] uppercase tracking-[0.12em] text-text-mute">Use a larger screen to host</span>
+        <span data-testid="host-needs-larger-screen-{{.ID}}" class="md:hidden inline-flex items-center justify-center w-9 h-9 text-text-mute" title="Use a larger screen to host" aria-label="Use a larger screen to host">
+            <svg viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>
+        </span>
         {{if .HostHasRunningGame}}
             <button type="button" data-testid="host-action-{{.ID}}" onclick="openModal('modal-restart-host-{{.ID}}')" class="hidden md:inline-flex btn-primary">Change quiz</button>
         {{else}}

--- a/test/e2e/tests/host-picker-mobile.spec.ts
+++ b/test/e2e/tests/host-picker-mobile.spec.ts
@@ -3,9 +3,9 @@ import { importQuiz, setQuizMode } from './helpers';
 
 // #1050 — hosting a session needs the big-screen lobby, which does not fit on a
 // phone, so on the host picker (/host/quizzes) the "Host this" button is hidden
-// below the md breakpoint and a plain "use a larger screen" note takes its
-// place. These specs pin that the right one shows at each width by visibility,
-// not pixel geometry, so they stay deterministic.
+// below the md breakpoint and a monitor icon takes its place (#1058). These
+// specs pin that the right one shows at each width by visibility, not pixel
+// geometry, so they stay deterministic.
 
 const MOBILE = { width: 390, height: 844 } as const;
 const WIDE = { width: 1280, height: 800 } as const;


### PR DESCRIPTION
Opened this draft PR for #1058.

## Change

On the host quiz picker (`/host/quizzes`), small screens below the `md` breakpoint showed "Use a larger screen to host" as text that wrapped multiple lines on narrow cards. Replaced it with a compact Lucide monitor icon (`w-4 h-4`) in a `w-9 h-9` container, matching the dimensions of the adjacent action buttons. The `title` and `aria-label` carry the full message for hover tooltips and screen readers, so no information is lost.

The `data-testid="host-needs-larger-screen-{id}"` is unchanged, so the existing e2e visibility assertions pass without modification. Updated the test comment to reflect the icon.

## Verification

`make lint-fix`, `make check` (83.1% coverage), `make smoke`, `make test-e2e` (271 passed, 0 failed).

Closes #1058

_— glm-5.2, for @starquake_