### PR TITLE
Link the live demo and refresh its README media

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ If contributions come in later, I'll start from [Ghostty's AI_POLICY.md](https:/
 
 ## Demo
 
+Try it live at **[demo.topbanana.app](https://demo.topbanana.app/)**. One click signs you in to a shared host account — no sign-up — so you can build and host a quiz. Everything resets daily.
+
 ### Game
 ![Image](https://github.com/user-attachments/assets/ebf9de5c-47b6-410f-b8b8-7d29200fa193)
 
 ### Admin interface
 ![Image](https://github.com/user-attachments/assets/77d8a814-df67-449b-a7af-15814fc21333)
-
-A link to a live demo will be provided soon.
 
 ## Features
 - **Quiz authoring**: Create and edit quizzes from the admin UI — title, description, and multi-option questions.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ If contributions come in later, I'll start from [Ghostty's AI_POLICY.md](https:/
 Try it live at **[demo.topbanana.app](https://demo.topbanana.app/)**. One click signs you in to a shared host account — no sign-up — so you can build and host a quiz. Everything resets daily.
 
 ### Game
-![Image](https://github.com/user-attachments/assets/ebf9de5c-47b6-410f-b8b8-7d29200fa193)
+
+https://github.com/user-attachments/assets/cb8c8f0b-d2e3-40e7-9753-fa029fd1b20a
 
 ### Admin interface
-![Image](https://github.com/user-attachments/assets/77d8a814-df67-449b-a7af-15814fc21333)
+
+![Admin interface](https://github.com/user-attachments/assets/6746a9b3-68db-46c5-8161-5b3d59fd7664)
 
 ## Features
 - **Quiz authoring**: Create and edit quizzes from the admin UI — title, description, and multi-option questions.


### PR DESCRIPTION
Links the live demo from the README and replaces the two Demo-section screenshots with a player-interface video and an admin screenshot.

Changes:
- Add a link to https://demo.topbanana.app/ in the Demo section (replacing the old "a link will be provided soon" line).
- Replace the "Game" screenshot with a short portrait player video: the home page, then playing a "Guess the Flag" quiz (two rounds of image questions) and finishing first on the leaderboard. Recorded at 620x880 (H.264 mp4, ~0.6MB); no audio, since the embed is silent on GitHub.
- Replace the "Admin interface" screenshot with a fresh admin quiz-view shot (hero, actions, and rounds).

Docs-only change; no code paths touched.

Closes #1152

_— Claude Code, for @starquake_
