### PR TITLE
Title releases with the bare version and move the descriptive title into the body

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -133,13 +133,13 @@ No need to ask the user for the version — derive it.
    git push origin vYYYY.M.N
 
    gh release create vYYYY.M.N \
-     --title "vYYYY.M.N — <short factual title from the lead sentence>" \
-     --notes-file <(awk '/^## vYYYY.M.N/{flag=1; next} /^## v/{flag=0} flag' RELEASE_NOTES.md) \
+     --title "vYYYY.M.N" \
+     --notes-file <({ printf '## <short factual title from the lead sentence>\n\n'; awk '/^## vYYYY.M.N/{flag=1; next} /^## v/{flag=0} flag' RELEASE_NOTES.md; }) \
      --generate-notes \
      --notes-start-tag <previous-tag>
    ```
 
-   The `--notes-file` extract pulls just the new release's section out of `RELEASE_NOTES.md`. `--generate-notes` is **mandatory**: gh prepends the curated `--notes-file` body and appends GitHub's auto-generated "What's Changed" PR list plus the Full Changelog link, so the release body reads `curated notes` then `## What's Changed`. `--notes-start-tag <previous-tag>` (the same previous tag from step 2) scopes that PR list to this release's range. Every release must carry the PR list — it is the per-PR engineering history `RELEASE_NOTES.md` points readers to; omitting `--generate-notes` is the drift that left several releases without it. Use a process substitution (or a temp file) — `gh release create` reads `--notes-file` from a file path.
+   **The GitHub release title is just the bare version (`vYYYY.M.N`)** so the releases list stays clean; the descriptive `<short factual title from the lead sentence>` becomes the **first heading of the body** (`## <title>`, version dropped since the release already carries it), not the release title. The `--notes-file` process substitution therefore prints that heading first, then the awk extract of the new release's section out of `RELEASE_NOTES.md`. `--generate-notes` is **mandatory**: gh prepends the curated `--notes-file` body and appends GitHub's auto-generated "What's Changed" PR list plus the Full Changelog link, so the release body reads `## <title>` then `curated notes` then `## What's Changed`. `--notes-start-tag <previous-tag>` (the same previous tag from step 2) scopes that PR list to this release's range. Every release must carry the PR list — it is the per-PR engineering history `RELEASE_NOTES.md` points readers to; omitting `--generate-notes` is the drift that left several releases without it. Use a process substitution (or a temp file) — `gh release create` reads `--notes-file` from a file path.
 
 9. Confirm the release page renders the notes correctly: `gh release view vYYYY.M.N`. Then confirm the production deploy fired: the tag's `CI` run (its `promote` job) must go green, which is what triggers `deploy-production`. If `promote` failed because the image was not yet published when you tagged, re-run that job once the image exists (`gh run rerun <tag-CI-run-id> --failed`) - do not push a new tag.
 


### PR DESCRIPTION
The GitHub release title is now just the bare version (`vYYYY.M.N`) so the releases list stays clean; the descriptive one-line title moves to the first heading of the release body (`## <title>`, version dropped since the release already carries it). Updates the release-notes skill's `gh release create` step accordingly.

The already-shipped v2026.7.0 release has been updated to this shape directly.

_— Claude Code, for @starquake_