### PR TITLE
Add quiz archive export with images and sounds

### DIFF
--- a/internal/admin/export_test.go
+++ b/internal/admin/export_test.go
@@ -167,3 +167,16 @@ func ParseUploadCounts(r *http.Request) (uploaded, failed, cancelled int) {
 
 // UploadCountCeiling exposes the unexported clamp value for tests.
 const UploadCountCeiling = uploadCountCeiling
+
+// WriteQuizArchive exposes the unexported quiz-archive writer so the external
+// admin_test package can pin the manifest + media bundling without driving the
+// full HTTP handler (#1113).
+var WriteQuizArchive = writeQuizArchive
+
+// ArchiveFormatVersion exposes the on-disk manifest version constant so the
+// export test can assert the stamped value without hard-coding it.
+const ArchiveFormatVersion = archiveFormatVersion
+
+// ArchiveExtForMedia exposes the unexported MIME-to-archive-extension mapper so
+// the export test can pin every branch without driving the full exporter.
+var ArchiveExtForMedia = archiveExtForMedia

--- a/internal/admin/quizarchive.go
+++ b/internal/admin/quizarchive.go
@@ -1,0 +1,74 @@
+package admin
+
+// archiveFormatVersion is the on-disk schema version stamped into every
+// exported quiz archive's manifest. It lets a later importer reject (or
+// migrate) an archive whose layout it does not understand. Bump it only on
+// a breaking change to the manifest shape.
+const archiveFormatVersion = 1
+
+// quizArchiveManifest is the decoded form of the quiz.json file at the root
+// of an exported quiz archive (the .zip). It is a superset of the
+// paste-import payload ([quizImportPayload]): it reuses the same field names
+// so the import slice can share the round/question/option shape, and adds
+// FormatVersion, Visibility, Mode, and per-question Image / Audio references
+// that point at the archive's media/<id>.<ext> files. Only serialization is
+// exercised today (export); the import slice consumes the same types.
+//
+// Questions and Rounds are mutually exclusive, mirroring the import payload:
+// a quiz with authored rounds exports Rounds; a flat quiz exports a top-level
+// Questions list.
+type quizArchiveManifest struct {
+	FormatVersion    int                   `json:"formatVersion"`
+	Title            string                `json:"title"`
+	Description      string                `json:"description"`
+	TimeLimitSeconds *int                  `json:"timeLimitSeconds,omitempty"`
+	Visibility       string                `json:"visibility"`
+	Mode             string                `json:"mode"`
+	Questions        []quizArchiveQuestion `json:"questions,omitempty"`
+	Rounds           []quizArchiveRound    `json:"rounds,omitempty"`
+}
+
+// quizArchiveRound is one authored round in the manifest.
+type quizArchiveRound struct {
+	Title                   string                `json:"title"`
+	Summary                 string                `json:"summary,omitempty"`
+	BoundaryDurationSeconds *int                  `json:"boundaryDurationSeconds,omitempty"`
+	Questions               []quizArchiveQuestion `json:"questions"`
+}
+
+// quizArchiveQuestion is one question in the manifest. Image and Audio are
+// nil when the question has no attached media; when set they reference a file
+// in the archive's media/ directory by relative path.
+type quizArchiveQuestion struct {
+	Text             string               `json:"text"`
+	TimeLimitSeconds *int                 `json:"timeLimitSeconds,omitempty"`
+	Image            *quizArchiveImageRef `json:"image,omitempty"`
+	Audio            *quizArchiveAudioRef `json:"audio,omitempty"`
+	Options          []quizArchiveOption  `json:"options"`
+}
+
+// quizArchiveOption is one answer option in the manifest.
+type quizArchiveOption struct {
+	Text    string `json:"text"`
+	Correct bool   `json:"correct"`
+}
+
+// quizArchiveImageRef points at an image file stored in the archive. File is
+// the archive-relative path ("media/<id>.<ext>"); MIME is the stored content
+// type so the importer can re-register the media without re-sniffing.
+type quizArchiveImageRef struct {
+	File string `json:"file"`
+	MIME string `json:"mime"`
+}
+
+// quizArchiveAudioRef points at an audio file stored in the archive. It
+// carries the same File / MIME as the image ref plus the advisory audio
+// metadata (host-supplied description, duration, repeat flag) so an import
+// round-trips the clip's playback behaviour.
+type quizArchiveAudioRef struct {
+	File        string `json:"file"`
+	MIME        string `json:"mime"`
+	Description string `json:"description,omitempty"`
+	DurationMs  *int   `json:"durationMs,omitempty"`
+	Repeat      bool   `json:"repeat,omitempty"`
+}

--- a/internal/admin/quizexport.go
+++ b/internal/admin/quizexport.go
@@ -1,0 +1,399 @@
+package admin
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/quiz"
+)
+
+// archiveDecimalBase is the base used to render media and quiz ids into the
+// archive's media filenames and the fallback download filename.
+const archiveDecimalBase = 10
+
+// MediaArchiver is the slice of the media service the exporter needs: resolve
+// a media row's metadata and open its stored full file for reading. Defined
+// consumer-side so the admin package depends only on the two reads it makes;
+// the concrete *media.Service satisfies it. Open returns the concrete
+// [os.File] the service hands back; the exporter only reads and closes it.
+type MediaArchiver interface {
+	Get(ctx context.Context, id int64) (*media.Media, error)
+	Open(relPath string) (*os.File, error)
+}
+
+// archiveExtForMedia returns the archive filename extension for a stored media
+// row, derived from its MIME with a fallback to the stored file's extension.
+// The importer reads media/<id>.<ext> back, so the extension only has to be a
+// stable, recognisable label for the bytes.
+func archiveExtForMedia(m *media.Media) string {
+	switch m.MIME {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	case "audio/mpeg":
+		return ".mp3"
+	case "audio/mp4":
+		return ".m4a"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/wav":
+		return ".wav"
+	default:
+		if ext := path.Ext(m.Path); ext != "" {
+			return ext
+		}
+
+		return ".bin"
+	}
+}
+
+// archiveMediaPath is the archive-relative path of a media file, keyed by the
+// media id so the same id referenced by several questions maps to one file.
+func archiveMediaPath(m *media.Media) string {
+	return "media/" + strconv.FormatInt(m.ID, archiveDecimalBase) + archiveExtForMedia(m)
+}
+
+// quizSlugFilename returns the download filename for a quiz archive: its slug
+// plus ".zip", falling back to the quiz id when the slug is somehow empty so
+// the Content-Disposition header always names a file.
+func quizSlugFilename(qz *quiz.Quiz) string {
+	slug := qz.Slug
+	if slug == "" {
+		slug = "quiz-" + strconv.FormatInt(qz.ID, archiveDecimalBase)
+	}
+
+	return slug + ".zip"
+}
+
+// defaultExportRoundTitle is the title the store stamps on every quiz's
+// auto-created round. A single round still carrying it marks an unauthored
+// (flat) quiz. Invariant pinned by TestFlatQuizDetection.
+const defaultExportRoundTitle = "Round 1"
+
+// isFlatQuiz reports whether the quiz should export a flat top-level
+// questions[] rather than rounds[]: true only for a single round still named
+// the default "Round 1", which is exactly what importing a flat questions[]
+// produces.
+func isFlatQuiz(rounds []*quiz.Round) bool {
+	return len(rounds) == 1 && rounds[0].Title == defaultExportRoundTitle
+}
+
+// timeLimitPtr returns a pointer to the quiz time limit, or nil for the zero
+// value so the manifest omits it. The quiz default is always non-zero in
+// practice (the store backfills it), but a zero stays omitted for cleanliness.
+func timeLimitPtr(v int) *int {
+	if v == 0 {
+		return nil
+	}
+
+	return &v
+}
+
+// manifestBuilder collects the unique referenced media as it builds the
+// manifest, deduping by media id so a row referenced by several questions is
+// loaded once and written to the archive once. media holds the resolved rows
+// keyed by id; the archive's media files are written from it after the
+// manifest is assembled.
+type manifestBuilder struct {
+	svc   MediaArchiver
+	media map[int64]*media.Media
+}
+
+func newManifestBuilder(svc MediaArchiver) *manifestBuilder {
+	return &manifestBuilder{svc: svc, media: make(map[int64]*media.Media)}
+}
+
+// build assembles the full manifest for the quiz. It groups the quiz's
+// questions under their rounds in position order and decides the XOR shape:
+// a quiz with a single unauthored default round exports a flat top-level
+// questions[]; anything else (a renamed round, or more than one round) exports
+// rounds[]. This mirrors the importer, where a flat questions[] lands every
+// question in the single default round.
+func (b *manifestBuilder) build(
+	ctx context.Context, qz *quiz.Quiz, rounds []*quiz.Round,
+) (quizArchiveManifest, error) {
+	manifest := quizArchiveManifest{
+		FormatVersion:    archiveFormatVersion,
+		Title:            qz.Title,
+		Description:      qz.Description,
+		TimeLimitSeconds: timeLimitPtr(qz.TimeLimitSeconds),
+		Visibility:       qz.Visibility,
+		Mode:             qz.Mode,
+	}
+
+	byRound := make(map[int64][]*quiz.Question, len(rounds))
+	for _, q := range qz.Questions {
+		byRound[q.RoundID] = append(byRound[q.RoundID], q)
+	}
+
+	if isFlatQuiz(rounds) {
+		questions, err := b.questions(ctx, byRound[rounds[0].ID])
+		if err != nil {
+			return quizArchiveManifest{}, err
+		}
+		manifest.Questions = questions
+
+		return manifest, nil
+	}
+
+	manifest.Rounds = make([]quizArchiveRound, 0, len(rounds))
+	for _, rnd := range rounds {
+		questions, err := b.questions(ctx, byRound[rnd.ID])
+		if err != nil {
+			return quizArchiveManifest{}, err
+		}
+		manifest.Rounds = append(manifest.Rounds, quizArchiveRound{
+			Title:                   rnd.Title,
+			Summary:                 rnd.Summary,
+			BoundaryDurationSeconds: rnd.BoundaryDurationSeconds,
+			Questions:               questions,
+		})
+	}
+
+	return manifest, nil
+}
+
+// questions maps a round's questions onto their manifest entries.
+func (b *manifestBuilder) questions(
+	ctx context.Context, questions []*quiz.Question,
+) ([]quizArchiveQuestion, error) {
+	out := make([]quizArchiveQuestion, 0, len(questions))
+	for _, q := range questions {
+		entry, err := b.question(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entry)
+	}
+
+	return out, nil
+}
+
+// question builds the manifest entry for one question, resolving its image and
+// audio references and copying its options.
+func (b *manifestBuilder) question(ctx context.Context, q *quiz.Question) (quizArchiveQuestion, error) {
+	imageRef, err := b.imageRef(ctx, q.ImageMediaID)
+	if err != nil {
+		return quizArchiveQuestion{}, err
+	}
+	audioRef, err := b.audioRef(ctx, q.AudioMediaID, q.AudioRepeat)
+	if err != nil {
+		return quizArchiveQuestion{}, err
+	}
+
+	options := make([]quizArchiveOption, 0, len(q.Options))
+	for _, o := range q.Options {
+		options = append(options, quizArchiveOption{Text: o.Text, Correct: o.Correct})
+	}
+
+	return quizArchiveQuestion{
+		Text:             q.Text,
+		TimeLimitSeconds: q.TimeLimitSeconds,
+		Image:            imageRef,
+		Audio:            audioRef,
+		Options:          options,
+	}, nil
+}
+
+// imageRef resolves the image media id into a manifest ref, recording the
+// referenced media for later file writing. A nil id yields a nil ref.
+func (b *manifestBuilder) imageRef(ctx context.Context, id *int64) (*quizArchiveImageRef, error) {
+	if id == nil {
+		return nil, nil //nolint:nilnil // nil ref means "no image attached", the natural sentinel here.
+	}
+	m, err := b.resolve(ctx, *id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &quizArchiveImageRef{File: archiveMediaPath(m), MIME: m.MIME}, nil
+}
+
+// audioRef resolves the audio media id into a manifest ref, carrying the clip's
+// advisory metadata and the repeat flag. A nil id yields a nil ref.
+func (b *manifestBuilder) audioRef(ctx context.Context, id *int64, repeat bool) (*quizArchiveAudioRef, error) {
+	if id == nil {
+		return nil, nil //nolint:nilnil // nil ref means "no audio attached", the natural sentinel here.
+	}
+	m, err := b.resolve(ctx, *id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &quizArchiveAudioRef{
+		File:        archiveMediaPath(m),
+		MIME:        m.MIME,
+		Description: m.Description,
+		DurationMs:  m.DurationMs,
+		Repeat:      repeat,
+	}, nil
+}
+
+// resolve loads a media row once and caches it for the export, so a media id
+// referenced by several questions is read from the store a single time.
+func (b *manifestBuilder) resolve(ctx context.Context, id int64) (*media.Media, error) {
+	if m, ok := b.media[id]; ok {
+		return m, nil
+	}
+	m, err := b.svc.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("loading media %d for export: %w", id, err)
+	}
+	b.media[id] = m
+
+	return m, nil
+}
+
+// writeQuizArchive builds the quiz's manifest and writes the archive (a .zip)
+// to w: quiz.json plus one media/<id>.<ext> file per unique referenced media.
+// It reads only via the quiz store and the media service; it persists nothing.
+func writeQuizArchive(
+	ctx context.Context, w io.Writer, quizStore quiz.Store, mediaSvc MediaArchiver, quizID int64,
+) error {
+	qz, err := quizStore.GetQuiz(ctx, quizID)
+	if err != nil {
+		return fmt.Errorf("loading quiz %d for export: %w", quizID, err)
+	}
+	rounds, err := quizStore.ListRoundsByQuiz(ctx, quizID)
+	if err != nil {
+		return fmt.Errorf("loading rounds for quiz %d export: %w", quizID, err)
+	}
+
+	builder := newManifestBuilder(mediaSvc)
+	manifest, err := builder.build(ctx, qz, rounds)
+	if err != nil {
+		return err
+	}
+
+	zw := zip.NewWriter(w)
+	if err = writeManifestEntry(zw, manifest); err != nil {
+		return err
+	}
+	if err = writeMediaEntries(zw, mediaSvc, builder.media); err != nil {
+		return err
+	}
+	if err = zw.Close(); err != nil {
+		return fmt.Errorf("closing quiz archive: %w", err)
+	}
+
+	return nil
+}
+
+// writeManifestEntry writes the indented quiz.json into the archive.
+func writeManifestEntry(zw *zip.Writer, manifest quizArchiveManifest) error {
+	out, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding quiz manifest: %w", err)
+	}
+	entry, err := zw.Create("quiz.json")
+	if err != nil {
+		return fmt.Errorf("creating manifest entry: %w", err)
+	}
+	if _, err = entry.Write(out); err != nil {
+		return fmt.Errorf("writing manifest entry: %w", err)
+	}
+
+	return nil
+}
+
+// writeMediaEntries copies each unique referenced media's full file into the
+// archive. Export the full file (m.Path), not the thumbnail: import
+// regenerates the thumbnail from the original.
+func writeMediaEntries(zw *zip.Writer, mediaSvc MediaArchiver, items map[int64]*media.Media) error {
+	for _, m := range items {
+		if err := writeMediaEntry(zw, mediaSvc, m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeMediaEntry copies one media file's bytes into the archive at its
+// id-keyed path.
+func writeMediaEntry(zw *zip.Writer, mediaSvc MediaArchiver, m *media.Media) error {
+	src, err := mediaSvc.Open(m.Path)
+	if err != nil {
+		return fmt.Errorf("opening media %d file for export: %w", m.ID, err)
+	}
+	defer func() { _ = src.Close() }()
+
+	entry, err := zw.Create(archiveMediaPath(m))
+	if err != nil {
+		return fmt.Errorf("creating media entry for %d: %w", m.ID, err)
+	}
+	if _, err = io.Copy(entry, src); err != nil {
+		return fmt.Errorf("writing media entry for %d: %w", m.ID, err)
+	}
+
+	return nil
+}
+
+// HandleQuizExport returns the per-quiz export handler. It loads the quiz,
+// enforces the same creator-or-admin edit gate the quiz view applies, then
+// streams a .zip bundling the quiz manifest and its referenced media. The
+// archive is buffered before any header is written so a build failure returns
+// a clean 500 rather than a truncated body; quiz archives are admin-only and
+// size-bounded, so buffering in memory is acceptable.
+func HandleQuizExport(logger *slog.Logger, quizStore quiz.Store, mediaSvc MediaArchiver) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		quizID, ok := handlers.ParseIDFromPath(w, r, logger, "quizID")
+		if !ok {
+			return
+		}
+
+		qz, err := quizStore.GetQuiz(r.Context(), quizID)
+		if err != nil {
+			if errors.Is(err, quiz.ErrQuizNotFound) || errors.Is(err, quiz.ErrQuestionNotFound) {
+				logger.InfoContext(r.Context(), "quiz not found for export", slog.Any("err", err))
+				http.NotFound(w, r)
+
+				return
+			}
+			logger.ErrorContext(r.Context(), "error loading quiz for export", slog.Any("err", err))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Same gate the quiz view's edit affordances use (#281/#538): the
+		// session player must be the quiz creator or an admin.
+		if !canEditQuiz(r, qz.CreatedByPlayerID) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+
+			return
+		}
+
+		var buf bytes.Buffer
+		if err = writeQuizArchive(r.Context(), &buf, quizStore, mediaSvc, quizID); err != nil {
+			logger.ErrorContext(r.Context(), "error building quiz archive", slog.Any("err", err))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+quizSlugFilename(qz)+"\"")
+		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+		if _, err = w.Write(buf.Bytes()); err != nil {
+			logger.ErrorContext(r.Context(), "error writing quiz archive response", slog.Any("err", err))
+		}
+	})
+}

