### PR TITLE
Guard live-session phase transitions and quiz-less starts

### DIFF
--- a/internal/clientapi/sessions.go
+++ b/internal/clientapi/sessions.go
@@ -175,10 +175,10 @@ func HandleSessionReady(service *livesession.Service) http.Handler {
 // arm, cancel) into an [http.Handler]. The three controls share the same shape:
 // resolve the context player, run action, then map the result - nil or the
 // supplied idempotent sentinel to 204, ErrSessionNotFound to 404, ErrNotHost to
-// 403, anything else to a logged 500. action is the only thing that differs per
-// control; idempotent is the per-control "already in that state" sentinel (an
-// already-started game for start, an already-left lobby for arm/cancel) that
-// maps to a 204 no-op; what names the action in the log messages.
+// 403, ErrNoQuizToStart to 409, anything else to a logged 500. action is the
+// only thing that differs per control; idempotent is the per-control "already in
+// that state" sentinel (an already-started game for start, an already-left lobby
+// for arm/cancel) that maps to a 204 no-op; what names the action in the logs.
 func hostSessionAction(
 	what string,
 	idempotent error,
@@ -205,6 +205,8 @@ func hostSessionAction(
 			http.NotFound(w, r)
 		case errors.Is(err, livesession.ErrNotHost):
 			http.Error(w, "forbidden", http.StatusForbidden)
+		case errors.Is(err, livesession.ErrNoQuizToStart):
+			http.Error(w, "this room has no quiz to start", http.StatusConflict)
 		default:
 			writeInternalError(w, r, logger, "error on session "+what, err)
 		}
@@ -214,8 +216,8 @@ func hostSessionAction(
 // HandleSessionStart is the host "Start now" control: it begins the game
 // immediately, skipping any armed last-call countdown. Only the host may call
 // it. Returns 204 on success, 403 when the caller is not the host, 404 for an
-// unknown code, and 204 (idempotent no-op) when the session has already
-// started.
+// unknown code, 409 when the room has no quiz to start, and 204 (idempotent
+// no-op) when the session has already started.
 func HandleSessionStart(service *livesession.Service) http.Handler {
 	return hostSessionAction("start", livesession.ErrSessionAlreadyStarted, service.Start)
 }
@@ -223,8 +225,8 @@ func HandleSessionStart(service *livesession.Service) http.Handler {
 // HandleSessionArmStart arms the host's last-call countdown (the "Start in 60s"
 // control): it stamps the absolute start deadline that every surface renders.
 // Only the host may call it. Returns 204 on success, 403 when the caller is not
-// the host, 404 for an unknown code, and 204 (idempotent no-op) when the
-// session has already left the lobby.
+// the host, 404 for an unknown code, 409 when the room has no quiz to start, and
+// 204 (idempotent no-op) when the session has already left the lobby.
 func HandleSessionArmStart(service *livesession.Service) http.Handler {
 	return hostSessionAction("arm-start", livesession.ErrNotInLobby,
 		func(ctx context.Context, code string, playerID int64) error {

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -912,14 +912,15 @@ func (q *Queries) SetSessionPlayerReady(ctx context.Context, arg SetSessionPlaye
 	return q.db.ExecContext(ctx, setSessionPlayerReady, arg.IsReady, arg.SessionID, arg.PlayerID)
 }
 
-const setSessionQuestion = `-- name: SetSessionQuestion :exec
+const setSessionQuestion = `-- name: SetSessionQuestion :execresult
 UPDATE sessions
 SET phase               = 'question',
-    current_round_id    = ?,
-    current_question_id = ?,
-    question_started_at = ?,
-    question_expires_at = ?
-WHERE id = ?
+    current_round_id    = ?1,
+    current_question_id = ?2,
+    question_started_at = ?3,
+    question_expires_at = ?4
+WHERE id = ?5
+  AND phase = ?6
 `
 
 type SetSessionQuestionParams struct {
@@ -928,73 +929,92 @@ type SetSessionQuestionParams struct {
 	QuestionStartedAt sql.NullTime
 	QuestionExpiresAt sql.NullTime
 	ID                string
+	ExpectedPhase     string
 }
 
 // Issues a question: records the current round + question and the server
 // answer window (started_at -> expires_at), and moves into the question phase.
-func (q *Queries) SetSessionQuestion(ctx context.Context, arg SetSessionQuestionParams) error {
-	_, err := q.db.ExecContext(ctx, setSessionQuestion,
+// Optimistic write; see SetSessionRoundIntro.
+func (q *Queries) SetSessionQuestion(ctx context.Context, arg SetSessionQuestionParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, setSessionQuestion,
 		arg.CurrentRoundID,
 		arg.CurrentQuestionID,
 		arg.QuestionStartedAt,
 		arg.QuestionExpiresAt,
 		arg.ID,
+		arg.ExpectedPhase,
 	)
-	return err
 }
 
-const setSessionReveal = `-- name: SetSessionReveal :exec
+const setSessionReveal = `-- name: SetSessionReveal :execresult
 UPDATE sessions
 SET phase = 'reveal'
-WHERE id = ?
+WHERE id = ?1
+  AND phase = ?2
+  AND current_question_id = ?3
 `
+
+type SetSessionRevealParams struct {
+	ID                string
+	ExpectedPhase     string
+	CurrentQuestionID sql.NullInt64
+}
 
 // Moves the session into the reveal phase, leaving the current question and
 // its window in place so a reader still sees which question is being revealed.
-func (q *Queries) SetSessionReveal(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, setSessionReveal, id)
-	return err
+// Optimistic write; see SetSessionRoundIntro. The current_question_id guard also
+// pins the reveal to the question the runner scored.
+func (q *Queries) SetSessionReveal(ctx context.Context, arg SetSessionRevealParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, setSessionReveal, arg.ID, arg.ExpectedPhase, arg.CurrentQuestionID)
 }
 
-const setSessionRoundIntro = `-- name: SetSessionRoundIntro :exec
+const setSessionRoundIntro = `-- name: SetSessionRoundIntro :execresult
 UPDATE sessions
 SET phase               = 'round_intro',
-    current_round_id    = ?,
+    current_round_id    = ?1,
     current_question_id = NULL,
     question_started_at = NULL,
     question_expires_at = NULL
-WHERE id = ?
+WHERE id = ?2
+  AND phase = ?3
 `
 
 type SetSessionRoundIntroParams struct {
 	CurrentRoundID sql.NullInt64
 	ID             string
+	ExpectedPhase  string
 }
 
-// Moves the session into the round_intro phase for the given round and clears
-// the per-question runner columns (the intro screen runs before any question
-// is issued).
-func (q *Queries) SetSessionRoundIntro(ctx context.Context, arg SetSessionRoundIntroParams) error {
-	_, err := q.db.ExecContext(ctx, setSessionRoundIntro, arg.CurrentRoundID, arg.ID)
-	return err
+// Moves the session into the round_intro phase for the given round.
+// Optimistic write: the expected_phase guard writes only from the phase the
+// runner loaded, so a stale beat cannot resurrect a room ended in between; zero
+// rows affected means the runner lost the race.
+func (q *Queries) SetSessionRoundIntro(ctx context.Context, arg SetSessionRoundIntroParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, setSessionRoundIntro, arg.CurrentRoundID, arg.ID, arg.ExpectedPhase)
 }
 
-const setSessionRoundResults = `-- name: SetSessionRoundResults :exec
+const setSessionRoundResults = `-- name: SetSessionRoundResults :execresult
 UPDATE sessions
 SET phase               = 'round_results',
     current_question_id = NULL,
     question_started_at = NULL,
     question_expires_at = NULL
-WHERE id = ?
+WHERE id = ?1
+  AND phase = ?2
 `
+
+type SetSessionRoundResultsParams struct {
+	ID            string
+	ExpectedPhase string
+}
 
 // Moves the session into the round_results phase shown after the last question
 // of a round (before the next round's intro). current_round_id stays put so the
 // state read knows which round just finished; the per-question runner columns
 // are cleared because no question is live in this phase.
-func (q *Queries) SetSessionRoundResults(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, setSessionRoundResults, id)
-	return err
+// Optimistic write; see SetSessionRoundIntro.
+func (q *Queries) SetSessionRoundResults(ctx context.Context, arg SetSessionRoundResultsParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, setSessionRoundResults, arg.ID, arg.ExpectedPhase)
 }
 
 const startSession = `-- name: StartSession :execresult

--- a/internal/livesession/livesession.go
+++ b/internal/livesession/livesession.go
@@ -75,6 +75,12 @@ var (
 	// game). A mid-game call, or a call on a terminally finished room, is
 	// rejected. Handlers treat it as an idempotent no-op (a stale tab re-posted).
 	ErrGameInFlight = errors.New("room already has a game running")
+
+	// ErrNoQuizToStart is returned by [Service.Start] and [Service.ArmStart]
+	// when the room has no quiz assigned: starting one would wedge it in a
+	// phantom game (started but stuck in the lobby with no plan to run).
+	// Handlers map it to 409.
+	ErrNoQuizToStart = errors.New("session has no quiz to start")
 )
 
 // Phase is the server-authoritative state-machine label for a session.
@@ -327,23 +333,29 @@ type Store interface {
 	// left the lobby.
 	CancelStart(ctx context.Context, sessionID string) error
 	// EnterRoundIntro moves the session into the round_intro phase for the
-	// given round, clearing the per-question runner columns.
-	EnterRoundIntro(ctx context.Context, sessionID string, roundID int64) error
+	// given round, clearing the per-question runner columns. Optimistic write
+	// against expected (the phase the caller loaded): reports false when no row
+	// was written because the session moved on, so the caller skips the rest.
+	EnterRoundIntro(ctx context.Context, sessionID string, expected Phase, roundID int64) (bool, error)
 	// EnterQuestion issues a question: records the current round + question
 	// and the server answer window, and moves into the question phase.
+	// Optimistic write; see EnterRoundIntro.
 	EnterQuestion(
 		ctx context.Context,
 		sessionID string,
+		expected Phase,
 		roundID, questionID int64,
 		startedAt, expiresAt time.Time,
-	) error
+	) (bool, error)
 	// EnterReveal moves the session into the reveal phase, leaving the
-	// current question and window in place.
-	EnterReveal(ctx context.Context, sessionID string) error
+	// current question and window in place. Optimistic write; see
+	// EnterRoundIntro. questionID pins the reveal to the scored question.
+	EnterReveal(ctx context.Context, sessionID string, expected Phase, questionID int64) (bool, error)
 	// EnterRoundResults moves the session into the round_results phase shown
 	// after the last question of a round, leaving current_round_id in place so
-	// a reader knows which round just finished.
-	EnterRoundResults(ctx context.Context, sessionID string) error
+	// a reader knows which round just finished. Optimistic write; see
+	// EnterRoundIntro.
+	EnterRoundResults(ctx context.Context, sessionID string, expected Phase) (bool, error)
 	// Finish ends the session terminally: marks it finished and clears the
 	// per-question runner columns. Used when the room is actually closed (idle
 	// auto-close, or an explicit host End session).
@@ -670,13 +682,10 @@ func (s *Service) SetReady(ctx context.Context, joinCode string, playerID int64,
 	return nil
 }
 
-// Start begins the game immediately (the host "Start now" control). Only the
-// host may call it. Marks the session started and hands it to the runner to
-// enter the first round at once, so it also skips (overrides) any armed
-// last-call countdown. Returns [ErrSessionNotFound] for an unknown code,
-// [ErrNotHost] when the caller is not the host, and [ErrSessionAlreadyStarted]
-// when the session has already left the lobby (treated as an idempotent no-op
-// by the handler).
+// Start begins the game immediately (the host "Start now" control), marking the
+// session started and driving it into the first round, overriding any armed
+// countdown. Host-gated. Errors: [ErrSessionNotFound], [ErrNotHost],
+// [ErrNoQuizToStart], [ErrSessionAlreadyStarted] (an idempotent no-op).
 func (s *Service) Start(ctx context.Context, joinCode string, hostPlayerID int64) error {
 	sess, err := s.store.GetSessionByJoinCode(ctx, normalizeJoinCode(joinCode))
 	if err != nil {
@@ -686,6 +695,9 @@ func (s *Service) Start(ctx context.Context, joinCode string, hostPlayerID int64
 		s.logNonHostAttempt(ctx, "start", sess.JoinCode, hostPlayerID)
 
 		return ErrNotHost
+	}
+	if sess.QuizID == nil {
+		return ErrNoQuizToStart
 	}
 
 	won, err := s.store.MarkStarted(ctx, sess.ID)
@@ -758,13 +770,10 @@ func (s *Service) StartQuiz(ctx context.Context, joinCode string, hostPlayerID, 
 }
 
 // ArmStart arms the host's last-call countdown (the "Start in 60s" control):
-// it stamps the absolute deadline at now + the configured countdown, so every
-// surface renders the same server-clock countdown and the runner starts the
-// game once it elapses. Host-gated and lobby-phase only. Joins during the
-// countdown do not reset it (the deadline is absolute). Re-arming while in the
-// lobby overwrites the deadline. Returns [ErrSessionNotFound] for an unknown
-// code, [ErrNotHost] when the caller is not the host, and [ErrNotInLobby] when
-// the session has already left the lobby.
+// it stamps the absolute deadline at now + the configured countdown, which the
+// runner starts the game on once it elapses. Host-gated and lobby-phase only; an
+// absolute deadline that joins do not reset and a re-arm overwrites. Errors:
+// [ErrSessionNotFound], [ErrNotHost], [ErrNoQuizToStart], [ErrNotInLobby].
 func (s *Service) ArmStart(ctx context.Context, joinCode string, hostPlayerID int64, now time.Time) error {
 	sess, err := s.store.GetSessionByJoinCode(ctx, normalizeJoinCode(joinCode))
 	if err != nil {
@@ -774,6 +783,9 @@ func (s *Service) ArmStart(ctx context.Context, joinCode string, hostPlayerID in
 		s.logNonHostAttempt(ctx, "armStart", sess.JoinCode, hostPlayerID)
 
 		return ErrNotHost
+	}
+	if sess.QuizID == nil {
+		return ErrNoQuizToStart
 	}
 
 	countdown := s.startCountdown

--- a/internal/livesession/livesession_test.go
+++ b/internal/livesession/livesession_test.go
@@ -173,17 +173,23 @@ func (*fakeStore) CancelStart(context.Context, string) error {
 	return errors.ErrUnsupported
 }
 
-func (*fakeStore) EnterRoundIntro(context.Context, string, int64) error {
-	return errors.ErrUnsupported
+func (*fakeStore) EnterRoundIntro(context.Context, string, Phase, int64) (bool, error) {
+	return false, errors.ErrUnsupported
 }
 
-func (*fakeStore) EnterQuestion(context.Context, string, int64, int64, time.Time, time.Time) error {
-	return errors.ErrUnsupported
+func (*fakeStore) EnterQuestion(
+	context.Context, string, Phase, int64, int64, time.Time, time.Time,
+) (bool, error) {
+	return false, errors.ErrUnsupported
 }
 
-func (*fakeStore) EnterReveal(context.Context, string) error { return errors.ErrUnsupported }
+func (*fakeStore) EnterReveal(context.Context, string, Phase, int64) (bool, error) {
+	return false, errors.ErrUnsupported
+}
 
-func (*fakeStore) EnterRoundResults(context.Context, string) error { return errors.ErrUnsupported }
+func (*fakeStore) EnterRoundResults(context.Context, string, Phase) (bool, error) {
+	return false, errors.ErrUnsupported
+}
 
 func (*fakeStore) Finish(context.Context, string) error { return errors.ErrUnsupported }
 
@@ -663,9 +669,14 @@ func TestService_GetSessionState_QuestionPhaseWithoutQuiz(t *testing.T) {
 	}
 
 	// Drive the quiz-less room straight into the question phase: quiz_id stays
-	// NULL, current_question_id points at the seeded question.
-	if err = h.store.EnterQuestion(ctx, sess.ID, q.RoundID, q.ID, start, start.Add(10*time.Second)); err != nil {
+	// NULL, current_question_id points at the seeded question. The room is still
+	// in the lobby, so the optimistic write expects that phase.
+	applied, err := h.store.EnterQuestion(ctx, sess.ID, PhaseLobby, q.RoundID, q.ID, start, start.Add(10*time.Second))
+	if err != nil {
 		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	}
+	if !applied {
+		t.Fatal("EnterQuestion applied = false, want true")
 	}
 
 	state, err := h.service.GetSessionState(ctx, sess.JoinCode, hostID)
@@ -680,5 +691,50 @@ func TestService_GetSessionState_QuestionPhaseWithoutQuiz(t *testing.T) {
 	}
 	if state.CurrentQuestion != nil {
 		t.Errorf("CurrentQuestion = %v, want nil (no quiz to resolve the question)", state.CurrentQuestion)
+	}
+}
+
+// TestService_StartRejectsQuizlessRoom pins that Start and ArmStart on a
+// quiz-less room fail with ErrNoQuizToStart and leave it a plain lobby a host
+// can still arm a quiz into (#1177).
+func TestService_StartRejectsQuizlessRoom(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	h := newEmptyRoomHarness(t, start)
+	ctx := t.Context()
+
+	const hostID int64 = 1 // seeded admin
+	sess, err := h.service.CreateSession(ctx, nil, hostID)
+	if err != nil {
+		t.Fatalf("CreateSession (empty) err = %v, want nil", err)
+	}
+
+	if got, want := h.service.Start(ctx, sess.JoinCode, hostID), ErrNoQuizToStart; !errors.Is(got, want) {
+		t.Errorf("Start on quiz-less room err = %v, want %v", got, want)
+	}
+	if got, want := h.service.ArmStart(ctx, sess.JoinCode, hostID, start), ErrNoQuizToStart; !errors.Is(got, want) {
+		t.Errorf("ArmStart on quiz-less room err = %v, want %v", got, want)
+	}
+
+	// Not wedged: still a plain lobby, never marked started, no armed countdown.
+	after, err := h.store.GetSessionByID(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	if got, want := after.Phase, PhaseLobby; got != want {
+		t.Errorf("phase after refused start = %q, want %q", got, want)
+	}
+	if after.StartedAt != nil {
+		t.Errorf("StartedAt after refused start = %v, want nil (room must not be marked started)", after.StartedAt)
+	}
+	if after.StartAt != nil {
+		t.Errorf("StartAt after refused arm = %v, want nil (no countdown must be armed)", after.StartAt)
+	}
+
+	// Still armable: the host can point it at a quiz and start it.
+	qz := seedRunnerQuizSlug(t, h.quizStore, "quizless-start-guard", [][]bool{{true}})
+	if err = h.service.StartQuiz(ctx, sess.JoinCode, hostID, qz.ID); err != nil {
+		t.Fatalf("StartQuiz after refused start err = %v, want nil (room must not be wedged)", err)
 	}
 }

--- a/internal/livesession/runner.go
+++ b/internal/livesession/runner.go
@@ -330,7 +330,8 @@ func (r *Runner) advanceQuestion(ctx context.Context, sess *Session, now time.Ti
 	}
 
 	r.scoreQuestion(ctx, sess)
-	if err := r.store.EnterReveal(ctx, sess.ID); err != nil {
+	applied, err := r.store.EnterReveal(ctx, sess.ID, sess.Phase, *sess.CurrentQuestionID)
+	if err != nil {
 		r.logger.WarnContext(
 			ctx,
 			"runner failed to enter reveal",
@@ -338,6 +339,9 @@ func (r *Runner) advanceQuestion(ctx context.Context, sess *Session, now time.Ti
 			slog.Any("err", err),
 		)
 
+		return
+	}
+	if !applied {
 		return
 	}
 	r.markPhase(sess.ID, now)
@@ -424,7 +428,8 @@ func (r *Runner) enterFirstRound(ctx context.Context, sess *Session, now time.Ti
 // enterRoundIntro persists the round_intro transition and stamps the beat
 // clock so the intro shows for the full RoundIntroBeat.
 func (r *Runner) enterRoundIntro(ctx context.Context, sess *Session, roundID int64, now time.Time) {
-	if err := r.store.EnterRoundIntro(ctx, sess.ID, roundID); err != nil {
+	applied, err := r.store.EnterRoundIntro(ctx, sess.ID, sess.Phase, roundID)
+	if err != nil {
 		r.logger.WarnContext(
 			ctx,
 			"runner failed to enter round intro",
@@ -432,6 +437,9 @@ func (r *Runner) enterRoundIntro(ctx context.Context, sess *Session, roundID int
 			slog.Any("err", err),
 		)
 
+		return
+	}
+	if !applied {
 		return
 	}
 	r.markPhase(sess.ID, now)
@@ -443,7 +451,8 @@ func (r *Runner) enterRoundIntro(ctx context.Context, sess *Session, roundID int
 // finished) and stamps the beat clock so the standings show for the full
 // RoundResultsBeat.
 func (r *Runner) enterRoundResults(ctx context.Context, sess *Session, now time.Time) {
-	if err := r.store.EnterRoundResults(ctx, sess.ID); err != nil {
+	applied, err := r.store.EnterRoundResults(ctx, sess.ID, sess.Phase)
+	if err != nil {
 		r.logger.WarnContext(
 			ctx,
 			"runner failed to enter round results",
@@ -451,6 +460,9 @@ func (r *Runner) enterRoundResults(ctx context.Context, sess *Session, now time.
 			slog.Any("err", err),
 		)
 
+		return
+	}
+	if !applied {
 		return
 	}
 	r.markPhase(sess.ID, now)
@@ -472,7 +484,8 @@ func (r *Runner) issueQuestion(ctx context.Context, sess *Session, q *quiz.Quest
 		quizID = *sess.QuizID
 	}
 	expires := startedAt.Add(r.questionWindow(ctx, quizID, q))
-	if err := r.store.EnterQuestion(ctx, sess.ID, q.RoundID, q.ID, startedAt, expires); err != nil {
+	applied, err := r.store.EnterQuestion(ctx, sess.ID, sess.Phase, q.RoundID, q.ID, startedAt, expires)
+	if err != nil {
 		r.logger.WarnContext(
 			ctx,
 			"runner failed to enter question",
@@ -480,6 +493,9 @@ func (r *Runner) issueQuestion(ctx context.Context, sess *Session, q *quiz.Quest
 			slog.Any("err", err),
 		)
 
+		return
+	}
+	if !applied {
 		return
 	}
 	r.markPhase(sess.ID, now)

--- a/internal/queries/sessions.sql
+++ b/internal/queries/sessions.sql
@@ -171,35 +171,43 @@ SET start_at = NULL
 WHERE id = ?
   AND started_at IS NULL;
 
--- name: SetSessionRoundIntro :exec
--- Moves the session into the round_intro phase for the given round and clears
--- the per-question runner columns (the intro screen runs before any question
--- is issued).
+-- name: SetSessionRoundIntro :execresult
+-- Moves the session into the round_intro phase for the given round.
+-- Optimistic write: the expected_phase guard writes only from the phase the
+-- runner loaded, so a stale beat cannot resurrect a room ended in between; zero
+-- rows affected means the runner lost the race.
 UPDATE sessions
 SET phase               = 'round_intro',
-    current_round_id    = ?,
+    current_round_id    = sqlc.arg('current_round_id'),
     current_question_id = NULL,
     question_started_at = NULL,
     question_expires_at = NULL
-WHERE id = ?;
+WHERE id = sqlc.arg('id')
+  AND phase = sqlc.arg('expected_phase');
 
--- name: SetSessionQuestion :exec
+-- name: SetSessionQuestion :execresult
 -- Issues a question: records the current round + question and the server
 -- answer window (started_at -> expires_at), and moves into the question phase.
+-- Optimistic write; see SetSessionRoundIntro.
 UPDATE sessions
 SET phase               = 'question',
-    current_round_id    = ?,
-    current_question_id = ?,
-    question_started_at = ?,
-    question_expires_at = ?
-WHERE id = ?;
+    current_round_id    = sqlc.arg('current_round_id'),
+    current_question_id = sqlc.arg('current_question_id'),
+    question_started_at = sqlc.arg('question_started_at'),
+    question_expires_at = sqlc.arg('question_expires_at')
+WHERE id = sqlc.arg('id')
+  AND phase = sqlc.arg('expected_phase');
 
--- name: SetSessionReveal :exec
+-- name: SetSessionReveal :execresult
 -- Moves the session into the reveal phase, leaving the current question and
 -- its window in place so a reader still sees which question is being revealed.
+-- Optimistic write; see SetSessionRoundIntro. The current_question_id guard also
+-- pins the reveal to the question the runner scored.
 UPDATE sessions
 SET phase = 'reveal'
-WHERE id = ?;
+WHERE id = sqlc.arg('id')
+  AND phase = sqlc.arg('expected_phase')
+  AND current_question_id = sqlc.arg('current_question_id');
 
 -- name: SetSessionFinished :exec
 -- Ends the session: marks it finished and clears the per-question runner
@@ -419,17 +427,19 @@ WHERE session_id = sqlc.arg('session_id')
   AND player_id = sqlc.arg('player_id')
   AND game_seq = (SELECT s.game_seq FROM sessions s WHERE s.id = sqlc.arg('session_id'));
 
--- name: SetSessionRoundResults :exec
+-- name: SetSessionRoundResults :execresult
 -- Moves the session into the round_results phase shown after the last question
 -- of a round (before the next round's intro). current_round_id stays put so the
 -- state read knows which round just finished; the per-question runner columns
 -- are cleared because no question is live in this phase.
+-- Optimistic write; see SetSessionRoundIntro.
 UPDATE sessions
 SET phase               = 'round_results',
     current_question_id = NULL,
     question_started_at = NULL,
     question_expires_at = NULL
-WHERE id = ?;
+WHERE id = sqlc.arg('id')
+  AND phase = sqlc.arg('expected_phase');
 
 -- name: ListSessionStandings :many
 -- Per-player standings for a session: the score the player earned in the given

--- a/internal/store/livesession.go
+++ b/internal/store/livesession.go
@@ -257,50 +257,75 @@ func (s *LiveSessionStore) CancelStart(ctx context.Context, sessionID string) er
 }
 
 // EnterRoundIntro moves the session into the round_intro phase for the round.
-func (s *LiveSessionStore) EnterRoundIntro(ctx context.Context, sessionID string, roundID int64) error {
-	if err := s.q.SetSessionRoundIntro(ctx, db.SetSessionRoundIntroParams{
+// Optimistic write against expected (the phase the runner loaded): reports false
+// when it wrote no row because the session moved on (e.g. was ended).
+func (s *LiveSessionStore) EnterRoundIntro(
+	ctx context.Context, sessionID string, expected livesession.Phase, roundID int64,
+) (bool, error) {
+	res, err := s.q.SetSessionRoundIntro(ctx, db.SetSessionRoundIntroParams{
 		CurrentRoundID: sql.NullInt64{Int64: roundID, Valid: true},
 		ID:             sessionID,
-	}); err != nil {
-		return fmt.Errorf("failed to enter round intro: %w", err)
+		ExpectedPhase:  string(expected),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to enter round intro: %w", err)
 	}
 
-	return nil
+	return database.MustRowsAffected(res) > 0, nil
 }
 
-// EnterQuestion issues a question with its server answer window.
+// EnterQuestion issues a question with its server answer window. Optimistic
+// write; see EnterRoundIntro.
 func (s *LiveSessionStore) EnterQuestion(
-	ctx context.Context, sessionID string, roundID, questionID int64, startedAt, expiresAt time.Time,
-) error {
-	if err := s.q.SetSessionQuestion(ctx, db.SetSessionQuestionParams{
+	ctx context.Context, sessionID string, expected livesession.Phase,
+	roundID, questionID int64, startedAt, expiresAt time.Time,
+) (bool, error) {
+	res, err := s.q.SetSessionQuestion(ctx, db.SetSessionQuestionParams{
 		CurrentRoundID:    sql.NullInt64{Int64: roundID, Valid: true},
 		CurrentQuestionID: sql.NullInt64{Int64: questionID, Valid: true},
 		QuestionStartedAt: sql.NullTime{Time: startedAt, Valid: true},
 		QuestionExpiresAt: sql.NullTime{Time: expiresAt, Valid: true},
 		ID:                sessionID,
-	}); err != nil {
-		return fmt.Errorf("failed to enter question: %w", err)
+		ExpectedPhase:     string(expected),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to enter question: %w", err)
 	}
 
-	return nil
+	return database.MustRowsAffected(res) > 0, nil
 }
 
-// EnterReveal moves the session into the reveal phase.
-func (s *LiveSessionStore) EnterReveal(ctx context.Context, sessionID string) error {
-	if err := s.q.SetSessionReveal(ctx, sessionID); err != nil {
-		return fmt.Errorf("failed to enter reveal: %w", err)
+// EnterReveal moves the session into the reveal phase. Optimistic write; see
+// EnterRoundIntro. questionID pins the reveal to the question the runner scored.
+func (s *LiveSessionStore) EnterReveal(
+	ctx context.Context, sessionID string, expected livesession.Phase, questionID int64,
+) (bool, error) {
+	res, err := s.q.SetSessionReveal(ctx, db.SetSessionRevealParams{
+		ID:                sessionID,
+		ExpectedPhase:     string(expected),
+		CurrentQuestionID: sql.NullInt64{Int64: questionID, Valid: true},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to enter reveal: %w", err)
 	}
 
-	return nil
+	return database.MustRowsAffected(res) > 0, nil
 }
 
-// EnterRoundResults moves the session into the round_results phase.
-func (s *LiveSessionStore) EnterRoundResults(ctx context.Context, sessionID string) error {
-	if err := s.q.SetSessionRoundResults(ctx, sessionID); err != nil {
-		return fmt.Errorf("failed to enter round results: %w", err)
+// EnterRoundResults moves the session into the round_results phase. Optimistic
+// write; see EnterRoundIntro.
+func (s *LiveSessionStore) EnterRoundResults(
+	ctx context.Context, sessionID string, expected livesession.Phase,
+) (bool, error) {
+	res, err := s.q.SetSessionRoundResults(ctx, db.SetSessionRoundResultsParams{
+		ID:            sessionID,
+		ExpectedPhase: string(expected),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to enter round results: %w", err)
 	}
 
-	return nil
+	return database.MustRowsAffected(res) > 0, nil
 }
 
 // Finish ends the session terminally.

--- a/internal/store/livesession_test.go
+++ b/internal/store/livesession_test.go
@@ -375,8 +375,12 @@ func TestLiveSessionStore_PhaseTransitions(t *testing.T) {
 		t.Error("second MarkStarted won = true, want false")
 	}
 
-	if err = sessionStore.EnterRoundIntro(t.Context(), sess.ID, q.RoundID); err != nil {
+	introApplied, err := sessionStore.EnterRoundIntro(t.Context(), sess.ID, livesession.PhaseLobby, q.RoundID)
+	if err != nil {
 		t.Fatalf("EnterRoundIntro err = %v, want nil", err)
+	}
+	if !introApplied {
+		t.Fatal("EnterRoundIntro applied = false, want true")
 	}
 	intro, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
 	if err != nil {
@@ -391,8 +395,14 @@ func TestLiveSessionStore_PhaseTransitions(t *testing.T) {
 
 	started := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
 	expires := started.Add(10 * time.Second)
-	if err = sessionStore.EnterQuestion(t.Context(), sess.ID, q.RoundID, q.ID, started, expires); err != nil {
+	questionApplied, err := sessionStore.EnterQuestion(
+		t.Context(), sess.ID, livesession.PhaseRoundIntro, q.RoundID, q.ID, started, expires,
+	)
+	if err != nil {
 		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	}
+	if !questionApplied {
+		t.Fatal("EnterQuestion applied = false, want true")
 	}
 	question, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
 	if err != nil {
@@ -408,8 +418,12 @@ func TestLiveSessionStore_PhaseTransitions(t *testing.T) {
 		t.Errorf("QuestionExpiresAt = %v, want %v", question.QuestionExpiresAt, expires)
 	}
 
-	if err = sessionStore.EnterReveal(t.Context(), sess.ID); err != nil {
+	revealApplied, err := sessionStore.EnterReveal(t.Context(), sess.ID, livesession.PhaseQuestion, q.ID)
+	if err != nil {
 		t.Fatalf("EnterReveal err = %v, want nil", err)
+	}
+	if !revealApplied {
+		t.Fatal("EnterReveal applied = false, want true")
 	}
 	reveal, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
 	if err != nil {
@@ -1029,14 +1043,20 @@ func TestLiveSessionStore_EnterRoundResults(t *testing.T) {
 		t.Fatalf("CreateSession err = %v, want nil", err)
 	}
 	started := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
-	if err := sessionStore.EnterQuestion(
-		t.Context(), sess.ID, q.RoundID, q.ID, started, started.Add(10*time.Second),
+	if applied, err := sessionStore.EnterQuestion(
+		t.Context(), sess.ID, livesession.PhaseLobby, q.RoundID, q.ID, started, started.Add(10*time.Second),
 	); err != nil {
 		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	} else if !applied {
+		t.Fatal("EnterQuestion applied = false, want true")
 	}
 
-	if err := sessionStore.EnterRoundResults(t.Context(), sess.ID); err != nil {
+	if applied, err := sessionStore.EnterRoundResults(
+		t.Context(), sess.ID, livesession.PhaseQuestion,
+	); err != nil {
 		t.Fatalf("EnterRoundResults err = %v, want nil", err)
+	} else if !applied {
+		t.Fatal("EnterRoundResults applied = false, want true")
 	}
 	got, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
 	if err != nil {
@@ -1050,6 +1070,74 @@ func TestLiveSessionStore_EnterRoundResults(t *testing.T) {
 	}
 	if got.CurrentQuestionID != nil {
 		t.Errorf("round_results CurrentQuestionID = %v, want nil", *got.CurrentQuestionID)
+	}
+}
+
+// TestLiveSessionStore_StaleTransitionDoesNotResurrectFinished pins that a stale
+// transition write (the phase the runner loaded before EndSession finished the
+// room) is a no-op and leaves the session finished (#1176).
+func TestLiveSessionStore_StaleTransitionDoesNotResurrectFinished(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+	sessionStore := NewLiveSessionStore(db, slog.Default())
+	qz := newLiveQuizWithQuestion(t, quizStore)
+	q := qz.Questions[0]
+
+	sess := &livesession.Session{QuizID: liveQuizIDPtr(qz.ID), HostPlayerID: seededAdminID, JoinCode: "STAL23"}
+	if err := sessionStore.CreateSession(t.Context(), sess); err != nil {
+		t.Fatalf("CreateSession err = %v, want nil", err)
+	}
+	// Drive the room into the question phase, then finish it under the runner.
+	started := time.Date(2026, time.June, 5, 12, 0, 0, 0, time.UTC)
+	if _, err := sessionStore.EnterQuestion(
+		t.Context(), sess.ID, livesession.PhaseLobby, q.RoundID, q.ID, started, started.Add(10*time.Second),
+	); err != nil {
+		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	}
+	if err := sessionStore.Finish(t.Context(), sess.ID); err != nil {
+		t.Fatalf("Finish err = %v, want nil", err)
+	}
+
+	// Each stale write (the pre-finish phase) must be a no-op.
+	reveal, err := sessionStore.EnterReveal(t.Context(), sess.ID, livesession.PhaseQuestion, q.ID)
+	if err != nil {
+		t.Fatalf("EnterReveal err = %v, want nil", err)
+	}
+	if reveal {
+		t.Error("stale EnterReveal applied = true, want false (must not resurrect finished room)")
+	}
+	results, err := sessionStore.EnterRoundResults(t.Context(), sess.ID, livesession.PhaseReveal)
+	if err != nil {
+		t.Fatalf("EnterRoundResults err = %v, want nil", err)
+	}
+	if results {
+		t.Error("stale EnterRoundResults applied = true, want false")
+	}
+	intro, err := sessionStore.EnterRoundIntro(t.Context(), sess.ID, livesession.PhaseRoundResults, q.RoundID)
+	if err != nil {
+		t.Fatalf("EnterRoundIntro err = %v, want nil", err)
+	}
+	if intro {
+		t.Error("stale EnterRoundIntro applied = true, want false")
+	}
+	question, err := sessionStore.EnterQuestion(
+		t.Context(), sess.ID, livesession.PhaseRoundIntro, q.RoundID, q.ID, started, started.Add(10*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("EnterQuestion err = %v, want nil", err)
+	}
+	if question {
+		t.Error("stale EnterQuestion applied = true, want false")
+	}
+
+	final, err := sessionStore.GetSessionByID(t.Context(), sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID err = %v, want nil", err)
+	}
+	if got, want := final.Phase, livesession.PhaseFinished; got != want {
+		t.Errorf("phase after stale beats = %q, want %q (room stayed finished)", got, want)
 	}
 }
 

--- a/test/integration/session_armed_start_test.go
+++ b/test/integration/session_armed_start_test.go
@@ -139,3 +139,64 @@ func TestSessionArmedStart_LobbyPhaseOnly(t *testing.T) {
 		t.Errorf("startAt after start = %v, want nil (no countdown once running)", got)
 	}
 }
+
+// createEmptyRoom opens a host room with no quiz (quizId omitted) and returns
+// its join code.
+func createEmptyRoom(ctx context.Context, t *testing.T, client *http.Client, baseURL string) string {
+	t.Helper()
+	resp := httpPostJSON(ctx, t, client, baseURL+"/api/sessions", `{}`)
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusCreated; got != want {
+		t.Fatalf("create empty room status = %d, want %d", got, want)
+	}
+	var body struct {
+		JoinCode string `json:"joinCode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode create empty room: %v", err)
+	}
+	if body.JoinCode == "" {
+		t.Fatal("create empty room returned empty join code")
+	}
+
+	return body.JoinCode
+}
+
+// startQuizlessRoom posts the host start and asserts it is refused with 409.
+func startQuizlessRoom(ctx context.Context, t *testing.T, client *http.Client, baseURL, code string) {
+	t.Helper()
+	resp := httpPostJSON(ctx, t, client, fmt.Sprintf("%s/api/sessions/%s/start", baseURL, code), `{}`)
+	defer closeBody(t, resp.Body)
+	if got, want := resp.StatusCode, http.StatusConflict; got != want {
+		t.Errorf("start quiz-less room status = %d, want %d", got, want)
+	}
+}
+
+// TestSession_StartAndArmRejectQuizlessRoom pins that POST /start and /arm-start
+// on a quiz-less room return 409 and leave it a plain lobby (#1177).
+func TestSession_StartAndArmRejectQuizlessRoom(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupIntegration(t)
+	baseURL := setup.BaseURL
+
+	host := &http.Client{
+		Jar:           mustJar(t),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	registerVerifyAndSignIn(ctx, t, host, baseURL, setup.DBURI, "quizless-host", "quizless-host-pass-123")
+
+	code := createEmptyRoom(ctx, t, host, baseURL)
+
+	startQuizlessRoom(ctx, t, host, baseURL, code)
+	armStart(ctx, t, host, baseURL, code, http.StatusConflict)
+
+	// Not wedged: still a lobby with no armed countdown.
+	after := getArmedStartState(ctx, t, host, baseURL, code)
+	if got, want := after.Phase, "lobby"; got != want {
+		t.Errorf("phase after refused start = %q, want %q", got, want)
+	}
+	if after.StartAt != nil {
+		t.Errorf("startAt after refused arm = %v, want nil", after.StartAt)
+	}
+}


### PR DESCRIPTION
Two live-session audit fixes.

- **#1177:** `Start`/`ArmStart` now reject a quiz-less room (`ErrNoQuizToStart` -> 409) before marking it started, instead of wedging it in the lobby with the runner retrying forever.
- **#1176:** the four runner phase UPDATEs are now optimistic (`AND phase = <expected>`, `:execresult`); the runner treats 0 rows as "lost the race" and skips, so a stale beat can't overwrite a `finished` room that `EndSession` set concurrently. `internal/db/` regenerated via sqlc.

Tests: quiz-less start rejected + room stays a clean lobby; stale transitions over a finished session all report `applied=false`; full-stack 409 on `/start` and `/arm-start`. `make check`/`make smoke` pass.

Closes #1177
Closes #1176

_— Claude Code, for @starquake_
