### PR TITLE
Fix flaky quiz Save redirect in e2e create helper

### DIFF
--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import type { APIRequestContext } from '@playwright/test';
+import type { APIRequestContext, Response } from '@playwright/test';
 
 import type { Locator, Page } from './fixtures';
 import { test, expect } from './fixtures';
@@ -249,22 +249,69 @@ export async function seedQuiz(
   });
 }
 
-export async function createQuizWithQuestions(
-  page: Page,
-  title: string,
-  questions: readonly QuestionSpec[] = QUIZ_QUESTIONS,
-): Promise<void> {
-  // Create the quiz; the save handler redirects to the quiz view at
-  // /admin/quizzes/{id}, where each question is added in turn.
+// submitNewQuizForm fills and submits the create-quiz form, binding the wait to
+// the Save POST so it can never race the navigation, and returns that response.
+// The create handler 303-redirects to /admin/quizzes/{id} on success; a non-303
+// re-renders the form in place at /admin/quizzes (a 400 field error, a 409 slug
+// collision, ...), which clicking-then-asserting-the-URL would otherwise surface
+// only as an opaque toHaveURL timeout on the bare list URL (#1090).
+async function submitNewQuizForm(page: Page, title: string): Promise<Response> {
   await page.goto('/admin/quizzes/new');
   await page.locator('input[name=title]').fill(title);
   // The description is rendered as a <textarea> on the redesigned form,
   // not an <input>. The :is() selector keeps the helper resilient to either.
   await page.locator(':is(input, textarea)[name=description]').fill('E2E generated quiz');
-  await page.getByRole('button', { name: 'Save' }).click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
+  const [saveResp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.request().method() === 'POST' && new URL(r.url()).pathname === '/admin/quizzes',
+    ),
+    page.getByRole('button', { name: 'Save' }).click(),
+  ]);
+  return saveResp;
+}
 
