### PR TITLE
Show the original uploaded filename as a caption in the admin media library

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1230,6 +1230,10 @@ type MediaCardData struct {
 	// the audio library and the question picker. Empty for an unlabelled clip and
 	// for image tiles, which do not surface it.
 	Description string
+	// OriginalFilename is the file's original upload name (#1137), surfaced in the
+	// library so a host can match a stored file back to its source. Empty when the
+	// upload carried no usable name.
+	OriginalFilename string
 }
 
 // DurationLabel renders DurationMs as an "M:SS" clip-length label, or "" when
@@ -1254,12 +1258,13 @@ func mediaCardDataFromMedia(items []*media.Media) []MediaCardData {
 	cards := make([]MediaCardData, 0, len(items))
 	for _, m := range items {
 		cards = append(cards, MediaCardData{
-			ID:          m.ID,
-			Width:       m.Width,
-			Height:      m.Height,
-			DurationMs:  m.DurationMs,
-			QuizID:      m.QuizID,
-			Description: m.Description,
+			ID:               m.ID,
+			Width:            m.Width,
+			Height:           m.Height,
+			DurationMs:       m.DurationMs,
+			QuizID:           m.QuizID,
+			Description:      m.Description,
+			OriginalFilename: m.OriginalFilename,
 		})
 	}
 

--- a/internal/admin/quizarchive.go
+++ b/internal/admin/quizarchive.go
@@ -56,19 +56,24 @@ type quizArchiveOption struct {
 // quizArchiveImageRef points at an image file stored in the archive. File is
 // the archive-relative path ("media/<id>.<ext>"); MIME is the stored content
 // type so the importer can re-register the media without re-sniffing.
+// OriginalFilename carries the row's original upload name (#1137) so a re-import
+// restores the library tooltip; empty for archives written before it was added.
 type quizArchiveImageRef struct {
-	File string `json:"file"`
-	MIME string `json:"mime"`
+	File             string `json:"file"`
+	MIME             string `json:"mime"`
+	OriginalFilename string `json:"originalFilename,omitempty"`
 }
 
 // quizArchiveAudioRef points at an audio file stored in the archive. It
 // carries the same File / MIME as the image ref plus the advisory audio
 // metadata (host-supplied description, duration, repeat flag) so an import
-// round-trips the clip's playback behaviour.
+// round-trips the clip's playback behaviour. OriginalFilename is the row's
+// original upload name (#1137), empty for pre-#1137 archives.
 type quizArchiveAudioRef struct {
-	File        string `json:"file"`
-	MIME        string `json:"mime"`
-	Description string `json:"description,omitempty"`
-	DurationMs  *int   `json:"durationMs,omitempty"`
-	Repeat      bool   `json:"repeat,omitempty"`
+	File             string `json:"file"`
+	MIME             string `json:"mime"`
+	Description      string `json:"description,omitempty"`
+	DurationMs       *int   `json:"durationMs,omitempty"`
+	Repeat           bool   `json:"repeat,omitempty"`
+	OriginalFilename string `json:"originalFilename,omitempty"`
 }

--- a/internal/admin/quizexport.go
+++ b/internal/admin/quizexport.go
@@ -223,7 +223,11 @@ func (b *manifestBuilder) imageRef(ctx context.Context, id *int64) (*quizArchive
 		return nil, err
 	}
 
-	return &quizArchiveImageRef{File: archiveMediaPath(m), MIME: m.MIME}, nil
+	return &quizArchiveImageRef{
+		File:             archiveMediaPath(m),
+		MIME:             m.MIME,
+		OriginalFilename: m.OriginalFilename,
+	}, nil
 }
 
 // audioRef resolves the audio media id into a manifest ref, carrying the clip's
@@ -238,11 +242,12 @@ func (b *manifestBuilder) audioRef(ctx context.Context, id *int64, repeat bool) 
 	}
 
 	return &quizArchiveAudioRef{
-		File:        archiveMediaPath(m),
-		MIME:        m.MIME,
-		Description: m.Description,
-		DurationMs:  m.DurationMs,
-		Repeat:      repeat,
+		File:             archiveMediaPath(m),
+		MIME:             m.MIME,
+		Description:      m.Description,
+		DurationMs:       m.DurationMs,
+		Repeat:           repeat,
+		OriginalFilename: m.OriginalFilename,
 	}, nil
 }
 

--- a/internal/admin/quizexport_test.go
+++ b/internal/admin/quizexport_test.go
@@ -224,7 +224,7 @@ func TestWriteQuizArchive(t *testing.T) {
 	qz := env.seedQuiz(t, roundedQuiz())
 
 	// Store one image + one audio clip in the quiz's library.
-	img, err := mediaSvc.StoreImage(t.Context(), qz.ID, testExportPlayerID, bytes.NewReader(tinyPNG(t)))
+	img, err := mediaSvc.StoreImage(t.Context(), qz.ID, testExportPlayerID, "pic.png", bytes.NewReader(tinyPNG(t)))
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}

--- a/internal/admin/quizexport_test.go
+++ b/internal/admin/quizexport_test.go
@@ -57,16 +57,18 @@ type exportOption struct {
 }
 
 type exportImageRef struct {
-	File string `json:"file"`
-	MIME string `json:"mime"`
+	File             string `json:"file"`
+	MIME             string `json:"mime"`
+	OriginalFilename string `json:"originalFilename"`
 }
 
 type exportAudioRef struct {
-	File        string `json:"file"`
-	MIME        string `json:"mime"`
-	Description string `json:"description"`
-	DurationMs  *int   `json:"durationMs"`
-	Repeat      bool   `json:"repeat"`
+	File             string `json:"file"`
+	MIME             string `json:"mime"`
+	Description      string `json:"description"`
+	DurationMs       *int   `json:"durationMs"`
+	Repeat           bool   `json:"repeat"`
+	OriginalFilename string `json:"originalFilename"`
 }
 
 // tinyPNG returns a small valid 4x4 PNG, a valid upload StoreImage can process.
@@ -536,6 +538,9 @@ func assertImageRef(t *testing.T, ref *exportImageRef, img *media.Media) {
 	if got, want := ref.File, "media/"+strconv.FormatInt(img.ID, 10)+".jpg"; got != want {
 		t.Errorf("image ref File = %q, want %q", got, want)
 	}
+	if got, want := ref.OriginalFilename, img.OriginalFilename; got != want {
+		t.Errorf("image ref OriginalFilename = %q, want %q", got, want)
+	}
 }
 
 func assertAudioRef(t *testing.T, ref *exportAudioRef, aud *media.Media) {
@@ -561,6 +566,9 @@ func assertAudioRef(t *testing.T, ref *exportAudioRef, aud *media.Media) {
 	}
 	if !ref.Repeat {
 		t.Error("audio ref Repeat = false, want true")
+	}
+	if got, want := ref.OriginalFilename, aud.OriginalFilename; got != want {
+		t.Errorf("audio ref OriginalFilename = %q, want %q", got, want)
 	}
 }
 

