### PR TITLE
Track main on the demo deployment via the edge image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -383,12 +383,15 @@ jobs:
     permissions:
       contents: read
       packages: read
-    # Gated so a missing demo host does not red the release pipeline.
-    # Only fires when DEMO_DEPLOY_ENABLED is set and either a v* release
-    # tag triggered this workflow or a manual dispatch targets 'demo'.
+    # Gated so a missing demo host does not red the main or release
+    # pipeline. Fires when DEMO_DEPLOY_ENABLED is set and CI succeeded on
+    # main (the demo tracks main via the edge image, like staging) or on a
+    # v* release tag (deploy that version), or on a manual dispatch to
+    # 'demo' (deploy edge).
     if: >-
       vars.DEMO_DEPLOY_ENABLED == 'true' &&
-      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) ||
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+        (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v'))) ||
        (github.event_name == 'workflow_dispatch' && inputs.environment == 'demo'))
     environment:
       name: demo
@@ -400,13 +403,19 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # A v* release tag deploys that version (retagged by promote from the
+      # tested main image). Main CI success or a manual dispatch deploys the
+      # current main build (edge), so the demo tracks main without a release.
+      # edge is signed on main, so the cosign identity check below still holds.
       - name: Determine image tag
         id: tag
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          IMAGE_TAG="${{ github.event.workflow_run.head_branch || github.ref_name }}"
-          IMAGE_TAG="${IMAGE_TAG#v}"
-          if [[ ! "$IMAGE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            IMAGE_TAG="latest"
+          if [[ "$HEAD_BRANCH" == v* ]]; then
+            IMAGE_TAG="${HEAD_BRANCH#v}"
+          else
+            IMAGE_TAG="edge"
           fi
           echo "tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
I opened this draft PR. It makes the **demo deployment track `main`** so you can iterate on it without cutting a release, while keeping the `v*` release deploy.

## What changed
`deploy-demo` (in `deploy.yml`) now fires on three triggers, all still gated on `vars.DEMO_DEPLOY_ENABLED`:
- **CI success on `main`** -> deploys the **`edge`** image (latest main), the same way the staging box tracks main.
- **A `v*` release tag** -> deploys that version (unchanged).
- **Manual dispatch** (Actions -> Deploy -> `demo`) -> deploys `edge`.

The image-tag step resolves a `v*` head branch to the version and everything else (main runs, manual dispatch) to `edge`. `edge` is built, pushed, and cosign-signed on `main`, so the existing signature check (`ci.yml@refs/heads/main`) still passes - no `ci.yml` or cosign changes, and the digest pinning is unchanged.

## Why edge/main
Feature branches never publish an image (PR builds don't push; only `main` publishes `edge` + `sha-<sha>`), and their images wouldn't match the main-scoped cosign identity. `edge` = latest `main` is the only branch build that is both present and signed, and `main` already carries demo mode.

## Validation
YAML parses; the tag-step script is shellcheck-clean; `deploy-production` is untouched (it keeps deploying releases / `latest`). A true end-to-end run needs the provisioned demo box + the `demo` environment/secrets + `DEMO_DEPLOY_ENABLED=true`, so it can't be exercised in CI here - the first real merge or dispatch validates it.

## Prereqs to see it run
Provision the demo host, create the `demo` GitHub environment + secrets (`SSH_*`, a demo `SESSION_KEY`, `HEALTH_URL`), and set `DEMO_DEPLOY_ENABLED=true`. After that, every merge to `main` redeploys the demo box, and `v*` tags deploy the release.

_— Claude Code, for @starquake_
