### PR TITLE
Read the demo deployment URL from vars.SERVER_URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -395,7 +395,7 @@ jobs:
        (github.event_name == 'workflow_dispatch' && inputs.environment == 'demo'))
     environment:
       name: demo
-      url: "${{ env.SERVER_URL }}"
+      url: "${{ vars.SERVER_URL }}"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Reads the demo environment's deployment `url:` from `vars.SERVER_URL` instead of the empty `env.SERVER_URL`, so its "View deployment" link renders once the demo environment exists.