--- a/internal/admin/quizimportarchive.go
+++ b/internal/admin/quizimportarchive.go
@@ -65,7 +65,7 @@ var ErrArchiveInvalidQuiz = errors.New("archive is not a valid quiz")
 // consumer-side so the admin package depends only on what it calls; the concrete
 // *media.Service satisfies it.
 type MediaImporter interface {
-	StoreImage(ctx context.Context, quizID, createdBy int64, r io.Reader) (*media.Media, error)
+	StoreImage(ctx context.Context, quizID, createdBy int64, filename string, r io.Reader) (*media.Media, error)
 	StoreAudio(
 		ctx context.Context, quizID, createdBy int64, durationMs int, description, filename string, r io.Reader,
 	) (*media.Media, error)

--- a/internal/admin/quizimportarchive_test.go
+++ b/internal/admin/quizimportarchive_test.go
@@ -95,7 +95,7 @@ func exportArchiveBytes(t *testing.T) []byte {
 	mediaSvc := newMediaServiceOverTemp(t, env)
 	qz := env.seedQuiz(t, roundedQuiz())
 
-	img, err := mediaSvc.StoreImage(t.Context(), qz.ID, testExportPlayerID, bytes.NewReader(tinyPNG(t)))
+	img, err := mediaSvc.StoreImage(t.Context(), qz.ID, testExportPlayerID, "pic.png", bytes.NewReader(tinyPNG(t)))
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}

--- a/internal/admin/quizimportarchive_test.go
+++ b/internal/admin/quizimportarchive_test.go
@@ -432,6 +432,12 @@ func assertImportedMedia(t *testing.T, env *adminEnv, imported *quiz.Quiz) {
 	imageID := images[0].ID
 	audio := audios[0]
 
+	// The original upload filename round-trips through the manifest (#1137), so a
+	// re-imported quiz restores the library tooltip rather than a synthetic path.
+	if got, want := images[0].OriginalFilename, "pic.png"; got != want {
+		t.Errorf("restored image OriginalFilename = %q, want %q", got, want)
+	}
+
 	withImage, withAudio := questionsByMedia(imported, imageID, audio.ID)
 	if got, want := withImage, 2; got != want {
 		t.Errorf("questions referencing the restored image = %d, want %d", got, want)
@@ -476,6 +482,9 @@ func assertAudioMeta(t *testing.T, imported *quiz.Quiz, audio *media.Media) {
 
 	if got, want := audio.Description, "Theme"; got != want {
 		t.Errorf("audio Description = %q, want %q", got, want)
+	}
+	if got, want := audio.OriginalFilename, "theme.mp3"; got != want {
+		t.Errorf("audio OriginalFilename = %q, want %q", got, want)
 	}
 	if audio.DurationMs == nil {
 		t.Fatal("audio DurationMs = nil, want 1234")

--- a/internal/admin/quizimportrestore.go
+++ b/internal/admin/quizimportrestore.go
@@ -109,7 +109,7 @@ func (r *mediaRestorer) resolveImage(ctx context.Context, ref *quizArchiveImageR
 	}
 	defer func() { _ = rc.Close() }()
 
-	stored, err := r.mediaSvc.StoreImage(ctx, r.quizID, r.importerID, rc)
+	stored, err := r.mediaSvc.StoreImage(ctx, r.quizID, r.importerID, ref.File, rc)
 	if err != nil {
 		return nil, fmt.Errorf("restoring image %q: %w", ref.File, err)
 	}

--- a/internal/admin/quizimportrestore.go
+++ b/internal/admin/quizimportrestore.go
@@ -109,7 +109,7 @@ func (r *mediaRestorer) resolveImage(ctx context.Context, ref *quizArchiveImageR
 	}
 	defer func() { _ = rc.Close() }()
 
-	stored, err := r.mediaSvc.StoreImage(ctx, r.quizID, r.importerID, ref.File, rc)
+	stored, err := r.mediaSvc.StoreImage(ctx, r.quizID, r.importerID, ref.OriginalFilename, rc)
 	if err != nil {
 		return nil, fmt.Errorf("restoring image %q: %w", ref.File, err)
 	}
@@ -137,7 +137,7 @@ func (r *mediaRestorer) resolveAudio(ctx context.Context, ref *quizArchiveAudioR
 	defer func() { _ = rc.Close() }()
 
 	stored, err := r.mediaSvc.StoreAudio(
-		ctx, r.quizID, r.importerID, durationMsFor(ref.DurationMs), ref.Description, ref.File, rc,
+		ctx, r.quizID, r.importerID, durationMsFor(ref.DurationMs), ref.Description, ref.OriginalFilename, rc,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("restoring audio %q: %w", ref.File, err)

--- a/internal/db/media.sql.go
+++ b/internal/db/media.sql.go
@@ -39,7 +39,8 @@ func (q *Queries) CountMediaByQuizAndType(ctx context.Context, arg CountMediaByQ
 const createMedia = `-- name: CreateMedia :one
 INSERT INTO media (
     quiz_id, type, mime, path, thumb_path,
-    width, height, size_bytes, sha256, duration_ms, description, created_by_player_id, ready
+    width, height, size_bytes, sha256, duration_ms, description, original_filename,
+    created_by_player_id, ready
 )
 VALUES (
     ?1,
@@ -54,9 +55,10 @@ VALUES (
     ?10,
     ?11,
     ?12,
+    ?13,
     0
 )
-RETURNING id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description
+RETURNING id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description, original_filename
 `
 
 type CreateMediaParams struct {
@@ -71,6 +73,7 @@ type CreateMediaParams struct {
 	Sha256            string
 	DurationMs        sql.NullInt64
 	Description       string
+	OriginalFilename  string
 	CreatedByPlayerID int64
 }
 
@@ -97,6 +100,7 @@ func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (Mediu
 		arg.Sha256,
 		arg.DurationMs,
 		arg.Description,
+		arg.OriginalFilename,
 		arg.CreatedByPlayerID,
 	)
 	var i Medium
@@ -116,6 +120,7 @@ func (q *Queries) CreateMedia(ctx context.Context, arg CreateMediaParams) (Mediu
 		&i.Ready,
 		&i.DurationMs,
 		&i.Description,
+		&i.OriginalFilename,
 	)
 	return i, err
 }
@@ -134,7 +139,7 @@ func (q *Queries) DeleteMedia(ctx context.Context, id int64) (sql.Result, error)
 }
 
 const getMedia = `-- name: GetMedia :one
-SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description
+SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description, original_filename
 FROM media
 WHERE id = ?1
 `
@@ -160,12 +165,13 @@ func (q *Queries) GetMedia(ctx context.Context, id int64) (Medium, error) {
 		&i.Ready,
 		&i.DurationMs,
 		&i.Description,
+		&i.OriginalFilename,
 	)
 	return i, err
 }
 
 const listMediaByQuiz = `-- name: ListMediaByQuiz :many
-SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description
+SELECT id, quiz_id, type, mime, path, thumb_path, width, height, size_bytes, sha256, created_by_player_id, created_at, ready, duration_ms, description, original_filename
 FROM media
 WHERE quiz_id = ?1
   AND ready = 1
@@ -203,6 +209,7 @@ func (q *Queries) ListMediaByQuiz(ctx context.Context, quizID int64) ([]Medium, 
 			&i.Ready,
 			&i.DurationMs,
 			&i.Description,
+			&i.OriginalFilename,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -94,6 +94,7 @@ type Medium struct {
 	Ready             int64
 	DurationMs        sql.NullInt64
 	Description       string
+	OriginalFilename  string
 }
 
 type Option struct {

--- a/internal/media/audio.go
+++ b/internal/media/audio.go
@@ -66,11 +66,12 @@ const (
 
 // StoreAudio persists an already-browser-playable audio upload as-is under
 // <root>/<quizID>/<id><ext>, recording a media row with the sniffed MIME, byte
-// size, sha256, the caller-supplied duration, and a description label. Audio is
-// not decoded or transcoded server-side: the format is detected by sniffing
-// magic bytes, and an unrecognised container is rejected with ErrUnsupportedAudio
-// rather than converted. durationMs is advisory (read in-browser by the caller);
-// a value of zero or less stores NULL.
+// size, sha256, the caller-supplied duration, a description label, and the
+// original upload filename (base name, length-capped) as OriginalFilename for the
+// library tooltip (#1137). Audio is not decoded or transcoded server-side: the
+// format is detected by sniffing magic bytes, and an unrecognised container is
+// rejected with ErrUnsupportedAudio rather than converted. durationMs is advisory
+// (read in-browser by the caller); a value of zero or less stores NULL.
 //
 // description is the host-facing library label (#1072). When it is empty it
 // defaults to filename without its extension, so a clip always has a readable
@@ -105,6 +106,7 @@ func (s *Service) StoreAudio(
 		SHA256:            hex.EncodeToString(sum[:]),
 		DurationMs:        durationToPtr(durationMs),
 		Description:       defaultDescription(description, filename),
+		OriginalFilename:  sanitizeFilename(filename),
 		CreatedByPlayerID: createdBy,
 	})
 	if err != nil {

--- a/internal/media/audio.go
+++ b/internal/media/audio.go
@@ -182,13 +182,7 @@ func defaultDescription(description, filename string) string {
 // maxDescriptionLen runes, the single normalization both the upload default and
 // the inline edit apply so the stored value is bounded and consistent.
 func normalizeDescription(description string) string {
-	trimmed := strings.TrimSpace(description)
-	runes := []rune(trimmed)
-	if len(runes) > maxDescriptionLen {
-		trimmed = strings.TrimSpace(string(runes[:maxDescriptionLen]))
-	}
-
-	return trimmed
+	return capRunes(description, maxDescriptionLen)
 }
 
 // durationToPtr maps a caller-supplied duration in milliseconds to the *int the

--- a/internal/media/audio_test.go
+++ b/internal/media/audio_test.go
@@ -179,6 +179,33 @@ func TestServiceStoreAudioAcceptsFormats(t *testing.T) {
 	}
 }
 
+// TestServiceStoreAudioRecordsOriginalFilename pins that StoreAudio records the
+// base name of the client-supplied upload filename as the row's OriginalFilename,
+// and that it round-trips through the DB (#1137).
+func TestServiceStoreAudioRecordsOriginalFilename(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	m, err := fx.svc.StoreAudio(
+		t.Context(), fx.quizID, seededAdminID, 1000, "Theme", "uploads/Intro Theme.mp3", bytes.NewReader(mp3ID3()),
+	)
+	if err != nil {
+		t.Fatalf("StoreAudio err = %v, want nil", err)
+	}
+	if got, want := m.OriginalFilename, "Intro Theme.mp3"; got != want {
+		t.Errorf("OriginalFilename = %q, want %q (base name only)", got, want)
+	}
+
+	stored, err := fx.svc.Get(t.Context(), m.ID)
+	if err != nil {
+		t.Fatalf("Get err = %v, want nil", err)
+	}
+	if got, want := stored.OriginalFilename, "Intro Theme.mp3"; got != want {
+		t.Errorf("stored OriginalFilename = %q, want %q", got, want)
+	}
+}
+
 // TestServiceStoreAudioPersistsDuration pins that the stored duration round-trips
 // through the DB (not just the in-memory return), and that a non-positive
 // duration stores NULL.

--- a/internal/media/export_test.go
+++ b/internal/media/export_test.go
@@ -22,3 +22,7 @@ var ExportSniffAudio = sniffAudio
 // ExportDefaultDescription re-exports the unexported description-defaulting
 // helper for tests.
 var ExportDefaultDescription = defaultDescription
+
+// ExportSanitizeFilename re-exports the unexported upload-filename sanitizer for
+// tests.
+var ExportSanitizeFilename = sanitizeFilename

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -46,7 +46,12 @@ type Media struct {
 	// Description is a host-supplied, host-facing label for the row (#1072).
 	// Defaults to the uploaded filename without its extension and is editable
 	// afterwards; the empty string means unlabelled.
-	Description       string
+	Description string
+	// OriginalFilename is the client-supplied upload filename, reduced to its
+	// base name and length-capped (#1137), kept so a host can tell which source
+	// file a stored media row came from. Empty when the upload carried no usable
+	// name and for rows predating the column.
+	OriginalFilename  string
 	CreatedByPlayerID int64
 	CreatedAt         time.Time
 }

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // fullSuffix and thumbSuffix name the two files a stored image writes under
@@ -148,12 +149,35 @@ func sanitizeFilename(filename string) string {
 	if base == "." || base == string(filepath.Separator) {
 		return ""
 	}
-	runes := []rune(base)
-	if len(runes) > maxOriginalFilenameLen {
-		base = strings.TrimSpace(string(runes[:maxOriginalFilenameLen]))
+
+	return capRunes(stripControlRunes(base), maxOriginalFilenameLen)
+}
+
+// capRunes trims s and caps it to limit runes, trimming again after a mid-string
+// cut so a truncation never leaves trailing whitespace. Shared by the filename
+// and description normalizers so their length-cap semantics stay identical.
+func capRunes(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) > limit {
+		s = strings.TrimSpace(string(runes[:limit]))
 	}
 
-	return base
+	return s
+}
+
+// stripControlRunes drops Unicode control characters (newlines, tabs, etc.) from
+// s so a crafted upload filename cannot render as a garbled multi-line library
+// tooltip (#1137). html/template already escapes the HTML-dangerous characters;
+// this is display hygiene for the title text.
+func stripControlRunes(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+
+		return r
+	}, s)
 }
 
 // Delete removes the media row, then unlinks its two files best-effort. A

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 )
 
 // fullSuffix and thumbSuffix name the two files a stored image writes under
@@ -158,12 +159,12 @@ func sanitizeFilename(filename string) string {
 // and description normalizers so their length-cap semantics stay identical.
 func capRunes(s string, limit int) string {
 	s = strings.TrimSpace(s)
-	runes := []rune(s)
-	if len(runes) > limit {
-		s = strings.TrimSpace(string(runes[:limit]))
+	if utf8.RuneCountInString(s) <= limit {
+		return s
 	}
 
-	return s
+	// Over the cap: materialise the runes only now, to slice at the limit-th one.
+	return strings.TrimSpace(string([]rune(s)[:limit]))
 }
 
 // stripControlRunes drops Unicode control characters (newlines, tabs, etc.) from

--- a/internal/media/service.go
+++ b/internal/media/service.go
@@ -68,7 +68,9 @@ func NewService(store Store, root string, imageMaxBytes, audioMaxBytes int64, lo
 // StoreImage processes the upload into a normalised jpeg full image plus
 // thumbnail, writes both under <root>/<quizID>/, inserts the media row with the
 // relative paths and metadata, and returns the stored Media. createdBy is the
-// uploading player.
+// uploading player; filename is the client-supplied upload name, stored (base
+// name, length-capped) as the row's OriginalFilename so the library can show it
+// as a tooltip (#1137).
 //
 // The row is inserted not-ready, then the files are written, the paths
 // recorded, and only then the row is flipped ready (a two-phase commit, #992).
@@ -78,7 +80,9 @@ func NewService(store Store, root string, imageMaxBytes, audioMaxBytes int64, lo
 // any step removes the just-written files and the row so a failed upload leaves
 // no orphans. The stored Path / ThumbPath are relative to root so a later root
 // remount does not strand the references.
-func (s *Service) StoreImage(ctx context.Context, quizID, createdBy int64, r io.Reader) (*Media, error) {
+func (s *Service) StoreImage(
+	ctx context.Context, quizID, createdBy int64, filename string, r io.Reader,
+) (*Media, error) {
 	// Two ctx.Err checks around Process: the first skips Process if the
 	// cancel already arrived (Process is the CPU-heavy decode + re-encode);
 	// the second catches a cancel that arrived during Process, which is sync
@@ -106,6 +110,7 @@ func (s *Service) StoreImage(ctx context.Context, quizID, createdBy int64, r io.
 		Height:            processed.Height,
 		SizeBytes:         int64(processed.SizeBytes),
 		SHA256:            processed.SHA256,
+		OriginalFilename:  sanitizeFilename(filename),
 		CreatedByPlayerID: createdBy,
 	})
 	if err != nil {
@@ -125,6 +130,30 @@ func (s *Service) StoreImage(ctx context.Context, quizID, createdBy int64, r io.
 	row.ThumbPath = relThumb
 
 	return row, nil
+}
+
+// maxOriginalFilenameLen bounds a stored original filename so a crafted upload
+// cannot persist an unbounded string. Measured in runes so a multi-byte name is
+// not cut mid-character. The library truncates visually anyway; this is the
+// storage guard.
+const maxOriginalFilenameLen = 255
+
+// sanitizeFilename reduces a client-supplied upload filename to the value stored
+// as a media row's OriginalFilename (#1137): its base name (stripping any
+// directory components a crafted client may prepend), length-capped. A name that
+// is empty or resolves to no real base ("." or a bare separator) yields the empty
+// string so an unnamed upload stores no tooltip rather than a stray ".".
+func sanitizeFilename(filename string) string {
+	base := filepath.Base(strings.TrimSpace(filename))
+	if base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	runes := []rune(base)
+	if len(runes) > maxOriginalFilenameLen {
+		base = strings.TrimSpace(string(runes[:maxOriginalFilenameLen]))
+	}
+
+	return base
 }
 
 // Delete removes the media row, then unlinks its two files best-effort. A

--- a/internal/media/service_test.go
+++ b/internal/media/service_test.go
@@ -199,8 +199,8 @@ func TestServiceStoreImageSanitizesFilename(t *testing.T) {
 }
 
 // TestSanitizeFilename pins the upload-filename sanitizer: it reduces a name to
-// its base, drops directory-only and empty inputs to the empty string, and caps
-// the length in runes (#1137).
+// its base, drops directory-only and empty inputs to the empty string, strips
+// control characters, and caps the length in runes (#1137).
 func TestSanitizeFilename(t *testing.T) {
 	t.Parallel()
 
@@ -208,12 +208,14 @@ func TestSanitizeFilename(t *testing.T) {
 		in   string
 		want string
 	}{
-		"plain name":       {in: "photo.png", want: "photo.png"},
-		"strips directory": {in: "uploads/sub/photo.png", want: "photo.png"},
-		"trims whitespace": {in: "  photo.png  ", want: "photo.png"},
-		"empty":            {in: "", want: ""},
-		"dot":              {in: ".", want: ""},
-		"root separator":   {in: "/", want: ""},
+		"plain name":           {in: "photo.png", want: "photo.png"},
+		"strips directory":     {in: "uploads/sub/photo.png", want: "photo.png"},
+		"trims whitespace":     {in: "  photo.png  ", want: "photo.png"},
+		"empty":                {in: "", want: ""},
+		"dot":                  {in: ".", want: ""},
+		"root separator":       {in: "/", want: ""},
+		"strips control runes": {in: "pho\nto\t.png", want: "photo.png"},
+		"control runes only":   {in: "\x00\x01\x02", want: ""},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/media/service_test.go
+++ b/internal/media/service_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,7 +108,13 @@ func TestServiceStoreRoundTrip(t *testing.T) {
 
 	fx := newServiceWithQuiz(t)
 
-	m, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 800, 400)))
+	m, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 800, 400)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -156,6 +163,73 @@ func TestServiceStoreRoundTrip(t *testing.T) {
 	if got, want := row.SHA256, m.SHA256; got != want {
 		t.Errorf("stored SHA256 = %q, want %q", got, want)
 	}
+	if got, want := m.OriginalFilename, "pic.png"; got != want {
+		t.Errorf("OriginalFilename = %q, want %q", got, want)
+	}
+	if got, want := row.OriginalFilename, "pic.png"; got != want {
+		t.Errorf("stored OriginalFilename = %q, want %q", got, want)
+	}
+}
+
+// TestServiceStoreImageSanitizesFilename pins that StoreImage records the base
+// name of the client-supplied upload filename (stripping any directory
+// components) as the row's OriginalFilename (#1137).
+func TestServiceStoreImageSanitizesFilename(t *testing.T) {
+	t.Parallel()
+
+	fx := newServiceWithQuiz(t)
+
+	m, err := fx.svc.StoreImage(
+		t.Context(), fx.quizID, seededAdminID, "uploads/sub/My Vacation.png", bytes.NewReader(pngUpload(t, 64, 64)),
+	)
+	if err != nil {
+		t.Fatalf("StoreImage err = %v, want nil", err)
+	}
+	if got, want := m.OriginalFilename, "My Vacation.png"; got != want {
+		t.Errorf("OriginalFilename = %q, want %q (base name only)", got, want)
+	}
+
+	row, err := fx.svc.Get(t.Context(), m.ID)
+	if err != nil {
+		t.Fatalf("Get err = %v, want nil", err)
+	}
+	if got, want := row.OriginalFilename, "My Vacation.png"; got != want {
+		t.Errorf("stored OriginalFilename = %q, want %q", got, want)
+	}
+}
+
+// TestSanitizeFilename pins the upload-filename sanitizer: it reduces a name to
+// its base, drops directory-only and empty inputs to the empty string, and caps
+// the length in runes (#1137).
+func TestSanitizeFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in   string
+		want string
+	}{
+		"plain name":       {in: "photo.png", want: "photo.png"},
+		"strips directory": {in: "uploads/sub/photo.png", want: "photo.png"},
+		"trims whitespace": {in: "  photo.png  ", want: "photo.png"},
+		"empty":            {in: "", want: ""},
+		"dot":              {in: ".", want: ""},
+		"root separator":   {in: "/", want: ""},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := ExportSanitizeFilename(tc.in), tc.want; got != want {
+				t.Errorf("ExportSanitizeFilename(%q) = %q, want %q", tc.in, got, want)
+			}
+		})
+	}
+
+	t.Run("caps length", func(t *testing.T) {
+		t.Parallel()
+		if got, want := len([]rune(ExportSanitizeFilename(strings.Repeat("a", 300)))), 255; got != want {
+			t.Errorf("len(runes) = %d, want %d (capped)", got, want)
+		}
+	})
 }
 
 // TestServiceStoreImageOverCap pins that an image upload over the configured
@@ -175,7 +249,7 @@ func TestServiceStoreImageOverCap(t *testing.T) {
 	const tinyCap int64 = 8
 	svc := NewService(store.NewMediaStore(db, slog.Default()), root, tinyCap, testAudioMaxBytes, slog.Default())
 
-	_, err := svc.StoreImage(t.Context(), quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	_, err := svc.StoreImage(t.Context(), quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)))
 	if got, want := err, ErrUploadTooLarge; !errors.Is(got, want) {
 		t.Errorf("StoreImage err = %v, want %v", got, want)
 	}
@@ -193,7 +267,7 @@ func TestServiceStoreCancelledBeforeProcessing(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	_, err := fx.svc.StoreImage(ctx, fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	_, err := fx.svc.StoreImage(ctx, fx.quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)))
 	if got, want := err, context.Canceled; !errors.Is(got, want) {
 		t.Errorf("StoreImage err = %v, want %v", got, want)
 	}
@@ -272,7 +346,7 @@ func TestServiceStoreCancelledMidFlightCleansUp(t *testing.T) {
 	wrapped := &cancelOnUpdatePathsStore{Store: innerStore, cancel: cancel}
 	svc := NewService(wrapped, root, testImageMaxBytes, testAudioMaxBytes, slog.Default())
 
-	_, err := svc.StoreImage(ctx, quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	_, err := svc.StoreImage(ctx, quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)))
 	if err == nil {
 		t.Fatal("StoreImage err = nil, want non-nil (ctx was cancelled mid-flight)")
 	}
@@ -330,7 +404,7 @@ func TestServiceStoreCancelledAfterPathsLeavesNothing(t *testing.T) {
 	wrapped := &cancelAfterPathsStore{Store: innerStore, cancel: cancel}
 	svc := NewService(wrapped, root, testImageMaxBytes, testAudioMaxBytes, slog.Default())
 
-	_, err := svc.StoreImage(ctx, quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	_, err := svc.StoreImage(ctx, quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)))
 	if err == nil {
 		t.Fatal("StoreImage err = nil, want non-nil (ctx cancelled after paths committed)")
 	}
@@ -397,7 +471,7 @@ func TestServiceStoreCreateMediaFailureLeavesNoDir(t *testing.T) {
 		t.Fatalf("db.Close err = %v, want nil", err)
 	}
 
-	_, err := svc.StoreImage(t.Context(), quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	_, err := svc.StoreImage(t.Context(), quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)))
 	if err == nil {
 		t.Fatal("StoreImage err = nil, want non-nil (CreateMedia ran against a closed DB)")
 	}
@@ -418,7 +492,13 @@ func TestServiceDeleteRemovesRowAndFiles(t *testing.T) {
 
 	fx := newServiceWithQuiz(t)
 
-	m, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 320, 240)))
+	m, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 320, 240)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -459,11 +539,23 @@ func TestServiceListByQuizScoped(t *testing.T) {
 	// A second quiz in the same DB whose media must not leak into quizA's list.
 	quizB := seedQuiz(t, fx.db, "media-svc-b")
 
-	first, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 100, 100)))
+	first, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 100, 100)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage first err = %v, want nil", err)
 	}
-	second, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 120, 120)))
+	second, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 120, 120)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage second err = %v, want nil", err)
 	}
@@ -471,6 +563,7 @@ func TestServiceListByQuizScoped(t *testing.T) {
 		t.Context(),
 		quizB,
 		seededAdminID,
+		"pic.png",
 		bytes.NewReader(pngUpload(t, 80, 80)),
 	); err != nil {
 		t.Fatalf("StoreImage quizB err = %v, want nil", err)
@@ -499,7 +592,13 @@ func TestServiceOpenRoundTrip(t *testing.T) {
 
 	fx := newServiceWithQuiz(t)
 
-	m, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 200, 200)))
+	m, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 200, 200)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -543,7 +642,13 @@ func TestServiceQuizDeleteCascadesMedia(t *testing.T) {
 
 	fx := newServiceWithQuiz(t)
 
-	m, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 160, 90)))
+	m, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 160, 90)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -564,7 +669,13 @@ func TestServiceStoreFlipsRowReady(t *testing.T) {
 
 	fx := newServiceWithQuiz(t)
 
-	m, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 100, 100)))
+	m, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 100, 100)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -624,7 +735,13 @@ func TestServiceSweepStaleNotReadyDropsRowAndFiles(t *testing.T) {
 	staleID := seedNotReadyMedia(t, fx, staleFull, staleThumb, "2000-01-01 00:00:00")
 	freshID := seedNotReadyMedia(t, fx, "1/101.jpg", "1/101-thumb.jpg",
 		time.Now().UTC().Format("2006-01-02 15:04:05"))
-	readyMedia, err := fx.svc.StoreImage(t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)))
+	readyMedia, err := fx.svc.StoreImage(
+		t.Context(),
+		fx.quizID,
+		seededAdminID,
+		"pic.png",
+		bytes.NewReader(pngUpload(t, 64, 64)),
+	)
 	if err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}
@@ -664,7 +781,7 @@ func TestService_RemoveQuizDir(t *testing.T) {
 	fx := newServiceWithQuiz(t)
 
 	if _, err := fx.svc.StoreImage(
-		t.Context(), fx.quizID, seededAdminID, bytes.NewReader(pngUpload(t, 64, 64)),
+		t.Context(), fx.quizID, seededAdminID, "pic.png", bytes.NewReader(pngUpload(t, 64, 64)),
 	); err != nil {
 		t.Fatalf("StoreImage err = %v, want nil", err)
 	}

--- a/internal/mediahttp/mediahttp.go
+++ b/internal/mediahttp/mediahttp.go
@@ -30,8 +30,9 @@ type Viewer func(r *http.Request) (*auth.Player, bool)
 // service.
 type MediaService interface {
 	// StoreImage processes an uploaded image through the pipeline, writes the jpeg
-	// full + thumbnail under the quiz directory, records a row, and returns it.
-	StoreImage(ctx context.Context, quizID, createdBy int64, r io.Reader) (*media.Media, error)
+	// full + thumbnail under the quiz directory, records a row (with filename as
+	// the row's original upload name), and returns it.
+	StoreImage(ctx context.Context, quizID, createdBy int64, filename string, r io.Reader) (*media.Media, error)
 	// StoreAudio validates and stores an already-browser-playable audio upload
 	// as-is, recording an audio row with the caller-supplied duration and a
 	// description label (defaulting to filename without extension when empty), and

--- a/internal/mediahttp/upload.go
+++ b/internal/mediahttp/upload.go
@@ -374,7 +374,7 @@ func storeOneUpload(
 		}
 	}()
 
-	stored, err := svc.StoreImage(ctx, quizID, playerID, file)
+	stored, err := svc.StoreImage(ctx, quizID, playerID, header.Filename, file)
 	if err != nil {
 		return 0, fmt.Errorf("storing upload part %q: %w", header.Filename, err)
 	}

--- a/internal/migrations/20260702120000_media_original_filename.sql
+++ b/internal/migrations/20260702120000_media_original_filename.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- Records the original uploaded filename on a media row (#1137) so the admin
+-- library can show a host, as a tooltip, which file a thumbnail or audio row
+-- came from - handy when matching a picture to the right question. The value is
+-- the client-supplied upload filename, reduced to its base name and
+-- length-capped before it is stored.
+--
+-- NOT NULL DEFAULT '' so every existing row gets an empty filename without a
+-- backfill, and a caller that has no filename stores the empty string rather
+-- than NULL. ADD COLUMN is an in-place change in SQLite (no table rebuild), so
+-- even though media is a parent table (questions references it) a plain ALTER
+-- inside goose's default transaction is fine, exactly as 20260620120000 added
+-- description.
+-- +goose StatementBegin
+ALTER TABLE media ADD COLUMN original_filename TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE media DROP COLUMN original_filename;
+-- +goose StatementEnd

--- a/internal/migrations/media_original_filename_test.go
+++ b/internal/migrations/media_original_filename_test.go
@@ -1,0 +1,113 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/starquake/topbanana/internal/dbtest"
+)
+
+// mediaOriginalFilenameVersion is the #1137 migration adding
+// media.original_filename.
+const mediaOriginalFilenameVersion = 20260702120000
+
+// TestMediaOriginalFilenameMigration_Column pins the #1137 schema addition:
+// media gains an original_filename column.
+func TestMediaOriginalFilenameMigration_Column(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	if !tableColumns(t, db, "media")["original_filename"] {
+		t.Error("media is missing the original_filename column")
+	}
+}
+
+// TestMediaOriginalFilenameMigration_DefaultAndRoundTrip pins that an existing
+// row reads back the empty-string default (no backfill needed) and that an
+// explicit filename stores and reads back.
+func TestMediaOriginalFilenameMigration_DefaultAndRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Media original filename", "media-original-filename-roundtrip")
+
+	defaulted := seedMedia(t, db, quizID)
+	var gotDefault string
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT original_filename FROM media WHERE id = ?", defaulted,
+	).Scan(&gotDefault); err != nil {
+		t.Fatalf("read default original_filename err = %v, want nil", err)
+	}
+	if gotDefault != "" {
+		t.Errorf("original_filename = %q, want empty default", gotDefault)
+	}
+
+	if _, err := db.ExecContext(
+		t.Context(), "UPDATE media SET original_filename = ? WHERE id = ?", "sunset.png", defaulted,
+	); err != nil {
+		t.Fatalf("set original_filename err = %v, want nil", err)
+	}
+	var got string
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT original_filename FROM media WHERE id = ?", defaulted,
+	).Scan(&got); err != nil {
+		t.Fatalf("read original_filename err = %v, want nil", err)
+	}
+	if want := "sunset.png"; got != want {
+		t.Errorf("original_filename = %q, want %q", got, want)
+	}
+}
+
+// TestMediaOriginalFilenameMigration_DownUpRoundTrips pins that the #1137
+// migration runs both directions against a populated DB: Down drops the column
+// and Up re-adds it with the empty-string default.
+func TestMediaOriginalFilenameMigration_DownUpRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	t.Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			t.Errorf("db.Close err = %v", cerr)
+		}
+	})
+
+	quizID := seedQuiz(t, db, "Media original filename down-up", "media-original-filename-down-up")
+	seedMedia(t, db, quizID)
+
+	if err := goose.DownTo(db, ".", mediaOriginalFilenameVersion-1); err != nil {
+		t.Fatalf("goose.DownTo err = %v, want nil", err)
+	}
+	if tableColumns(t, db, "media")["original_filename"] {
+		t.Error("media still has original_filename after Down, want it dropped")
+	}
+
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("goose.Up err = %v, want nil", err)
+	}
+	if !tableColumns(t, db, "media")["original_filename"] {
+		t.Error("media is missing original_filename after re-Up")
+	}
+
+	var n int
+	if err := db.QueryRowContext(
+		t.Context(), "SELECT count(*) FROM media WHERE quiz_id = ? AND original_filename = ''", quizID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count default original filenames err = %v, want nil", err)
+	}
+	if n == 0 {
+		t.Error("no rows read back the empty original_filename default after re-Up")
+	}
+}

--- a/internal/migrations/media_type_audio_test.go
+++ b/internal/migrations/media_type_audio_test.go
@@ -54,6 +54,9 @@ func TestMediaTypeAudioMigration_CheckAndShape(t *testing.T) {
 		// description is added later by 20260620120000; dbtest.Open migrates to
 		// the latest schema, so it is present here (#1072).
 		"description",
+		// original_filename is added later by 20260702120000; dbtest.Open
+		// migrates to the latest schema, so it is present here (#1137).
+		"original_filename",
 	}
 	gotCols := tableColumns(t, db, "media")
 	for _, col := range wantCols {

--- a/internal/queries/media.sql
+++ b/internal/queries/media.sql
@@ -11,7 +11,8 @@
 -- and the not-ready sweep drops the stranded row plus its files.
 INSERT INTO media (
     quiz_id, type, mime, path, thumb_path,
-    width, height, size_bytes, sha256, duration_ms, description, created_by_player_id, ready
+    width, height, size_bytes, sha256, duration_ms, description, original_filename,
+    created_by_player_id, ready
 )
 VALUES (
     sqlc.arg('quiz_id'),
@@ -25,6 +26,7 @@ VALUES (
     sqlc.arg('sha256'),
     sqlc.arg('duration_ms'),
     sqlc.arg('description'),
+    sqlc.arg('original_filename'),
     sqlc.arg('created_by_player_id'),
     0
 )

--- a/internal/store/media.go
+++ b/internal/store/media.go
@@ -40,6 +40,7 @@ func (s *MediaStore) CreateMedia(ctx context.Context, m *media.Media) (*media.Me
 		Sha256:            m.SHA256,
 		DurationMs:        nullableInt(m.DurationMs),
 		Description:       m.Description,
+		OriginalFilename:  m.OriginalFilename,
 		CreatedByPlayerID: m.CreatedByPlayerID,
 	})
 	if err != nil {
@@ -212,6 +213,7 @@ func mediaFromRow(row db.Medium) *media.Media {
 		SHA256:            row.Sha256,
 		DurationMs:        nullableIntToPtr(row.DurationMs),
 		Description:       row.Description,
+		OriginalFilename:  row.OriginalFilename,
 		CreatedByPlayerID: row.CreatedByPlayerID,
 		CreatedAt:         row.CreatedAt,
 	}

--- a/internal/store/media_test.go
+++ b/internal/store/media_test.go
@@ -174,6 +174,55 @@ func TestMediaStore_DescriptionRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMediaStore_OriginalFilenameRoundTrip pins that a row's original upload
+// filename survives the create/get/list round trip and that a row that never sets
+// one reads back the empty-string default (#1137).
+func TestMediaStore_OriginalFilenameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s, quizID := newMediaStoreWithQuiz(t)
+
+	named := newMediaRow(quizID)
+	named.OriginalFilename = "holiday photo.png"
+	created, err := s.CreateMedia(t.Context(), named)
+	if err != nil {
+		t.Fatalf("CreateMedia err = %v, want nil", err)
+	}
+	if got, want := created.OriginalFilename, "holiday photo.png"; got != want {
+		t.Errorf("created OriginalFilename = %q, want %q", got, want)
+	}
+	if err = s.MarkMediaReady(t.Context(), created.ID); err != nil {
+		t.Fatalf("MarkMediaReady err = %v, want nil", err)
+	}
+
+	got, err := s.GetMedia(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("GetMedia err = %v, want nil", err)
+	}
+	if got, want := got.OriginalFilename, "holiday photo.png"; got != want {
+		t.Errorf("GetMedia OriginalFilename = %q, want %q", got, want)
+	}
+
+	list, err := s.ListMediaByQuiz(t.Context(), quizID)
+	if err != nil {
+		t.Fatalf("ListMediaByQuiz err = %v, want nil", err)
+	}
+	if got, want := len(list), 1; got != want {
+		t.Fatalf("ListMediaByQuiz len = %d, want %d", got, want)
+	}
+	if got, want := list[0].OriginalFilename, "holiday photo.png"; got != want {
+		t.Errorf("ListMediaByQuiz OriginalFilename = %q, want %q", got, want)
+	}
+
+	unnamed, err := s.CreateMedia(t.Context(), newMediaRow(quizID))
+	if err != nil {
+		t.Fatalf("CreateMedia (unnamed) err = %v, want nil", err)
+	}
+	if got, want := unnamed.OriginalFilename, ""; got != want {
+		t.Errorf("unnamed OriginalFilename = %q, want %q (empty default)", got, want)
+	}
+}
+
 // TestMediaStore_UpdateDescription pins that UpdateMediaDescription overwrites the
 // label and that an unknown id maps to media.ErrMediaNotFound (#1072).
 func TestMediaStore_UpdateDescription(t *testing.T) {

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -324,6 +324,7 @@
                                     class="block w-full p-0 aspect-square overflow-hidden rounded-lg border border-border-soft bg-surface cursor-pointer hover:border-accent focus-visible:outline-none focus-visible:shadow-focus">
                                 <img src="/media/{{.ID}}/thumb"
                                      alt="Quiz image {{.ID}}"
+                                     {{if .OriginalFilename}}title="{{.OriginalFilename}}"{{end}}
                                      loading="lazy"
                                      width="{{.Width}}" height="{{.Height}}"
                                      class="h-full w-full object-cover"
@@ -517,6 +518,7 @@
                              removes both atomically (no orphan dialogs). */}}
                         <li id="sound-tile-{{.ID}}"
                             data-testid="audio-library-item"
+                            {{if .OriginalFilename}}title="{{.OriginalFilename}}"{{end}}
                             class="flex flex-wrap items-center gap-3 rounded-lg border border-border-soft bg-surface px-4 py-3">
                             <div class="flex min-w-0 grow items-center gap-3">
                                 <span class="shrink-0 text-text-dim" aria-hidden="true">

--- a/internal/web/tmpl/admin/pages/quizview.gohtml
+++ b/internal/web/tmpl/admin/pages/quizview.gohtml
@@ -324,12 +324,17 @@
                                     class="block w-full p-0 aspect-square overflow-hidden rounded-lg border border-border-soft bg-surface cursor-pointer hover:border-accent focus-visible:outline-none focus-visible:shadow-focus">
                                 <img src="/media/{{.ID}}/thumb"
                                      alt="Quiz image {{.ID}}"
-                                     {{if .OriginalFilename}}title="{{.OriginalFilename}}"{{end}}
                                      loading="lazy"
                                      width="{{.Width}}" height="{{.Height}}"
                                      class="h-full w-full object-cover"
                                      data-testid="library-thumb">
                             </button>
+                            {{/* Original upload filename shown as a caption under the
+                                 thumbnail (#1137) so a host can match a stored image to
+                                 its source; truncated to keep the grid tidy. */}}
+                            {{if .OriginalFilename}}
+                                <p class="mt-1 truncate text-[0.72rem] text-text-dim" data-testid="library-filename">{{.OriginalFilename}}</p>
+                            {{end}}
                             {{/* Always visible on touch; hover-fade gated on
                                  (hover: hover) so an iPad keeps it visible. */}}
                             <button type="button" aria-label="Delete image {{.ID}}"
@@ -518,7 +523,6 @@
                              removes both atomically (no orphan dialogs). */}}
                         <li id="sound-tile-{{.ID}}"
                             data-testid="audio-library-item"
-                            {{if .OriginalFilename}}title="{{.OriginalFilename}}"{{end}}
                             class="flex flex-wrap items-center gap-3 rounded-lg border border-border-soft bg-surface px-4 py-3">
                             <div class="flex min-w-0 grow items-center gap-3">
                                 <span class="shrink-0 text-text-dim" aria-hidden="true">
@@ -538,6 +542,12 @@
                                     class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border-soft bg-bg/80 text-text-dim transition hover:bg-danger hover:text-text focus-visible:outline-none focus-visible:shadow-focus">
                                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6.5 1a.5.5 0 0 0-.5.5V2H3a.5.5 0 0 0 0 1h.5l.6 9.1a1.5 1.5 0 0 0 1.5 1.4h4.8a1.5 1.5 0 0 0 1.5-1.4L12.5 3h.5a.5.5 0 0 0 0-1h-3v-.5a.5.5 0 0 0-.5-.5h-3zM6 6a.5.5 0 0 1 1 0v5a.5.5 0 0 1-1 0V6zm3 0a.5.5 0 0 1 1 0v5a.5.5 0 0 1-1 0V6z"/></svg>
                             </button>
+                            {{/* Original upload filename as a full-width caption line
+                                 under the row controls (#1137); basis-full drops it to
+                                 its own line. */}}
+                            {{if .OriginalFilename}}
+                                <p class="basis-full truncate text-[0.72rem] text-text-dim" data-testid="audio-library-filename">{{.OriginalFilename}}</p>
+                            {{end}}
                             <div id="modal-delete-sound-{{.ID}}" role="dialog" aria-modal="true" aria-labelledby="modal-delete-sound-{{.ID}}-title" class="hidden fixed inset-0 z-40 flex items-center justify-center bg-bg/80 backdrop-blur-sm p-4">
                                 <div class="absolute inset-0" onclick="closeModal('modal-delete-sound-{{.ID}}')"></div>
                                 <div class="relative w-full max-w-[480px] mx-auto bg-surface border border-accent-line rounded-lg shadow-2xl">

--- a/test/integration/media_audio_test.go
+++ b/test/integration/media_audio_test.go
@@ -242,7 +242,7 @@ func TestMediaAudioLibraryAndPicker_Integration(t *testing.T) {
 			fmt.Sprintf(`src="/media/%d"`, audioID),
 			`data-testid="audio-duration"`,
 			"1:35",
-			`title="tune.mp3"`,
+			`data-testid="audio-library-filename">tune.mp3</p>`,
 			fmt.Sprintf(`action="/admin/quizzes/%d/media/audio"`, quizID),
 		} {
 			if !strings.Contains(page, want) {

--- a/test/integration/media_audio_test.go
+++ b/test/integration/media_audio_test.go
@@ -242,6 +242,7 @@ func TestMediaAudioLibraryAndPicker_Integration(t *testing.T) {
 			fmt.Sprintf(`src="/media/%d"`, audioID),
 			`data-testid="audio-duration"`,
 			"1:35",
+			`title="tune.mp3"`,
 			fmt.Sprintf(`action="/admin/quizzes/%d/media/audio"`, quizID),
 		} {
 			if !strings.Contains(page, want) {

--- a/test/integration/media_test.go
+++ b/test/integration/media_test.go
@@ -543,6 +543,7 @@ func TestMediaLibraryView_Integration(t *testing.T) {
 		for _, want := range []string{
 			fmt.Sprintf(`src="/media/%d/thumb"`, mediaID),
 			fmt.Sprintf(`openImageViewer('/media/%d')`, mediaID),
+			`title="pic.png"`,
 			`enctype="multipart/form-data"`,
 		} {
 			if !strings.Contains(page, want) {

--- a/test/integration/media_test.go
+++ b/test/integration/media_test.go
@@ -543,7 +543,7 @@ func TestMediaLibraryView_Integration(t *testing.T) {
 		for _, want := range []string{
 			fmt.Sprintf(`src="/media/%d/thumb"`, mediaID),
 			fmt.Sprintf(`openImageViewer('/media/%d')`, mediaID),
-			`title="pic.png"`,
+			`data-testid="library-filename">pic.png</p>`,
 			`enctype="multipart/form-data"`,
 		} {
 			if !strings.Contains(page, want) {


### PR DESCRIPTION
Uploaded media now records the original upload filename, carried across export/import, and the admin library shows it as a caption under each image thumbnail and audio row so a host can match a stored image or clip back to its source file.

- Migration adds `original_filename TEXT NOT NULL DEFAULT ''` to `media` (plain `ADD COLUMN` in goose's default transaction).
- The client filename is plumbed through `StoreImage` / `StoreAudio` -> `CreateMedia`, sanitized to its base name, stripped of control characters, and capped at 255 runes.
- The library renders it as a truncating, auto-escaped text caption under the image thumbnail and in the audio row (not a hover tooltip).
- The quiz-archive manifest carries `originalFilename` per media ref (additive, `omitempty`, no format-version bump), so a re-imported or seeded/demo quiz restores the real name; pre-#1137 archives restore with an empty name.

Applied to both images and audio. Tests: migration up/down round-trip, store/service round-trip, sanitizer unit test (incl. control chars), an export/import round-trip asserting the restored name, and the library rendering the caption. `make check` (incl. smoke) green.

Closes #1137

_— Claude Code, for @starquake_
