### PR TITLE
Harden solo play answer submission and remove the pre-game quiz dump

### DIFF
--- a/internal/clientapi/clientapi.go
+++ b/internal/clientapi/clientapi.go
@@ -179,34 +179,6 @@ func gateQuizRead(
 	return canReadQuiz(w, r, visibility)
 }
 
-// quizGetOptionResponse, quizGetQuestionResponse, and quizGetResponse are
-// the wire shape of the solo play data endpoint (HandleQuizGet). Declared
-// at package scope so the question-mapping helper can build them outside
-// the handler body.
-type quizGetOptionResponse struct {
-	ID   int64  `json:"id"`
-	Text string `json:"text"`
-}
-
-type quizGetQuestionResponse struct {
-	ID          int64                   `json:"id"`
-	Text        string                  `json:"text"`
-	Position    int                     `json:"position"`
-	ImageURL    string                  `json:"imageUrl,omitempty"`
-	AudioURL    string                  `json:"audioUrl,omitempty"`
-	AudioRepeat bool                    `json:"audioRepeat,omitempty"`
-	Options     []quizGetOptionResponse `json:"options"`
-}
-
-type quizGetResponse struct {
-	ID          int64                     `json:"id"`
-	Title       string                    `json:"title"`
-	Slug        string                    `json:"slug"`
-	Description string                    `json:"description"`
-	CreatedAt   time.Time                 `json:"createdAt"`
-	Questions   []quizGetQuestionResponse `json:"questions"`
-}
-
 // decimalBase is the radix used when formatting ids as strings.
 const decimalBase = 10
 
@@ -219,79 +191,6 @@ func mediaURL(mediaID *int64) string {
 	}
 
 	return "/media/" + strconv.FormatInt(*mediaID, decimalBase)
-}
-
-// quizGetQuestions maps a quiz's questions + options onto the play
-// endpoint's wire shape. correct-flag and time-limit fields are
-// deliberately omitted so the solo client never receives the answer key.
-func quizGetQuestions(qz *quiz.Quiz) []quizGetQuestionResponse {
-	questions := make([]quizGetQuestionResponse, 0, len(qz.Questions))
-	for _, qs := range qz.Questions {
-		opts := make([]quizGetOptionResponse, 0, len(qs.Options))
-		for _, o := range qs.Options {
-			opts = append(opts, quizGetOptionResponse{ID: o.ID, Text: o.Text})
-		}
-		questions = append(questions, quizGetQuestionResponse{
-			ID:          qs.ID,
-			Text:        qs.Text,
-			Position:    qs.Position,
-			ImageURL:    mediaURL(qs.ImageMediaID),
-			AudioURL:    mediaURL(qs.AudioMediaID),
-			AudioRepeat: qs.AudioRepeat,
-			Options:     opts,
-		})
-	}
-
-	return questions
-}
-
-// HandleQuizGet returns a single quiz with its questions and options.
-func HandleQuizGet(logger *slog.Logger, quizStore quiz.Store) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		quizID, ok := handlers.ParseIDFromSlugPath(w, r, logger, "slugID")
-		if !ok {
-			return
-		}
-
-		qz, err := quizStore.GetQuiz(r.Context(), quizID)
-		if err != nil {
-			if errors.Is(err, quiz.ErrQuizNotFound) {
-				http.NotFound(w, r)
-
-				return
-			}
-			writeInternalError(w, r, logger, "error retrieving quiz from store", err)
-
-			return
-		}
-		if !canReadQuiz(w, r, qz.Visibility) {
-			return
-		}
-		// Live quizzes are hosted-only (MP-0 / #677): the solo play
-		// endpoint must not serve one. A 404 keeps it indistinguishable
-		// from a missing quiz so a hosted quiz can't be pre-played.
-		if qz.Mode == quiz.ModeLive {
-			http.NotFound(w, r)
-
-			return
-		}
-
-		res := quizGetResponse{
-			ID:          qz.ID,
-			Title:       qz.Title,
-			Slug:        qz.Slug,
-			Description: qz.Description,
-			CreatedAt:   qz.CreatedAt,
-			Questions:   quizGetQuestions(qz),
-		}
-
-		err = handlers.EncodeJSON(w, http.StatusOK, res)
-		if err != nil {
-			logger.ErrorContext(r.Context(), "error encoding quizResponse", slog.Any("err", err))
-
-			return
-		}
-	})
 }
 
 // leaderboardLimit caps the number of rows the REST + SSE leaderboards
