### PR TITLE
Harden unverified-account login and gate password-reset routes on SMTP

### DIFF
--- a/internal/auth/google.go
+++ b/internal/auth/google.go
@@ -171,7 +171,7 @@ func HandleGoogleCallback(
 	sessions *session.Manager,
 	games AnonymousGameMigrator,
 	adminEmails []string,
-	registrationEnabled bool,
+	registrationEnabled, forgotPasswordEnabled bool,
 ) http.Handler {
 	renderer := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
 
@@ -185,7 +185,7 @@ func HandleGoogleCallback(
 		http.SetCookie(w, googleNextCookie("", authn.cfg.SecureCookies, -1))
 
 		if msg, ok := validateCallbackRequest(authn.stateKey, r); !ok {
-			renderGoogleError(renderer, w, r, msg, registrationEnabled)
+			renderGoogleError(renderer, w, r, msg, registrationEnabled, forgotPasswordEnabled)
 
 			return
 		}
@@ -197,7 +197,7 @@ func HandleGoogleCallback(
 			return
 		}
 		if result.UserMessage != "" {
-			renderGoogleError(renderer, w, r, result.UserMessage, registrationEnabled)
+			renderGoogleError(renderer, w, r, result.UserMessage, registrationEnabled, forgotPasswordEnabled)
 
 			return
 		}
@@ -213,7 +213,7 @@ func HandleGoogleCallback(
 			if !errors.Is(err, ErrRegistrationDisabled) {
 				logger.ErrorContext(r.Context(), "error linking google player", slog.Any("err", err))
 			}
-			renderGoogleError(renderer, w, r, googleLinkErrorMessage(err), registrationEnabled)
+			renderGoogleError(renderer, w, r, googleLinkErrorMessage(err), registrationEnabled, forgotPasswordEnabled)
 
 			return
 		}
@@ -230,7 +230,7 @@ func HandleGoogleCallback(
 				slog.Int64("player_id", player.ID))
 			renderGoogleError(renderer, w, r,
 				"Sign-in blocked: your email is not verified. Try requesting a verification link.",
-				registrationEnabled)
+				registrationEnabled, forgotPasswordEnabled)
 
 			return
 		}
@@ -813,12 +813,13 @@ func renderGoogleError(
 	w http.ResponseWriter,
 	r *http.Request,
 	message string,
-	registrationEnabled bool,
+	registrationEnabled, forgotPasswordEnabled bool,
 ) {
 	renderer.Render(w, r, http.StatusUnauthorized, formData{
-		Title:        "Log in",
-		Message:      message,
-		ShowRegister: registrationEnabled,
-		ShowGoogle:   true,
+		Title:              "Log in",
+		Message:            message,
+		ShowRegister:       registrationEnabled,
+		ShowGoogle:         true,
+		ShowForgotPassword: forgotPasswordEnabled,
 	})
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -110,6 +110,9 @@ type formData struct {
 	// GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_REDIRECT_URL
 	// env vars is unset.
 	ShowGoogle bool
+	// ShowForgotPassword renders the "Forgot your password?" link; false
+	// when SMTP is unconfigured and the reset routes are unmounted (#1170).
+	ShowForgotPassword bool
 	// Next is the validated same-site return path the login flow
 	// should send the user to on success (#449). Empty string means
 	// "no return target known"; callers fall back to the role landing.
@@ -436,7 +439,7 @@ func HandleLoginForm(
 	csrfMgr *csrf.Manager,
 	players PlayerStore,
 	sessions *session.Manager,
-	registrationEnabled, googleEnabled bool,
+	registrationEnabled, googleEnabled, forgotPasswordEnabled bool,
 ) http.Handler {
 	renderer := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
 
@@ -446,10 +449,11 @@ func HandleLoginForm(
 			return
 		}
 		renderer.Render(w, r, http.StatusOK, formData{
-			Title:        "Log in",
-			ShowRegister: registrationEnabled,
-			ShowGoogle:   googleEnabled,
-			Next:         next,
+			Title:              "Log in",
+			ShowRegister:       registrationEnabled,
+			ShowGoogle:         googleEnabled,
+			ShowForgotPassword: forgotPasswordEnabled,
+			Next:               next,
 		})
 	})
 }
