### PR TITLE
Run upload auth before parsing and extend the upload write deadline

### DIFF
--- a/internal/mediahttp/upload.go
+++ b/internal/mediahttp/upload.go
@@ -566,7 +566,12 @@ func MaxMultipartFormMiddlewareWithLimit(maxBytes int64, next http.Handler) http
 		// deadline here. If the underlying ResponseWriter does not support a
 		// deadline (unlikely under net/http) the call is a silent no-op and
 		// the request still uses the global ReadTimeout.
-		_ = http.NewResponseController(w).SetReadDeadline(time.Now().Add(uploadReadDeadline))
+		rc := http.NewResponseController(w)
+		_ = rc.SetReadDeadline(time.Now().Add(uploadReadDeadline))
+		// WriteTimeout counts from accept; extend it alongside the read deadline
+		// so a slow upload's response still lands instead of resetting (which
+		// triggers a duplicate-producing retry).
+		_ = rc.SetWriteDeadline(time.Now().Add(uploadReadDeadline))
 		// MaxBytesReader above bounds the body, so the parse cannot exhaust
 		// memory despite gosec's G120 flag on the bare ParseMultipartForm call.
 		if err := r.ParseMultipartForm(multipartMemoryBytes); err != nil { //nolint:gosec // body capped above

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -629,10 +629,12 @@ func addMediaRoutes(
 
 	addQuizImportArchiveRoute(mux, logger, stores, csrfMgr, svc, cfg, requireGameHost)
 
+	// auth outermost so an unauthenticated caller is rejected before the body is
+	// spooled; the parse still precedes CSRF, which reads the token from PostForm.
 	uploadBudget := mediahttp.NewUploadBudgetLimiter(cfg.MediaUploadBudget, cfg.MediaUploadBudgetWindow)
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/media",
-		mediahttp.MaxMultipartFormMiddleware(csrfMgr.Middleware(requireGameHost(
+		requireGameHost(mediahttp.MaxMultipartFormMiddleware(csrfMgr.Middleware(
 			mediahttp.HandleMediaUpload(logger, svc, stores.Quizzes, uploadBudget, cfg.MediaQuizImageLimit),
 		))),
 	)
@@ -644,7 +646,7 @@ func addMediaRoutes(
 	// differ.
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/media/audio",
-		mediahttp.MaxMultipartFormMiddleware(csrfMgr.Middleware(requireGameHost(
+		requireGameHost(mediahttp.MaxMultipartFormMiddleware(csrfMgr.Middleware(
 			mediahttp.HandleAudioUpload(logger, svc, stores.Quizzes, uploadBudget, cfg.MediaQuizImageLimit),
 		))),
 	)
@@ -689,12 +691,12 @@ func addMediaRoutes(
 // addQuizImportArchiveRoute registers the quiz-archive import POST (#1113): a
 // multipart upload that restores a quiz plus its media from an exported .zip.
 // Split out of addMediaRoutes so that function stays under revive's
-// function-length cap. The multipart middleware caps the body at
-// MEDIA_IMPORT_MAX_BYTES (well above the per-image cap, since the archive bundles
-// a whole library) and parses the form so the CSRF token in PostForm is visible;
-// the importer then bounds zip-bomb expansion via the per-entry and total
-// uncompressed guards. A modest per-host import budget reuses the upload-budget
-// limiter, charged once per import.
+// function-length cap. auth outermost so an unauthenticated caller is rejected
+// before the body is spooled (see the media route). The body is capped at
+// MEDIA_IMPORT_MAX_BYTES (above the per-image cap, since the archive bundles a
+// whole library); the importer then bounds zip-bomb expansion via the per-entry
+// and total uncompressed guards. A per-host import budget is charged once per
+// import.
 func addQuizImportArchiveRoute(
 	mux *http.ServeMux,
 	logger *slog.Logger,
@@ -708,7 +710,7 @@ func addQuizImportArchiveRoute(
 	limits := admin.NewArchiveImportLimits(cfg.MediaImageMaxBytes, cfg.MediaAudioMaxBytes, cfg.MediaImportMaxBytes)
 	mux.Handle(
 		"POST /admin/quizzes/import/archive",
-		mediahttp.MaxMultipartFormMiddlewareWithLimit(cfg.MediaImportMaxBytes, csrfMgr.Middleware(requireGameHost(
+		requireGameHost(mediahttp.MaxMultipartFormMiddlewareWithLimit(cfg.MediaImportMaxBytes, csrfMgr.Middleware(
 			admin.HandleQuizImportArchive(logger, csrfMgr, stores.Quizzes, svc, budget, limits),
 		))),
 	)

--- a/test/integration/upload_deadline_test.go
+++ b/test/integration/upload_deadline_test.go
@@ -1,0 +1,147 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUploadAuthBeforeSpool_Integration pins that auth runs before the multipart
+// parse on the upload/import routes (#1173): a cookieless POST gets the auth 303,
+// not the parse's 400 or CSRF's 403, so the body is never spooled.
+func TestUploadAuthBeforeSpool_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupMedia(t, nil)
+	baseURL := setup.BaseURL
+
+	routes := []struct {
+		name string
+		path string
+	}{
+		{name: "media upload", path: "/admin/quizzes/1/media"},
+		{name: "audio upload", path: "/admin/quizzes/1/media/audio"},
+		{name: "archive import", path: "/admin/quizzes/import/archive"},
+	}
+	for _, route := range routes {
+		t.Run(route.name+" route rejects a cookieless caller before parsing the body", func(t *testing.T) {
+			t.Parallel()
+
+			// Keep the 303 rather than following it to /login.
+			anon := newAnonClient(t)
+			anon.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			}
+
+			// A valid body: a 303 (not the CSRF 403) proves auth ran before parse.
+			body, contentType := multipartImage(t, "probe.png", pngBytes(t, 8, 8), "not-a-real-token")
+			req := newMultipartReq(ctx, t, baseURL+route.path, body, contentType)
+			resp, err := anon.Do(req)
+			if err != nil {
+				t.Fatalf("Do err = %v, want nil", err)
+			}
+			defer closeBody(t, resp.Body)
+
+			if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+				t.Errorf(
+					"cookieless %s status = %d, want %d (login redirect, auth before parse)",
+					route.name, got, want,
+				)
+			}
+			if got := resp.Header.Get("Location"); !strings.HasPrefix(got, "/login") {
+				t.Errorf("cookieless %s Location = %q, want a /login redirect", route.name, got)
+			}
+		})
+	}
+}
+
+// TestSlowUploadResponseWrites_Integration pins that a body streamed slower than
+// the WriteTimeout still gets its 303 written and stores exactly one media row
+// (#1172). The default 10s WriteTimeout is kept, not shrunk, so the bcrypt-heavy
+// setup requests do not flake under coverage load.
+func TestSlowUploadResponseWrites_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, setup := setupMedia(t, map[string]string{
+		"ADMIN_EMAILS": "slow-boss@example.test",
+	})
+	baseURL := setup.BaseURL
+
+	registerAdminClient(ctx, t, baseURL, setup.DBURI, "slow-boss")
+	owner := registerAdminClient(ctx, t, baseURL, setup.DBURI, "slow-owner")
+	makeHost(ctx, t, setup.DBURI, "slow-owner")
+	quizID := createQuizAs(ctx, t, owner, baseURL, "Slow Upload Quiz")
+
+	token := fetchCSRFToken(ctx, t, owner, baseURL+"/admin/quizzes")
+	body, contentType := multipartImage(t, "slow.png", pngBytes(t, 64, 64), token)
+
+	// Stream over ~13s, past the 10s WriteTimeout.
+	slow := newSlowReader(body.Bytes(), 13*time.Second, 26)
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, baseURL+fmt.Sprintf("/admin/quizzes/%d/media", quizID), slow,
+	)
+	if err != nil {
+		t.Fatalf("NewRequest err = %v, want nil", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := owner.Do(req)
+	if err != nil {
+		t.Fatalf("slow upload Do err = %v, want nil (write deadline must be extended)", err)
+	}
+	defer closeBody(t, resp.Body)
+
+	if got, want := resp.StatusCode, http.StatusSeeOther; got != want {
+		rb, _ := io.ReadAll(resp.Body)
+		t.Fatalf("slow upload status = %d, want %d; body=%q", got, want, rb)
+	}
+	want := fmt.Sprintf("/admin/quizzes/%d?uploaded=1&failed=0&cancelled=0#images", quizID)
+	if got := resp.Header.Get("Location"); got != want {
+		t.Errorf("slow upload redirect Location = %q, want %q", got, want)
+	}
+
+	items, err := setup.Stores.Media.ListMediaByQuiz(ctx, quizID)
+	if err != nil {
+		t.Fatalf("ListMediaByQuiz err = %v, want nil", err)
+	}
+	if got, want := len(items), 1; got != want {
+		t.Errorf("stored media rows = %d, want %d (a failed response write plus retry would duplicate)", got, want)
+	}
+}
+
+// slowReader emits data in fixed-size chunks, sleeping before each so the body
+// takes at least the requested duration to stream.
+type slowReader struct {
+	data  []byte
+	off   int
+	chunk int
+	delay time.Duration
+}
+
+// newSlowReader streams data across at least total, split into chunks slices.
+func newSlowReader(data []byte, total time.Duration, chunks int) *slowReader {
+	chunk := max((len(data)+chunks-1)/chunks, 1)
+
+	return &slowReader{
+		data:  data,
+		chunk: chunk,
+		delay: total / time.Duration(chunks),
+	}
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.off >= len(s.data) {
+		return 0, io.EOF
+	}
+	// Sleep before every chunk so total stream time is chunks*delay.
+	time.Sleep(s.delay)
+
+	end := min(s.off+s.chunk, len(s.data))
+	n := copy(p, s.data[s.off:end])
+	s.off += n
+
+	return n, nil
+}


### PR DESCRIPTION
Two upload fixes in the same multipart middleware.

- **#1173:** `requireGameHost` is now outermost on the media-upload, audio-upload, and archive-import routes, so an unauthenticated caller is rejected on its cookie before the middleware extends the read deadline to 5 min and spools the body. Parse still runs immediately before CSRF, so token validation is unaffected.
- **#1172:** the middleware now extends the write deadline alongside the read deadline, so a slow upload's response actually writes instead of failing on the 10s `WriteTimeout` and triggering a duplicate-producing retry.

Tests (`test/integration/upload_deadline_test.go`): cookieless POST to each route gets the auth 303; a ~13s body still writes its 303 and stores exactly one row. Both revert-verified. `make check`/`make smoke` pass.

Closes #1173
Closes #1172

_— Claude Code, for @starquake_
