### PR TITLE
Ignore the runtime media upload directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ go.work.sum
 .env.*
 !.env.example
 
+# Uploaded media (default MEDIA_DIR; see internal/config). Runtime uploads,
+# never tracked.
+media/
+
 # Editor/IDE
 # .idea/
 # .vscode/


### PR DESCRIPTION
Opened by Claude Code. Adds `media/` (the default `MEDIA_DIR`) to `.gitignore` so runtime image/sound uploads written by the dev server are never tracked. No code change.

No associated ticket.

_— Claude Code, for @starquake_