-  for (const [index, q] of questions.entries()) {
+// deleteQuizByTitle removes a quiz the admin owns by exact title, no-op if none
+// exists. The admin delete route cascades through the quiz's questions, media,
+// games, and sessions, so it leaves no leftovers for the next create.
+async function deleteQuizByTitle(page: Page, title: string): Promise<void> {
+  await page.goto('/admin/quizzes');
+  const link = page.getByRole('link', { name: title, exact: true });
+  if ((await link.count()) === 0) return;
+  const href = await link.first().getAttribute('href');
+  const quizID = /\/admin\/quizzes\/(\d+)/.exec(href ?? '')?.[1];
+  if (!quizID) throw new Error(`deleteQuizByTitle(${title}): no quiz id in href ${href}`);
+  const csrfToken = await page.locator('input[name="csrf_token"]').first().inputValue();
+  const resp = await page.request.post(`/admin/quizzes/${quizID}/delete`, { form: { csrf_token: csrfToken } });
+  if (!resp.ok()) {
+    throw new Error(`deleteQuizByTitle(${title}): delete ${quizID} -> ${resp.status()} ${await resp.text()}`);
+  }
+}
+
+export async function createQuizWithQuestions(
+  page: Page,
+  title: string,
+  questions: readonly QuestionSpec[] = QUIZ_QUESTIONS,
+): Promise<void> {
+  // Create the quiz, then add each question in turn on the quiz view. A worker
+  // keeps one SQLite DB for its whole life, and the quiz slug is derived from
+  // the title (the sole UNIQUE column), so re-creating the same title in a
+  // worker - under --repeat-each, or on a Playwright retry that re-runs this
+  // helper - hits a 409 slug collision. On that collision, delete the leftover
+  // quiz and re-create so every attempt starts from a pristine quiz rather than
+  // dead-ending on the create redirect or inheriting a prior run's state (#1090).
+  let saveResp = await submitNewQuizForm(page, title);
+  if (saveResp.status() === 409) {
+    await deleteQuizByTitle(page, title);
+    saveResp = await submitNewQuizForm(page, title);
+  }
+  if (saveResp.status() !== 303) {
+    throw new Error(
+      `quiz Save (POST /admin/quizzes) returned ${saveResp.status()}, expected a 303 redirect; body=${await saveResp.text()}`,
+    );
+  }
+  await page.waitForURL(/\/admin\/quizzes\/\d+$/);
+
+  for (const q of questions) {
     // Each round carries its own "Add question" button now (#929); the
     // imported quiz has a single default round, so the first match is it.
     // The link targets the round-scoped create form, so the URL carries a
@@ -272,12 +319,9 @@ export async function createQuizWithQuestions(
     await page.getByRole('link', { name: /add question/i }).first().click();
     await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/new\?round_id=\d+$/);
 
-    // Question text became a <textarea> in the redesign.
+    // Question text became a <textarea> in the redesign. Position is
+    // auto-assigned by the server now (#16) - no input field on the form.
     await page.locator(':is(input, textarea)[name=text]').fill(q.text);
-    // Position is auto-assigned by the server now (#16) — no input field
-    // on the question form. The index variable is kept on the for-of
-    // signature so future helpers can use it without re-binding.
-    void index;
     for (let i = 0; i < q.options.length; i++) {
       await page.locator(`input[name="option[${i}].text"]`).fill(q.options[i]);
       if (q.correctIndices.includes(i)) {

--- a/test/e2e/tests/quiz-create-idempotent.spec.ts
+++ b/test/e2e/tests/quiz-create-idempotent.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures';
+import { adminStatePath } from '../e2e-auth';
+import { createQuizWithQuestions, QUIZ_QUESTIONS } from './helpers';
+
+test.use({ storageState: adminStatePath() });
+
+// Pins the #1090 contract for the shared createQuizWithQuestions helper. A
+// Playwright worker keeps one SQLite DB for its whole life, and the quiz slug is
+// derived from the title (the sole UNIQUE column on quizzes). So creating the
+// same title twice in a worker - under --repeat-each, or on a retry that re-runs
+// the setup helper - hits a 409 slug collision that re-renders the create form
+// in place at /admin/quizzes. The helper must recover (delete the leftover and
+// re-create) instead of timing out on the create redirect, and the resulting
+// quiz must carry each question exactly once - no duplicates, no state inherited
+// from the previous attempt.
+test('re-creating a quiz with an existing title yields a clean quiz, not a slug-collision timeout', async ({
+  page,
+  browserName,
+}) => {
+  const title = `E2E Idempotent Quiz ${browserName}`;
+
+  await createQuizWithQuestions(page, title, QUIZ_QUESTIONS);
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
+
+  // Second create with the same title: the slug collision is recovered instead
+  // of dead-ending at the create redirect.
+  await createQuizWithQuestions(page, title, QUIZ_QUESTIONS);
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
+
+  await expect(page.locator('.q-text')).toHaveCount(QUIZ_QUESTIONS.length);
+  for (const q of QUIZ_QUESTIONS) {
+    await expect(page.locator('.q-text', { hasText: q.text })).toHaveCount(1);
+  }
+});


### PR DESCRIPTION
I (Claude Code) opened this draft.

Closes #1090

## Root cause (confirmed, reproduced deterministically)

The page lands on the bare list `/admin/quizzes` only when the create `POST /admin/quizzes` returns a **non-303 re-render in place** — not a slow redirect. A successful create 303-redirects to `/admin/quizzes/{id}`; an in-flight/slow nav would still read `/admin/quizzes/new`. So the list URL means the POST committed a non-redirect response.

`slug` is the only `UNIQUE` column on `quizzes`, and the slug is derived from the title (`slug.Make(title)`). Each Playwright worker keeps **one persistent SQLite DB for its whole lifetime** (no per-test reset). So creating a quiz with the same title twice in one worker — under `--repeat-each`, or on a **Playwright retry** that re-runs `createQuizWithQuestions` with the same fixed title — hits the slug collision; the handler returns **409** and re-renders the form at `/admin/quizzes`. `expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/)` then times out reporting `Received: .../admin/quizzes`.

Most callers pass a fixed title (`E2E Spoiler Quiz ${browserName}`, etc.). The audio spec was already hardened with a `uniqueTitle` (its comment cites the `quizzes.title` uniqueness constraint), which is why the audio spec alone passes under `--repeat-each`. The shared helper stayed fragile for every fixed-title caller and for retries — and the retry case is the real CI manifestation: a spec fails for its own reason, the retry collides on the slug, and the failure is reported at `helpers.ts` `toHaveURL` instead of the spec's own assertion.

Reproduced deterministically: two `createQuizWithQuestions` calls with the same fixed title in one worker -> `toHaveURL(...) failed / Received string: ".../admin/quizzes"` at the helper, at the **default 5s** timeout — so it is not slow navigation, and bumping the timeout never helps.

## Fix

`test/e2e/tests/helpers.ts` — `createQuizWithQuestions`:

- Bind the Save click to its `POST /admin/quizzes` response (`Promise.all([waitForResponse, click])`) so the wait can never race the navigation, then `waitForURL(/\/admin\/quizzes\/\d+$/)`.
- On a **409** slug collision (a quiz with this title already exists from a prior repeat/retry), **delete the leftover quiz and re-create**, so every attempt starts from a pristine quiz. Reusing the existing quiz was rejected because stateful callers (the media-upload specs) would then accumulate uploads across attempts; the admin delete route cascades through questions, media, games, and sessions, so re-create leaves no residue.
- On any other non-303, throw with the status + body so a genuine validation/server failure is self-diagnosing instead of an opaque URL timeout.

Keeps the title stable (callers look quizzes up by title) and the helper signature unchanged. Adds `quiz-create-idempotent.spec.ts` pinning the contract: re-creating a quiz with an existing title yields a clean quiz with each question exactly once, not a slug-collision timeout.

## Validation

- `quiz-create-idempotent.spec.ts`: passes on chromium + firefox under `--repeat-each=3`.
- `quiz-audio-upload` (fixed-title, stateful uploads) under `--repeat-each=4`: 17 passed (it had 9 failures with a reuse-only approach — the reason delete-and-recreate was chosen).
- Full `make test-e2e`: 273 passed, 4 skipped (pre-existing), 0 failed.
- `make check`: green (coverage 83.1%).

_— Claude Code, for @starquake_
