### PR TITLE
Remove stale TODO comments and enable godox TODO keyword

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,7 +154,7 @@ linters:
       allow-unused: true
     godox:
       keywords:
-#        - TODO     # will be enabled in the future
+        - TODO
         - BUG
         - FIXME
   exclusions:

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -176,9 +176,8 @@ type Question struct {
 	QuestionID   int64
 	QuizQuestion *quiz.Question
 	StartedAt    time.Time
-	// TODO: change this to time duration like 10s instead of timestamp?
-	ExpiredAt time.Time
-	Answers   []*Answer
+	ExpiredAt    time.Time
+	Answers      []*Answer
 	// Position is the 1-indexed ordinal of this question in the
 	// game's issued sequence ("Q 3 of 4"). Populated by
 	// [Service.GetNextQuestion]; zero on Questions loaded from the

--- a/internal/game/scoring.go
+++ b/internal/game/scoring.go
@@ -13,7 +13,6 @@ const maxPoints = 1000
 
 // CalculateScore calculates the score for a given answer.
 func (s *Service) CalculateScore(ctx context.Context, a *Answer) int {
-	// TODO: Should this be the points for answering immediately? Or within one second?
 	return scoreAnswerCurve(ctx, s.logger, a.Option.Correct, a.Question.StartedAt, a.Question.ExpiredAt, a.AnsweredAt)
 }
 


### PR DESCRIPTION
Opened by Claude Code.

Closes #1114

## What changed

- Removed two stale speculative-design TODO comment lines (behaviour unchanged):
  - `internal/game/game.go` — `// TODO: change this to time duration like 10s instead of timestamp?` (in the `Question` struct; the field block was re-aligned so it stays gofmt-clean).
  - `internal/game/scoring.go` — `// TODO: Should this be the points for answering immediately? Or within one second?` (in `CalculateScore`).
- `.golangci.yml`: enabled the `godox` linter `TODO` keyword (uncommented it; `BUG`/`FIXME` were already on).

## Other TODOs found

Before enabling, a repo-wide `rg -n 'TODO' --type go` sweep (godox scans all Go incl. `_test.go`) found ONLY those two TODOs, matching the prior sweep. Nothing else to resolve.

## Verification

No new Go test is needed for this change. The proof is `make check` passing with godox-TODO enabled: `golangci-lint run` reports `0 issues.` and the full suite is green (exit 0).

_— Claude Code, for @starquake_