### PR TITLE
Suppress the Server response header

### DIFF
--- a/internal/server/securityheaders.go
+++ b/internal/server/securityheaders.go
@@ -43,6 +43,11 @@ func securityHeaders(cfg *config.Config) func(http.Handler) http.Handler {
 			h.Set("X-Content-Type-Options", "nosniff")
 			h.Set("Referrer-Policy", "no-referrer")
 			h.Set("X-Frame-Options", "DENY")
+			// Suppress the Server header to drop a little stack fingerprinting.
+			// A nil map entry is the net/http-documented way to suppress a
+			// response header: nothing is emitted for the key, and any value an
+			// earlier layer set is cleared.
+			h["Server"] = nil
 			if cfg.SecureCookies() {
 				h.Set("Strict-Transport-Security", strictTransportSecurity)
 			}

--- a/internal/server/securityheaders_test.go
+++ b/internal/server/securityheaders_test.go
@@ -59,6 +59,30 @@ func TestSecurityHeaders_SetsAllHeaders(t *testing.T) {
 			t.Errorf("header %q = %q, want %q", k, got, want)
 		}
 	}
+	if got, want := rec.Header().Get("Server"), ""; got != want {
+		t.Errorf("Server header = %q, want %q (absent)", got, want)
+	}
+}
+
+// TestSecurityHeaders_SuppressesServer pins that the middleware suppresses the
+// Server response header (a little stack-fingerprinting hardening). A Server
+// value is seeded before the middleware runs so the test fails if the
+// middleware stops clearing it, not just if net/http happens not to add one.
+func TestSecurityHeaders_SuppressesServer(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{AppEnvironment: config.AppEnvironmentProduction}
+	handler := securityHeaders(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Server", "topbanana")
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+
+	if got, want := rec.Header().Get("Server"), ""; got != want {
+		t.Errorf("Server header = %q, want %q (absent)", got, want)
+	}
 }
 
 // TestSecurityHeaders_HSTSGatedOnSecureCookies pins that HSTS is only set when

--- a/test/integration/security_headers_test.go
+++ b/test/integration/security_headers_test.go
@@ -38,6 +38,9 @@ func assertCommonSecurityHeaders(t *testing.T, resp *http.Response) {
 			t.Errorf("header %q = %q, want %q", k, got, v)
 		}
 	}
+	if got, want := resp.Header.Get("Server"), ""; got != want {
+		t.Errorf("Server header = %q, want %q (absent)", got, want)
+	}
 }
 
 // assertHSTSPresent checks that Strict-Transport-Security is set (used in


### PR DESCRIPTION
I (Claude Code) opened this draft PR for #1123.

## What

The security-header middleware (`internal/server/securityheaders.go`) sets CSP, nosniff, X-Frame-Options, Referrer-Policy and HSTS but left the `Server` response header untouched. This suppresses it to drop a little stack fingerprinting (minor hardening, not a vulnerability).

## Plan / changes

- `internal/server/securityheaders.go`: clear the `Server` header in the same middleware via `w.Header()["Server"] = nil` (the net/http-documented way to suppress a response header: nothing is emitted for the key, and any value an earlier layer set is cleared).
- `internal/server/securityheaders_test.go`: assert `Server` is absent on a normal response in the existing test, plus a dedicated `TestSecurityHeaders_SuppressesServer` that seeds a `Server` value before the middleware runs and asserts it is cleared (so the test fails if the suppression is removed, not just because net/http happens not to add one).
- `test/integration/security_headers_test.go`: assert `Server` is absent on the live wire across every surface (`assertCommonSecurityHeaders`).

## Verification

Empirically confirmed that Go's net/http does not auto-add a `Server` header by default, so this is defense in depth plus clearing any value a fronting layer might set. Temporarily removing the suppression line makes `TestSecurityHeaders_SuppressesServer` fail (`Server header = "topbanana", want "" (absent)`), confirming the test is a real regression guard. The integration test exercises the live wire through a real `http.Server`.

`make check` passes (lint + sql-lint + build + all Go tests, including the integration suite; smoke startup ok).

Out of scope (per ticket): the CSP `unsafe-inline` / `unsafe-eval` follow-up acknowledged at securityheaders.go:9-15.

Closes #1123

_— Claude Code, for @starquake_