--- a/internal/admin/quizexport_test.go
+++ b/internal/admin/quizexport_test.go
@@ -1,0 +1,615 @@
+package admin_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/admin"
+	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/media"
+	"github.com/starquake/topbanana/internal/quiz"
+	"github.com/starquake/topbanana/internal/store"
+)
+
+// exportManifest is the decoded shape of the archive's quiz.json. It restates
+// the manifest fields the export test reads back; the production types are
+// unexported, so the test decodes into its own mirror.
+type exportManifest struct {
+	FormatVersion    int              `json:"formatVersion"`
+	Title            string           `json:"title"`
+	Description      string           `json:"description"`
+	TimeLimitSeconds *int             `json:"timeLimitSeconds"`
+	Visibility       string           `json:"visibility"`
+	Mode             string           `json:"mode"`
+	Questions        []exportQuestion `json:"questions"`
+	Rounds           []exportRound    `json:"rounds"`
+}
+
+type exportRound struct {
+	Title                   string           `json:"title"`
+	Summary                 string           `json:"summary"`
+	BoundaryDurationSeconds *int             `json:"boundaryDurationSeconds"`
+	Questions               []exportQuestion `json:"questions"`
+}
+
+type exportQuestion struct {
+	Text             string          `json:"text"`
+	TimeLimitSeconds *int            `json:"timeLimitSeconds"`
+	Image            *exportImageRef `json:"image"`
+	Audio            *exportAudioRef `json:"audio"`
+	Options          []exportOption  `json:"options"`
+}
+
+type exportOption struct {
+	Text    string `json:"text"`
+	Correct bool   `json:"correct"`
+}
+
+type exportImageRef struct {
+	File string `json:"file"`
+	MIME string `json:"mime"`
+}
+
+type exportAudioRef struct {
+	File        string `json:"file"`
+	MIME        string `json:"mime"`
+	Description string `json:"description"`
+	DurationMs  *int   `json:"durationMs"`
+	Repeat      bool   `json:"repeat"`
+}
+
+// tinyPNG returns a small valid 4x4 PNG, a valid upload StoreImage can process.
+func tinyPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := range 4 {
+		for x := range 4 {
+			img.Set(x, y, color.RGBA{R: uint8(x * 40), G: uint8(y * 40), B: 200, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode err = %v, want nil", err)
+	}
+
+	return buf.Bytes()
+}
+
+// tinyMP3 returns a minimal payload that sniffs as MP3 via the ID3 magic, a
+// valid upload StoreAudio accepts. The trailing bytes give the row a size.
+func tinyMP3() []byte {
+	return append([]byte("ID3"), bytes.Repeat([]byte{0x00}, 32)...)
+}
+
+// newMediaServiceOverTemp builds a real media Service writing under a fresh
+// temp dir, sharing the env's DB so stored rows resolve through the same store
+// the quiz reads.
+func newMediaServiceOverTemp(t *testing.T, e *adminEnv) *media.Service {
+	t.Helper()
+
+	return media.NewService(
+		store.NewMediaStore(e.db, slog.New(slog.DiscardHandler)),
+		t.TempDir(),
+		10<<20,
+		20<<20,
+		slog.New(slog.DiscardHandler),
+	)
+}
+
+// attachMedia sets the question's image/audio ids (0 leaves a field unset) and
+// persists via the real update path, so the exported quiz tree reflects it.
+func attachMedia(t *testing.T, e *adminEnv, q *quiz.Question, imageID, audioID int64, repeat bool) {
+	t.Helper()
+
+	if imageID != 0 {
+		q.ImageMediaID = &imageID
+	}
+	if audioID != 0 {
+		q.AudioMediaID = &audioID
+		q.AudioRepeat = repeat
+	}
+	if err := e.quizzes.UpdateQuestion(t.Context(), q); err != nil {
+		t.Fatalf("UpdateQuestion err = %v, want nil", err)
+	}
+}
+
+// roundedQuiz returns an owned quiz authored with two rounds, so the export
+// exercises the rounds[] path. The first round's two questions hold the media
+// attachments; the second round has a plain question.
+func roundedQuiz() *quiz.Quiz {
+	qz := ownedQuiz("Capitals", "capitals")
+	qz.Description = "A tour of capitals."
+	qz.TimeLimitSeconds = 12
+	qz.Mode = quiz.ModeLive
+	qz.Rounds = []*quiz.Round{
+		{
+			Title:   "Warm-up",
+			Summary: "An easy start.",
+			Questions: []*quiz.Question{
+				{
+					Text:     "Capital of France?",
+					Position: 1,
+					Options: []*quiz.Option{
+						{Text: "Paris", Correct: true},
+						{Text: "Lyon", Correct: false},
+					},
+				},
+				{
+					Text:     "Capital of Spain?",
+					Position: 2,
+					Options: []*quiz.Option{
+						{Text: "Madrid", Correct: true},
+						{Text: "Seville", Correct: false},
+					},
+				},
+			},
+		},
+		{
+			Title:                   "Finish",
+			BoundaryDurationSeconds: ptr(15),
+			Questions: []*quiz.Question{
+				{
+					Text:     "Capital of Italy?",
+					Position: 3,
+					Options: []*quiz.Option{
+						{Text: "Rome", Correct: true},
+						{Text: "Milan", Correct: false},
+					},
+				},
+			},
+		},
+	}
+
+	return qz
+}
+
+func ptr(v int) *int { return &v }
+
+// readArchive unzips the export bytes into a name->bytes map and decodes the
+// manifest, failing the test on any structural problem.
+func readArchive(t *testing.T, raw []byte) (map[string][]byte, exportManifest) {
+	t.Helper()
+
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("zip.NewReader err = %v, want nil", err)
+	}
+	files := make(map[string][]byte, len(zr.File))
+	for _, f := range zr.File {
+		rc, openErr := f.Open()
+		if openErr != nil {
+			t.Fatalf("open %q err = %v, want nil", f.Name, openErr)
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			t.Fatalf("read %q err = %v, want nil", f.Name, readErr)
+		}
+		files[f.Name] = data
+	}
+
+	manifestBytes, ok := files["quiz.json"]
+	if !ok {
+		t.Fatal("archive missing quiz.json")
+	}
+	var manifest exportManifest
+	if err = json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatalf("decode quiz.json err = %v, want nil", err)
+	}
+
+	return files, manifest
+}
+
+// TestWriteQuizArchive pins the export: the manifest carries the quiz fields
+// and the rounds/questions/options, the image + audio refs resolve to bundled
+// media files, and a media id attached to two questions yields exactly one
+// archive file with both questions referencing it.
+func TestWriteQuizArchive(t *testing.T) {
+	t.Parallel()
+
+	env := newAdminEnv(t)
+	mediaSvc := newMediaServiceOverTemp(t, env)
+
+	qz := env.seedQuiz(t, roundedQuiz())
+
+	// Store one image + one audio clip in the quiz's library.
+	img, err := mediaSvc.StoreImage(t.Context(), qz.ID, testExportPlayerID, bytes.NewReader(tinyPNG(t)))
+	if err != nil {
+		t.Fatalf("StoreImage err = %v, want nil", err)
+	}
+	aud, err := mediaSvc.StoreAudio(
+		t.Context(), qz.ID, testExportPlayerID, 1234, "Theme", "theme.mp3", bytes.NewReader(tinyMP3()),
+	)
+	if err != nil {
+		t.Fatalf("StoreAudio err = %v, want nil", err)
+	}
+
+	// Attach the SAME image to both first-round questions (dedupe case) and the
+	// audio to the first question with repeat on.
+	r0 := qz.Rounds[0]
+	attachMedia(t, env, r0.Questions[0], img.ID, aud.ID, true)
+	attachMedia(t, env, r0.Questions[1], img.ID, 0, false)
+
+	var buf bytes.Buffer
+	if err = WriteQuizArchive(t.Context(), &buf, env.quizzes, mediaSvc, qz.ID); err != nil {
+		t.Fatalf("WriteQuizArchive err = %v, want nil", err)
+	}
+
+	files, manifest := readArchive(t, buf.Bytes())
+
+	assertManifestHeader(t, manifest)
+	assertRounds(t, manifest, img, aud)
+	assertMediaFiles(t, files, img, aud)
+	assertImageDedupe(t, files, manifest, img)
+}
+
+// flatQuizWithQuestions returns an owned quiz with two top-level questions and
+// no authored rounds, so the store drops them into its single auto-stamped
+// "Round 1" default round - the shape isFlatQuiz must recognise as flat.
+func flatQuizWithQuestions(title, slug string) *quiz.Quiz {
+	qz := ownedQuiz(title, slug)
+	qz.Questions = []*quiz.Question{
+		{
+			Text:     "Capital of France?",
+			Position: 1,
+			Options: []*quiz.Option{
+				{Text: "Paris", Correct: true},
+				{Text: "Lyon", Correct: false},
+			},
+		},
+		{
+			Text:     "Capital of Spain?",
+			Position: 2,
+			Options: []*quiz.Option{
+				{Text: "Madrid", Correct: true},
+				{Text: "Seville", Correct: false},
+			},
+		},
+	}
+
+	return qz
+}
+
+// TestFlatQuizDetection pins isFlatQuiz against the store's default-round
+// behaviour (the auto-stamped "Round 1"): a quiz that has never had a round
+// authored - whether it has zero questions or several - exports a flat
+// top-level questions[] with an empty rounds[]. A regression that wrongly
+// emitted rounds[] for such a quiz fails here. The defaultExportRoundTitle
+// constant's doc comment points at this test.
+func TestFlatQuizDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		quiz          *quiz.Quiz
+		wantQuestions int
+	}{
+		{
+			name:          "zero-question flat quiz",
+			quiz:          ownedQuiz("Empty", "empty-flat"),
+			wantQuestions: 0,
+		},
+		{
+			name:          "populated flat quiz",
+			quiz:          flatQuizWithQuestions("Capitals", "capitals-flat"),
+			wantQuestions: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newAdminEnv(t)
+			mediaSvc := newMediaServiceOverTemp(t, env)
+			qz := env.seedQuiz(t, tt.quiz)
+
+			var buf bytes.Buffer
+			if err := WriteQuizArchive(t.Context(), &buf, env.quizzes, mediaSvc, qz.ID); err != nil {
+				t.Fatalf("WriteQuizArchive err = %v, want nil", err)
+			}
+
+			_, manifest := readArchive(t, buf.Bytes())
+
+			// Flat quiz: rounds[] is empty and the questions live at the top level.
+			if got, want := len(manifest.Rounds), 0; got != want {
+				t.Errorf("len(Rounds) = %d, want %d (flat quiz emits no rounds[])", got, want)
+			}
+			if got, want := len(manifest.Questions), tt.wantQuestions; got != want {
+				t.Errorf("len(Questions) = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestArchiveExtForMedia pins the MIME-to-extension mapping for every branch,
+// including the fallback to the stored file's extension and the final .bin.
+func TestArchiveExtForMedia(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mime string
+		path string
+		want string
+	}{
+		{name: "jpeg", mime: "image/jpeg", path: "1/1.jpg", want: ".jpg"},
+		{name: "png", mime: "image/png", path: "1/1.png", want: ".png"},
+		{name: "webp", mime: "image/webp", path: "1/1.webp", want: ".webp"},
+		{name: "gif", mime: "image/gif", path: "1/1.gif", want: ".gif"},
+		{name: "mp3", mime: "audio/mpeg", path: "1/1.mp3", want: ".mp3"},
+		{name: "m4a", mime: "audio/mp4", path: "1/1.m4a", want: ".m4a"},
+		{name: "ogg", mime: "audio/ogg", path: "1/1.ogg", want: ".ogg"},
+		{name: "wav", mime: "audio/wav", path: "1/1.wav", want: ".wav"},
+		{name: "unknown mime uses path ext", mime: "application/octet-stream", path: "1/1.dat", want: ".dat"},
+		{name: "unknown mime no ext is bin", mime: "application/octet-stream", path: "1/1", want: ".bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := ArchiveExtForMedia(&media.Media{MIME: tt.mime, Path: tt.path}), tt.want; got != want {
+				t.Errorf("ArchiveExtForMedia(MIME=%q, Path=%q) = %q, want %q", tt.mime, tt.path, got, want)
+			}
+		})
+	}
+}
+
+// exportRequest builds a GET export request for the given quiz id with the
+// supplied player on its context, the way the route's auth middleware would.
+func exportRequest(t *testing.T, quizID int64, player *auth.Player) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodGet, "/admin/quizzes/"+strconv.FormatInt(quizID, 10)+"/export", nil,
+	)
+	req.SetPathValue("quizID", strconv.FormatInt(quizID, 10))
+
+	return req.WithContext(auth.WithPlayer(req.Context(), player))
+}
+
+// TestHandleQuizExport pins the handler: a missing quiz is a 404, a non-owner
+// non-admin is a 403, and the owner gets a 200 zip with the slug filename.
+func TestHandleQuizExport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner downloads zip", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		mediaSvc := newMediaServiceOverTemp(t, env)
+		qz := env.seedQuiz(t, ownedQuiz("Solo Quiz", "solo-quiz"))
+
+		rr := httptest.NewRecorder()
+		HandleQuizExport(env.logger, env.quizzes, mediaSvc).ServeHTTP(
+			rr, exportRequest(t, qz.ID, &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}),
+		)
+
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+		if got, want := rr.Header().Get("Content-Type"), "application/zip"; got != want {
+			t.Errorf("Content-Type = %q, want %q", got, want)
+		}
+		if got, want := rr.Header().Get("Content-Disposition"), `attachment; filename="solo-quiz.zip"`; got != want {
+			t.Errorf("Content-Disposition = %q, want %q", got, want)
+		}
+		// The body is a real zip carrying the manifest.
+		_, manifest := readArchive(t, rr.Body.Bytes())
+		if got, want := manifest.Title, "Solo Quiz"; got != want {
+			t.Errorf("manifest Title = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing quiz is 404", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		mediaSvc := newMediaServiceOverTemp(t, env)
+
+		rr := httptest.NewRecorder()
+		HandleQuizExport(env.logger, env.quizzes, mediaSvc).ServeHTTP(
+			rr, exportRequest(t, 9999, &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}),
+		)
+
+		if got, want := rr.Code, http.StatusNotFound; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("non-owner is 403", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		mediaSvc := newMediaServiceOverTemp(t, env)
+		qz := env.seedQuiz(t, ownedQuiz("Owned", "owned-quiz"))
+
+		rr := httptest.NewRecorder()
+		// A signed-in player who is neither the creator nor an admin.
+		HandleQuizExport(env.logger, env.quizzes, mediaSvc).ServeHTTP(
+			rr, exportRequest(t, qz.ID, &auth.Player{ID: nonOwnerID, Role: auth.RolePlayer}),
+		)
+
+		if got, want := rr.Code, http.StatusForbidden; got != want {
+			t.Fatalf("status = %d, want %d", got, want)
+		}
+	})
+}
+
+func assertManifestHeader(t *testing.T, manifest exportManifest) {
+	t.Helper()
+
+	if got, want := manifest.FormatVersion, ArchiveFormatVersion; got != want {
+		t.Errorf("FormatVersion = %d, want %d", got, want)
+	}
+	if got, want := manifest.Title, "Capitals"; got != want {
+		t.Errorf("Title = %q, want %q", got, want)
+	}
+	if got, want := manifest.Description, "A tour of capitals."; got != want {
+		t.Errorf("Description = %q, want %q", got, want)
+	}
+	if manifest.TimeLimitSeconds == nil {
+		t.Fatal("TimeLimitSeconds = nil, want 12")
+	}
+	if got, want := *manifest.TimeLimitSeconds, 12; got != want {
+		t.Errorf("TimeLimitSeconds = %d, want %d", got, want)
+	}
+	if got, want := manifest.Visibility, quiz.VisibilityPublic; got != want {
+		t.Errorf("Visibility = %q, want %q", got, want)
+	}
+	if got, want := manifest.Mode, quiz.ModeLive; got != want {
+		t.Errorf("Mode = %q, want %q", got, want)
+	}
+	// A multi-round quiz exports rounds[], not a flat questions[].
+	if len(manifest.Questions) != 0 {
+		t.Errorf("top-level Questions = %d entries, want 0 (rounds[] path)", len(manifest.Questions))
+	}
+	if got, want := len(manifest.Rounds), 2; got != want {
+		t.Fatalf("len(Rounds) = %d, want %d", got, want)
+	}
+}
+
+func assertRounds(t *testing.T, manifest exportManifest, img, aud *media.Media) {
+	t.Helper()
+
+	first := manifest.Rounds[0]
+	if got, want := first.Title, "Warm-up"; got != want {
+		t.Errorf("Rounds[0].Title = %q, want %q", got, want)
+	}
+	if got, want := first.Summary, "An easy start."; got != want {
+		t.Errorf("Rounds[0].Summary = %q, want %q", got, want)
+	}
+	if got, want := len(first.Questions), 2; got != want {
+		t.Fatalf("Rounds[0] questions = %d, want %d", got, want)
+	}
+
+	q0 := first.Questions[0]
+	if got, want := q0.Text, "Capital of France?"; got != want {
+		t.Errorf("Rounds[0].Questions[0].Text = %q, want %q", got, want)
+	}
+	if got, want := len(q0.Options), 2; got != want {
+		t.Fatalf("Rounds[0].Questions[0] options = %d, want %d", got, want)
+	}
+	if got, want := q0.Options[0].Text, "Paris"; got != want {
+		t.Errorf("option[0].Text = %q, want %q", got, want)
+	}
+	if !q0.Options[0].Correct {
+		t.Error("option[0].Correct = false, want true")
+	}
+
+	assertImageRef(t, q0.Image, img)
+	assertAudioRef(t, q0.Audio, aud)
+
+	second := manifest.Rounds[1]
+	if got, want := second.Title, "Finish"; got != want {
+		t.Errorf("Rounds[1].Title = %q, want %q", got, want)
+	}
+	if second.BoundaryDurationSeconds == nil {
+		t.Fatal("Rounds[1].BoundaryDurationSeconds = nil, want 15")
+	}
+	if got, want := *second.BoundaryDurationSeconds, 15; got != want {
+		t.Errorf("Rounds[1].BoundaryDurationSeconds = %d, want %d", got, want)
+	}
+}
+
+func assertImageRef(t *testing.T, ref *exportImageRef, img *media.Media) {
+	t.Helper()
+
+	if ref == nil {
+		t.Fatal("question image ref = nil, want set")
+	}
+	if got, want := ref.MIME, img.MIME; got != want {
+		t.Errorf("image ref MIME = %q, want %q", got, want)
+	}
+	if got, want := ref.File, "media/"+strconv.FormatInt(img.ID, 10)+".jpg"; got != want {
+		t.Errorf("image ref File = %q, want %q", got, want)
+	}
+}
+
+func assertAudioRef(t *testing.T, ref *exportAudioRef, aud *media.Media) {
+	t.Helper()
+
+	if ref == nil {
+		t.Fatal("question audio ref = nil, want set")
+	}
+	if got, want := ref.MIME, aud.MIME; got != want {
+		t.Errorf("audio ref MIME = %q, want %q", got, want)
+	}
+	if got, want := ref.File, "media/"+strconv.FormatInt(aud.ID, 10)+".mp3"; got != want {
+		t.Errorf("audio ref File = %q, want %q", got, want)
+	}
+	if got, want := ref.Description, "Theme"; got != want {
+		t.Errorf("audio ref Description = %q, want %q", got, want)
+	}
+	if ref.DurationMs == nil {
+		t.Fatal("audio ref DurationMs = nil, want 1234")
+	}
+	if got, want := *ref.DurationMs, 1234; got != want {
+		t.Errorf("audio ref DurationMs = %d, want %d", got, want)
+	}
+	if !ref.Repeat {
+		t.Error("audio ref Repeat = false, want true")
+	}
+}
+
+func assertMediaFiles(t *testing.T, files map[string][]byte, img, aud *media.Media) {
+	t.Helper()
+
+	imagePath := "media/" + strconv.FormatInt(img.ID, 10) + ".jpg"
+	if got, ok := files[imagePath]; !ok || len(got) == 0 {
+		t.Errorf("archive missing non-empty %q (ok=%t, len=%d)", imagePath, ok, len(got))
+	}
+	audioPath := "media/" + strconv.FormatInt(aud.ID, 10) + ".mp3"
+	if got, ok := files[audioPath]; !ok || len(got) == 0 {
+		t.Errorf("archive missing non-empty %q (ok=%t, len=%d)", audioPath, ok, len(got))
+	}
+}
+
+func assertImageDedupe(t *testing.T, files map[string][]byte, manifest exportManifest, img *media.Media) {
+	t.Helper()
+
+	imagePath := "media/" + strconv.FormatInt(img.ID, 10) + ".jpg"
+
+	// The shared image is present once (a map key is unique), and only two
+	// media files total exist - the image and the audio - so the image
+	// referenced by both first-round questions was not duplicated.
+	if _, ok := files[imagePath]; !ok {
+		t.Errorf("archive missing shared image %q", imagePath)
+	}
+	mediaFiles := 0
+	for name := range files {
+		if strings.HasPrefix(name, "media/") {
+			mediaFiles++
+		}
+	}
+	if got, want := mediaFiles, 2; got != want {
+		t.Errorf("media files in archive = %d, want %d (one image + one audio, deduped)", got, want)
+	}
+
+	// Both first-round questions reference that same file.
+	refs := 0
+	for _, q := range manifest.Rounds[0].Questions {
+		if q.Image != nil && q.Image.File == imagePath {
+			refs++
+		}
+	}
+	if got, want := refs, 2; got != want {
+		t.Errorf("questions referencing %q = %d, want %d", imagePath, got, want)
+	}
+}
+
+// testExportPlayerID is the uploading player for the export fixtures; the
+// seeded admin (id 1) owns the quiz, so attribute uploads to it.
+const testExportPlayerID int64 = 1

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -588,6 +588,18 @@ func addMediaRoutes(
 	requireGameHost := func(h http.Handler) http.Handler {
 		return auth.RequireGameHost(auth.RequireVerifiedEmail(h), stores.Players, sessions, csrfMgr, logger)
 	}
+
+	// Per-quiz archive export (#1113): a read-only GET that streams the quiz
+	// tree plus its referenced media as a .zip. Gated like the other read-only
+	// admin quiz routes (requireGameHost; a download needs no CSRF); the handler
+	// adds the per-quiz creator-or-admin gate. It depends on the media service
+	// (Get + Open) via the narrow admin.MediaArchiver interface, which *svc
+	// satisfies.
+	mux.Handle(
+		"GET /admin/quizzes/{quizID}/export",
+		requireGameHost(admin.HandleQuizExport(logger, stores.Quizzes, svc)),
+	)
+
 	uploadBudget := mediahttp.NewUploadBudgetLimiter(cfg.MediaUploadBudget, cfg.MediaUploadBudgetWindow)
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/media",

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -104,6 +104,15 @@
                     <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
                     <span>Edit quiz</span>
                 </a>
+                {{/* Export bundles the quiz tree plus its referenced media into
+                     a downloadable .zip (#1113). Plain GET link, same gate as
+                     Edit. */}}
+                <a href="/admin/quizzes/{{.Quiz.ID}}/export"
+                   data-testid="export-quiz"
+                   class="btn-ghost gap-2">
+                    <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/><path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/></svg>
+                    <span>Export</span>
+                </a>
                 <button type="button"
                         onclick="openModal('modal-delete-quiz-{{.Quiz.ID}}')"
                         class="inline-flex items-center justify-center gap-2 min-h-[44px] px-4 rounded-sm bg-transparent text-danger border border-danger/40 font-semibold text-xs uppercase tracking-[0.12em] transition-colors hover:bg-danger/10 hover:border-danger focus-visible:outline-none focus-visible:shadow-focus cursor-pointer">


### PR DESCRIPTION
Opened by Claude Code. First of two slices for #1113 (import/export quizzes including images and sounds): this slice adds **export**; the next adds **import**. No `Closes` here — the import slice closes the ticket.

## What this does

A per-quiz export that bundles the quiz tree plus its referenced images and sounds into one downloadable `.zip`.

- `GET /admin/quizzes/{quizID}/export` — read-only, `requireGameHost` + the same creator-or-admin gate the quiz view uses. Streams `application/zip` with `Content-Disposition: attachment; filename="<slug>.zip"`.
- An **Export** link on the quiz detail page (editor-gated, `data-testid="export-quiz"`).
- Archive layout: `quiz.json` (a versioned manifest) plus `media/<id>.<ext>` — one file per unique referenced media (full image, audio as-is; the thumbnail is regenerated on import). Media is de-duplicated by id, so an image reused across questions is stored once and referenced N times.

## Portable format

`quiz.json` is a superset of the existing paste-import payload plus `formatVersion`, `visibility`/`mode`, and per-question `image`/`audio` references pointing at the archive files:

```jsonc
{
  "formatVersion": 1,
  "title": "...", "description": "...", "timeLimitSeconds": 10,
  "visibility": "public", "mode": "solo",
  "rounds": [ { "title": "...", "summary": "...", "boundaryDurationSeconds": 15,
    "questions": [ {
      "text": "...", "timeLimitSeconds": 20,
      "image": { "file": "media/12.jpg", "mime": "image/jpeg" },
      "audio": { "file": "media/13.mp3", "mime": "audio/mpeg", "description": "...", "durationMs": 1234, "repeat": true },
      "options": [ { "text": "...", "correct": true } ]
    } ] } ]
}
```

A quiz with authored rounds exports `rounds[]`; a flat quiz exports a top-level `questions[]`, mirroring the importer. The import slice consumes this same shape.

## Plan (agreed)

- Portable `.zip` (manifest + media); admin web UI (download here, upload on import) — the only fit for staging to production, since production runs distroless with no shell.
- Single quiz per archive. On import, visibility is picked on the form (default = the manifest value).
- Delivered as two slices: this PR (export), then import with media (will `Closes #1113`).

## Tests

- `internal/admin/quizexport_test.go` (integration, real DB + temp media dir): seeds a quiz with an image and an audio question, exports, and asserts the manifest fields, the image/audio refs (description/duration/repeat), non-empty media bytes, and the dedupe invariant. `TestFlatQuizDetection` pins the flat-vs-rounds shape; `TestArchiveExtForMedia` covers the MIME-to-extension map.
- `make check` green (coverage 83.2%), `make smoke` ok. Self-reviewed with `/code-review` (high), `/go-style-review`, `/frontend-style-review` — no critical or correctness findings; minor test/coverage hardening applied.
- `make test-e2e` not run yet — deferred to the import slice so the e2e can exercise the full export to import round trip in one spec.

## For you

- The Export link is on the quiz **detail** page only. Want it on the quiz **list** page too, or detail-only?
- Left as a draft. Say the word and I'll mark it ready for review, then start the import slice.

_— Claude Code, for @starquake_
