### PR TITLE
Fix option IDOR, media file orphaning, and retention sweep TOCTOU

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1835,11 +1835,7 @@ func HandleQuizSetMode(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore qui
 	})
 }
 
-// QuizMediaRemover is the slice of the media service the quiz-delete handler
-// needs: drop a quiz's whole on-disk media directory. The quiz-delete cascade
-// removes the media rows, but nothing unlinks their files, so the handler calls
-// this to leave no orphaned files behind (#1174). Defined consumer-side; the
-// concrete *media.Service satisfies it.
+// QuizMediaRemover drops a quiz's on-disk media directory (#1174).
 type QuizMediaRemover interface {
 	RemoveQuizDir(quizID int64) error
 }
@@ -1872,10 +1868,8 @@ func HandleQuizDelete(
 			return
 		}
 
-		// The media rows cascade off the deleted quiz row, but their files do
-		// not; unlink the quiz's media directory best-effort. A failure here
-		// leaves orphaned files for the cleanup tooling but must not fail the
-		// delete the DB already committed.
+		// The cascade drops the media rows but not their files; unlink them
+		// best-effort without failing the already-committed delete.
 		if err := mediaSvc.RemoveQuizDir(quizID); err != nil {
 			logger.WarnContext(r.Context(), "failed to remove quiz media directory after delete",
 				slog.Int64("quiz_id", quizID), slog.Any("err", err))

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1835,8 +1835,19 @@ func HandleQuizSetMode(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore qui
 	})
 }
 
+// QuizMediaRemover is the slice of the media service the quiz-delete handler
+// needs: drop a quiz's whole on-disk media directory. The quiz-delete cascade
+// removes the media rows, but nothing unlinks their files, so the handler calls
+// this to leave no orphaned files behind (#1174). Defined consumer-side; the
+// concrete *media.Service satisfies it.
+type QuizMediaRemover interface {
+	RemoveQuizDir(quizID int64) error
+}
+
 // HandleQuizDelete deletes a quiz and all its questions and options.
-func HandleQuizDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store) http.Handler {
+func HandleQuizDelete(
+	logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz.Store, mediaSvc QuizMediaRemover,
+) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ok bool
 
@@ -1859,6 +1870,15 @@ func HandleQuizDelete(logger *slog.Logger, csrfMgr *csrf.Manager, quizStore quiz
 			render500(w, r, logger, csrfMgr)
 
 			return
+		}
+
+		// The media rows cascade off the deleted quiz row, but their files do
+		// not; unlink the quiz's media directory best-effort. A failure here
+		// leaves orphaned files for the cleanup tooling but must not fail the
+		// delete the DB already committed.
+		if err := mediaSvc.RemoveQuizDir(quizID); err != nil {
+			logger.WarnContext(r.Context(), "failed to remove quiz media directory after delete",
+				slog.Int64("quiz_id", quizID), slog.Any("err", err))
 		}
 
 		// htmx removes the card in place via an outerHTML swap; a plain

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -2486,8 +2486,7 @@ func TestHandleQuizDelete(t *testing.T) {
 	})
 }
 
-// TestHandleQuizDelete_RemovesMediaFiles pins the #1174 fix: deleting a quiz
-// unlinks its on-disk media directory, not just the cascaded media rows.
+// TestHandleQuizDelete_RemovesMediaFiles: deleting a quiz unlinks its media dir (#1174).
 func TestHandleQuizDelete_RemovesMediaFiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -21,6 +23,7 @@ import (
 	"github.com/starquake/topbanana/internal/livesession"
 	"github.com/starquake/topbanana/internal/media"
 	"github.com/starquake/topbanana/internal/quiz"
+	"github.com/starquake/topbanana/internal/store"
 )
 
 // newGameService wires the env's real stores into a fresh [game.Service]
@@ -2461,7 +2464,7 @@ func TestHandleQuizDelete(t *testing.T) {
 		env := newAdminEnv(t)
 		qz := env.seedQuiz(t, ownedQuiz("Q", "q"))
 
-		handler := HandleQuizDelete(logger, nil, env.quizzes)
+		handler := HandleQuizDelete(logger, nil, env.quizzes, newMediaServiceOverTemp(t, env))
 		req := httptest.NewRequestWithContext(
 			t.Context(), http.MethodPost,
 			fmt.Sprintf("/admin/quizzes/%d/delete", qz.ID), nil,
@@ -2483,6 +2486,51 @@ func TestHandleQuizDelete(t *testing.T) {
 	})
 }
 
+// TestHandleQuizDelete_RemovesMediaFiles pins the #1174 fix: deleting a quiz
+// unlinks its on-disk media directory, not just the cascaded media rows.
+func TestHandleQuizDelete_RemovesMediaFiles(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	env := newAdminEnv(t)
+	qz := env.seedQuiz(t, ownedQuiz("Q", "q"))
+
+	root := t.TempDir()
+	mediaSvc := media.NewService(
+		store.NewMediaStore(env.db, slog.New(slog.DiscardHandler)),
+		root, 10<<20, 20<<20, slog.New(slog.DiscardHandler),
+	)
+	if _, err := mediaSvc.StoreImage(
+		t.Context(), qz.ID, testAdminID, "pic.png", bytes.NewReader(tinyPNG(t)),
+	); err != nil {
+		t.Fatalf("StoreImage err = %v, want nil", err)
+	}
+
+	quizDir := filepath.Join(root, strconv.FormatInt(qz.ID, 10))
+	if _, statErr := os.Stat(quizDir); statErr != nil {
+		t.Fatalf("quiz media dir not present before delete: %v", statErr)
+	}
+
+	handler := HandleQuizDelete(logger, nil, env.quizzes, mediaSvc)
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		fmt.Sprintf("/admin/quizzes/%d/delete", qz.ID), nil,
+	)
+	req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, withTestAdmin(req))
+
+	if got, want := rr.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("got status code %v, want %v, log:\n%v", got, want, buf.String())
+	}
+	if _, statErr := os.Stat(quizDir); !os.IsNotExist(statErr) {
+		t.Fatalf("quiz media dir still present after delete: err = %v, want not-exist", statErr)
+	}
+}
+
 func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 	t.Parallel()
 
