### PR TITLE
Match the import JSON sample and field docs to the parser

### DIFF
--- a/internal/admin/export_test.go
+++ b/internal/admin/export_test.go
@@ -121,6 +121,11 @@ type QuizImportOptionPayload = quizImportOptionPayload
 // without spinning the full HTTP handler.
 var QuizFromImportPayload = quizFromImportPayload
 
+// QuizImportExample exposes the exact JSON sample rendered on the import
+// page so the golden test can decode it through the real importer,
+// keeping the on-screen example and the parser from drifting (#1138).
+const QuizImportExample = quizImportExample
+
 // StripCodeFences exposes the unexported fenced-code-block stripper so the
 // test package can pin the paste-from-an-LLM-code-block tolerance.
 var StripCodeFences = stripCodeFences

--- a/internal/admin/quizimport_test.go
+++ b/internal/admin/quizimport_test.go
@@ -1,10 +1,39 @@
 package admin_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/starquake/topbanana/internal/admin"
 )
+
+// TestQuizImportExampleParses is the golden test that the exact JSON
+// sample rendered on the import screen parses cleanly through the real
+// importer: the same DisallowUnknownFields decode and payload-to-domain
+// translation the POST handler runs, then the shared form validation.
+// It fails if the sample carries a field the parser rejects (or drops a
+// documented one), so the on-screen example and the parser cannot drift
+// (#1138).
+func TestQuizImportExampleParses(t *testing.T) {
+	t.Parallel()
+
+	var payload admin.QuizImportPayload
+	dec := json.NewDecoder(strings.NewReader(admin.QuizImportExample))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&payload); err != nil {
+		t.Fatalf("decoding sample: err = %v, want nil", err)
+	}
+
+	qz, err := admin.QuizFromImportPayload(payload)
+	if err != nil {
+		t.Fatalf("QuizFromImportPayload err = %v, want nil", err)
+	}
+
+	if problems := admin.ValidateQuizForm(t.Context(), qz); len(problems) > 0 {
+		t.Errorf("ValidateQuizForm problems = %v, want none", problems)
+	}
+}
 
 // TestQuizFromImportPayload_MapsQuestions pins the payload-to-domain
 // translation: the title drives the slug, and questions keep their

--- a/internal/admin/quizimport_test.go
+++ b/internal/admin/quizimport_test.go
@@ -12,9 +12,11 @@ import (
 // sample rendered on the import screen parses cleanly through the real
 // importer: the same DisallowUnknownFields decode and payload-to-domain
 // translation the POST handler runs, then the shared form validation.
-// It fails if the sample carries a field the parser rejects (or drops a
-// documented one), so the on-screen example and the parser cannot drift
-// (#1138).
+// DisallowUnknownFields fails the test if the sample carries a field the
+// parser rejects (a renamed or undocumented key), and the boundary-override
+// assertion below fails it if the sample stops demonstrating the
+// boundaryDurationSeconds optional the field reference documents, so the
+// on-screen example and the parser cannot drift (#1138).
 func TestQuizImportExampleParses(t *testing.T) {
 	t.Parallel()
 
@@ -32,6 +34,18 @@ func TestQuizImportExampleParses(t *testing.T) {
 
 	if problems := admin.ValidateQuizForm(t.Context(), qz); len(problems) > 0 {
 		t.Errorf("ValidateQuizForm problems = %v, want none", problems)
+	}
+
+	boundarySet := false
+	for _, r := range qz.Rounds {
+		if r.BoundaryDurationSeconds != nil {
+			boundarySet = true
+
+			break
+		}
+	}
+	if !boundarySet {
+		t.Error("sample no longer sets boundaryDurationSeconds on any round (#1138)")
 	}
 }
 

--- a/internal/web/tmpl/admin/pages/quizimport.gohtml
+++ b/internal/web/tmpl/admin/pages/quizimport.gohtml
@@ -148,6 +148,7 @@ Fields:
 - rounds (array, in play order, required) - each named round has:
     - title (string, required)
     - summary (string, optional) - shown to the player between rounds
+    - boundaryDurationSeconds (integer, optional) - seconds the round's intro and recap cards show before auto-advancing; omit to inherit the quiz default
     - questions (array, in play order, required) - each has:
         - text (string, required)
         - options (array of {text, correct}, required) - mark at least one correct; more than one may be correct
@@ -168,8 +169,10 @@ Give me X rounds of Y questions.</code></pre>
             <li><code class="font-mono text-[0.8rem]">title</code> - string, required. Slug is derived server-side.</li>
             <li><code class="font-mono text-[0.8rem]">description</code> - string, required.</li>
             <li><code class="font-mono text-[0.8rem]">timeLimitSeconds</code> - integer, optional. Quiz-wide default answer window.</li>
+            <li><code class="font-mono text-[0.8rem]">rounds[]</code> or <code class="font-mono text-[0.8rem]">questions[]</code> - array, required. Supply exactly one: <code class="font-mono text-[0.8rem]">rounds[]</code> for named rounds (the prompt above), or a top-level <code class="font-mono text-[0.8rem]">questions[]</code> for a single flat round. Not both, not neither. A top-level question takes the same shape as a round's question.</li>
             <li><code class="font-mono text-[0.8rem]">rounds[].title</code> - string, required. Names the round.</li>
             <li><code class="font-mono text-[0.8rem]">rounds[].summary</code> - string, optional. Shown to the player between rounds.</li>
+            <li><code class="font-mono text-[0.8rem]">rounds[].boundaryDurationSeconds</code> - integer, optional. Seconds the round's intro and recap cards show before auto-advancing; omit to inherit the quiz default.</li>
             <li><code class="font-mono text-[0.8rem]">rounds[].questions[].text</code> - string, required.</li>
             <li><code class="font-mono text-[0.8rem]">rounds[].questions[].timeLimitSeconds</code> - integer, optional. Overrides the quiz default.</li>
             <li><code class="font-mono text-[0.8rem]">rounds[].questions[].options[]</code> - array of <code class="font-mono text-[0.8rem]">{text, correct}</code>. At least one option must be correct; more than one may be correct, and the player scores by picking any correct option.</li>


### PR DESCRIPTION
The Import JSON screen's sample and field docs had drifted from what the importer accepts. Corrected the on-screen docs to match the parser (`quizImportPayload`, decoded with `DisallowUnknownFields`); no parser change.

- `boundaryDurationSeconds` was in the sample but documented nowhere — now described as an optional per-round auto-advance override.
- The flat top-level `questions[]` alternative was undocumented and `rounds` was mislabelled "required" — now documents `rounds[]` OR `questions[]` (exactly one).

A golden test (`TestQuizImportExampleParses`) decodes the exact on-screen sample through the real importer and asserts it still exercises `boundaryDurationSeconds`, so the sample and parser can't drift again. `make check` + `make smoke` green.

Closes #1138

_— Claude Code, for @starquake_