@@ -513,6 +517,9 @@ type LoginDeps struct {
 	BaseURL             string
 	RegistrationEnabled bool
 	GoogleEnabled       bool
+	// ForgotPasswordEnabled shows the "Forgot your password?" link on the
+	// login form's error re-renders; false when SMTP is unconfigured (#1170).
+	ForgotPasswordEnabled bool
 	// Tasks tracks the detached verify-email resend so a graceful
 	// shutdown drains it before the DB closes (#740). Nil in unit tests,
 	// which then run the dispatch untracked.
@@ -542,9 +549,10 @@ func HandleLoginSubmit(
 ) http.Handler {
 	renderer := newTemplateRenderer(logger, csrfMgr, "auth/pages/login.gohtml")
 	formCfg := loginFormCfg{
-		render:              renderer,
-		registrationEnabled: deps.RegistrationEnabled,
-		googleEnabled:       deps.GoogleEnabled,
+		render:                renderer,
+		registrationEnabled:   deps.RegistrationEnabled,
+		googleEnabled:         deps.GoogleEnabled,
+		forgotPasswordEnabled: deps.ForgotPasswordEnabled,
 	}
 	// dummyHash computes a bcrypt hash once on first use. The handler runs
 	// CheckPassword against it when the email does not exist so the
@@ -636,11 +644,8 @@ func completeLogin(
 	// password is not penalised for earlier typos).
 	clearAccountFailures(deps.AccountLimiter, email)
 
-	// Credentials are correct but the account email is unverified
-	// (#492): refuse the sign-in, re-render the login form with a
-	// generic "check your email" banner, and dispatch a fresh verify
-	// link best-effort. The banner names no address and does not confirm
-	// the password (#787).
+	// Refuse an unverified account; renderUnverifiedLogin keeps the
+	// response indistinguishable from a wrong password (#492/#787/#1171).
 	if !player.IsEmailVerified() {
 		logger.InfoContext(r.Context(), "login blocked: email not verified",
 			slog.Int64(logPlayerKey, player.ID),
@@ -700,9 +705,10 @@ func recordAccountFailure(limiter *AccountLoginLimiter, account string) {
 // the inner helpers (authenticateLogin, renderInvalidCredentials,
 // renderLoginRateLimited) stay under revive's argument-limit.
 type loginFormCfg struct {
-	render              *render.Renderer
-	registrationEnabled bool
-	googleEnabled       bool
+	render                *render.Renderer
+	registrationEnabled   bool
+	googleEnabled         bool
+	forgotPasswordEnabled bool
 }
 
 // loginCreds bundles the per-attempt credential inputs so
@@ -779,21 +785,10 @@ func authenticateLogin(
 	return player, true
 }
 
-// renderUnverifiedLogin re-renders the login form with a generic
-// "check your email" banner and fires a fresh verify-email send through
-// the per-IP resend limiter. Status stays 200 OK so an unverified
-// visitor who reloads sees the form again without the browser flagging a
-// 4xx (the response shape mirrors the verify-email/request flow's
-// success render).
-//
-// The banner deliberately names no address and does not confirm the
-// password was right. Echoing the address ("we resent the link to
-// <email>") only happens when credentials are correct, so it would leak
-// both account existence and password correctness - an enumeration /
-// password oracle. The generic wording (#787, reversing the #492
-// address echo) keeps an unverified-but-correct attempt indistinguishable
-// from a wrong-password one. The submitted email is preserved in the
-// field only so a real user does not have to retype it.
+// renderUnverifiedLogin refuses a correct-password login against an
+// unverified account. It renders byte-identically to the wrong-password
+// 401 so a correct password isn't a password oracle; the verify-email
+// resend is dispatched silently (#492/#787/#1171).
 func renderUnverifiedLogin(
 	logger *slog.Logger,
 	cfg loginFormCfg,
@@ -804,14 +799,7 @@ func renderUnverifiedLogin(
 	email string,
 ) {
 	dispatchVerifyResend(r, logger, deps, player)
-	cfg.render.Render(w, r, http.StatusOK, formData{
-		Title:        "Log in",
-		Email:        email,
-		Message:      "Check your email to finish signing in.",
-		ShowRegister: cfg.registrationEnabled,
-		ShowGoogle:   cfg.googleEnabled,
-		Next:         SafeNextPath(r.PostFormValue("next")),
-	})
+	renderInvalidCredentials(cfg, w, r, email)
 }
 
 // dispatchVerifyResend mirrors dispatchVerifyEmail but routes through
@@ -865,12 +853,13 @@ func renderLoginRateLimited(
 	seconds := int((wait + time.Second - 1) / time.Second)
 	w.Header().Set("Retry-After", strconv.Itoa(seconds))
 	cfg.render.Render(w, r, http.StatusTooManyRequests, formData{
-		Title:        "Log in",
-		Email:        email,
-		Message:      "Too many attempts. Try again in a moment.",
-		ShowRegister: cfg.registrationEnabled,
-		ShowGoogle:   cfg.googleEnabled,
-		Next:         SafeNextPath(r.PostFormValue("next")),
+		Title:              "Log in",
+		Email:              email,
+		Message:            "Too many attempts. Try again in a moment.",
+		ShowRegister:       cfg.registrationEnabled,
+		ShowGoogle:         cfg.googleEnabled,
+		ShowForgotPassword: cfg.forgotPasswordEnabled,
+		Next:               SafeNextPath(r.PostFormValue("next")),
 	})
 }
 
@@ -967,11 +956,12 @@ func renderInvalidCredentials(
 	email string,
 ) {
 	cfg.render.Render(w, r, http.StatusUnauthorized, formData{
-		Title:        "Log in",
-		Email:        email,
-		Message:      "Invalid email or password.",
-		ShowRegister: cfg.registrationEnabled,
-		ShowGoogle:   cfg.googleEnabled,
+		Title:              "Log in",
+		Email:              email,
+		Message:            "Invalid email or password.",
+		ShowRegister:       cfg.registrationEnabled,
+		ShowGoogle:         cfg.googleEnabled,
+		ShowForgotPassword: cfg.forgotPasswordEnabled,
 		// Preserve the posted next so a failed login attempt does not
 		// drop the visitor's intended destination (#449).
 		Next: SafeNextPath(r.PostFormValue("next")),

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -618,6 +618,7 @@ func TestHandleLoginForm_GET_RendersForm(t *testing.T) {
 		session.New([]byte("k"), true),
 		false,
 		false,
+		false,
 	)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
@@ -640,6 +641,7 @@ func TestHandleLoginForm_RegistrationDisabled_HidesRegisterLink(t *testing.T) {
 		nil,
 		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
 		session.New([]byte("k"), true),
+		false,
 		false,
 		false,
 	)
@@ -666,6 +668,7 @@ func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 		session.New([]byte("k"), true),
 		true,
 		false,
+		false,
 	)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
@@ -677,6 +680,60 @@ func TestHandleLoginForm_RegistrationEnabled_ShowsRegisterLink(t *testing.T) {
 	}
 	if got, want := rec.Body.String(), `href="/register"`; !strings.Contains(got, want) {
 		t.Errorf("body should contain %q when registration is enabled, got %q", want, got)
+	}
+}
+
+// TestHandleLoginForm_SMTPUnconfigured_HidesForgotLink: no forgot-password
+// link when SMTP is unconfigured (the routes are unmounted) (#1170).
+func TestHandleLoginForm_SMTPUnconfigured_HidesForgotLink(t *testing.T) {
+	t.Parallel()
+
+	handler := HandleLoginForm(
+		discardLogger(),
+		nil,
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
+		session.New([]byte("k"), true),
+		false,
+		false,
+		false,
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got := rec.Body.String(); strings.Contains(got, "/forgot-password") {
+		t.Errorf("body should not link to /forgot-password when SMTP is unconfigured, got %q", got)
+	}
+}
+
+// TestHandleLoginForm_SMTPConfigured_ShowsForgotLink: the forgot-password
+// link renders when SMTP is configured (#1170).
+func TestHandleLoginForm_SMTPConfigured_ShowsForgotLink(t *testing.T) {
+	t.Parallel()
+
+	handler := HandleLoginForm(
+		discardLogger(),
+		nil,
+		store.NewPlayerStore(dbtest.Open(t), discardLogger()),
+		session.New([]byte("k"), true),
+		false,
+		false,
+		true,
+	)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := rec.Body.String(), `href="/forgot-password"`; !strings.Contains(got, want) {
+		t.Errorf("body should link to /forgot-password when SMTP is configured, got %q", got)
 	}
 }
 
@@ -711,7 +768,7 @@ func TestHandleLoginForm_AlreadySignedIn_RedirectsToLanding(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, player.ID, 0)
@@ -743,7 +800,7 @@ func TestHandleLoginForm_AnonymousSession_RendersForm(t *testing.T) {
 	}
 
 	sessions := session.New([]byte("k"), true)
-	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false)
+	handler := HandleLoginForm(discardLogger(), nil, players, sessions, false, false, false)
 
 	rec := httptest.NewRecorder()
 	sessions.Set(rec, anon.ID, 0)
@@ -1126,14 +1183,9 @@ func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 	}
 }
 
-// TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends pins #492 +
-// #787: valid credentials against a row whose email_verified_at is NULL
-// must re-render the login form (no 303 to landing, no session cookie
-// set) and trigger a fresh verify-email send through the wired-in
-// mailer. The banner is the generic "check your email" message that
-// names no address and does not confirm the password (#787), so an
-// unverified-but-correct attempt is indistinguishable from a
-// wrong-password one.
+// TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends: an unverified
+// account is refused with the generic 401 (no session), and the verify
+// email still resends silently (#492/#787/#1171).
 func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 	t.Parallel()
 
@@ -1166,18 +1218,18 @@ func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 		"password": {"correctbattery"},
 	})
 
-	if got, want := rec.Code, http.StatusOK; got != want {
+	if got, want := rec.Code, http.StatusUnauthorized; got != want {
 		t.Fatalf("status = %d, want %d (body=%q)", got, want, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if want := "Check your email to finish signing in."; !strings.Contains(body, want) {
-		t.Errorf("body missing generic check-email banner; body=%.300q", body)
+	if want := "Invalid email or password."; !strings.Contains(body, want) {
+		t.Errorf("body missing generic invalid-credentials banner; body=%.300q", body)
 	}
-	// The banner must NOT echo the address or otherwise confirm the
-	// credentials were correct (#787); doing so would make this an
-	// account-existence + password oracle.
-	if dontWant := "resent the link to"; strings.Contains(body, dontWant) {
-		t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, body)
+	// The response must not confirm the password was correct (#787/#1171).
+	for _, dontWant := range []string{"Check your email", "resent the link to", "finish signing in"} {
+		if strings.Contains(body, dontWant) {
+			t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, body)
+		}
 	}
 	for _, c := range rec.Result().Cookies() {
 		if c.Name == session.CookieName && c.Value != "" {
@@ -1200,6 +1252,68 @@ func TestHandleLoginSubmit_UnverifiedEmail_RefusesAndResends(t *testing.T) {
 	}
 	if got, want := len(tokens.Created()), 1; got != want {
 		t.Errorf("tokens.Created() len = %d, want %d", got, want)
+	}
+}
+
+// TestHandleLoginSubmit_UnverifiedEmail_IndistinguishableFromWrongPassword:
+// correct and wrong passwords against an unverified account yield
+// byte-identical responses, yet only the correct one resends (#1171).
+func TestHandleLoginSubmit_UnverifiedEmail_IndistinguishableFromWrongPassword(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	hash, err := HashPassword("correctbattery")
+	if err != nil {
+		t.Fatalf("HashPassword err = %v, want nil", err)
+	}
+	if _, err := players.CreatePlayer(t.Context(), "unv", "unv@example.test", hash, RolePlayer); err != nil {
+		t.Fatalf("CreatePlayer err = %v, want nil", err)
+	}
+
+	tokens := &recordingVerifyTokenStore{}
+	sender := &recordingSender{}
+	tracker := bgtasks.New()
+	handler := HandleLoginSubmit(discardLogger(), nil, LoginDeps{
+		Players:       players,
+		Sessions:      session.New([]byte("k"), true),
+		Limiter:       NewLoginRateLimiter(0, nil),
+		Mailer:        sender,
+		Tokens:        tokens,
+		ResendLimiter: NewVerifyResendLimiter(time.Minute, nil),
+		BaseURL:       "https://topbanana.example",
+		Tasks:         tracker,
+	})
+
+	correct := postForm(t, handler, "/login", url.Values{
+		"email":    {"unv@example.test"},
+		"password": {"correctbattery"},
+	})
+	wrong := postForm(t, handler, "/login", url.Values{
+		"email":    {"unv@example.test"},
+		"password": {"wrong-password-no"},
+	})
+
+	if got, want := correct.Code, wrong.Code; got != want {
+		t.Errorf("status codes differ: correct-password = %d, wrong-password = %d (must match)", got, want)
+	}
+	if got, want := correct.Body.String(), wrong.Body.String(); got != want {
+		t.Errorf("response bodies differ between correct and wrong password (must be byte-identical)\n"+
+			"correct=%.300q\nwrong=%.300q", got, want)
+	}
+
+	// Only the correct-password attempt resends the verification email.
+	if err := tracker.Wait(t.Context()); err != nil {
+		t.Fatalf("tracker.Wait err = %v, want nil", err)
+	}
+	sent := sender.Sent()
+	if got, want := len(sent), 1; got != want {
+		t.Fatalf("sender.Sent() len = %d, want %d (only the correct-password attempt resends)", got, want)
+	}
+	if got, want := sent[0].To, "unv@example.test"; got != want {
+		t.Errorf("sent[0].To = %q, want %q", got, want)
+	}
+	if got, want := sent[0].Kind, mailer.KindVerify; got != want {
+		t.Errorf("sent[0].Kind = %q, want %q", got, want)
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -207,7 +207,11 @@ func addEmailFlowRoutes(
 		)),
 	))
 
-	addPasswordResetRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
+	// Without SMTP the reset email can never send, so mounting these would
+	// dead-end every user; gate them like the Google-login routes (#1170).
+	if cfg.SMTPConfigured() {
+		addPasswordResetRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
+	}
 
 	mux.Handle("GET /accept-invite", auth.HandleAcceptInviteForm(logger, csrfMgr, stores.Invites))
 	mux.Handle("POST /accept-invite", admin.MaxFormSizeMiddleware(csrfMW(
@@ -331,7 +335,7 @@ func addAuthRoutes(
 			"GET /login/google/callback",
 			auth.HandleGoogleCallback(
 				logger, googleAuth, csrfMgr, stores.OAuth, stores.Players, stores.AdminPlayers, sessions,
-				stores.GameMigrator, cfg.AdminEmails, cfg.RegistrationEnabled,
+				stores.GameMigrator, cfg.AdminEmails, cfg.RegistrationEnabled, cfg.SMTPConfigured(),
 			),
 		)
 	} else {
@@ -365,26 +369,31 @@ func addLoginRoutes(
 	loginLimiter := auth.NewLoginRateLimiter(cfg.LoginCooldown, cfg.TrustedProxyCIDRs)
 	accountLoginLimiter := auth.NewAccountLoginLimiter(auth.AccountLoginThreshold(), auth.AccountLoginCooldown())
 	loginResendLimiter := auth.NewVerifyResendLimiter(auth.VerifyResendCooldown(), cfg.TrustedProxyCIDRs)
+	forgotPasswordEnabled := cfg.SMTPConfigured()
 	mux.Handle(
 		"GET /login",
-		auth.HandleLoginForm(logger, csrfMgr, stores.Players, sessions, cfg.RegistrationEnabled, googleEnabled),
+		auth.HandleLoginForm(
+			logger, csrfMgr, stores.Players, sessions,
+			cfg.RegistrationEnabled, googleEnabled, forgotPasswordEnabled,
+		),
 	)
 	mux.Handle(
 		"POST /login",
 		csrfMW(auth.HandleLoginSubmit(
 			logger, csrfMgr, auth.LoginDeps{
-				Players:             stores.Players,
-				Sessions:            sessions,
-				Games:               stores.GameMigrator,
-				Limiter:             loginLimiter,
-				AccountLimiter:      accountLoginLimiter,
-				Mailer:              mail.Tester,
-				Tokens:              stores.VerifyTokens,
-				ResendLimiter:       loginResendLimiter,
-				BaseURL:             cfg.BaseURL,
-				RegistrationEnabled: cfg.RegistrationEnabled,
-				GoogleEnabled:       googleEnabled,
-				Tasks:               mail.Tasks,
+				Players:               stores.Players,
+				Sessions:              sessions,
+				Games:                 stores.GameMigrator,
+				Limiter:               loginLimiter,
+				AccountLimiter:        accountLoginLimiter,
+				Mailer:                mail.Tester,
+				Tokens:                stores.VerifyTokens,
+				ResendLimiter:         loginResendLimiter,
+				BaseURL:               cfg.BaseURL,
+				RegistrationEnabled:   cfg.RegistrationEnabled,
+				GoogleEnabled:         googleEnabled,
+				ForgotPasswordEnabled: forgotPasswordEnabled,
+				Tasks:                 mail.Tasks,
 			},
 		)),
 	)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -246,6 +246,65 @@ func TestAddRoutes_RegisterDisabled_Returns404(t *testing.T) {
 	}
 }
 
+// TestAddRoutes_ForgotPassword_GatedOnSMTP: the forgot/reset routes are
+// mounted only when SMTP is configured, else they 404 (#1170).
+func TestAddRoutes_ForgotPassword_GatedOnSMTP(t *testing.T) {
+	t.Parallel()
+
+	paths := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "Forgot GET", method: http.MethodGet, path: "/forgot-password"},
+		{name: "Forgot POST", method: http.MethodPost, path: "/forgot-password"},
+		{name: "Reset GET", method: http.MethodGet, path: "/reset-password"},
+		{name: "Reset POST", method: http.MethodPost, path: "/reset-password"},
+	}
+
+	t.Run("unconfigured 404s", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newRouter(t, dbtest.Open(t), &config.Config{})
+		for _, tc := range paths {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+				rec := httptest.NewRecorder()
+				mux.ServeHTTP(rec, req)
+
+				if got, want := rec.Code, http.StatusNotFound; got != want {
+					t.Errorf("status = %d, want %d for %s %s", got, want, tc.method, tc.path)
+				}
+			})
+		}
+	})
+
+	t.Run("configured is mounted", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Config{
+			SessionKey: "test-session-key",
+			SMTPHost:   "smtp.example.test",
+			SMTPPort:   587,
+			SMTPFrom:   "noreply@example.test",
+		}
+		mux := newRouter(t, dbtest.Open(t), cfg)
+		for _, tc := range paths {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+				rec := httptest.NewRecorder()
+				mux.ServeHTTP(rec, req)
+
+				if got := rec.Code; got == http.StatusNotFound {
+					t.Errorf("unexpected 404 for %s %s when SMTP is configured", tc.method, tc.path)
+				}
+			})
+		}
+	})
+}
+
 func TestAddRoutes_UnknownRouteReturns404(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/tmpl/auth/pages/login.gohtml
+++ b/internal/web/tmpl/auth/pages/login.gohtml
@@ -25,7 +25,7 @@
                 <input id="password" name="password" type="password" required
                        autocomplete="current-password"
                        class="form-input">
-                <p class="mt-2 text-xs text-text-mute"><a href="/forgot-password" class="underline">Forgot your password?</a></p>
+                {{if .ShowForgotPassword}}<p class="mt-2 text-xs text-text-mute"><a href="/forgot-password" class="underline">Forgot your password?</a></p>{{end}}
                 <p class="mt-2 text-xs text-text-mute"><a href="/verify-email/request" class="underline">Didn't get the verification email?</a></p>
             </div>
 

--- a/test/integration/forgot_password_test.go
+++ b/test/integration/forgot_password_test.go
@@ -9,15 +9,28 @@ import (
 	"testing"
 )
 
+// smtpEnabledEnv builds a startServer env wired to a fake SMTP server, the
+// condition under which the forgot/reset routes are mounted (#1170).
+func smtpEnabledEnv(t *testing.T) map[string]string {
+	t.Helper()
+	smtp := startFakeSMTP(t)
+
+	return map[string]string{
+		"REGISTRATION_ENABLED": "true",
+		"SMTP_HOST":            smtp.host(t),
+		"SMTP_PORT":            smtp.port(t),
+		"SMTP_FROM":            "noreply@topbanana.example",
+		"SMTP_TLS":             "false",
+	}
+}
+
 // TestForgotPassword_GETRendersForm pins that an anonymous visitor
 // reaches the forgot-password form and sees the identifier input + a
 // CSRF token.
 func TestForgotPassword_GETRendersForm(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 
 	resp := getWith(ctx, t, authClient(t), srv.BaseURL+"/forgot-password")
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
@@ -49,9 +62,7 @@ func TestForgotPassword_POSTAlwaysFlashesGenericSuccess(t *testing.T) {
 		t.Run(ident, func(t *testing.T) {
 			t.Parallel()
 
-			ctx, srv := startServer(t, map[string]string{
-				"REGISTRATION_ENABLED": "true",
-			})
+			ctx, srv := startServer(t, smtpEnabledEnv(t))
 			dbConn, stores := openStores(t, srv.DBURI)
 			defer dbConn.Close() //nolint:errcheck // cleanup.
 
@@ -91,9 +102,7 @@ func TestForgotPassword_POSTAlwaysFlashesGenericSuccess(t *testing.T) {
 func TestForgotPassword_RateLimited(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 
 	client := authClient(t)
 	first := postForgot(ctx, t, client, srv.BaseURL, "anyone")

--- a/test/integration/google_login_test.go
+++ b/test/integration/google_login_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -326,6 +327,39 @@ func TestGoogleLogin_CallbackRejectsStateMismatch(t *testing.T) {
 
 	if got, want := resp.StatusCode, http.StatusUnauthorized; got != want {
 		t.Errorf("callback status = %d, want %d", got, want)
+	}
+}
+
+// TestGoogleLogin_CallbackError_ShowsForgotLinkWhenSMTPConfigured: the
+// OAuth-error login re-render links to /forgot-password when SMTP is
+// configured, like the plain /login form (#1170).
+func TestGoogleLogin_CallbackError_ShowsForgotLinkWhenSMTPConfigured(t *testing.T) {
+	t.Parallel()
+
+	mock := newGoogleMock(t)
+	mock.email = "forgot-link@example.test"
+	mock.emailVerified = true
+
+	ctx, srv := startGoogleServerEnv(t, mock, smtpEnabledEnv(t))
+
+	client := authClient(t)
+	// A mismatched state drives the callback to its error re-render.
+	startResp := doGet(ctx, t, client, srv.BaseURL+"/login/google")
+	_ = mustFindStateCookie(t, startResp.Cookies)
+
+	callbackURL := srv.BaseURL + testGoogleRedirectPath + "?code=some-code&state=tampered"
+	resp := getWith(ctx, t, client, callbackURL)
+	defer resp.Body.Close() //nolint:errcheck // cleanup.
+
+	if got, want := resp.StatusCode, http.StatusUnauthorized; got != want {
+		t.Fatalf("callback status = %d, want %d", got, want)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll err = %v, want nil", err)
+	}
+	if got, want := string(body), `href="/forgot-password"`; !strings.Contains(got, want) {
+		t.Errorf("google error re-render should link to /forgot-password when SMTP is configured; got %.400q", got)
 	}
 }
 

--- a/test/integration/login_unverified_test.go
+++ b/test/integration/login_unverified_test.go
@@ -13,17 +13,10 @@ import (
 	"github.com/starquake/topbanana/internal/session"
 )
 
-// TestLogin_UnverifiedEmail_BlocksAndResends pins #492: a credentialled
-// account whose email_verified_at is NULL must be refused at /login.
-// Drives the full handler chain so route wiring, CSRF, the login
-// limiter, and the verify-resend dispatch all participate.
-//
-// The integration server keeps the no-op mailer in front of the
-// diagnostics Tester, so the side-effect we can observe is the
-// email_verify_tokens row the dispatch commits before SMTP. Register
-// commits one such row; a successful login-time resend pushes the
-// count up to two. We also assert that no session cookie is issued
-// and that the response body carries the verify banner.
+// TestLogin_UnverifiedEmail_BlocksAndResends: an unverified account is
+// refused with the generic 401 (no session) end-to-end, and the resend
+// still fires - observed via the second email_verify_tokens row the
+// dispatch commits before SMTP (#492/#1171).
 func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	t.Parallel()
 
@@ -73,21 +66,21 @@ func TestLogin_UnverifiedEmail_BlocksAndResends(t *testing.T) {
 	resp := postLoginFormFull(ctx, t, loginClient, srv.BaseURL, loginCSRF, displayName+"@example.test", password)
 	defer resp.Body.Close() //nolint:errcheck // cleanup.
 
-	if got, want := resp.StatusCode, http.StatusOK; got != want {
+	if got, want := resp.StatusCode, http.StatusUnauthorized; got != want {
 		t.Fatalf("login status = %d, want %d", got, want)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("ReadAll err = %v, want nil", err)
 	}
-	if got, want := string(body), "Check your email to finish signing in."; !strings.Contains(got, want) {
-		t.Errorf("body missing generic check-email banner; body=%.300q", got)
+	if got, want := string(body), "Invalid email or password."; !strings.Contains(got, want) {
+		t.Errorf("body missing generic invalid-credentials banner; body=%.300q", got)
 	}
-	// The banner must not confirm the credentials were correct (#787):
-	// an unverified-but-correct attempt has to read the same as a
-	// wrong-password one, so no "we resent the link to <address>" echo.
-	if dontWant := "resent the link to"; strings.Contains(string(body), dontWant) {
-		t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, string(body))
+	// The response must not confirm the password was correct (#787/#1171).
+	for _, dontWant := range []string{"Check your email", "resent the link to", "finish signing in"} {
+		if strings.Contains(string(body), dontWant) {
+			t.Errorf("body leaks credential-correct confirmation %q; body=%.300q", dontWant, string(body))
+		}
 	}
 	for _, c := range resp.Cookies() {
 		if c.Name == session.CookieName && c.Value != "" {

--- a/test/integration/reset_password_test.go
+++ b/test/integration/reset_password_test.go
@@ -21,9 +21,7 @@ import (
 func TestResetPassword_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 
 	// First password-bearing registrant is promoted to admin, so the
 	// reset-token holder's role landing is /admin/quizzes. The signed
@@ -119,9 +117,7 @@ func hasSessionCookie(resp *http.Response) bool {
 func TestResetPassword_RejectsConsumedReplay(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
@@ -165,9 +161,7 @@ func TestResetPassword_RejectsConsumedReplay(t *testing.T) {
 func TestResetPassword_PasswordTooShort(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
@@ -206,7 +200,7 @@ func TestResetPassword_PasswordTooShort(t *testing.T) {
 func TestResetForm_DeadTokenRendersInvalid(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, nil)
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 
@@ -254,7 +248,7 @@ func TestResetForm_DeadTokenRendersInvalid(t *testing.T) {
 func TestResetForm_LiveTokenRendersForm(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, nil)
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 	dbConn, stores := openStores(t, srv.DBURI)
 	defer dbConn.Close() //nolint:errcheck // cleanup.
 

--- a/test/integration/trusted_proxy_test.go
+++ b/test/integration/trusted_proxy_test.go
@@ -17,10 +17,9 @@ import (
 func TestTrustedProxy_XFFHonouredWhenConfigured(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-		"TRUSTED_PROXY_IPS":    "127.0.0.1/32,::1/128",
-	})
+	env := smtpEnabledEnv(t)
+	env["TRUSTED_PROXY_IPS"] = "127.0.0.1/32,::1/128"
+	ctx, srv := startServer(t, env)
 
 	client := authClient(t)
 	first := postForgotWithXFF(ctx, t, client, srv.BaseURL, "1.2.3.4")
@@ -49,9 +48,7 @@ func TestTrustedProxy_XFFHonouredWhenConfigured(t *testing.T) {
 func TestTrustedProxy_XFFIgnoredByDefault(t *testing.T) {
 	t.Parallel()
 
-	ctx, srv := startServer(t, map[string]string{
-		"REGISTRATION_ENABLED": "true",
-	})
+	ctx, srv := startServer(t, smtpEnabledEnv(t))
 
 	client := authClient(t)
 	first := postForgotWithXFF(ctx, t, client, srv.BaseURL, "1.2.3.4")


### PR DESCRIPTION
Two auth audit fixes.

- **#1171:** a correct password on an unverified account returned `200` + a distinct banner vs `401` for a wrong one -- a password-confirmation oracle. The correct-unverified path now renders the byte-identical `401` invalid-credentials response and dispatches the verify-email resend silently. Tests assert indistinguishable responses while the resend still fires.
- **#1170:** `/forgot-password` + `/reset-password` are now mounted only when `cfg.SMTPConfigured()`, and the login "Forgot your password?" link is gated on the same flag (all render sites), so a no-SMTP instance no longer offers a dead-end reset form. Tests assert 404-when-unconfigured / present-when-configured.

Scope is the statically-unconfigured SMTP case only. `make check`/`make smoke` pass.

Closes #1171
Closes #1170

_— Claude Code, for @starquake_