@@ -2494,7 +2542,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 
 		env := newAdminEnv(t)
 
-		handler := HandleQuizDelete(logger, nil, env.quizzes)
+		handler := HandleQuizDelete(logger, nil, env.quizzes, newMediaServiceOverTemp(t, env))
 		req := httptest.NewRequestWithContext(
 			t.Context(), http.MethodPost, "/admin/quizzes/not-an-int/delete", nil,
 		)
@@ -2518,7 +2566,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 
 		// requireQuizOwner runs first now (#281); a missing quiz
 		// surfaces from GetQuiz, not from the DeleteQuiz return path.
-		handler := HandleQuizDelete(logger, nil, env.quizzes)
+		handler := HandleQuizDelete(logger, nil, env.quizzes, newMediaServiceOverTemp(t, env))
 		req := httptest.NewRequestWithContext(
 			t.Context(), http.MethodPost, "/admin/quizzes/999/delete", nil,
 		)
@@ -2542,7 +2590,7 @@ func TestHandleQuizDelete_ErrorHandling(t *testing.T) {
 		qz := env.seedQuiz(t, ownedQuiz("Q", "q"))
 		env.closeStore(t)
 
-		handler := HandleQuizDelete(logger, nil, env.quizzes)
+		handler := HandleQuizDelete(logger, nil, env.quizzes, newMediaServiceOverTemp(t, env))
 		req := httptest.NewRequestWithContext(
 			t.Context(), http.MethodPost,
 			fmt.Sprintf("/admin/quizzes/%d/delete", qz.ID), nil,

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -166,7 +166,7 @@ type DeleteOptionParams struct {
 	QuestionID int64
 }
 
-// Scoped by question_id for the same ownership boundary as UpdateOption (#1165).
+// Scoped by question_id to keep the ownership boundary (#1165).
 func (q *Queries) DeleteOption(ctx context.Context, arg DeleteOptionParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, deleteOption, arg.ID, arg.QuestionID)
 }
@@ -921,9 +921,7 @@ type UpdateOptionParams struct {
 	QuestionID int64
 }
 
-// Scoped by question_id so a crafted option id from another owner's quiz
-// cannot cross the ownership boundary (#1165). A mismatched question_id
-// affects 0 rows, which callers treat as an error.
+// Scoped by question_id to keep the ownership boundary (#1165).
 func (q *Queries) UpdateOption(ctx context.Context, arg UpdateOptionParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, updateOption,
 		arg.Text,

--- a/internal/db/quizzes.sql.go
+++ b/internal/db/quizzes.sql.go
@@ -158,10 +158,17 @@ func (q *Queries) CreateQuiz(ctx context.Context, arg CreateQuizParams) (Quiz, e
 const deleteOption = `-- name: DeleteOption :execresult
 DELETE FROM options
 WHERE id = ?
+  AND question_id = ?
 `
 
-func (q *Queries) DeleteOption(ctx context.Context, id int64) (sql.Result, error) {
-	return q.db.ExecContext(ctx, deleteOption, id)
+type DeleteOptionParams struct {
+	ID         int64
+	QuestionID int64
+}
+
+// Scoped by question_id for the same ownership boundary as UpdateOption (#1165).
+func (q *Queries) DeleteOption(ctx context.Context, arg DeleteOptionParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, deleteOption, arg.ID, arg.QuestionID)
 }
 
 const deleteQuestion = `-- name: DeleteQuestion :execresult
@@ -904,16 +911,26 @@ UPDATE options
 SET text = ?,
     is_correct = ?
 WHERE id = ?
+  AND question_id = ?
 `
 
 type UpdateOptionParams struct {
-	Text      string
-	IsCorrect bool
-	ID        int64
+	Text       string
+	IsCorrect  bool
+	ID         int64
+	QuestionID int64
 }
 
+// Scoped by question_id so a crafted option id from another owner's quiz
+// cannot cross the ownership boundary (#1165). A mismatched question_id
+// affects 0 rows, which callers treat as an error.
 func (q *Queries) UpdateOption(ctx context.Context, arg UpdateOptionParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, updateOption, arg.Text, arg.IsCorrect, arg.ID)
+	return q.db.ExecContext(ctx, updateOption,
+		arg.Text,
+		arg.IsCorrect,
+		arg.ID,
+		arg.QuestionID,
+	)
 }
 
 const updateQuestion = `-- name: UpdateQuestion :execresult

--- a/internal/db/retention.sql.go
+++ b/internal/db/retention.sql.go
@@ -14,10 +14,17 @@ const deletePlayersByIDs = `-- name: DeletePlayersByIDs :exec
 DELETE
 FROM players
 WHERE id IN (/*SLICE:ids*/?)
+  AND role = 'player'
+  AND email IS NULL
+  AND password_hash IS NULL
+  AND display_name_claimed = 0
 `
 
 // Hard-deletes the given player rows. Run last in the anonymous-player
 // sweep, after every game_* row that references them has been removed.
+// Re-asserts the anonymity predicate so the delete is a no-op for any id
+// that was claimed (registered, verified, or renamed) between the snapshot
+// and this delete (#1175): a guest active in that TOCTOU window survives.
 func (q *Queries) DeletePlayersByIDs(ctx context.Context, ids []int64) error {
 	query := deletePlayersByIDs
 	var queryParams []interface{}

--- a/internal/db/retention.sql.go
+++ b/internal/db/retention.sql.go
@@ -40,6 +40,54 @@ func (q *Queries) DeletePlayersByIDs(ctx context.Context, ids []int64) error {
 	return err
 }
 
+const filterAnonymousPlayerIDs = `-- name: FilterAnonymousPlayerIDs :many
+SELECT p.id
+FROM players p
+WHERE p.id IN (/*SLICE:ids*/?)
+  AND p.role = 'player'
+  AND p.email IS NULL
+  AND p.password_hash IS NULL
+  AND p.display_name_claimed = 0
+`
+
+// Returns the subset of the given ids still matching the anonymity predicate.
+// The sweep snapshots stale ids, but a guest can claim their account (register,
+// verify, or rename) before the batch runs; re-filtering here keeps the whole
+// batch atomic so a since-claimed survivor keeps BOTH its player row and its
+// game data, not just the row (#1175).
+func (q *Queries) FilterAnonymousPlayerIDs(ctx context.Context, ids []int64) ([]int64, error) {
+	query := filterAnonymousPlayerIDs
+	var queryParams []interface{}
+	if len(ids) > 0 {
+		for _, v := range ids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAbandonedGameIDs = `-- name: ListAbandonedGameIDs :many
 SELECT g.id
 FROM games g

--- a/internal/db/retention.sql.go
+++ b/internal/db/retention.sql.go
@@ -20,11 +20,9 @@ WHERE id IN (/*SLICE:ids*/?)
   AND display_name_claimed = 0
 `
 
-// Hard-deletes the given player rows. Run last in the anonymous-player
-// sweep, after every game_* row that references them has been removed.
-// Re-asserts the anonymity predicate so the delete is a no-op for any id
-// that was claimed (registered, verified, or renamed) between the snapshot
-// and this delete (#1175): a guest active in that TOCTOU window survives.
+// Hard-deletes the given player rows. Run last in the anonymous-player sweep,
+// after every game_* row that references them has been removed. Re-asserts the
+// anonymity predicate as defense-in-depth so a since-claimed id survives (#1175).
 func (q *Queries) DeletePlayersByIDs(ctx context.Context, ids []int64) error {
 	query := deletePlayersByIDs
 	var queryParams []interface{}
@@ -50,11 +48,8 @@ WHERE p.id IN (/*SLICE:ids*/?)
   AND p.display_name_claimed = 0
 `
 
-// Returns the subset of the given ids still matching the anonymity predicate.
-// The sweep snapshots stale ids, but a guest can claim their account (register,
-// verify, or rename) before the batch runs; re-filtering here keeps the whole
-// batch atomic so a since-claimed survivor keeps BOTH its player row and its
-// game data, not just the row (#1175).
+// Returns the subset of the given ids still anonymous, so the sweep spares a
+// guest claimed after the snapshot (#1175).
 func (q *Queries) FilterAnonymousPlayerIDs(ctx context.Context, ids []int64) ([]int64, error) {
 	query := filterAnonymousPlayerIDs
 	var queryParams []interface{}

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -275,9 +275,7 @@ VALUES (?, ?, ?)
 RETURNING *;
 
 -- name: UpdateOption :execresult
--- Scoped by question_id so a crafted option id from another owner's quiz
--- cannot cross the ownership boundary (#1165). A mismatched question_id
--- affects 0 rows, which callers treat as an error.
+-- Scoped by question_id to keep the ownership boundary (#1165).
 UPDATE options
 SET text = ?,
     is_correct = ?
@@ -285,7 +283,7 @@ WHERE id = ?
   AND question_id = ?;
 
 -- name: DeleteOption :execresult
--- Scoped by question_id for the same ownership boundary as UpdateOption (#1165).
+-- Scoped by question_id to keep the ownership boundary (#1165).
 DELETE FROM options
 WHERE id = ?
   AND question_id = ?;

--- a/internal/queries/quizzes.sql
+++ b/internal/queries/quizzes.sql
@@ -275,14 +275,20 @@ VALUES (?, ?, ?)
 RETURNING *;
 
 -- name: UpdateOption :execresult
+-- Scoped by question_id so a crafted option id from another owner's quiz
+-- cannot cross the ownership boundary (#1165). A mismatched question_id
+-- affects 0 rows, which callers treat as an error.
 UPDATE options
 SET text = ?,
     is_correct = ?
-WHERE id = ?;
+WHERE id = ?
+  AND question_id = ?;
 
 -- name: DeleteOption :execresult
+-- Scoped by question_id for the same ownership boundary as UpdateOption (#1165).
 DELETE FROM options
-WHERE id = ?;
+WHERE id = ?
+  AND question_id = ?;
 
 -- name: BumpQuizPlayCountForGame :exec
 -- Increments the durable hit counter (#891) for the quiz that owns this solo

--- a/internal/queries/retention.sql
+++ b/internal/queries/retention.sql
@@ -31,6 +31,20 @@ WHERE p.role = 'player'
               (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
   );
 
+-- name: FilterAnonymousPlayerIDs :many
+-- Returns the subset of the given ids still matching the anonymity predicate.
+-- The sweep snapshots stale ids, but a guest can claim their account (register,
+-- verify, or rename) before the batch runs; re-filtering here keeps the whole
+-- batch atomic so a since-claimed survivor keeps BOTH its player row and its
+-- game data, not just the row (#1175).
+SELECT p.id
+FROM players p
+WHERE p.id IN (sqlc.slice('ids'))
+  AND p.role = 'player'
+  AND p.email IS NULL
+  AND p.password_hash IS NULL
+  AND p.display_name_claimed = 0;
+
 -- name: ListGameIDsForPlayers :many
 -- Lists every distinct game id any of the given players participates in.
 -- The anonymous-player sweep snapshots these up front so the dependent

--- a/internal/queries/retention.sql
+++ b/internal/queries/retention.sql
@@ -42,9 +42,16 @@ WHERE gp.player_id IN (sqlc.slice('player_ids'));
 -- name: DeletePlayersByIDs :exec
 -- Hard-deletes the given player rows. Run last in the anonymous-player
 -- sweep, after every game_* row that references them has been removed.
+-- Re-asserts the anonymity predicate so the delete is a no-op for any id
+-- that was claimed (registered, verified, or renamed) between the snapshot
+-- and this delete (#1175): a guest active in that TOCTOU window survives.
 DELETE
 FROM players
-WHERE id IN (sqlc.slice('ids'));
+WHERE id IN (sqlc.slice('ids'))
+  AND role = 'player'
+  AND email IS NULL
+  AND password_hash IS NULL
+  AND display_name_claimed = 0;
 
 -- name: ListAbandonedGameIDs :many
 -- Lists ids of games that are NOT finished and were created more than 30

--- a/internal/queries/retention.sql
+++ b/internal/queries/retention.sql
@@ -32,11 +32,8 @@ WHERE p.role = 'player'
   );
 
 -- name: FilterAnonymousPlayerIDs :many
--- Returns the subset of the given ids still matching the anonymity predicate.
--- The sweep snapshots stale ids, but a guest can claim their account (register,
--- verify, or rename) before the batch runs; re-filtering here keeps the whole
--- batch atomic so a since-claimed survivor keeps BOTH its player row and its
--- game data, not just the row (#1175).
+-- Returns the subset of the given ids still anonymous, so the sweep spares a
+-- guest claimed after the snapshot (#1175).
 SELECT p.id
 FROM players p
 WHERE p.id IN (sqlc.slice('ids'))
@@ -54,11 +51,9 @@ FROM game_participants gp
 WHERE gp.player_id IN (sqlc.slice('player_ids'));
 
 -- name: DeletePlayersByIDs :exec
--- Hard-deletes the given player rows. Run last in the anonymous-player
--- sweep, after every game_* row that references them has been removed.
--- Re-asserts the anonymity predicate so the delete is a no-op for any id
--- that was claimed (registered, verified, or renamed) between the snapshot
--- and this delete (#1175): a guest active in that TOCTOU window survives.
+-- Hard-deletes the given player rows. Run last in the anonymous-player sweep,
+-- after every game_* row that references them has been removed. Re-asserts the
+-- anonymity predicate as defense-in-depth so a since-claimed id survives (#1175).
 DELETE
 FROM players
 WHERE id IN (sqlc.slice('ids'))

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -75,16 +75,10 @@ func addRoutes(
 	if cfg.DemoMode {
 		mux.Handle("POST /demo/enter", demo.HandleEnter(sessions, stores.Players, logger))
 	}
+	mediaSvc := media.NewService(stores.Media, cfg.MediaDir, cfg.MediaImageMaxBytes, cfg.MediaAudioMaxBytes, logger)
+	gameDeps.mediaSvc = mediaSvc
 	addAdminRoutes(mux, logger, stores, gameDeps, sessions, csrfMgr, emailDeps, playerDeps)
-	addMediaRoutes(
-		mux,
-		logger,
-		stores,
-		sessions,
-		csrfMgr,
-		media.NewService(stores.Media, cfg.MediaDir, cfg.MediaImageMaxBytes, cfg.MediaAudioMaxBytes, logger),
-		cfg,
-	)
+	addMediaRoutes(mux, logger, stores, sessions, csrfMgr, mediaSvc, cfg)
 	if cfg.ProfileEnabled {
 		addProfileRoutes(mux, logger, stores, sessions, csrfMgr, cfg, mail)
 	}
@@ -503,6 +497,9 @@ type adminGameDeps struct {
 	// uploadLimits are the media caps the quiz view shows a host and feeds to
 	// the client-side pre-upload size guard (#1139).
 	uploadLimits admin.MediaUploadLimits
+	// mediaSvc lets the quiz-delete handler unlink a deleted quiz's on-disk
+	// media directory, which the DB cascade alone leaves orphaned (#1174).
+	mediaSvc *media.Service
 }
 
 func addAdminRoutes(
@@ -566,7 +563,7 @@ func addAdminRoutes(
 	)
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/delete",
-		csrfMW(requireGameHost(admin.HandleQuizDelete(logger, csrfMgr, stores.Quizzes))),
+		csrfMW(requireGameHost(admin.HandleQuizDelete(logger, csrfMgr, stores.Quizzes, gameDeps.mediaSvc))),
 	)
 	mux.Handle(
 		"POST /admin/quizzes/{quizID}/players/{playerID}/reset",

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -497,8 +497,7 @@ type adminGameDeps struct {
 	// uploadLimits are the media caps the quiz view shows a host and feeds to
 	// the client-side pre-upload size guard (#1139).
 	uploadLimits admin.MediaUploadLimits
-	// mediaSvc lets the quiz-delete handler unlink a deleted quiz's on-disk
-	// media directory, which the DB cascade alone leaves orphaned (#1174).
+	// mediaSvc lets the quiz-delete handler unlink a deleted quiz's files (#1174).
 	mediaSvc *media.Service
 }
 

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -1,9 +1,18 @@
 package store
 
+import "context"
+
 // ParseSQLiteTimestamp exposes the unexported parseSQLiteTimestamp helper
 // so the external store_test package can pin its two accepted formats and
 // the nil-on-unparseable fall-through without exporting it from the package.
 var ParseSQLiteTimestamp = parseSQLiteTimestamp
+
+// SweepPlayerBatchForTest exposes sweepPlayerBatch so a test can feed a
+// snapshotted id set and exercise the mid-batch anonymity re-filter directly,
+// simulating a guest claimed between snapshot and sweep.
+func (s *RetentionStore) SweepPlayerBatchForTest(ctx context.Context, playerIDs []int64) error {
+	return s.sweepPlayerBatch(ctx, playerIDs)
+}
 
 // SetSessionIDForTest forces the store to mint the given session primary key so
 // a test can trigger the id-PK-collision branch of CreateSession.

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -7,9 +7,7 @@ import "context"
 // the nil-on-unparseable fall-through without exporting it from the package.
 var ParseSQLiteTimestamp = parseSQLiteTimestamp
 
-// SweepPlayerBatchForTest exposes sweepPlayerBatch so a test can feed a
-// snapshotted id set and exercise the mid-batch anonymity re-filter directly,
-// simulating a guest claimed between snapshot and sweep.
+// SweepPlayerBatchForTest exposes sweepPlayerBatch to drive it with a fixed id set.
 func (s *RetentionStore) SweepPlayerBatchForTest(ctx context.Context, playerIDs []int64) error {
 	return s.sweepPlayerBatch(ctx, playerIDs)
 }

--- a/internal/store/quiz.go
+++ b/internal/store/quiz.go
@@ -1169,7 +1169,7 @@ func (s *QuizStore) handleOptions(ctx context.Context, q *db.Queries, qs *quiz.Q
 			// UPDATE
 			incomingIDs[o.ID] = true
 
-			if updateErr := s.updateOption(ctx, q, o); updateErr != nil {
+			if updateErr := s.updateOption(ctx, q, qs.ID, o); updateErr != nil {
 				return fmt.Errorf("failed to update option: %w", updateErr)
 			}
 		}
@@ -1182,7 +1182,7 @@ func (s *QuizStore) handleOptions(ctx context.Context, q *db.Queries, qs *quiz.Q
 		}
 	}
 
-	if err = s.deleteOptions(ctx, q, deleteIDs); err != nil {
+	if err = s.deleteOptions(ctx, q, qs.ID, deleteIDs); err != nil {
 		return fmt.Errorf("failed to delete options: %w", err)
 	}
 
@@ -1204,11 +1204,12 @@ func (*QuizStore) createOption(ctx context.Context, q *db.Queries, o *quiz.Optio
 	return nil
 }
 
-func (*QuizStore) updateOption(ctx context.Context, q *db.Queries, o *quiz.Option) error {
+func (*QuizStore) updateOption(ctx context.Context, q *db.Queries, questionID int64, o *quiz.Option) error {
 	res, err := q.UpdateOption(ctx, db.UpdateOptionParams{
-		Text:      o.Text,
-		IsCorrect: o.Correct,
-		ID:        o.ID,
+		Text:       o.Text,
+		IsCorrect:  o.Correct,
+		ID:         o.ID,
+		QuestionID: questionID,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update option: %w", err)
@@ -1220,9 +1221,9 @@ func (*QuizStore) updateOption(ctx context.Context, q *db.Queries, o *quiz.Optio
 	return nil
 }
 
-func (s *QuizStore) deleteOptions(ctx context.Context, q *db.Queries, ids []int64) error {
+func (s *QuizStore) deleteOptions(ctx context.Context, q *db.Queries, questionID int64, ids []int64) error {
 	for _, id := range ids {
-		if err := s.deleteOption(ctx, q, id); err != nil {
+		if err := s.deleteOption(ctx, q, questionID, id); err != nil {
 			return fmt.Errorf("failed to delete option %d: %w", id, err)
 		}
 	}
@@ -1230,8 +1231,11 @@ func (s *QuizStore) deleteOptions(ctx context.Context, q *db.Queries, ids []int6
 	return nil
 }
 
-func (*QuizStore) deleteOption(ctx context.Context, q *db.Queries, id int64) error {
-	res, err := q.DeleteOption(ctx, id)
+func (*QuizStore) deleteOption(ctx context.Context, q *db.Queries, questionID, id int64) error {
+	res, err := q.DeleteOption(ctx, db.DeleteOptionParams{
+		ID:         id,
+		QuestionID: questionID,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to delete option %d: %w", id, err)
 	}

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -2640,10 +2640,8 @@ func TestQuizStore_DeleteOption_BumpsParentQuizUpdatedAt(t *testing.T) {
 	}
 }
 
-// TestQuizStore_UpdateQuestion_RejectsCrossQuestionOptionID pins the #1165
-// fix: an option UPDATE whose id belongs to a different question must not
-// cross the ownership boundary. The store scopes the UPDATE by question_id,
-// so the crafted id affects 0 rows and the victim row is left untouched.
+// TestQuizStore_UpdateQuestion_RejectsCrossQuestionOptionID: an option UPDATE
+// targeting another question's option id affects no rows (#1165).
 func TestQuizStore_UpdateQuestion_RejectsCrossQuestionOptionID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/quiz_test.go
+++ b/internal/store/quiz_test.go
@@ -2640,6 +2640,63 @@ func TestQuizStore_DeleteOption_BumpsParentQuizUpdatedAt(t *testing.T) {
 	}
 }
 
+// TestQuizStore_UpdateQuestion_RejectsCrossQuestionOptionID pins the #1165
+// fix: an option UPDATE whose id belongs to a different question must not
+// cross the ownership boundary. The store scopes the UPDATE by question_id,
+// so the crafted id affects 0 rows and the victim row is left untouched.
+func TestQuizStore_UpdateQuestion_RejectsCrossQuestionOptionID(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.Open(t)
+	quizStore := NewQuizStore(db, slog.Default())
+
+	quizzes := newTestQuizzes()
+	attacker, victim := quizzes[0], quizzes[1]
+	if err := quizStore.CreateQuiz(t.Context(), attacker); err != nil {
+		t.Fatalf("failed to create attacker quiz: %v", err)
+	}
+	if err := quizStore.CreateQuiz(t.Context(), victim); err != nil {
+		t.Fatalf("failed to create victim quiz: %v", err)
+	}
+
+	victimOption := victim.Questions[0].Options[0]
+	wantText := victimOption.Text
+	wantCorrect := victimOption.Correct
+
+	attackerQuestion := attacker.Questions[0]
+	attackerQuestion.Options = []*quiz.Option{
+		{ID: victimOption.ID, QuestionID: attackerQuestion.ID, Text: "HACKED", Correct: !wantCorrect},
+	}
+
+	err := quizStore.UpdateQuestion(t.Context(), attackerQuestion)
+	if got, want := err, quiz.ErrUpdatingOptionNoRowsAffected; !errors.Is(got, want) {
+		t.Fatalf("err = %v, want %v", got, want)
+	}
+
+	gotVictim, err := quizStore.GetQuestion(t.Context(), victim.Questions[0].ID)
+	if err != nil {
+		t.Fatalf("failed to get victim question: %v", err)
+	}
+
+	var found *quiz.Option
+	for _, o := range gotVictim.Options {
+		if o.ID == victimOption.ID {
+			found = o
+
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("victim option %d was deleted", victimOption.ID)
+	}
+	if got, want := found.Text, wantText; got != want {
+		t.Errorf("victim option Text = %q, want %q", got, want)
+	}
+	if got, want := found.Correct, wantCorrect; got != want {
+		t.Errorf("victim option Correct = %v, want %v", got, want)
+	}
+}
+
 func TestQuizStore_ListQuizzes_OrderedByUpdatedAtDesc(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/retention.go
+++ b/internal/store/retention.go
@@ -106,12 +106,25 @@ func (s *RetentionStore) SweepAbandonedGames(ctx context.Context, days int) erro
 }
 
 // sweepPlayerBatch deletes one chunk of anonymous players and all their game
-// data inside a single transaction. The player rows go last so every game_*
-// row that references them is already gone; a batch may reference more than
-// retentionBatchSize games, so the game-id deletes are chunked too.
+// data inside a single transaction. The snapshot ids are re-filtered to those
+// still matching the anonymity predicate at the top of the transaction, so a
+// guest who claimed their account (register / verify / rename) in the TOCTOU
+// window between snapshot and sweep keeps BOTH their player row and their game
+// data (#1175); the whole batch runs on the filtered set. The player rows go
+// last so every game_* row that references them is already gone; a batch may
+// reference more than retentionBatchSize games, so the game-id deletes are
+// chunked too.
 func (s *RetentionStore) sweepPlayerBatch(ctx context.Context, playerIDs []int64) error {
 	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
-		gameIDs, err := q.ListGameIDsForPlayers(ctx, playerIDs)
+		stillAnon, err := q.FilterAnonymousPlayerIDs(ctx, playerIDs)
+		if err != nil {
+			return fmt.Errorf("failed to re-filter anonymous players: %w", err)
+		}
+		if len(stillAnon) == 0 {
+			return nil
+		}
+
+		gameIDs, err := q.ListGameIDsForPlayers(ctx, stillAnon)
 		if err != nil {
 			return fmt.Errorf("failed to list games for stale anonymous players: %w", err)
 		}
@@ -121,7 +134,7 @@ func (s *RetentionStore) sweepPlayerBatch(ctx context.Context, playerIDs []int64
 			}
 		}
 
-		if err := q.DeletePlayersByIDs(ctx, playerIDs); err != nil {
+		if err := q.DeletePlayersByIDs(ctx, stillAnon); err != nil {
 			return fmt.Errorf("failed to delete stale anonymous players: %w", err)
 		}
 

--- a/internal/store/retention.go
+++ b/internal/store/retention.go
@@ -106,14 +106,11 @@ func (s *RetentionStore) SweepAbandonedGames(ctx context.Context, days int) erro
 }
 
 // sweepPlayerBatch deletes one chunk of anonymous players and all their game
-// data inside a single transaction. The snapshot ids are re-filtered to those
-// still matching the anonymity predicate at the top of the transaction, so a
-// guest who claimed their account (register / verify / rename) in the TOCTOU
-// window between snapshot and sweep keeps BOTH their player row and their game
-// data (#1175); the whole batch runs on the filtered set. The player rows go
-// last so every game_* row that references them is already gone; a batch may
-// reference more than retentionBatchSize games, so the game-id deletes are
-// chunked too.
+// data inside a single transaction. The snapshot ids are re-filtered to the
+// still-anonymous subset first so a guest claimed after the snapshot keeps both
+// their row and their game data (#1175). The player rows go last so every
+// game_* row that references them is already gone; a batch may reference more
+// than retentionBatchSize games, so the game-id deletes are chunked too.
 func (s *RetentionStore) sweepPlayerBatch(ctx context.Context, playerIDs []int64) error {
 	err := database.ExecTx(ctx, s.db, func(q *db.Queries) error {
 		stillAnon, err := q.FilterAnonymousPlayerIDs(ctx, playerIDs)

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -107,18 +107,69 @@ func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
 	}
 }
 
+// TestSweepPlayerBatch_SparesClaimedPlayerGameData pins the #1175 batch-level
+// fix: sweepPlayerBatch re-filters its snapshotted ids to the still-anonymous
+// subset before deleting anything, so a guest claimed in the TOCTOU window
+// keeps BOTH their player row and their game data, not just the row.
+func TestSweepPlayerBatch_SparesClaimedPlayerGameData(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := dbtest.Open(t)
+
+	ownerID := insertSignedInPlayer(ctx, t, conn, "quiz-owner", seedRecent)
+	q := seedQuiz(ctx, t, conn, "toctou-quiz", seedOld, ownerID)
+
+	guestID := insertAnonPlayer(ctx, t, conn, "guest-claims-late", seedOld)
+	gameID := insertGame(ctx, t, conn, "g-toctou", q.quizID, seedOld)
+	insertParticipant(ctx, t, conn, gameID, guestID, q.quizID, seedOld)
+	gq := insertGameQuestion(ctx, t, conn, gameID, q.q1, seedOld)
+	insertGameAnswer(ctx, t, conn, gameID, guestID, gq, q.opt1, seedOld)
+
+	// The guest was snapshotted as anonymous, then claims their name before the
+	// batch delete runs.
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE players SET display_name_claimed = 1 WHERE id = ?`, guestID,
+	); err != nil {
+		t.Fatalf("marking guest claimed err = %v, want nil", err)
+	}
+
+	retention := NewRetentionStore(conn, slog.Default())
+	if err := retention.SweepPlayerBatchForTest(ctx, []int64{guestID}); err != nil {
+		t.Fatalf("SweepPlayerBatchForTest err = %v, want nil", err)
+	}
+
+	if got, want := playerExists(ctx, t, conn, guestID), true; got != want {
+		t.Errorf("claimed guest exists = %v, want %v (must survive the sweep)", got, want)
+	}
+	if got, want := rowExists(ctx, t, conn, `SELECT COUNT(*) FROM games WHERE id = ?`, gameID), true; got != want {
+		t.Errorf("guest game exists = %v, want %v (must survive the sweep)", got, want)
+	}
+	if got, want := rowExists(
+		ctx, t, conn, `SELECT COUNT(*) FROM game_answers WHERE game_id = ?`, gameID,
+	), true; got != want {
+		t.Errorf("guest game answer exists = %v, want %v (must survive the sweep)", got, want)
+	}
+}
+
+// rowExists reports whether the given single-count query returns a positive
+// count for the bound argument.
+func rowExists(ctx context.Context, t *testing.T, conn *sql.DB, query string, arg any) bool {
+	t.Helper()
+
+	var count int
+	if err := conn.QueryRowContext(ctx, query, arg).Scan(&count); err != nil {
+		t.Fatalf("counting rows err = %v, want nil", err)
+	}
+
+	return count > 0
+}
+
 // playerExists reports whether a players row with the given id is present.
 func playerExists(ctx context.Context, t *testing.T, conn *sql.DB, id int64) bool {
 	t.Helper()
 
-	var count int
-	if err := conn.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM players WHERE id = ?`, id,
-	).Scan(&count); err != nil {
-		t.Fatalf("counting player %d err = %v, want nil", id, err)
-	}
-
-	return count > 0
+	return rowExists(ctx, t, conn, `SELECT COUNT(*) FROM players WHERE id = ?`, id)
 }
 
 // TestSweepAbandonedGames_DeleteError pins the deleteGamesByIDs error

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -72,12 +72,8 @@ func TestRetentionSweep(t *testing.T) {
 	assertRetention(ctx, t, db, seed)
 }
 
-// TestDeletePlayersByIDs_SkipsClaimedPlayer pins the #1175 TOCTOU fix: the
-// anonymous-player sweep snapshots ids under the anonymity predicate, but a
-// guest can claim their account (register / verify / rename) before the
-// per-batch delete runs. DeletePlayersByIDs re-asserts the predicate in its
-// WHERE clause, so a since-claimed id survives while a still-anonymous id in
-// the same call is deleted.
+// TestDeletePlayersByIDs_SkipsClaimedPlayer: DeletePlayersByIDs deletes a still-
+// anonymous id but spares a since-claimed one in the same call (#1175).
 func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
 	t.Parallel()
 
@@ -87,8 +83,7 @@ func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
 	claimedID := insertAnonPlayer(ctx, t, conn, "guest-claims", seedOld)
 	stillAnonID := insertAnonPlayer(ctx, t, conn, "guest-stays", seedOld)
 
-	// Simulate the TOCTOU window: both ids were snapshotted as anonymous, but
-	// this one claims its display name before the batch delete lands.
+	// One id claims its name after the snapshot, before the delete.
 	if _, err := conn.ExecContext(ctx,
 		`UPDATE players SET display_name_claimed = 1 WHERE id = ?`, claimedID,
 	); err != nil {
@@ -107,10 +102,8 @@ func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
 	}
 }
 
-// TestSweepPlayerBatch_SparesClaimedPlayerGameData pins the #1175 batch-level
-// fix: sweepPlayerBatch re-filters its snapshotted ids to the still-anonymous
-// subset before deleting anything, so a guest claimed in the TOCTOU window
-// keeps BOTH their player row and their game data, not just the row.
+// TestSweepPlayerBatch_SparesClaimedPlayerGameData: a guest claimed after the
+// snapshot keeps both their player row and their game rows (#1175).
 func TestSweepPlayerBatch_SparesClaimedPlayerGameData(t *testing.T) {
 	t.Parallel()
 
@@ -126,8 +119,7 @@ func TestSweepPlayerBatch_SparesClaimedPlayerGameData(t *testing.T) {
 	gq := insertGameQuestion(ctx, t, conn, gameID, q.q1, seedOld)
 	insertGameAnswer(ctx, t, conn, gameID, guestID, gq, q.opt1, seedOld)
 
-	// The guest was snapshotted as anonymous, then claims their name before the
-	// batch delete runs.
+	// The guest claims their name after the snapshot, before the batch runs.
 	if _, err := conn.ExecContext(ctx,
 		`UPDATE players SET display_name_claimed = 1 WHERE id = ?`, guestID,
 	); err != nil {
@@ -152,8 +144,7 @@ func TestSweepPlayerBatch_SparesClaimedPlayerGameData(t *testing.T) {
 	}
 }
 
-// rowExists reports whether the given single-count query returns a positive
-// count for the bound argument.
+// rowExists reports whether the count query returns a positive count.
 func rowExists(ctx context.Context, t *testing.T, conn *sql.DB, query string, arg any) bool {
 	t.Helper()
 

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	dbgen "github.com/starquake/topbanana/internal/db"
 	"github.com/starquake/topbanana/internal/dbtest"
 	. "github.com/starquake/topbanana/internal/store"
 )
@@ -69,6 +70,55 @@ func TestRetentionSweep(t *testing.T) {
 	}
 
 	assertRetention(ctx, t, db, seed)
+}
+
+// TestDeletePlayersByIDs_SkipsClaimedPlayer pins the #1175 TOCTOU fix: the
+// anonymous-player sweep snapshots ids under the anonymity predicate, but a
+// guest can claim their account (register / verify / rename) before the
+// per-batch delete runs. DeletePlayersByIDs re-asserts the predicate in its
+// WHERE clause, so a since-claimed id survives while a still-anonymous id in
+// the same call is deleted.
+func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn := dbtest.Open(t)
+
+	claimedID := insertAnonPlayer(ctx, t, conn, "guest-claims", seedOld)
+	stillAnonID := insertAnonPlayer(ctx, t, conn, "guest-stays", seedOld)
+
+	// Simulate the TOCTOU window: both ids were snapshotted as anonymous, but
+	// this one claims its display name before the batch delete lands.
+	if _, err := conn.ExecContext(ctx,
+		`UPDATE players SET display_name_claimed = 1 WHERE id = ?`, claimedID,
+	); err != nil {
+		t.Fatalf("marking player claimed err = %v, want nil", err)
+	}
+
+	if err := dbgen.New(conn).DeletePlayersByIDs(ctx, []int64{claimedID, stillAnonID}); err != nil {
+		t.Fatalf("DeletePlayersByIDs err = %v, want nil", err)
+	}
+
+	if got, want := playerExists(ctx, t, conn, claimedID), true; got != want {
+		t.Errorf("claimed player exists = %v, want %v (must survive the sweep)", got, want)
+	}
+	if got, want := playerExists(ctx, t, conn, stillAnonID), false; got != want {
+		t.Errorf("still-anonymous player exists = %v, want %v (must be swept)", got, want)
+	}
+}
+
+// playerExists reports whether a players row with the given id is present.
+func playerExists(ctx context.Context, t *testing.T, conn *sql.DB, id int64) bool {
+	t.Helper()
+
+	var count int
+	if err := conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM players WHERE id = ?`, id,
+	).Scan(&count); err != nil {
+		t.Fatalf("counting player %d err = %v, want nil", id, err)
+	}
+
+	return count > 0
 }
 
 // TestSweepAbandonedGames_DeleteError pins the deleteGamesByIDs error


### PR DESCRIPTION
Three store/admin integrity fixes.

- **#1165 (option IDOR):** `UpdateOption`/`DeleteOption` are now scoped `WHERE id = ? AND question_id = ?`, so a crafted foreign `option[i].id` affects 0 rows and aborts the tx instead of overwriting another owner's options.
- **#1174 (media orphan):** `HandleQuizDelete` now calls `mediaSvc.RemoveQuizDir(quizID)` best-effort after delete. No change for question deletes -- media is a per-quiz library (`ON DELETE SET NULL`), so a question delete orphans nothing.
- **#1175 (retention TOCTOU):** `sweepPlayerBatch` re-filters its snapshot to the still-anonymous subset (`FilterAnonymousPlayerIDs`) and runs both the game-data and player deletes on that set, so a guest who claims their account mid-sweep keeps both its row and its game data; `DeletePlayersByIDs` also re-asserts the predicate as defense-in-depth.

Tests for each. `make check`/`make sql-lint`/`make smoke` all green.

Closes #1165
Closes #1174
Closes #1175

_— Claude Code, for @starquake_
