### PR TITLE
Guard populateInGame against a nil quiz

### DIFF
--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -1074,6 +1074,12 @@ func (s *Service) populateInGame(ctx context.Context, state *SessionState) error
 	if sess.Phase != PhaseQuestion && sess.Phase != PhaseReveal {
 		return nil
 	}
+	// A quiz-less room never reaches the question phase normally; guard the
+	// deref so an unusual quiz-less in-game state (e.g. a re-arm race) degrades
+	// to no live question rather than panicking, matching the sibling populators.
+	if state.Quiz == nil {
+		return nil
+	}
 
 	for _, q := range state.Quiz.Questions {
 		if q.ID == *sess.CurrentQuestionID {

--- a/internal/livesession/livesession_test.go
+++ b/internal/livesession/livesession_test.go
@@ -633,3 +633,52 @@ func TestService_SubmitAnswer_RespectsWindowBounds(t *testing.T) {
 		t.Errorf("SubmitAnswer after ExpiresAt err = %v, want %v", got, want)
 	}
 }
+
+// TestService_GetSessionState_QuestionPhaseWithoutQuiz pins the nil-quiz guard
+// in populateInGame (#1122): a quiz-less room that somehow sits in the question
+// phase (an unusual re-arm-race state) must read cleanly rather than
+// dereference a nil quiz. The room is driven there directly via the store so
+// quiz_id stays NULL while current_question_id points at a real question - a
+// state the normal service flow never produces, so the store builds it.
+func TestService_GetSessionState_QuestionPhaseWithoutQuiz(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newEmptyRoomHarness(t, start)
+	ctx := t.Context()
+
+	// A real question must exist so the session's current_question_id FK
+	// resolves while its quiz_id stays NULL (the re-arm race).
+	qz := seedRunnerQuizSlug(t, h.quizStore, "nil-quiz-guard", [][]bool{{true}})
+	full, err := h.quizStore.GetQuiz(ctx, qz.ID)
+	if err != nil {
+		t.Fatalf("GetQuiz err = %v, want nil", err)
+	}
+	q := full.Questions[0]
+
+	const hostID int64 = 1 // seeded admin
+	sess, err := h.service.CreateSession(ctx, nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession (empty) err = %v, want nil", err)
+	}
+
+	// Drive the quiz-less room straight into the question phase: quiz_id stays
+	// NULL, current_question_id points at the seeded question.
+	if err = h.store.EnterQuestion(ctx, sess.ID, q.RoundID, q.ID, start, start.Add(10*time.Second)); err != nil {
+		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	}
+
+	state, err := h.service.GetSessionState(ctx, sess.JoinCode, hostID)
+	if err != nil {
+		t.Fatalf("GetSessionState (quiz-less question phase) err = %v, want nil", err)
+	}
+	if got, want := state.Session.Phase, PhaseQuestion; got != want {
+		t.Errorf("Phase = %q, want %q", got, want)
+	}
+	if state.Quiz != nil {
+		t.Errorf("Quiz = %v, want nil (quiz-less room)", state.Quiz)
+	}
+	if state.CurrentQuestion != nil {
+		t.Errorf("CurrentQuestion = %v, want nil (no quiz to resolve the question)", state.CurrentQuestion)
+	}
+}


### PR DESCRIPTION
I (Claude Code) opened this draft PR.

Closes #1122

## Problem

`populateInGame` in `internal/livesession/livesession.go` dereferenced `state.Quiz.Questions` without checking the quiz was set, while its two sibling populators (`finishedStandings`, `populateRoundIntro`) already guard the nil-quiz case. Reaching this needs an unusual state -- a quiz-less room somehow in the question/reveal phase (e.g. a re-arm race) -- but the inconsistency was real and the fix is cheap.

## Change

- Add an early return in `populateInGame` when `state.Quiz == nil`, after the existing `CurrentQuestionID`/phase guards, so a quiz-less in-game state degrades to no live question rather than panicking. Normal paths (a quiz is set) are unaffected; `state.Quiz == nil` mirrors `sess.QuizID == nil` exactly via `lobbyQuiz`.
- Add a `livesession` layer test (`internal/livesession/livesession_test.go`, dbtest-backed, skips under -short). It seeds a real question, opens a quiz-less empty room, then drives that room into the question phase via the store (`EnterQuestion`) so `quiz_id` stays NULL while `current_question_id` points at the real question -- the exact re-arm-race state the normal service flow never produces. It then asserts `GetSessionState` returns cleanly (nil quiz, nil current question, no panic). I confirmed the test panics with the guard removed and passes with it.

## Verification

`make check` passes (no test failures; total coverage 83.1%, above the 80 floor).

_— Claude Code, for @starquake_