@@ -1096,6 +995,7 @@ func correctOptionIDsFromAnswer(a *game.Answer) []int64 {
 //   - ErrGameNotFound / ErrQuestionNotInGame -> 404
 //   - ErrOptionNotInQuestion -> 400
 //   - ErrAnswerAlreadyRecorded -> 409 (double-tap / retry; #353)
+//   - ErrAnswerWindowClosed -> 409 (answer arrived too late; #1163)
 //   - anything else -> 500 via writeInternalError
 func writeSubmitAnswerError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, err error) {
 	switch {
@@ -1103,7 +1003,7 @@ func writeSubmitAnswerError(w http.ResponseWriter, r *http.Request, logger *slog
 		http.NotFound(w, r)
 	case errors.Is(err, game.ErrOptionNotInQuestion):
 		http.Error(w, err.Error(), http.StatusBadRequest)
-	case errors.Is(err, game.ErrAnswerAlreadyRecorded):
+	case errors.Is(err, game.ErrAnswerAlreadyRecorded), errors.Is(err, game.ErrAnswerWindowClosed):
 		http.Error(w, err.Error(), http.StatusConflict)
 	default:
 		writeInternalError(w, r, logger, "error submitting answer", err)

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -72,97 +72,6 @@ func TestHandleQuizList(t *testing.T) {
 	})
 }
 
-func TestHandleQuizGet(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns full quiz with questions and options", func(t *testing.T) {
-		t.Parallel()
-
-		env := newTestEnv(t)
-		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz One", "quiz-one"))
-
-		handler := HandleQuizGet(env.logger, env.quizzes)
-
-		req := httptest.NewRequestWithContext(
-			t.Context(), http.MethodGet, fmt.Sprintf("/api/quizzes/quiz-one-%d", qz.ID), nil,
-		)
-		req.SetPathValue("slugID", fmt.Sprintf("quiz-one-%d", qz.ID))
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		if got, want := rec.Code, http.StatusOK; got != want {
-			t.Fatalf("status code = %v, want %v", got, want)
-		}
-
-		var result map[string]any
-		if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
-			t.Fatalf("failed to decode response: %v", err)
-		}
-
-		if got, want := result["title"], "Quiz One"; got != want {
-			t.Errorf("title = %v, want %v", got, want)
-		}
-
-		questions, ok := result["questions"].([]any)
-		if !ok {
-			t.Fatal("questions field missing or wrong type")
-		}
-
-		if got, want := len(questions), 2; got != want {
-			t.Fatalf("len(questions) = %v, want %v", got, want)
-		}
-
-		q, ok := questions[0].(map[string]any)
-		if !ok {
-			t.Fatal("question is not a map")
-		}
-
-		opts, ok := q["options"].([]any)
-		if !ok {
-			t.Fatal("options field missing or wrong type")
-		}
-
-		if got, want := len(opts), 2; got != want {
-			t.Errorf("len(options) = %v, want %v", got, want)
-		}
-	})
-
-	t.Run("returns 404 when quiz not found", func(t *testing.T) {
-		t.Parallel()
-
-		env := newTestEnv(t)
-
-		handler := HandleQuizGet(env.logger, env.quizzes)
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes/quiz-one-99", nil)
-		req.SetPathValue("slugID", "quiz-one-99")
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		if got, want := rec.Code, http.StatusNotFound; got != want {
-			t.Errorf("status code = %v, want %v", got, want)
-		}
-	})
-
-	t.Run("returns 500 on store error", func(t *testing.T) {
-		t.Parallel()
-
-		env := newTestEnv(t)
-		env.closeStore(t)
-
-		handler := HandleQuizGet(env.logger, env.quizzes)
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/quizzes/quiz-one-1", nil)
-		req.SetPathValue("slugID", "quiz-one-1")
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-
-		if got, want := rec.Code, http.StatusInternalServerError; got != want {
-			t.Errorf("status code = %v, want %v", got, want)
-		}
-	})
-}
-
 func TestHandleCreateGame(t *testing.T) {
 	t.Parallel()
 
@@ -983,6 +892,88 @@ func TestHandleAnswerPost(t *testing.T) {
 		mux.ServeHTTP(rec, req)
 
 		if got, want := rec.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 409 when the answer window has closed", func(t *testing.T) {
+		t.Parallel()
+
+		env := newTestEnv(t)
+		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz", "quiz"))
+		playerID := env.seedPlayer(t, "answer-late")
+
+		// A negative reveal delay issues the question with its window
+		// already in the past, so the submit lands past ExpiredAt plus the
+		// latency grace without any real waiting (#1163).
+		svc := game.NewService(env.games, env.quizzes, env.logger)
+		svc.SetRevealDelay(-time.Hour)
+
+		g, err := svc.CreateGame(t.Context(), qz.ID, playerID)
+		if err != nil {
+			t.Fatalf("CreateGame err = %v, want nil", err)
+		}
+		if _, err := svc.GetNext(t.Context(), g.ID, playerID); err != nil {
+			t.Fatalf("GetNext err = %v, want nil", err)
+		}
+		questionID, optionID := correctOptionID(t, qz, 0)
+
+		mux := http.NewServeMux()
+		mux.Handle(
+			"POST /api/games/{gameID}/questions/{questionID}/answers",
+			HandleAnswerPost(env.logger, svc),
+		)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), playerID), http.MethodPost,
+			fmt.Sprintf("/api/games/%s/questions/%d/answers", g.ID, questionID),
+			strings.NewReader(fmt.Sprintf(`{"optionId": %d}`, optionID)),
+		)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusConflict; got != want {
+			t.Errorf("status code = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns 404 when the question was deleted mid-game", func(t *testing.T) {
+		t.Parallel()
+
+		env := newTestEnv(t)
+		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz", "quiz"))
+		playerID := env.seedPlayer(t, "answer-qdeleted")
+
+		// Issue the first question through the real store, then drive the
+		// submit through a service whose quiz store reports the question as
+		// deleted - the mid-game deletion race (#1180). It must 404, not
+		// 500.
+		g, err := env.service.CreateGame(t.Context(), qz.ID, playerID)
+		if err != nil {
+			t.Fatalf("CreateGame err = %v, want nil", err)
+		}
+		if _, err := env.service.GetNext(t.Context(), g.ID, playerID); err != nil {
+			t.Fatalf("GetNext err = %v, want nil", err)
+		}
+		questionID, optionID := correctOptionID(t, qz, 0)
+
+		svc := game.NewService(env.games, deletedQuestionQuizStore{Store: env.quizzes}, env.logger)
+
+		mux := http.NewServeMux()
+		mux.Handle(
+			"POST /api/games/{gameID}/questions/{questionID}/answers",
+			HandleAnswerPost(env.logger, svc),
+		)
+
+		req := httptest.NewRequestWithContext(
+			withPlayer(t.Context(), playerID), http.MethodPost,
+			fmt.Sprintf("/api/games/%s/questions/%d/answers", g.ID, questionID),
+			strings.NewReader(fmt.Sprintf(`{"optionId": %d}`, optionID)),
+		)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if got, want := rec.Code, http.StatusNotFound; got != want {
 			t.Errorf("status code = %v, want %v", got, want)
 		}
 	})

--- a/internal/clientapi/clientapi_test.go
+++ b/internal/clientapi/clientapi_test.go
@@ -903,9 +903,7 @@ func TestHandleAnswerPost(t *testing.T) {
 		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz", "quiz"))
 		playerID := env.seedPlayer(t, "answer-late")
 
-		// A negative reveal delay issues the question with its window
-		// already in the past, so the submit lands past ExpiredAt plus the
-		// latency grace without any real waiting (#1163).
+		// Negative reveal delay issues the question already expired (#1163).
 		svc := game.NewService(env.games, env.quizzes, env.logger)
 		svc.SetRevealDelay(-time.Hour)
 
@@ -944,10 +942,8 @@ func TestHandleAnswerPost(t *testing.T) {
 		qz := env.seedQuiz(t, twoQuestionQuiz("Quiz", "quiz"))
 		playerID := env.seedPlayer(t, "answer-qdeleted")
 
-		// Issue the first question through the real store, then drive the
-		// submit through a service whose quiz store reports the question as
-		// deleted - the mid-game deletion race (#1180). It must 404, not
-		// 500.
+		// Issue the question for real, then submit through a store that
+		// reports it deleted - the mid-game race must 404, not 500 (#1180).
 		g, err := env.service.CreateGame(t.Context(), qz.ID, playerID)
 		if err != nil {
 			t.Fatalf("CreateGame err = %v, want nil", err)

--- a/internal/clientapi/helpers_test.go
+++ b/internal/clientapi/helpers_test.go
@@ -1,6 +1,7 @@
 package clientapi_test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,20 @@ import (
 	"github.com/starquake/topbanana/internal/quiz"
 	"github.com/starquake/topbanana/internal/store"
 )
+
+// deletedQuestionQuizStore wraps a real quiz.Store but reports every
+// question lookup as deleted (quiz.ErrQuestionNotFound). It reproduces the
+// #1180 race where a host deletes a question between SubmitAnswer's
+// GetGame and its GetQuestion lookup - a state a real FK makes otherwise
+// unreachable, because deleting a played question also removes the
+// game_questions row that keeps it in the game.
+type deletedQuestionQuizStore struct {
+	quiz.Store
+}
+
+func (deletedQuestionQuizStore) GetQuestion(_ context.Context, _ int64) (*quiz.Question, error) {
+	return nil, quiz.ErrQuestionNotFound
+}
 
 // seededAdminID is the id of the admin row inserted by migration
 // 20260111110308_add_admin_player.sql. Quiz fixtures attribute themselves

--- a/internal/clientapi/helpers_test.go
+++ b/internal/clientapi/helpers_test.go
@@ -17,12 +17,8 @@ import (
 	"github.com/starquake/topbanana/internal/store"
 )
 
-// deletedQuestionQuizStore wraps a real quiz.Store but reports every
-// question lookup as deleted (quiz.ErrQuestionNotFound). It reproduces the
-// #1180 race where a host deletes a question between SubmitAnswer's
-// GetGame and its GetQuestion lookup - a state a real FK makes otherwise
-// unreachable, because deleting a played question also removes the
-// game_questions row that keeps it in the game.
+// deletedQuestionQuizStore reports every question as deleted, faking the
+// #1180 mid-game delete race a real FK makes otherwise unreachable.
 type deletedQuestionQuizStore struct {
 	quiz.Store
 }

--- a/internal/game/clamp.go
+++ b/internal/game/clamp.go
@@ -2,22 +2,14 @@ package game
 
 import "time"
 
-// maxLatencyRefund bounds how far the #237 client tappedAt refund can
-// pull the recorded answer time earlier than the server received it.
-// Large enough to cover realistic network latency, small enough that a
-// crafted client cannot claim the window start (tappedAt == StartedAt) to
-// dodge the scoring curve and take full points after unlimited real time
-// (#1163).
+// maxLatencyRefund bounds the #237 tappedAt refund: enough for real
+// latency, too small for a client to claim the window start (#1163).
 const maxLatencyRefund = 2 * time.Second
 
-// clampTappedAt applies the #237 latency refund with a bounded window
-// (#1163): the recorded answer time is the client-supplied tappedAt only
-// when it falls inside [serverNow - maxRefund, serverNow]; otherwise it
-// is serverNow. Bounding the backward reach to maxRefund lets an honest
-// player on a slow link claw back their network latency without letting a
-// crafted client claim an arbitrarily early instant. The out-of-range
-// fallback is the upper bound so a claim can never score faster than the
-// player earned in real time.
+// clampTappedAt records tappedAt only when it lands in
+// [serverNow - maxRefund, serverNow], else serverNow. The bounded lower
+// edge refunds latency without letting a client claim an arbitrarily early
+// instant (#237, #1163).
 func clampTappedAt(tappedAt, serverNow time.Time, maxRefund time.Duration) time.Time {
 	floor := serverNow.Add(-maxRefund)
 	if tappedAt.IsZero() || tappedAt.Before(floor) || tappedAt.After(serverNow) {

--- a/internal/game/clamp.go
+++ b/internal/game/clamp.go
@@ -2,13 +2,25 @@ package game
 
 import "time"
 
-// clampTappedAt applies the #237 trust window: the recorded answer time
-// is the client-supplied tappedAt when it falls inside [startedAt,
-// serverNow], otherwise it's serverNow. The fallback is intentionally
-// the upper bound - an out-of-range claim should never give the player
-// a faster score than they earned in real time.
-func clampTappedAt(tappedAt, startedAt, serverNow time.Time) time.Time {
-	if tappedAt.IsZero() || tappedAt.Before(startedAt) || tappedAt.After(serverNow) {
+// maxLatencyRefund bounds how far the #237 client tappedAt refund can
+// pull the recorded answer time earlier than the server received it.
+// Large enough to cover realistic network latency, small enough that a
+// crafted client cannot claim the window start (tappedAt == StartedAt) to
+// dodge the scoring curve and take full points after unlimited real time
+// (#1163).
+const maxLatencyRefund = 2 * time.Second
+
+// clampTappedAt applies the #237 latency refund with a bounded window
+// (#1163): the recorded answer time is the client-supplied tappedAt only
+// when it falls inside [serverNow - maxRefund, serverNow]; otherwise it
+// is serverNow. Bounding the backward reach to maxRefund lets an honest
+// player on a slow link claw back their network latency without letting a
+// crafted client claim an arbitrarily early instant. The out-of-range
+// fallback is the upper bound so a claim can never score faster than the
+// player earned in real time.
+func clampTappedAt(tappedAt, serverNow time.Time, maxRefund time.Duration) time.Time {
+	floor := serverNow.Add(-maxRefund)
+	if tappedAt.IsZero() || tappedAt.Before(floor) || tappedAt.After(serverNow) {
 		return serverNow
 	}
 

--- a/internal/game/clamp_test.go
+++ b/internal/game/clamp_test.go
@@ -7,31 +7,33 @@ import (
 	. "github.com/starquake/topbanana/internal/game"
 )
 
-// TestClampTappedAt pins the #237 trust window. The recorded AnsweredAt
-// must equal the client's tappedAt only when it lands inside
-// [startedAt, serverNow] - anything else falls back to serverNow, never
-// to tappedAt. The asymmetry matters: a clamp that returned the closer
-// edge of the window would let a forward-skewed client get a faster
-// score than they actually earned.
+// TestClampTappedAt pins the #237 latency refund with the #1163 bound.
+// The recorded AnsweredAt equals the client's tappedAt only when it lands
+// inside [serverNow - maxRefund, serverNow]; anything else falls back to
+// serverNow, never to tappedAt. The lower bound is what stops a crafted
+// client from claiming the window start to take full points after
+// unlimited real time; the upper bound stops a forward-skewed client from
+// scoring faster than it earned.
 func TestClampTappedAt(t *testing.T) {
 	t.Parallel()
 
-	startedAt := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
-	serverNow := startedAt.Add(8 * time.Second)
+	serverNow := time.Date(2026, 5, 22, 12, 0, 8, 0, time.UTC)
+	const maxRefund = 2 * time.Second
+	floor := serverNow.Add(-maxRefund)
 	tests := []struct {
 		name     string
 		tappedAt time.Time
 		want     time.Time
 	}{
 		{
-			name:     "valid tap inside the window is recorded as-is",
-			tappedAt: startedAt.Add(3 * time.Second),
-			want:     startedAt.Add(3 * time.Second),
+			name:     "tap inside the refund window is recorded as-is",
+			tappedAt: serverNow.Add(-1 * time.Second),
+			want:     serverNow.Add(-1 * time.Second),
 		},
 		{
-			name:     "tap equal to startedAt is recorded as-is",
-			tappedAt: startedAt,
-			want:     startedAt,
+			name:     "tap equal to the refund floor is recorded as-is",
+			tappedAt: floor,
+			want:     floor,
 		},
 		{
 			name:     "tap equal to serverNow is recorded as-is",
@@ -39,8 +41,8 @@ func TestClampTappedAt(t *testing.T) {
 			want:     serverNow,
 		},
 		{
-			name:     "tap before startedAt clamps to serverNow",
-			tappedAt: startedAt.Add(-5 * time.Second),
+			name:     "tap before the refund floor clamps to serverNow",
+			tappedAt: serverNow.Add(-5 * time.Second),
 			want:     serverNow,
 		},
 		{
@@ -57,8 +59,8 @@ func TestClampTappedAt(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got, want := ExportClampTappedAt(tc.tappedAt, startedAt, serverNow), tc.want; !got.Equal(want) {
-				t.Errorf("clampTappedAt(%v, %v, %v) = %v, want %v", tc.tappedAt, startedAt, serverNow, got, want)
+			if got, want := ExportClampTappedAt(tc.tappedAt, serverNow, maxRefund), tc.want; !got.Equal(want) {
+				t.Errorf("clampTappedAt(%v, %v, %v) = %v, want %v", tc.tappedAt, serverNow, maxRefund, got, want)
 			}
 		})
 	}

--- a/internal/game/clamp_test.go
+++ b/internal/game/clamp_test.go
@@ -7,13 +7,8 @@ import (
 	. "github.com/starquake/topbanana/internal/game"
 )
 
-// TestClampTappedAt pins the #237 latency refund with the #1163 bound.
-// The recorded AnsweredAt equals the client's tappedAt only when it lands
-// inside [serverNow - maxRefund, serverNow]; anything else falls back to
-// serverNow, never to tappedAt. The lower bound is what stops a crafted
-// client from claiming the window start to take full points after
-// unlimited real time; the upper bound stops a forward-skewed client from
-// scoring faster than it earned.
+// TestClampTappedAt pins the bounded #237 refund: tappedAt is kept only
+// inside [serverNow - maxRefund, serverNow], else serverNow (#1163).
 func TestClampTappedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -51,11 +51,9 @@ var (
 	// the option being submitted does not belong to the supplied question.
 	ErrOptionNotInQuestion = errors.New("option does not belong to question")
 
-	// ErrAnswerWindowClosed is returned by [Service.SubmitAnswer] when the
-	// answer arrives after the question's window has closed (past
-	// ExpiredAt plus a small latency grace). A late answer scores nothing,
-	// so it is rejected rather than recorded (#1163). Handlers map it to
-	// 409.
+	// ErrAnswerWindowClosed is returned by [Service.SubmitAnswer] for an
+	// answer arriving past ExpiredAt plus the latency grace; it scores
+	// nothing, so it is rejected not recorded (#1163). Handlers map it to 409.
 	ErrAnswerWindowClosed = errors.New("answer window closed")
 
 	// ErrStartingGameNoRowsAffected is returned by [GameStore.StartGame]

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -51,6 +51,13 @@ var (
 	// the option being submitted does not belong to the supplied question.
 	ErrOptionNotInQuestion = errors.New("option does not belong to question")
 
+	// ErrAnswerWindowClosed is returned by [Service.SubmitAnswer] when the
+	// answer arrives after the question's window has closed (past
+	// ExpiredAt plus a small latency grace). A late answer scores nothing,
+	// so it is rejected rather than recorded (#1163). Handlers map it to
+	// 409.
+	ErrAnswerWindowClosed = errors.New("answer window closed")
+
 	// ErrStartingGameNoRowsAffected is returned by [GameStore.StartGame]
 	// when the UPDATE matched no rows - i.e. the game does not exist.
 	ErrStartingGameNoRowsAffected = errors.New("no rows affected when starting game")

--- a/internal/game/service.go
+++ b/internal/game/service.go
@@ -24,11 +24,8 @@ const (
 	// mobile network jitter.
 	defaultStalePeriod = 30 * time.Second
 
-	// lateAnswerGrace is how far past a question's ExpiredAt an answer may
-	// still land and be recorded, covering a last-instant tap delayed in
-	// flight. Beyond it [Service.SubmitAnswer] rejects the answer with
-	// [ErrAnswerWindowClosed] rather than storing a guaranteed-zero score
-	// (#1163).
+	// lateAnswerGrace is how far past ExpiredAt an answer may still land,
+	// covering a last-instant tap delayed in flight (#1163).
 	lateAnswerGrace = 2 * time.Second
 
 	// errGetGameFmt is the wrap format for store.GetGame errors. Every
@@ -442,11 +439,11 @@ func (s *Service) MarkRoundSeen(ctx context.Context, gameID string, playerID, ro
 	return nil
 }
 
-// SubmitAnswer records a player's answer. tappedAt is clamped to
-// [question.StartedAt, serverNow] so an honest player on a slow link
-// gets their network latency refunded while a clock-skewed client
-// cannot claim a moment outside the answer window. The clamp is
-// one-sided: claims can only pull the recorded time earlier (#237).
+// SubmitAnswer records a player's answer. Answers past the window
+// (ExpiredAt plus the latency grace) are rejected with
+// ErrAnswerWindowClosed; otherwise tappedAt is refunded up to
+// maxLatencyRefund so a slow link is not penalised but a client cannot
+// claim the window start (#237, #1163).
 func (s *Service) SubmitAnswer(
 	ctx context.Context,
 	gameID string,
@@ -471,9 +468,7 @@ func (s *Service) SubmitAnswer(
 		return nil, err
 	}
 
-	// Reject an answer that reaches the server after the window has closed
-	// (#1163). The grace covers a last-instant tap delayed in flight; past
-	// it the answer scores nothing, so it is refused rather than recorded.
+	// Reject an answer that lands past the window; it scores nothing (#1163).
 	now := time.Now()
 	if now.After(question.ExpiredAt.Add(lateAnswerGrace)) {
 		return nil, ErrAnswerWindowClosed
@@ -598,11 +593,8 @@ func (s *Service) resolveAnswerTarget(
 
 	quizQuestion, err := s.quizStore.GetQuestion(ctx, question.QuestionID)
 	if err != nil {
-		// The question row can vanish mid-game when a host deletes it
-		// between this call's GetGame and here. Treat the deleted row as
-		// no-longer-in-game so the submit path 404s gracefully, matching
-		// how GetNext advances past a missing question rather than 500ing
-		// (#1180).
+		// A host can delete the question mid-game; treat it as
+		// no-longer-in-game so the submit path 404s instead of 500ing (#1180).
 		if errors.Is(err, quiz.ErrQuestionNotFound) {
 			return nil, nil, fmt.Errorf(
 				"question %d deleted from game %s: %w", question.QuestionID, gameID, ErrQuestionNotInGame,

--- a/internal/game/service.go
+++ b/internal/game/service.go
@@ -24,6 +24,13 @@ const (
 	// mobile network jitter.
 	defaultStalePeriod = 30 * time.Second
 
+	// lateAnswerGrace is how far past a question's ExpiredAt an answer may
+	// still land and be recorded, covering a last-instant tap delayed in
+	// flight. Beyond it [Service.SubmitAnswer] rejects the answer with
+	// [ErrAnswerWindowClosed] rather than storing a guaranteed-zero score
+	// (#1163).
+	lateAnswerGrace = 2 * time.Second
+
 	// errGetGameFmt is the wrap format for store.GetGame errors. Every
 	// entry-point gate (GetNextQuestion, GetNext, MarkRoundSeen,
 	// SubmitAnswer, GetResults) wraps the failure with the same
@@ -464,6 +471,14 @@ func (s *Service) SubmitAnswer(
 		return nil, err
 	}
 
+	// Reject an answer that reaches the server after the window has closed
+	// (#1163). The grace covers a last-instant tap delayed in flight; past
+	// it the answer scores nothing, so it is refused rather than recorded.
+	now := time.Now()
+	if now.After(question.ExpiredAt.Add(lateAnswerGrace)) {
+		return nil, ErrAnswerWindowClosed
+	}
+
 	a := &Answer{
 		GameID:     gameID,
 		PlayerID:   playerID,
@@ -471,7 +486,7 @@ func (s *Service) SubmitAnswer(
 		Question:   question,
 		OptionID:   optionID,
 		Option:     option,
-		AnsweredAt: clampTappedAt(tappedAt, question.StartedAt, time.Now()),
+		AnsweredAt: clampTappedAt(tappedAt, now, maxLatencyRefund),
 	}
 
 	if err = s.store.CreateAnswer(ctx, a); err != nil {
@@ -583,6 +598,17 @@ func (s *Service) resolveAnswerTarget(
 
 	quizQuestion, err := s.quizStore.GetQuestion(ctx, question.QuestionID)
 	if err != nil {
+		// The question row can vanish mid-game when a host deletes it
+		// between this call's GetGame and here. Treat the deleted row as
+		// no-longer-in-game so the submit path 404s gracefully, matching
+		// how GetNext advances past a missing question rather than 500ing
+		// (#1180).
+		if errors.Is(err, quiz.ErrQuestionNotFound) {
+			return nil, nil, fmt.Errorf(
+				"question %d deleted from game %s: %w", question.QuestionID, gameID, ErrQuestionNotInGame,
+			)
+		}
+
 		return nil, nil, fmt.Errorf("failed to get question: %w", err)
 	}
 	question.QuizQuestion = quizQuestion

--- a/internal/game/service_test.go
+++ b/internal/game/service_test.go
@@ -415,6 +415,44 @@ func TestService_SubmitAnswer(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("rejects an answer that arrives after the window closes", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		db := dbtest.Open(t)
+
+		quizStore := store.NewQuizStore(db, slog.Default())
+		gameStore := store.NewGameStore(db, slog.Default())
+
+		testQuiz := newTestQuiz(t)
+		if err := quizStore.CreateQuiz(ctx, testQuiz); err != nil {
+			t.Fatalf("failed to create quiz: %v", err)
+		}
+
+		svc := NewService(gameStore, quizStore, slog.Default())
+		// A negative reveal delay issues the question with its window
+		// already in the past, so the answer below lands well past
+		// ExpiredAt plus the latency grace without any real waiting.
+		svc.SetRevealDelay(-time.Hour)
+
+		g, err := svc.CreateGame(ctx, testQuiz.ID, 1)
+		if err != nil {
+			t.Fatalf("failed to create game: %v", err)
+		}
+
+		gq, err := svc.GetNextQuestion(ctx, g.ID, 1)
+		if err != nil {
+			t.Fatalf("failed to get next question: %v", err)
+		}
+
+		correctOption := testQuiz.Questions[0].Options[0] // Paris, Correct: true
+
+		_, err = svc.SubmitAnswer(ctx, g.ID, 1, gq.QuizQuestion.ID, correctOption.ID, time.Time{})
+		if got, want := err, ErrAnswerWindowClosed; !errors.Is(got, want) {
+			t.Errorf("err = %v, want %v", got, want)
+		}
+	})
 }
 
 func TestService_GetResults(t *testing.T) {

--- a/internal/game/service_test.go
+++ b/internal/game/service_test.go
@@ -431,9 +431,7 @@ func TestService_SubmitAnswer(t *testing.T) {
 		}
 
 		svc := NewService(gameStore, quizStore, slog.Default())
-		// A negative reveal delay issues the question with its window
-		// already in the past, so the answer below lands well past
-		// ExpiredAt plus the latency grace without any real waiting.
+		// Negative reveal delay issues the question already expired.
 		svc.SetRevealDelay(-time.Hour)
 
 		g, err := svc.CreateGame(ctx, testQuiz.ID, 1)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1015,7 +1015,6 @@ func addAPIRoutes(
 		ensurePlayer(clientapi.HandlePlayerClaimName(logger, stores.Players, gameService)),
 	)
 	mux.Handle("GET /api/quizzes", ensurePlayer(clientapi.HandleQuizList(logger, stores.Quizzes)))
-	mux.Handle("GET /api/quizzes/{slugID}", ensurePlayer(clientapi.HandleQuizGet(logger, stores.Quizzes)))
 	mux.Handle(
 		"GET /api/quizzes/{slugID}/leaderboard",
 		ensurePlayer(clientapi.HandleQuizLeaderboard(logger, gameService)),

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -161,7 +161,6 @@ func TestAddRoutes_RegisteredRoutesDoNot404(t *testing.T) {
 		{name: "Admin Reset Player", method: http.MethodPost, path: "/admin/quizzes/1/players/2/reset"},
 
 		{name: "API Quiz List", method: http.MethodGet, path: "/api/quizzes"},
-		{name: "API Quiz Get", method: http.MethodGet, path: "/api/quizzes/" + slugID},
 		{name: "API Quiz Leaderboard", method: http.MethodGet, path: "/api/quizzes/" + slugID + "/leaderboard"},
 		{name: "API Quiz My Game", method: http.MethodGet, path: "/api/quizzes/" + slugID + "/my-game"},
 

--- a/test/integration/question_audio_test.go
+++ b/test/integration/question_audio_test.go
@@ -12,14 +12,8 @@ import (
 	"github.com/starquake/topbanana/internal/store"
 )
 
-// quizGetAudioRes decodes only the per-question audio field off the solo data
-// endpoint (GET /api/quizzes/{slugID}).
-type quizGetAudioRes struct {
-	Questions []questionAudioRes `json:"questions"`
-}
-
-// questionAudioRes is one question's text + audio field, shared by the solo
-// data and /next decode targets.
+// questionAudioRes is one question's text + audio field, shared by the /next
+// and live-session decode targets.
 type questionAudioRes struct {
 	Text     string `json:"text"`
 	AudioURL string `json:"audioUrl"`
@@ -70,10 +64,8 @@ func attachAudioToQuestion(
 	return row.ID
 }
 
-// TestQuestionAudio_SoloWire pins that the solo play endpoints surface a
-// question's attached sound as audioUrl = /media/<id> and omit the field when
-// the question has none. Covers both the bulk data endpoint
-// (GET /api/quizzes/{slugID}) and the per-question /next endpoint.
+// TestQuestionAudio_SoloWire pins that the per-question /next endpoint
+// surfaces a question's attached sound as audioUrl = /media/<id>.
 func TestQuestionAudio_SoloWire(t *testing.T) {
 	t.Parallel()
 
@@ -99,29 +91,6 @@ func TestQuestionAudio_SoloWire(t *testing.T) {
 
 	mediaID := attachAudioToQuestion(ctx, t, stores, qz.ID, qz.Questions[0].ID)
 	wantURL := fmt.Sprintf("/media/%d", mediaID)
-	slugID := fmt.Sprintf("%s-%d", qz.Slug, qz.ID)
-
-	t.Run("data endpoint carries audioUrl", func(t *testing.T) {
-		t.Parallel()
-		resp := httpGet(ctx, t, newAnonClient(t), fmt.Sprintf("%s/api/quizzes/%s", baseURL, slugID))
-		defer closeBody(t, resp.Body)
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("quiz get status = %d, want %d", got, want)
-		}
-		var body quizGetAudioRes
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			t.Fatalf("decode quiz get: %v", err)
-		}
-		if got, want := len(body.Questions), 2; got != want {
-			t.Fatalf("questions = %d, want %d", got, want)
-		}
-		if got, want := body.Questions[0].AudioURL, wantURL; got != want {
-			t.Errorf("question[0].audioUrl = %q, want %q", got, want)
-		}
-		if got := body.Questions[1].AudioURL; got != "" {
-			t.Errorf("question[1].audioUrl = %q, want empty (no sound attached)", got)
-		}
-	})
 
 	t.Run("next endpoint carries audioUrl", func(t *testing.T) {
 		t.Parallel()

--- a/test/integration/question_image_test.go
+++ b/test/integration/question_image_test.go
@@ -12,14 +12,8 @@ import (
 	"github.com/starquake/topbanana/internal/store"
 )
 
-// quizGetImageRes decodes only the per-question image field off the solo
-// data endpoint (GET /api/quizzes/{slugID}).
-type quizGetImageRes struct {
-	Questions []questionImageRes `json:"questions"`
-}
-
-// questionImageRes is one question's text + image field, shared by the solo
-// data and /next decode targets.
+// questionImageRes is one question's text + image field, shared by the /next
+// and live-session decode targets.
 type questionImageRes struct {
 	Text     string `json:"text"`
 	ImageURL string `json:"imageUrl"`
@@ -94,10 +88,8 @@ func createSoloGame(
 	return created
 }
 
-// TestQuestionImage_SoloWire pins that the solo play endpoints surface a
-// question's attached image as imageUrl = /media/<id> and omit the field when
-// the question has none. Covers both the bulk data endpoint
-// (GET /api/quizzes/{slugID}) and the per-question /next endpoint.
+// TestQuestionImage_SoloWire pins that the per-question /next endpoint
+// surfaces a question's attached image as imageUrl = /media/<id>.
 func TestQuestionImage_SoloWire(t *testing.T) {
 	t.Parallel()
 
@@ -123,29 +115,6 @@ func TestQuestionImage_SoloWire(t *testing.T) {
 
 	mediaID := attachMediaToQuestion(ctx, t, stores, qz.ID, qz.Questions[0].ID)
 	wantURL := fmt.Sprintf("/media/%d", mediaID)
-	slugID := fmt.Sprintf("%s-%d", qz.Slug, qz.ID)
-
-	t.Run("data endpoint carries imageUrl", func(t *testing.T) {
-		t.Parallel()
-		resp := httpGet(ctx, t, newAnonClient(t), fmt.Sprintf("%s/api/quizzes/%s", baseURL, slugID))
-		defer closeBody(t, resp.Body)
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("quiz get status = %d, want %d", got, want)
-		}
-		var body quizGetImageRes
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			t.Fatalf("decode quiz get: %v", err)
-		}
-		if got, want := len(body.Questions), 2; got != want {
-			t.Fatalf("questions = %d, want %d", got, want)
-		}
-		if got, want := body.Questions[0].ImageURL, wantURL; got != want {
-			t.Errorf("question[0].imageUrl = %q, want %q", got, want)
-		}
-		if got := body.Questions[1].ImageURL; got != "" {
-			t.Errorf("question[1].imageUrl = %q, want empty (no image attached)", got)
-		}
-	})
 
 	t.Run("next endpoint carries imageUrl", func(t *testing.T) {
 		t.Parallel()

--- a/test/integration/quiz_mode_test.go
+++ b/test/integration/quiz_mode_test.go
@@ -13,11 +13,8 @@ import (
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
-// TestQuizModeGating_Integration pins the MP-0 solo gate end-to-end
-// (#677): a live quiz is absent from the public/solo browse list and is
-// rejected by the game-create path - both with a 404 so a live quiz is
-// indistinguishable from a missing one. A solo quiz stays listed and
-// playable.
+// TestQuizModeGating_Integration pins the MP-0 solo gate (#677): a live
+// quiz is off the browse list and 404s game-create; a solo quiz stays playable.
 func TestQuizModeGating_Integration(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/quiz_mode_test.go
+++ b/test/integration/quiz_mode_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 // TestQuizModeGating_Integration pins the MP-0 solo gate end-to-end
-// (#677): a live quiz is absent from the public/solo browse list, is
-// rejected by the solo play data endpoint, and is rejected by the
-// game-create path - all with a 404 so a live quiz is indistinguishable
-// from a missing one. A solo quiz stays listed and playable.
+// (#677): a live quiz is absent from the public/solo browse list and is
+// rejected by the game-create path - both with a 404 so a live quiz is
+// indistinguishable from a missing one. A solo quiz stays listed and
+// playable.
 func TestQuizModeGating_Integration(t *testing.T) {
 	t.Parallel()
 
@@ -83,24 +83,6 @@ func TestQuizModeGating_Integration(t *testing.T) {
 		}
 		if seen["Live Mode Quiz"] {
 			t.Error("solo browse list surfaced the live quiz")
-		}
-	})
-
-	t.Run("solo play endpoint 404s the live quiz", func(t *testing.T) {
-		t.Parallel()
-		resp := httpGet(ctx, t, anonClient, fmt.Sprintf("%s/api/quizzes/%s-%d", baseURL, liveQz.Slug, liveQz.ID))
-		defer closeBody(t, resp.Body)
-		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
-			t.Errorf("status = %d, want %d", got, want)
-		}
-	})
-
-	t.Run("solo play endpoint still serves the solo quiz", func(t *testing.T) {
-		t.Parallel()
-		resp := httpGet(ctx, t, anonClient, fmt.Sprintf("%s/api/quizzes/%s-%d", baseURL, soloQz.Slug, soloQz.ID))
-		defer closeBody(t, resp.Body)
-		if got, want := resp.StatusCode, http.StatusOK; got != want {
-			t.Errorf("status = %d, want %d", got, want)
 		}
 	})
 

--- a/test/integration/quiz_visibility_test.go
+++ b/test/integration/quiz_visibility_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
-// TestQuizVisibility_Integration pins #103 end-to-end: a private quiz
-// disappears from /api/quizzes for everyone, its per-quiz endpoints (the
-// visibility-gated leaderboard) are reachable only by an authenticated
-// player, and it rejects a start-game POST from an anonymous visitor.
-// Unlisted is not on the public list but stays reachable on its per-quiz
-// endpoints.
+// TestQuizVisibility_Integration pins #103: a private quiz is hidden from
+// the list and its gated leaderboard is reachable only by an authed player;
+// unlisted is off the list but reachable by link.
 func TestQuizVisibility_Integration(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/quiz_visibility_test.go
+++ b/test/integration/quiz_visibility_test.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
-	"strings"
 	"testing"
 
 	"github.com/starquake/topbanana/internal/quiz"
 )
 
 // TestQuizVisibility_Integration pins #103 end-to-end: a private quiz
-// disappears from /api/quizzes for everyone, is reachable on its
-// direct endpoints only by an authenticated player, and rejects a
-// start-game POST from an anonymous visitor. Unlisted is not on the
-// public list but stays reachable on its direct endpoints.
+// disappears from /api/quizzes for everyone, its per-quiz endpoints (the
+// visibility-gated leaderboard) are reachable only by an authenticated
+// player, and it rejects a start-game POST from an anonymous visitor.
+// Unlisted is not on the public list but stays reachable on its per-quiz
+// endpoints.
 func TestQuizVisibility_Integration(t *testing.T) {
 	t.Parallel()
 
@@ -103,13 +103,13 @@ func TestQuizVisibility_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("anonymous can fetch unlisted by direct link", func(t *testing.T) {
+	t.Run("anonymous can reach unlisted leaderboard by direct link", func(t *testing.T) {
 		t.Parallel()
 		resp := httpGet(
 			ctx,
 			t,
 			anonClient,
-			fmt.Sprintf("%s/api/quizzes/%s-%d", baseURL, unlistedQz.Slug, unlistedQz.ID),
+			fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, unlistedQz.Slug, unlistedQz.ID),
 		)
 		defer closeBody(t, resp.Body)
 		if got, want := resp.StatusCode, http.StatusOK; got != want {
@@ -117,9 +117,12 @@ func TestQuizVisibility_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("anonymous gets 404 fetching private quiz directly", func(t *testing.T) {
+	t.Run("anonymous gets 404 reaching private quiz leaderboard directly", func(t *testing.T) {
 		t.Parallel()
-		resp := httpGet(ctx, t, anonClient, fmt.Sprintf("%s/api/quizzes/%s-%d", baseURL, privateQz.Slug, privateQz.ID))
+		resp := httpGet(
+			ctx, t, anonClient,
+			fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, privateQz.Slug, privateQz.ID),
+		)
 		defer closeBody(t, resp.Body)
 		if got, want := resp.StatusCode, http.StatusNotFound; got != want {
 			t.Errorf("status = %d, want %d", got, want)
@@ -153,21 +156,15 @@ func TestQuizVisibility_Integration(t *testing.T) {
 	// redirects normally (the login handler 303s on success).
 	authClient.CheckRedirect = nil
 
-	t.Run("logged-in player can fetch private quiz directly", func(t *testing.T) {
+	t.Run("logged-in player can reach private quiz leaderboard directly", func(t *testing.T) {
 		t.Parallel()
-		resp := httpGet(ctx, t, authClient, fmt.Sprintf("%s/api/quizzes/%s-%d", baseURL, privateQz.Slug, privateQz.ID))
+		resp := httpGet(
+			ctx, t, authClient,
+			fmt.Sprintf("%s/api/quizzes/%s-%d/leaderboard", baseURL, privateQz.Slug, privateQz.ID),
+		)
 		defer closeBody(t, resp.Body)
 		if got, want := resp.StatusCode, http.StatusOK; got != want {
 			t.Errorf("status = %d, want %d", got, want)
-		}
-		var body struct {
-			Title string `json:"title"`
-		}
-		if derr := json.NewDecoder(resp.Body).Decode(&body); derr != nil {
-			t.Fatalf("decode: %v", derr)
-		}
-		if got, want := body.Title, "Private Quiz"; !strings.Contains(got, want) {
-			t.Errorf("title = %q, should contain %q", got, want)
 		}
 	})
 }


### PR DESCRIPTION
Three solo-play hardening fixes.

- **#1163:** `SubmitAnswer` now rejects answers arriving past `ExpiredAt` + a short grace (`ErrAnswerWindowClosed` -> 409), and bounds the #237 latency refund to `[now-2s, now]` instead of clamping back to `StartedAt` -- so a client can no longer take unlimited time and score full points. Live-session path untouched.
- **#1180:** a question deleted mid-game now returns a graceful 404 (`ErrQuestionNotInGame`) instead of a 500 + operator ERROR log.
- **#1167:** removed `GET /api/quizzes/{slugID}`, which dumped all question/option text before a timed game. No consumer relies on it (client uses `/api/quizzes`, `/my-game`, `/leaderboard`, `/next`); affected tests repointed to the surviving `/leaderboard`.

Tests: bounded-refund clamp, late-answer rejection, handler 409/404. `make check`/`make smoke` pass.

Closes #1163
Closes #1180
Closes #1167

_— Claude Code, for @starquake_
