### PR TITLE
Harden host-start navigation and session cleanup in host e2e specs

### DIFF
--- a/test/e2e/tests/confirm-restart.spec.ts
+++ b/test/e2e/tests/confirm-restart.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures';
 import type { HostSessions } from './fixtures';
-import { importQuiz, setQuizMode, claimAndJoin, playerRow } from './helpers';
+import { importQuiz, setQuizMode, claimAndJoin, playerRow, waitForHostRoom } from './helpers';
 import type { APIRequestContext, Page } from '@playwright/test';
 
 // confirm-and-restart (#853): a host already running a game on quiz A opens
@@ -104,8 +104,7 @@ test.describe('confirm-and-restart hosting', () => {
     // Confirm: end the current session and start a new one hosting quiz B. The
     // host lands on a NEW big screen (a different /host/{code}).
     await modal.getByRole('button', { name: 'End and start' }).click();
-    await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
-    const newCode = host.url().split('/host/')[1];
+    const newCode = await waitForHostRoom(host);
     expect(newCode).not.toBe(runningCode);
     // The restart created this second room out of band (not via a factory open),
     // so register it for teardown too.

--- a/test/e2e/tests/connection-trouble.spec.ts
+++ b/test/e2e/tests/connection-trouble.spec.ts
@@ -11,6 +11,7 @@ import {
   markAdmin,
   login,
   setQuizMode,
+  waitForHostRoom,
 } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' and returns its id, mirroring
@@ -105,8 +106,7 @@ test.describe('live client connection trouble', () => {
     await page.getByRole('link', { name: quizTitle }).click();
     await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
     await page.getByRole('button', { name: 'Host live' }).click();
-    await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-    const code = page.url().split('/host/')[1];
+    const code = await waitForHostRoom(page);
     // page is this test's own freshly-registered admin host (not the shared
     // admin the factory opens), so register the room with the factory so
     // teardown ends it through page (#850).
@@ -167,8 +167,7 @@ test.describe('live client connection trouble', () => {
     await page.getByRole('link', { name: quizTitle }).click();
     await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
     await page.getByRole('button', { name: 'Host live' }).click();
-    await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-    const code = page.url().split('/host/')[1];
+    const code = await waitForHostRoom(page);
     hostSessions.track(page, code);
 
     await expect(page.getByTestId('session-gone')).toHaveCount(0);

--- a/test/e2e/tests/fixtures.ts
+++ b/test/e2e/tests/fixtures.ts
@@ -9,7 +9,7 @@ import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 
 import { SEED_ADMIN_PASSWORD_HASH, adminStatePath } from '../e2e-auth';
-import { endHostedSession } from './helpers';
+import { endHostedSession, waitForHostRoom } from './helpers';
 import { execSqlite } from './sqlite';
 
 // HostSessions is the test-scoped factory the host-session specs use to open
@@ -45,17 +45,6 @@ export type HostSessions = {
   // cookie -> a distinct anonymous player), auto-closed in teardown.
   newPlayerContext(): Promise<BrowserContext>;
 };
-
-// waitForHostRoom waits for the big-screen room URL after a host action and
-// returns the join code. It stops at 'commit' rather than the default 'load':
-// the big screen opens an SSE EventSource as it boots, and firefox holds the
-// page 'load' event open while that stream stays connected, so a default
-// waitForURL can hang past the test budget (#1035). Callers need only the
-// committed /host/<code> URL; the page's content is awaited by later locators.
-async function waitForHostRoom(host: Page): Promise<string> {
-  await host.waitForURL(/\/host\/[A-Z0-9]{6}$/, { waitUntil: 'commit' });
-  return host.url().split('/host/')[1];
-}
 
 async function makeHostSessions(
   browser: Browser,

--- a/test/e2e/tests/helpers.ts
+++ b/test/e2e/tests/helpers.ts
@@ -511,6 +511,20 @@ export async function answerRemainingQuestions(page: Page, fromIndex = 0): Promi
   await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible();
 }
 
+// waitForHostRoom waits for the big-screen room URL after a host-start action
+// (clicking "Host live", "Host a session", "Host this", or "End and start") and
+// returns the join code. It replaces a bare `expect(page).toHaveURL(/\/host\//)`,
+// whose 5s expect timeout was too tight for the `/host/<code>` navigation to land
+// under CI load (#1143): page.waitForURL is bounded by the test timeout, not the
+// 5s expect budget, so it absorbs a slow-runner navigation. It stops at 'commit'
+// rather than the default 'load': the big screen opens an SSE EventSource as it
+// boots, and firefox holds the page 'load' event open while that stream stays
+// connected, so a default wait can hang past the test budget (#1035).
+export async function waitForHostRoom(host: Page): Promise<string> {
+  await host.waitForURL(/\/host\/[A-Z0-9]{6}$/, { waitUntil: 'commit' });
+  return host.url().split('/host/')[1];
+}
+
 // endHostedSession ends a live session through its lobby End-session control so
 // the host's dashboard returns to a hostable state for the next test (a host
 // runs one session at a time, #850). Idempotent: a no-op if the room is already

--- a/test/e2e/tests/host-game.spec.ts
+++ b/test/e2e/tests/host-game.spec.ts
@@ -10,6 +10,7 @@ import {
   setQuizMode,
   importQuiz,
   playerRow,
+  waitForHostRoom,
 } from './helpers';
 
 // MP-8 (#685): the host TV in-game view. The host puts a live quiz on a TV,
@@ -85,8 +86,7 @@ test('host TV shows the live question, answered order, and the reveal', async ({
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   // Two players join from fresh anonymous contexts (each gets its own
   // anonymous player). They ready up so the host start has a non-empty,
@@ -224,8 +224,7 @@ test('the host TV roster reflects a player rename', async ({
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   // Player names are global on players.display_name now (#716), so use unique
   // names to avoid colliding with a parallel spec on the worker DB.
@@ -323,8 +322,7 @@ test('host TV round intro shows the round title, summary, and an accurate Round 
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   // One player joins and readies so the start has a non-empty, all-ready roster
   // and the runner advances into the round intro.

--- a/test/e2e/tests/host-lobby.spec.ts
+++ b/test/e2e/tests/host-lobby.spec.ts
@@ -8,6 +8,7 @@ import {
   setQuizMode,
   claimAndJoin,
   playerRow,
+  waitForHostRoom,
 } from './helpers';
 
 // MP-3 (#680): the host puts a live quiz on a TV and gets a lobby with the
@@ -44,9 +45,7 @@ test('host lobby shows the room code, QR, and a joined player readying up live',
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
 
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
-  expect(code).toMatch(/^[A-Z0-9]+$/);
+  const code = await waitForHostRoom(page);
 
   // Lobby chrome: the scan card, a server-rendered QR svg, and the big code.
   await expect(page.getByText('Scan to join')).toBeVisible();

--- a/test/e2e/tests/question-audio.spec.ts
+++ b/test/e2e/tests/question-audio.spec.ts
@@ -8,6 +8,7 @@ import {
   installPlaythroughClock,
   playerRow,
   setQuizMode,
+  waitForHostRoom,
   type QuestionSpec,
 } from './helpers';
 import { adminStatePath } from '../e2e-auth';
@@ -542,8 +543,7 @@ async function startLiveAudioSession(
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   const casey = `Casey-${browserName}-${Date.now()}`;
   const caseyCtx = await context.browser()!.newContext({ storageState: undefined, baseURL });

--- a/test/e2e/tests/question-image-unavailable.spec.ts
+++ b/test/e2e/tests/question-image-unavailable.spec.ts
@@ -102,10 +102,12 @@ test('the host bigscreen shows an Image unavailable placeholder when the questio
     await expect(placeholder).toContainText('Image unavailable');
     await expect(page.getByTestId('question-image')).toBeHidden();
   } finally {
-    await caseyCtx.close();
-    // End the session this spec started as the shared admin: a live game left
-    // running flips the next shared-admin host test's "Host live" into the
-    // confirm-restart modal (no /host/<code> navigation), stalling it (#1143).
+    // End the session this spec started as the shared admin BEFORE closing the
+    // player context, so a rejecting caseyCtx.close() cannot skip the
+    // session-end: a live game left running flips the next shared-admin host
+    // test's "Host live" into the confirm-restart modal (no /host/<code>
+    // navigation), stalling it (#1143).
     await endHostedSession(page, code).catch(() => undefined);
+    await caseyCtx.close();
   }
 });

--- a/test/e2e/tests/question-image-unavailable.spec.ts
+++ b/test/e2e/tests/question-image-unavailable.spec.ts
@@ -3,8 +3,10 @@ import {
   seedQuiz,
   attachQuizImage,
   setQuizMode,
+  endHostedSession,
   installPlaythroughClock,
   playerRow,
+  waitForHostRoom,
   type QuestionSpec,
 } from './helpers';
 import { adminStatePath } from '../e2e-auth';
@@ -70,8 +72,7 @@ test('the host bigscreen shows an Image unavailable placeholder when the questio
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   // One player joins and readies from a fresh anonymous context so the host
   // start has a non-empty, all-ready roster.
@@ -102,5 +103,9 @@ test('the host bigscreen shows an Image unavailable placeholder when the questio
     await expect(page.getByTestId('question-image')).toBeHidden();
   } finally {
     await caseyCtx.close();
+    // End the session this spec started as the shared admin: a live game left
+    // running flips the next shared-admin host test's "Host live" into the
+    // confirm-restart modal (no /host/<code> navigation), stalling it (#1143).
+    await endHostedSession(page, code).catch(() => undefined);
   }
 });

--- a/test/e2e/tests/question-image.spec.ts
+++ b/test/e2e/tests/question-image.spec.ts
@@ -1,7 +1,7 @@
 import type { APIRequestContext, Page } from '@playwright/test';
 
 import { test, expect } from './fixtures';
-import { createQuizWithQuestions, installPlaythroughClock, playerRow, setQuizMode, type QuestionSpec } from './helpers';
+import { createQuizWithQuestions, endHostedSession, installPlaythroughClock, playerRow, setQuizMode, waitForHostRoom, type QuestionSpec } from './helpers';
 import { adminStatePath } from '../e2e-auth';
 
 // Seed and author as the shared admin; play anonymously after clearing the
@@ -132,8 +132,7 @@ test('the question image renders on the host bigscreen during the question and r
   await page.getByRole('link', { name: quizTitle }).click();
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
 
   // ---- One player joins and readies from a fresh anonymous context so the
   // host start has a non-empty, all-ready roster.
@@ -172,5 +171,9 @@ test('the question image renders on the host bigscreen during the question and r
     await expect(questionImage).toBeVisible();
   } finally {
     await caseyCtx.close();
+    // End the session this spec started as the shared admin: a live game left
+    // running flips the next shared-admin host test's "Host live" into the
+    // confirm-restart modal (no /host/<code> navigation), stalling it (#1143).
+    await endHostedSession(page, code).catch(() => undefined);
   }
 });

--- a/test/e2e/tests/question-image.spec.ts
+++ b/test/e2e/tests/question-image.spec.ts
@@ -170,10 +170,12 @@ test('the question image renders on the host bigscreen during the question and r
     await expect(page.locator('[data-answer-option][data-correct="true"]')).toHaveCount(1, { timeout: 15_000 });
     await expect(questionImage).toBeVisible();
   } finally {
-    await caseyCtx.close();
-    // End the session this spec started as the shared admin: a live game left
-    // running flips the next shared-admin host test's "Host live" into the
-    // confirm-restart modal (no /host/<code> navigation), stalling it (#1143).
+    // End the session this spec started as the shared admin BEFORE closing the
+    // player context, so a rejecting caseyCtx.close() cannot skip the
+    // session-end: a live game left running flips the next shared-admin host
+    // test's "Host live" into the confirm-restart modal (no /host/<code>
+    // navigation), stalling it (#1143).
     await endHostedSession(page, code).catch(() => undefined);
+    await caseyCtx.close();
   }
 });

--- a/test/e2e/tests/session-first.spec.ts
+++ b/test/e2e/tests/session-first.spec.ts
@@ -63,7 +63,9 @@ test.describe('session-first live hosting', () => {
     // staging room open, "Host this" ARMS the quiz in that room but stays in the
     // lobby (#863) - it does NOT auto-start - so the host starts when ready.
     await host.getByTestId('pick-quiz-link').locator('a').click();
-    await expect(host).toHaveURL(/\/host\/quizzes$/);
+    // waitForURL (test-timeout budget) not expect().toHaveURL (5s) so a slow
+    // /host/quizzes navigation under CI load does not flake the assertion (#1143).
+    await host.waitForURL(/\/host\/quizzes$/);
     const quizCard = host.locator('article').filter({ hasText: quizTitle });
     await quizCard.getByRole('button', { name: 'Host this' }).click();
 

--- a/test/e2e/tests/session-first.spec.ts
+++ b/test/e2e/tests/session-first.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { seedQuiz, setQuizMode } from './helpers';
+import { seedQuiz, setQuizMode, waitForHostRoom } from './helpers';
 import type { Page } from '@playwright/test';
 
 // session-first live hosting (#836, #851): a host opens a live room BEFORE
@@ -69,7 +69,7 @@ test.describe('session-first live hosting', () => {
 
     // Back on the lobby the quiz is now armed: the Start controls appear and the
     // pick link is gone. The game has not started - the player is still waiting.
-    await expect(host).toHaveURL(/\/host\/[A-Z0-9]{6}$/);
+    await waitForHostRoom(host);
     await expect(host.getByTestId('start-now')).toBeVisible({ timeout: 15_000 });
     await expect(host.getByTestId('pick-quiz-link')).toBeHidden();
     await expect(page.getByTestId('question-view')).toBeHidden();

--- a/test/e2e/tests/session-leave.spec.ts
+++ b/test/e2e/tests/session-leave.spec.ts
@@ -10,6 +10,7 @@ import {
   setQuizMode,
   claimAndJoin,
   execSqlite,
+  waitForHostRoom,
 } from './helpers';
 
 // makeQuizLive flips a seeded quiz to mode='live' and returns its id, mirroring
@@ -62,8 +63,7 @@ test('a player leaving drops out of the host roster live', async ({
   await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
   await page.getByRole('button', { name: 'Host live' }).click();
 
-  await expect(page).toHaveURL(/\/host\/[A-Z0-9]+$/);
-  const code = page.url().split('/host/')[1];
+  const code = await waitForHostRoom(page);
   // page is this test's own freshly-registered admin host (not the shared admin
   // the factory opens), so register the room with the factory so teardown ends
   // it through page and the dashboard returns hostable for the next test (#850).


### PR DESCRIPTION
The `question-image` host-bigscreen e2e spec flaked on CI: the "Host live" click never reached `/host/<code>`.

**Root cause:** a test-isolation flake. `question-image.spec.ts` and `question-image-unavailable.spec.ts` start a live game as the shared admin but never end it. With a game running, the quiz view renders "Host live" as the confirm-restart modal instead of the form that navigates to `/host/<code>` (gated on `HostHasRunningGame`), so the next shared-admin host test clicks a modal-opener and its wait times out.

**Fix:** end the hosted session in both leaking specs (as `question-audio` already does), and promote the robust `waitForHostRoom` wait into shared `helpers.ts` in place of the bare 5s `expect().toHaveURL(/\/host\//)` across the inline host-start specs (`waitForURL` uses the test-timeout budget and stops at `commit` for the firefox SSE hang, #1035). Test-only.

Verified: the affected specs pass on chromium `--workers=1` (serial, so the leak -> victim path runs every time); CI runs both browsers.

Closes #1143

_— Claude Code, for @starquake_
