### PR TITLE
Harden the deploy pipeline against fork PRs, script injection, and open-registration defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
     environment:
       name: staging
       url: "${{ vars.SERVER_URL }}"
@@ -117,8 +117,9 @@ jobs:
           # broke the verify-email send on staging (#489).
           BASE_URL: ${{ vars.BASE_URL }}
           # REGISTRATION_ENABLED is an env-driven toggle so the
-          # operator can flip it without a redeploy. Defaults true on
-          # the compose side when unset here.
+          # operator can flip it without a redeploy. Defaults false on
+          # the compose side when unset here (fail-closed), so opening
+          # registration always requires setting this variable.
           REGISTRATION_ENABLED: ${{ vars.REGISTRATION_ENABLED }}
           # ADMIN_EMAILS is the comma-separated allowlist of emails
           # promoted to admin at registration time (#446). Sourced
@@ -200,7 +201,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository && startsWith(github.event.workflow_run.head_branch, 'v')) || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     environment:
       name: production
       url: "${{ vars.SERVER_URL }}"
@@ -213,8 +214,9 @@ jobs:
 
       - name: Determine image tag
         id: tag
+        env:
+          IMAGE_TAG: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         run: |
-          IMAGE_TAG="${{ github.event.workflow_run.head_branch || github.ref_name }}"
           IMAGE_TAG="${IMAGE_TAG#v}"
           if [[ ! "$IMAGE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             IMAGE_TAG="latest"
@@ -300,8 +302,9 @@ jobs:
           # broke the verify-email send on staging (#489).
           BASE_URL: ${{ vars.BASE_URL }}
           # REGISTRATION_ENABLED is an env-driven toggle so the
-          # operator can flip it without a redeploy. Defaults true on
-          # the compose side when unset here.
+          # operator can flip it without a redeploy. Defaults false on
+          # the compose side when unset here (fail-closed), so opening
+          # registration always requires setting this variable.
           REGISTRATION_ENABLED: ${{ vars.REGISTRATION_ENABLED }}
           # ADMIN_EMAILS is the comma-separated allowlist of emails
           # promoted to admin at registration time (#446). Sourced
@@ -391,6 +394,8 @@ jobs:
     if: >-
       vars.DEMO_DEPLOY_ENABLED == 'true' &&
       ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
         (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v'))) ||
        (github.event_name == 'workflow_dispatch' && inputs.environment == 'demo'))
     environment:

--- a/deployments/app/docker-compose.production.yml
+++ b/deployments/app/docker-compose.production.yml
@@ -14,11 +14,11 @@ services:
       # distroless image's app filesystem is ephemeral, so the default
       # ./media would be lost on every redeploy. Shares the data volume.
       - MEDIA_DIR=/home/nonroot/data/media
-      # REGISTRATION_ENABLED is now env-driven so the operator can
-      # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
-      # without a redeploy. Defaults true when unset so a fresh stack
-      # behaves the way the previously-hardcoded value did.
-      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
+      # REGISTRATION_ENABLED is env-driven so the operator can flip it
+      # via a GitHub Actions variable (vars.REGISTRATION_ENABLED) without
+      # a redeploy. Defaults false when unset to match the app's
+      # fail-closed default, so opening registration is always explicit.
+      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-false}
       # ADMIN_EMAILS pre-seeds the admin allowlist. Sourced from a
       # GitHub Actions variable (vars.ADMIN_EMAILS) so an operator can
       # rotate it without a redeploy; defaults to admin@example.test

--- a/deployments/app/docker-compose.staging.yml
+++ b/deployments/app/docker-compose.staging.yml
@@ -14,11 +14,11 @@ services:
       # distroless image's app filesystem is ephemeral, so the default
       # ./media would be lost on every redeploy. Shares the data volume.
       - MEDIA_DIR=/home/nonroot/data/media
-      # REGISTRATION_ENABLED is now env-driven so the operator can
-      # flip it via a GitHub Actions variable (vars.REGISTRATION_ENABLED)
-      # without a redeploy. Defaults true when unset so a fresh stack
-      # behaves the way the previously-hardcoded value did.
-      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-true}
+      # REGISTRATION_ENABLED is env-driven so the operator can flip it
+      # via a GitHub Actions variable (vars.REGISTRATION_ENABLED) without
+      # a redeploy. Defaults false when unset to match the app's
+      # fail-closed default, so opening registration is always explicit.
+      - REGISTRATION_ENABLED=${REGISTRATION_ENABLED:-false}
       # ADMIN_EMAILS pre-seeds the admin allowlist. Sourced from a
       # GitHub Actions variable (vars.ADMIN_EMAILS) so an operator can
       # rotate it without a redeploy; defaults to admin@example.test


### PR DESCRIPTION
Three deploy/CI audit fixes. YAML/compose only.

- **#1164 (fork-PR pwn):** every deploy job's `if` now also requires `workflow_run.event == 'push'` and `head_repository.full_name == github.repository`, so a fork PR can't fire a deploy with base-repo secrets. Existing gates unchanged.
- **#1168 (script injection):** the production "Determine image tag" step binds `head_branch` to an `env:` var and references quoted `"$IMAGE_TAG"` instead of interpolating it into the shell (the pattern `deploy-demo` already uses). No other untrusted `${{ github.event.* }}` interpolations remain.
- **#1169 (registration default):** `docker-compose.{staging,production}.yml` now default `REGISTRATION_ENABLED` to `false`, matching the Go fail-closed default; demo already hardcodes `false`.

Maintainer to confirm separately (I can't read repo settings): whether the staging/production/demo GitHub environments have required-reviewer protection. `actionlint` isn't on PATH here; verified by reading.

Closes #1164
Closes #1168
Closes #1169

_— Claude Code, for @starquake_
