### PR TITLE
Read deployment URLs from vars.SERVER_URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
     environment:
       name: staging
-      url: "${{ env.SERVER_URL }}"
+      url: "${{ vars.SERVER_URL }}"
 
     steps:
       - name: Checkout repository
@@ -203,7 +203,7 @@ jobs:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     environment:
       name: production
-      url: "${{ env.SERVER_URL }}"
+      url: "${{ vars.SERVER_URL }}"
 
     steps:
       - name: Checkout repository
@@ -395,7 +395,7 @@ jobs:
        (github.event_name == 'workflow_dispatch' && inputs.environment == 'demo'))
     environment:
       name: demo
-      url: "${{ env.SERVER_URL }}"
+      url: "${{ vars.SERVER_URL }}"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Reads the staging, production, and demo deployment `url:` from `vars.SERVER_URL` instead of the empty `env.SERVER_URL`, so the "View deployment" links render.
