### PR TITLE
Translate the outbound emails to Dutch

### DIFF
--- a/internal/admin/invites.go
+++ b/internal/admin/invites.go
@@ -11,6 +11,7 @@ import (
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/csrf"
 	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -167,7 +168,9 @@ func HandleInviteSubmit(logger *slog.Logger, csrfMgr *csrf.Manager, deps InviteD
 			return
 		}
 
-		result := sendInvite(r.Context(), logger, deps, email, note, actor.ID)
+		// The recipient has no account yet, so no stored locale; the invite
+		// email uses the inviting admin's request locale.
+		result := sendInvite(r.Context(), logger, deps, email, note, actor.ID, locale.Resolve(r))
 		if !result.ok {
 			renderInviteFormError(w, r, logger, csrfMgr, deps.Invites, http.StatusInternalServerError, inviteFormError{
 				email: email, note: note, msg: result.banner,
@@ -195,7 +198,10 @@ func HandleInviteResend(logger *slog.Logger, deps InviteDeps) http.Handler {
 			return
 		}
 
-		err := auth.ResendInviteEmail(r.Context(), deps.Invites, deps.Sender, deps.BaseURL, inviteID, time.Now().UTC())
+		// The invited recipient has no account, so no stored locale; the
+		// resent email uses the inviting admin's request locale.
+		err := auth.ResendInviteEmail(
+			r.Context(), deps.Invites, deps.Sender, deps.BaseURL, locale.Resolve(r), inviteID, time.Now().UTC())
 		switch {
 		case err == nil:
 			setInviteNotice(deps.Flash, w,
@@ -337,7 +343,7 @@ type inviteSendResult struct {
 // the instant the admin sees the confirmation (and keeps the flow
 // trivially testable).
 func sendInvite(
-	ctx context.Context, logger *slog.Logger, deps InviteDeps, email, note string, invitedByID int64,
+	ctx context.Context, logger *slog.Logger, deps InviteDeps, email, note string, invitedByID int64, loc string,
 ) inviteSendResult {
 	err := auth.SendInviteEmail(
 		ctx,
@@ -346,6 +352,7 @@ func sendInvite(
 		deps.BaseURL,
 		email,
 		note,
+		loc,
 		invitedByID,
 		time.Now().UTC(),
 	)

--- a/internal/admin/playeractions_dispatch.go
+++ b/internal/admin/playeractions_dispatch.go
@@ -16,12 +16,14 @@ import (
 // observable from the redirect timing. Returns false without dispatching
 // when email is not configured (nil tokens/sender or empty baseURL) so
 // the caller can skip the audit row and the success notice.
+//
+//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
 func dispatchAdminResendVerification(
 	ctx context.Context,
 	logger *slog.Logger,
 	tokens auth.VerifyTokenStore,
 	sender auth.VerifyEmailSender,
-	baseURL, recipient string,
+	baseURL, recipient, loc string,
 	playerID int64,
 	tasks *bgtasks.Tracker,
 ) bool {
@@ -38,7 +40,7 @@ func dispatchAdminResendVerification(
 	tasks.Go(func() {
 		defer cancel()
 		auth.SendVerifyEmailBestEffort(bg, logger, tokens, sender,
-			baseURL, recipient, playerID, time.Now().UTC())
+			baseURL, recipient, loc, playerID, time.Now().UTC())
 	})
 
 	return true

--- a/internal/admin/playeractions_dispatch.go
+++ b/internal/admin/playeractions_dispatch.go
@@ -17,7 +17,7 @@ import (
 // when email is not configured (nil tokens/sender or empty baseURL) so
 // the caller can skip the audit row and the success notice.
 //
-//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
+//nolint:revive // argument-limit: loc is message content; the rest is irreducible mail plumbing.
 func dispatchAdminResendVerification(
 	ctx context.Context,
 	logger *slog.Logger,

--- a/internal/admin/playeractions_dispatch_test.go
+++ b/internal/admin/playeractions_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/starquake/topbanana/internal/admin"
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/bgtasks"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -67,7 +68,8 @@ func TestDispatchAdminResendVerification_BoolContract(t *testing.T) {
 
 			tracker := bgtasks.New()
 			got := DispatchAdminResendVerification(
-				t.Context(), slog.Default(), tc.tokens, tc.sender, tc.baseURL, "to@example.test", testAdminID, tracker,
+				t.Context(), slog.Default(), tc.tokens, tc.sender, tc.baseURL, "to@example.test",
+				locale.LocaleEN, testAdminID, tracker,
 			)
 			if want := tc.wantResult; got != want {
 				t.Errorf("DispatchAdminResendVerification = %v, want %v", got, want)

--- a/internal/admin/playeractions_resend.go
+++ b/internal/admin/playeractions_resend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/bgtasks"
 	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/locale"
 )
 
 // HandlePlayerResendVerification handles
@@ -59,7 +60,7 @@ func HandlePlayerResendVerification(
 		}
 
 		if !dispatchAdminResendVerification(
-			r.Context(), logger, tokens, sender, baseURL, detail.Email, playerID, tasks,
+			r.Context(), logger, tokens, sender, baseURL, detail.Email, locale.Resolve(r), playerID, tasks,
 		) {
 			// No mail went out (email not configured), so roll the stamp
 			// back: an operator on a misconfigured instance is not throttled

--- a/internal/admin/playeractions_role.go
+++ b/internal/admin/playeractions_role.go
@@ -154,17 +154,23 @@ func writeRoleChange(
 	return false
 }
 
-// roleLabel maps a role constant to its human word, so the success
-// flash and the notification email name the tier the same way.
-func roleLabel(role string) string {
+// roleLabelKey maps a role constant to the catalog key for its human word,
+// so the role->word mapping lives in exactly one place.
+func roleLabelKey(role string) locale.MessageID {
 	switch role {
 	case auth.RoleAdmin:
-		return "admin"
+		return emailRoleChangeRoleAdminKey
 	case auth.RoleHost:
-		return "host"
+		return emailRoleChangeRoleHostKey
 	default:
-		return "player"
+		return emailRoleChangeRolePlayerKey
 	}
+}
+
+// roleLabel names the tier in English for the admin success flash (the admin
+// UI is English); the player-facing email uses localizedRoleLabel instead.
+func roleLabel(role string) string {
+	return locale.Translate(locale.LocaleEN, roleLabelKey(role))
 }
 
 // roleChangeNotice is the success flash naming the new tier.
@@ -172,17 +178,10 @@ func roleChangeNotice(role string) string {
 	return "Player role set to " + roleLabel(role) + "."
 }
 
-// localizedRoleLabel maps a role constant to its word in loc, for the
-// player-facing role-change email.
+// localizedRoleLabel names the tier in loc, for the player-facing
+// role-change email.
 func localizedRoleLabel(loc, role string) string {
-	switch role {
-	case auth.RoleAdmin:
-		return locale.Translate(loc, emailRoleChangeRoleAdminKey)
-	case auth.RoleHost:
-		return locale.Translate(loc, emailRoleChangeRoleHostKey)
-	default:
-		return locale.Translate(loc, emailRoleChangeRolePlayerKey)
-	}
+	return locale.Translate(loc, roleLabelKey(role))
 }
 
 // maybeNotifyRoleChange honours the opt-in checkbox: when it is unset it

--- a/internal/admin/playeractions_role.go
+++ b/internal/admin/playeractions_role.go
@@ -10,7 +10,17 @@ import (
 	"github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/bgtasks"
 	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// Role-change notice catalog keys.
+const (
+	emailRoleChangeSubjectKey    locale.MessageID = "email.roleChange.subject"
+	emailRoleChangeBodyKey       locale.MessageID = "email.roleChange.body"
+	emailRoleChangeRolePlayerKey locale.MessageID = "email.roleChange.rolePlayer"
+	emailRoleChangeRoleHostKey   locale.MessageID = "email.roleChange.roleHost"
+	emailRoleChangeRoleAdminKey  locale.MessageID = "email.roleChange.roleAdmin"
 )
 
 // roleIsValid reports whether the "role" form value is one of the three
@@ -162,6 +172,19 @@ func roleChangeNotice(role string) string {
 	return "Player role set to " + roleLabel(role) + "."
 }
 
+// localizedRoleLabel maps a role constant to its word in loc, for the
+// player-facing role-change email.
+func localizedRoleLabel(loc, role string) string {
+	switch role {
+	case auth.RoleAdmin:
+		return locale.Translate(loc, emailRoleChangeRoleAdminKey)
+	case auth.RoleHost:
+		return locale.Translate(loc, emailRoleChangeRoleHostKey)
+	default:
+		return locale.Translate(loc, emailRoleChangeRolePlayerKey)
+	}
+}
+
 // maybeNotifyRoleChange honours the opt-in checkbox: when it is unset it
 // returns an empty string so the flash is unchanged. When set, it
 // dispatches the role-change notice (if SMTP is configured and the target
@@ -189,7 +212,9 @@ func maybeNotifyRoleChange(
 	if detail.Email == "" || detail.EmailVerifiedAt == nil {
 		return " The player has no verified email, so no notification was sent."
 	}
-	dispatchRoleChangeNotice(r.Context(), logger, sender, detail.Email, desired, playerID, tasks)
+	// The player's own locale is not stored, so the notice uses the
+	// acting admin's request locale.
+	dispatchRoleChangeNotice(r.Context(), logger, sender, detail.Email, desired, playerID, tasks, locale.Resolve(r))
 
 	return " A notification email was sent to the player."
 }
@@ -207,12 +232,13 @@ func dispatchRoleChangeNotice(
 	recipient, role string,
 	playerID int64,
 	tasks *bgtasks.Tracker,
+	loc string,
 ) {
 	msg := mailer.Message{
 		To:      recipient,
-		Subject: "Your Top Banana! account role changed",
-		Body: "An administrator changed the role on your Top Banana! account to " + roleLabel(role) + ".\n\n" +
-			"If you have questions about this change, contact the site administrator.\n",
+		Subject: locale.Translate(loc, emailRoleChangeSubjectKey),
+		Body: locale.TranslateWith(loc, emailRoleChangeBodyKey,
+			map[string]string{"role": localizedRoleLabel(loc, role)}),
 		Kind: mailer.KindRoleChangeNotice,
 	}
 	bg, cancel := context.WithTimeout(context.WithoutCancel(ctx), mailer.SendTimeout+15*time.Second)

--- a/internal/admin/playeractions_role_test.go
+++ b/internal/admin/playeractions_role_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/starquake/topbanana/internal/admin"
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -56,6 +57,17 @@ func postRoleWith(
 	sender auth.VerifyEmailSender, mailConfigured bool,
 ) (*httptest.ResponseRecorder, auth.SignedFlashRead) {
 	t.Helper()
+
+	return postRoleWithLang(t, env, targetID, form, sender, mailConfigured, "")
+}
+
+// postRoleWithLang is postRoleWith with an explicit UI language: a
+// non-empty lang sets the lang cookie so the handler resolves that locale.
+func postRoleWithLang(
+	t *testing.T, env *adminEnv, targetID int64, form url.Values,
+	sender auth.VerifyEmailSender, mailConfigured bool, lang string,
+) (*httptest.ResponseRecorder, auth.SignedFlashRead) {
+	t.Helper()
 	flash := auth.NewSignedFlash([]byte("test-key-test-key-test-key-32byt"), false, "flash", "/admin")
 	handler := HandlePlayerSetRole(slog.New(slog.DiscardHandler), env.admin, sender, mailConfigured, flash, nil)
 
@@ -64,6 +76,9 @@ func postRoleWith(
 		strings.NewReader(form.Encode()),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if lang != "" {
+		req.AddCookie(&http.Cookie{Name: locale.CookieName, Value: lang})
+	}
 	req.SetPathValue("playerID", strconv.FormatInt(targetID, 10))
 	req = req.WithContext(auth.WithPlayer(req.Context(), &auth.Player{ID: testAdminID, Role: auth.RoleAdmin}))
 
@@ -166,6 +181,57 @@ func TestHandlePlayerSetRole_NotifyVerifiedSendsEmail(t *testing.T) {
 
 	if got, want := flash.Notice, "A notification email was sent to the player."; !strings.Contains(got, want) {
 		t.Errorf("flash.Notice = %q, should contain %q", got, want)
+	}
+}
+
+// TestHandlePlayerSetRole_NotifyDutch pins that the role-change notice is
+// localized to the acting admin's request locale, including the role word.
+func TestHandlePlayerSetRole_NotifyDutch(t *testing.T) {
+	t.Parallel()
+
+	env := newAdminEnv(t)
+	target := env.seedVerifiedNonAdminPlayer(t, "notify-nl-target", "notify-nl@example.test")
+	spy := newRoleMailSpy()
+
+	form := url.Values{"role": {auth.RoleHost}, "notify_email": {"on"}}
+	rec, _ := postRoleWithLang(t, env, target, form, spy, true, locale.LocaleNL)
+
+	if got, want := rec.Code, http.StatusSeeOther; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	select {
+	case msg := <-spy.sent:
+		if got, want := msg.Subject, "De rol van je Top Banana!-account is gewijzigd"; got != want {
+			t.Errorf("msg.Subject = %q, want %q", got, want)
+		}
+		if got, want := msg.Body, "Een beheerder heeft de rol"; !strings.Contains(got, want) {
+			t.Errorf("msg.Body = %q, should contain %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the role-change notice to dispatch")
+	}
+}
+
+// TestHandlePlayerSetRole_NotifyAdminRoleDutch pins the Dutch role word for
+// an admin promotion, exercising the localizedRoleLabel admin branch.
+func TestHandlePlayerSetRole_NotifyAdminRoleDutch(t *testing.T) {
+	t.Parallel()
+
+	env := newAdminEnv(t)
+	target := env.seedVerifiedNonAdminPlayer(t, "promote-nl-target", "promote-nl@example.test")
+	spy := newRoleMailSpy()
+
+	form := url.Values{"role": {auth.RoleAdmin}, "notify_email": {"on"}}
+	postRoleWithLang(t, env, target, form, spy, true, locale.LocaleNL)
+
+	select {
+	case msg := <-spy.sent:
+		if got, want := msg.Body, "gewijzigd naar beheerder"; !strings.Contains(got, want) {
+			t.Errorf("msg.Body = %q, should contain %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the role-change notice to dispatch")
 	}
 }
 

--- a/internal/auth/forgot.go
+++ b/internal/auth/forgot.go
@@ -121,7 +121,7 @@ func HandleForgotSubmit(
 
 		identifier := strings.TrimSpace(r.PostFormValue("identifier"))
 		if identifier != "" {
-			dispatchForgotIfMatch(r.Context(), logger, players, dispatch, identifier)
+			dispatchForgotIfMatch(r.Context(), logger, players, dispatch, identifier, locale.Resolve(r))
 		}
 
 		// Always flash the same success message - never reveal whether
@@ -141,7 +141,7 @@ func dispatchForgotIfMatch(
 	logger *slog.Logger,
 	players PlayerStore,
 	dispatch ForgotDispatchDeps,
-	identifier string,
+	identifier, loc string,
 ) {
 	p, ok := resolveForgotIdentifier(ctx, players, identifier)
 	if !ok || p.Email == "" {
@@ -157,7 +157,7 @@ func dispatchForgotIfMatch(
 	dispatch.Tasks.Go(func() {
 		defer cancel()
 		if err := SendResetEmail(sendCtx, dispatch.Tokens, dispatch.Sender, dispatch.BaseURL,
-			p.Email, p.ID, time.Now().UTC()); err != nil {
+			p.Email, loc, p.ID, time.Now().UTC()); err != nil {
 			logger.WarnContext(sendCtx, "forgot-password dispatch failed",
 				slog.Int64("player_id", p.ID), slog.Any("err", err))
 		}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -353,10 +353,8 @@ const (
 // so the collision response keeps the same timing as the success path. A nil
 // Mailer (unit tests) skips the send; failures are logged, never surfaced.
 //
-// This notice goes to the existing account owner but is triggered by an
-// unauthenticated submitter who controls their own request locale, so it is not
-// localized to that locale; English is the safe default until a stored recipient
-// locale exists.
+// Uses English, not the submitter's request locale: the submitter is
+// unauthenticated and does not own the recipient mailbox.
 func dispatchRegisterExisting(
 	ctx context.Context,
 	logger *slog.Logger,

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -278,7 +278,7 @@ func handleRegisterError(
 ) {
 	switch {
 	case errors.Is(err, ErrEmailTaken):
-		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail, locale.Resolve(r))
+		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail)
 		renderers.renderPending(w, r, input.CleanedEmail)
 	case errors.Is(err, ErrDisplayNameTaken):
 		renderers.form.Render(w, r, http.StatusConflict, formData{
@@ -352,11 +352,16 @@ const (
 // nothing. Runs detached with a bounded timeout, mirroring dispatchVerifyEmail,
 // so the collision response keeps the same timing as the success path. A nil
 // Mailer (unit tests) skips the send; failures are logged, never surfaced.
+//
+// This notice goes to the existing account owner but is triggered by an
+// unauthenticated submitter who controls their own request locale, so it is not
+// localized to that locale; English is the safe default until a stored recipient
+// locale exists.
 func dispatchRegisterExisting(
 	ctx context.Context,
 	logger *slog.Logger,
 	deps RegisterDeps,
-	recipient, loc string,
+	recipient string,
 ) {
 	if deps.Mailer == nil {
 		return
@@ -366,8 +371,8 @@ func dispatchRegisterExisting(
 		defer cancel()
 		msg := mailer.Message{
 			To:      recipient,
-			Subject: locale.Translate(loc, emailRegisterExistingSubjectKey),
-			Body:    locale.Translate(loc, emailRegisterExistingBodyKey),
+			Subject: locale.Translate(locale.LocaleEN, emailRegisterExistingSubjectKey),
+			Body:    locale.Translate(locale.LocaleEN, emailRegisterExistingBodyKey),
 			Kind:    mailer.KindRegisterExisting,
 		}
 		if err := deps.Mailer.Send(bg, msg); err != nil {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -235,7 +235,7 @@ func HandleRegisterSubmit(
 			return
 		}
 
-		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail)
+		dispatchVerifyEmail(r.Context(), logger, deps, player.ID, input.CleanedEmail, locale.Resolve(r))
 		renderers.renderPending(w, r, input.CleanedEmail)
 	})
 }
@@ -278,7 +278,7 @@ func handleRegisterError(
 ) {
 	switch {
 	case errors.Is(err, ErrEmailTaken):
-		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail)
+		dispatchRegisterExisting(r.Context(), logger, deps, input.CleanedEmail, locale.Resolve(r))
 		renderers.renderPending(w, r, input.CleanedEmail)
 	case errors.Is(err, ErrDisplayNameTaken):
 		renderers.form.Render(w, r, http.StatusConflict, formData{
@@ -321,7 +321,7 @@ func dispatchVerifyEmail(
 	logger *slog.Logger,
 	deps RegisterDeps,
 	playerID int64,
-	recipient string,
+	recipient, loc string,
 ) {
 	if deps.Mailer == nil || deps.Tokens == nil {
 		return
@@ -336,9 +336,15 @@ func dispatchVerifyEmail(
 	deps.Tasks.Go(func() {
 		defer cancel()
 		SendVerifyEmailBestEffort(bg, logger, deps.Tokens, deps.Mailer,
-			deps.BaseURL, recipient, playerID, time.Now().UTC())
+			deps.BaseURL, recipient, loc, playerID, time.Now().UTC())
 	})
 }
+
+// Register-existing notice catalog keys.
+const (
+	emailRegisterExistingSubjectKey locale.MessageID = "email.registerExisting.subject"
+	emailRegisterExistingBodyKey    locale.MessageID = "email.registerExisting.body"
+)
 
 // dispatchRegisterExisting notifies the owner of an already-registered address
 // that someone tried to register with it. The collided address IS the owner's
@@ -350,7 +356,7 @@ func dispatchRegisterExisting(
 	ctx context.Context,
 	logger *slog.Logger,
 	deps RegisterDeps,
-	recipient string,
+	recipient, loc string,
 ) {
 	if deps.Mailer == nil {
 		return
@@ -360,11 +366,9 @@ func dispatchRegisterExisting(
 		defer cancel()
 		msg := mailer.Message{
 			To:      recipient,
-			Subject: "Someone tried to register with your Top Banana! email",
-			Body: "Someone tried to create a Top Banana! account with this email address.\n\n" +
-				"An account already exists for this address. If it was you, sign in or reset your password instead.\n\n" +
-				"If it was not you, no action is needed.\n",
-			Kind: mailer.KindRegisterExisting,
+			Subject: locale.Translate(loc, emailRegisterExistingSubjectKey),
+			Body:    locale.Translate(loc, emailRegisterExistingBodyKey),
+			Kind:    mailer.KindRegisterExisting,
 		}
 		if err := deps.Mailer.Send(bg, msg); err != nil {
 			logger.WarnContext(bg, "register-existing notice failed", slog.Any("err", err))
@@ -828,11 +832,12 @@ func dispatchVerifyResend(
 	if _, allowed := deps.ResendLimiter.Allow(deps.ResendLimiter.ClientIP(r)); !allowed {
 		return
 	}
+	loc := locale.Resolve(r)
 	bg, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), verifyEmailDispatchTimeout)
 	deps.Tasks.Go(func() {
 		defer cancel()
 		SendVerifyEmailBestEffort(bg, logger, deps.Tokens, deps.Mailer,
-			deps.BaseURL, player.Email, player.ID, time.Now().UTC())
+			deps.BaseURL, player.Email, loc, player.ID, time.Now().UTC())
 	})
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -350,9 +350,12 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	}
 }
 
-// TestHandleRegisterSubmit_DuplicateEmailDutch pins that the out-of-band
-// register-existing notice is localized to the submitter's request locale.
-func TestHandleRegisterSubmit_DuplicateEmailDutch(t *testing.T) {
+// TestHandleRegisterSubmit_DuplicateEmailStaysEnglish pins that the
+// register-existing notice stays English even when the submitter's request
+// carries a lang=nl cookie: the notice reaches the existing account owner but is
+// triggered by an unauthenticated submitter who controls their own locale, so it
+// must not be localized to that attacker-chosen locale.
+func TestHandleRegisterSubmit_DuplicateEmailStaysEnglish(t *testing.T) {
 	t.Parallel()
 
 	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
@@ -380,11 +383,11 @@ func TestHandleRegisterSubmit_DuplicateEmailDutch(t *testing.T) {
 	if got, want := len(sent), 1; got != want {
 		t.Fatalf("sender.Sent() len = %d, want %d", got, want)
 	}
-	if got, want := sent[0].Subject, "Iemand probeerde te registreren met je Top Banana!-e-mailadres"; got != want {
+	if got, want := sent[0].Subject, "Someone tried to register with your Top Banana! email"; got != want {
 		t.Errorf("sent[0].Subject = %q, want %q", got, want)
 	}
 	if got, want := sent[0].Body,
-		"Iemand heeft geprobeerd een Top Banana!-account aan te maken"; !strings.Contains(got, want) {
+		"Someone tried to create a Top Banana! account with this email address."; !strings.Contains(got, want) {
 		t.Errorf("sent[0].Body = %q, should contain %q", got, want)
 	}
 }

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/starquake/topbanana/internal/auth"
 	"github.com/starquake/topbanana/internal/bgtasks"
 	"github.com/starquake/topbanana/internal/dbtest"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 	"github.com/starquake/topbanana/internal/session"
 	"github.com/starquake/topbanana/internal/store"
@@ -24,8 +25,21 @@ import (
 func postForm(t *testing.T, handler http.Handler, path string, values url.Values) *httptest.ResponseRecorder {
 	t.Helper()
 
+	return postFormLang(t, handler, path, values, "")
+}
+
+// postFormLang is postForm with an explicit UI language: a non-empty lang
+// sets the lang cookie so the handler resolves that locale.
+func postFormLang(
+	t *testing.T, handler http.Handler, path string, values url.Values, lang string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(values.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if lang != "" {
+		req.AddCookie(&http.Cookie{Name: locale.CookieName, Value: lang})
+	}
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -330,6 +344,48 @@ func TestHandleRegisterSubmit_DuplicateEmail(t *testing.T) {
 	}
 	if got, want := sent[0].To, "shared@example.test"; got != want {
 		t.Errorf("sent[0].To = %q, want %q", got, want)
+	}
+	if got, want := sent[0].Subject, "Someone tried to register with your Top Banana! email"; got != want {
+		t.Errorf("sent[0].Subject = %q, want %q", got, want)
+	}
+}
+
+// TestHandleRegisterSubmit_DuplicateEmailDutch pins that the out-of-band
+// register-existing notice is localized to the submitter's request locale.
+func TestHandleRegisterSubmit_DuplicateEmailDutch(t *testing.T) {
+	t.Parallel()
+
+	players := store.NewPlayerStore(dbtest.Open(t), discardLogger())
+	if _, err := players.CreatePlayer(t.Context(), "alice", "shared@example.test", "h", RolePlayer); err != nil {
+		t.Fatalf("seed CreatePlayer err = %v, want nil", err)
+	}
+
+	sender := &recordingSender{}
+	tracker := bgtasks.New()
+	handler := HandleRegisterSubmit(
+		discardLogger(), nil, players, session.New([]byte("k"), true),
+		RegisterDeps{Mailer: sender, Tasks: tracker},
+	)
+	postFormLang(t, handler, "/register", url.Values{
+		"display_name":     {"bob"},
+		"email":            {"shared@example.test"},
+		"password":         {"correctbattery"},
+		"password_confirm": {"correctbattery"},
+	}, locale.LocaleNL)
+
+	if err := tracker.Wait(t.Context()); err != nil {
+		t.Fatalf("tracker.Wait err = %v, want nil", err)
+	}
+	sent := sender.Sent()
+	if got, want := len(sent), 1; got != want {
+		t.Fatalf("sender.Sent() len = %d, want %d", got, want)
+	}
+	if got, want := sent[0].Subject, "Iemand probeerde te registreren met je Top Banana!-e-mailadres"; got != want {
+		t.Errorf("sent[0].Subject = %q, want %q", got, want)
+	}
+	if got, want := sent[0].Body,
+		"Iemand heeft geprobeerd een Top Banana!-account aan te maken"; !strings.Contains(got, want) {
+		t.Errorf("sent[0].Body = %q, should contain %q", got, want)
 	}
 }
 

--- a/internal/auth/invite.go
+++ b/internal/auth/invite.go
@@ -135,7 +135,7 @@ func HashInviteToken(raw string) string {
 // row is still committed so a future resend (slice 2) can run
 // independently of SMTP availability.
 //
-//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
+//nolint:revive // argument-limit: loc is message content; the rest is irreducible mail plumbing.
 func SendInviteEmail(
 	ctx context.Context,
 	invites InviteStore,

--- a/internal/auth/invite.go
+++ b/internal/auth/invite.go
@@ -8,7 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// Invite-email catalog keys.
+const (
+	emailInviteSubjectKey locale.MessageID = "email.invite.subject"
+	emailInviteBodyKey    locale.MessageID = "email.invite.body"
 )
 
 // InviteTokenTTL is the lifetime of an admin-issued invite link (#318).
@@ -127,11 +134,13 @@ func HashInviteToken(raw string) string {
 // caller so the admin handler can flash a meaningful message; the invite
 // row is still committed so a future resend (slice 2) can run
 // independently of SMTP availability.
+//
+//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
 func SendInviteEmail(
 	ctx context.Context,
 	invites InviteStore,
 	sender VerifyEmailSender,
-	baseURL, recipient, note string,
+	baseURL, recipient, note, loc string,
 	invitedByPlayerID int64,
 	now time.Time,
 ) error {
@@ -149,8 +158,8 @@ func SendInviteEmail(
 	}
 	msg := mailer.Message{
 		To:      recipient,
-		Subject: "You are invited to Top Banana!",
-		Body:    inviteEmailBody(link),
+		Subject: locale.Translate(loc, emailInviteSubjectKey),
+		Body:    inviteEmailBody(loc, link),
 		Kind:    mailer.KindInvite,
 	}
 	if sendErr := sender.Send(ctx, msg); sendErr != nil {
@@ -171,7 +180,7 @@ func ResendInviteEmail(
 	ctx context.Context,
 	invites InviteStore,
 	sender VerifyEmailSender,
-	baseURL string,
+	baseURL, loc string,
 	inviteID int64,
 	now time.Time,
 ) error {
@@ -189,8 +198,8 @@ func ResendInviteEmail(
 	}
 	msg := mailer.Message{
 		To:      recipient,
-		Subject: "You are invited to Top Banana!",
-		Body:    inviteEmailBody(link),
+		Subject: locale.Translate(loc, emailInviteSubjectKey),
+		Body:    inviteEmailBody(loc, link),
 		Kind:    mailer.KindInvite,
 	}
 	if sendErr := sender.Send(ctx, msg); sendErr != nil {
@@ -223,12 +232,7 @@ func buildInviteLink(baseURL, rawToken string) (string, error) {
 	return u.String(), nil
 }
 
-// inviteEmailBody is the plain-text body of the invite email. Mirrors
-// the reset/verify body shape so the channels read consistently.
-func inviteEmailBody(link string) string {
-	return "You have been invited to join Top Banana!\n\n" +
-		"Use the link below to choose a display name and password and set up your account:\n\n" +
-		link + "\n\n" +
-		"This link is valid for 7 days. If you were not expecting this invite, " +
-		"you can ignore this email.\n"
+// inviteEmailBody is the plain-text body of the invite email for loc.
+func inviteEmailBody(loc, link string) string {
+	return locale.TranslateWith(loc, emailInviteBodyKey, map[string]string{"link": link})
 }

--- a/internal/auth/invite_test.go
+++ b/internal/auth/invite_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -33,7 +34,7 @@ func TestSendInviteEmail_StoresAndSends(t *testing.T) {
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 
 	err := SendInviteEmail(t.Context(), invites, mailerStub,
-		"https://topbanana.example", "alice@example.test", "vip", 7, now)
+		"https://topbanana.example", "alice@example.test", "vip", locale.LocaleEN, 7, now)
 	if err != nil {
 		t.Fatalf("SendInviteEmail err = %v, want nil", err)
 	}
@@ -68,6 +69,34 @@ func TestSendInviteEmail_StoresAndSends(t *testing.T) {
 	if got, want := msg.Kind, mailer.KindInvite; got != want {
 		t.Errorf("msg.Kind = %q, want %q", got, want)
 	}
+	if got, want := msg.Subject, "You are invited to Top Banana!"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if !strings.Contains(msg.Body, "https://topbanana.example/accept-invite?token=") {
+		t.Errorf("msg.Body missing accept-invite link, got %q", msg.Body)
+	}
+}
+
+func TestSendInviteEmail_Dutch(t *testing.T) {
+	t.Parallel()
+
+	invites := &recordingInviteStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	err := SendInviteEmail(t.Context(), invites, mailerStub,
+		"https://topbanana.example", "alice@example.test", "", locale.LocaleNL, 7, now)
+	if err != nil {
+		t.Fatalf("SendInviteEmail err = %v, want nil", err)
+	}
+
+	msg := mailerStub.sent[0]
+	if got, want := msg.Subject, "Je bent uitgenodigd voor Top Banana!"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if got, want := msg.Body, "Deze link is 7 dagen geldig"; !strings.Contains(got, want) {
+		t.Errorf("msg.Body = %q, should contain %q", got, want)
+	}
 	if !strings.Contains(msg.Body, "https://topbanana.example/accept-invite?token=") {
 		t.Errorf("msg.Body missing accept-invite link, got %q", msg.Body)
 	}
@@ -82,7 +111,7 @@ func TestSendInviteEmail_StoreFailureSkipsSend(t *testing.T) {
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 
 	err := SendInviteEmail(t.Context(), invites, mailerStub,
-		"https://topbanana.example", "alice@example.test", "", 1, now)
+		"https://topbanana.example", "alice@example.test", "", locale.LocaleEN, 1, now)
 	if got, want := err, wantErr; !errors.Is(got, want) {
 		t.Errorf("err = %v, want wrapping %v", got, want)
 	}
@@ -98,7 +127,7 @@ func TestResendInviteEmail_RotatesAndSends(t *testing.T) {
 	mailerStub := &recordingSender{}
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 
-	err := ResendInviteEmail(t.Context(), invites, mailerStub, "https://topbanana.example", 42, now)
+	err := ResendInviteEmail(t.Context(), invites, mailerStub, "https://topbanana.example", locale.LocaleEN, 42, now)
 	if err != nil {
 		t.Fatalf("ResendInviteEmail err = %v, want nil", err)
 	}
@@ -135,7 +164,8 @@ func TestResendInviteEmail_RotateFailureSkipsSend(t *testing.T) {
 	invites := &recordingInviteStore{rotateErr: ErrInviteNotPending}
 	mailerStub := &recordingSender{}
 
-	err := ResendInviteEmail(t.Context(), invites, mailerStub, "https://topbanana.example", 1, time.Now())
+	err := ResendInviteEmail(
+		t.Context(), invites, mailerStub, "https://topbanana.example", locale.LocaleEN, 1, time.Now())
 	if got, want := err, ErrInviteNotPending; !errors.Is(got, want) {
 		t.Errorf("err = %v, want wrapping %v", got, want)
 	}
@@ -150,7 +180,7 @@ func TestBuildInviteLink_HappyPath(t *testing.T) {
 	invites := &recordingInviteStore{}
 	mailerStub := &recordingSender{}
 	if err := SendInviteEmail(t.Context(), invites, mailerStub,
-		"https://topbanana.example", "x@example.test", "", 1, time.Now()); err != nil {
+		"https://topbanana.example", "x@example.test", "", locale.LocaleEN, 1, time.Now()); err != nil {
 		t.Fatalf("SendInviteEmail err = %v, want nil", err)
 	}
 	body := mailerStub.sent[0].Body

--- a/internal/auth/reset.go
+++ b/internal/auth/reset.go
@@ -8,7 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// Reset-email catalog keys.
+const (
+	emailResetSubjectKey locale.MessageID = "email.reset.subject"
+	emailResetBodyKey    locale.MessageID = "email.reset.body"
 )
 
 // ResetTokenTTL is the lifetime of a forgot-password link. Shorter than
@@ -80,7 +87,7 @@ func SendResetEmail(
 	ctx context.Context,
 	tokens ResetTokenStore,
 	sender VerifyEmailSender,
-	baseURL, recipient string,
+	baseURL, recipient, loc string,
 	playerID int64,
 	now time.Time,
 ) error {
@@ -98,8 +105,8 @@ func SendResetEmail(
 	}
 	msg := mailer.Message{
 		To:      recipient,
-		Subject: "Reset your Top Banana! password",
-		Body:    resetEmailBody(link),
+		Subject: locale.Translate(loc, emailResetSubjectKey),
+		Body:    resetEmailBody(loc, link),
 		Kind:    mailer.KindReset,
 	}
 	if sendErr := sender.Send(ctx, msg); sendErr != nil {
@@ -132,12 +139,7 @@ func buildResetLink(baseURL, rawToken string) (string, error) {
 	return u.String(), nil
 }
 
-// resetEmailBody is the plain-text body of the reset email. Mirrors
-// the verify body shape so the two channels read consistently.
-func resetEmailBody(link string) string {
-	return "We received a request to reset your Top Banana! password.\n\n" +
-		"Click the link below to choose a new one:\n\n" +
-		link + "\n\n" +
-		"This link is valid for 30 minutes. If you did not request a reset,\n" +
-		"you can ignore this email.\n"
+// resetEmailBody is the plain-text body of the reset email for loc.
+func resetEmailBody(loc, link string) string {
+	return locale.TranslateWith(loc, emailResetBodyKey, map[string]string{"link": link})
 }

--- a/internal/auth/reset_test.go
+++ b/internal/auth/reset_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -33,7 +34,7 @@ func TestSendResetEmail_StoresAndSends(t *testing.T) {
 	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 
 	err := SendResetEmail(t.Context(), tokens, mailerStub,
-		"https://topbanana.example", "alice@example.test", 42, now)
+		"https://topbanana.example", "alice@example.test", locale.LocaleEN, 42, now)
 	if err != nil {
 		t.Fatalf("SendResetEmail err = %v, want nil", err)
 	}
@@ -62,6 +63,34 @@ func TestSendResetEmail_StoresAndSends(t *testing.T) {
 	if got, want := msg.Kind, mailer.KindReset; got != want {
 		t.Errorf("msg.Kind = %q, want %q", got, want)
 	}
+	if got, want := msg.Subject, "Reset your Top Banana! password"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if !strings.Contains(msg.Body, "https://topbanana.example/reset-password?token=") {
+		t.Errorf("msg.Body missing reset link, got %q", msg.Body)
+	}
+}
+
+func TestSendResetEmail_Dutch(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingResetTokenStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendResetEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", locale.LocaleNL, 42, now)
+	if err != nil {
+		t.Fatalf("SendResetEmail err = %v, want nil", err)
+	}
+
+	msg := mailerStub.sent[0]
+	if got, want := msg.Subject, "Stel je Top Banana!-wachtwoord opnieuw in"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if got, want := msg.Body, "Deze link is 30 minuten geldig"; !strings.Contains(got, want) {
+		t.Errorf("msg.Body = %q, should contain %q", got, want)
+	}
 	if !strings.Contains(msg.Body, "https://topbanana.example/reset-password?token=") {
 		t.Errorf("msg.Body missing reset link, got %q", msg.Body)
 	}
@@ -76,7 +105,7 @@ func TestSendResetEmail_StoreFailureSkipsSend(t *testing.T) {
 	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 
 	err := SendResetEmail(t.Context(), tokens, mailerStub,
-		"https://topbanana.example", "alice@example.test", 1, now)
+		"https://topbanana.example", "alice@example.test", locale.LocaleEN, 1, now)
 	if got, want := err, wantErr; !errors.Is(got, want) {
 		t.Errorf("err = %v, want wrapping %v", got, want)
 	}
@@ -93,7 +122,7 @@ func TestBuildResetLink_HappyPath(t *testing.T) {
 	tokens := &recordingResetTokenStore{}
 	mailerStub := &recordingSender{}
 	if err := SendResetEmail(t.Context(), tokens, mailerStub,
-		"https://topbanana.example", "x@example.test", 1, time.Now()); err != nil {
+		"https://topbanana.example", "x@example.test", locale.LocaleEN, 1, time.Now()); err != nil {
 		t.Fatalf("SendResetEmail err = %v, want nil", err)
 	}
 	body := mailerStub.sent[0].Body

--- a/internal/auth/verify.go
+++ b/internal/auth/verify.go
@@ -17,9 +17,7 @@ import (
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
-// Verify-email catalog keys. The register-time and email-change variants
-// carry separate subjects and bodies so a recipient who did not initiate
-// an email change can tell the two flows apart.
+// Verify-email catalog keys.
 const (
 	emailVerifySubjectKey       locale.MessageID = "email.verify.subject"
 	emailVerifyBodyKey          locale.MessageID = "email.verify.body"
@@ -151,7 +149,7 @@ func SendVerifyEmail(
 // the same plumbing. An empty pendingEmail mints a register-time row
 // that behaves identically to today's flow.
 //
-//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
+//nolint:revive // argument-limit: loc is message content; the rest is irreducible mail plumbing.
 func SendVerifyEmailWithPending(
 	ctx context.Context,
 	tokens VerifyTokenStore,
@@ -190,7 +188,7 @@ func SendVerifyEmailWithPending(
 // so an SMTP outage or a mis-typed recipient does not block the
 // signup from completing; the user can retry via the resend flow.
 //
-//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
+//nolint:revive // argument-limit: loc is message content; the rest is irreducible mail plumbing.
 func SendVerifyEmailBestEffort(
 	ctx context.Context,
 	logger *slog.Logger,

--- a/internal/auth/verify.go
+++ b/internal/auth/verify.go
@@ -13,7 +13,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
+)
+
+// Verify-email catalog keys. The register-time and email-change variants
+// carry separate subjects and bodies so a recipient who did not initiate
+// an email change can tell the two flows apart.
+const (
+	emailVerifySubjectKey       locale.MessageID = "email.verify.subject"
+	emailVerifyBodyKey          locale.MessageID = "email.verify.body"
+	emailChangeVerifySubjectKey locale.MessageID = "email.emailChangeVerify.subject"
+	emailChangeVerifyBodyKey    locale.MessageID = "email.emailChangeVerify.body"
 )
 
 // VerifyTokenTTL is the lifetime of a freshly minted verify-email link.
@@ -124,11 +135,11 @@ func SendVerifyEmail(
 	ctx context.Context,
 	tokens VerifyTokenStore,
 	sender VerifyEmailSender,
-	baseURL, recipient string,
+	baseURL, recipient, loc string,
 	playerID int64,
 	now time.Time,
 ) error {
-	return SendVerifyEmailWithPending(ctx, tokens, sender, baseURL, recipient, "", playerID, now)
+	return SendVerifyEmailWithPending(ctx, tokens, sender, baseURL, recipient, "", loc, playerID, now)
 }
 
 // SendVerifyEmailWithPending is the extended variant used by the
@@ -139,11 +150,13 @@ func SendVerifyEmail(
 // from pendingEmail so a future "notify old address" flow can reuse
 // the same plumbing. An empty pendingEmail mints a register-time row
 // that behaves identically to today's flow.
+//
+//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
 func SendVerifyEmailWithPending(
 	ctx context.Context,
 	tokens VerifyTokenStore,
 	sender VerifyEmailSender,
-	baseURL, recipient, pendingEmail string,
+	baseURL, recipient, pendingEmail, loc string,
 	playerID int64,
 	now time.Time,
 ) error {
@@ -161,8 +174,8 @@ func SendVerifyEmailWithPending(
 	}
 	msg := mailer.Message{
 		To:      recipient,
-		Subject: verifyEmailSubject(pendingEmail),
-		Body:    verifyEmailBody(link, pendingEmail),
+		Subject: verifyEmailSubject(loc, pendingEmail),
+		Body:    verifyEmailBody(loc, link, pendingEmail),
 		Kind:    mailer.KindVerify,
 	}
 	if sendErr := sender.Send(ctx, msg); sendErr != nil {
@@ -176,16 +189,18 @@ func SendVerifyEmailWithPending(
 // any failure rather than surfacing it. Used by the register handler
 // so an SMTP outage or a mis-typed recipient does not block the
 // signup from completing; the user can retry via the resend flow.
+//
+//nolint:revive // argument-limit: loc is message content alongside recipient; the rest is the irreducible mail plumbing.
 func SendVerifyEmailBestEffort(
 	ctx context.Context,
 	logger *slog.Logger,
 	tokens VerifyTokenStore,
 	sender VerifyEmailSender,
-	baseURL, recipient string,
+	baseURL, recipient, loc string,
 	playerID int64,
 	now time.Time,
 ) {
-	if err := SendVerifyEmail(ctx, tokens, sender, baseURL, recipient, playerID, now); err != nil {
+	if err := SendVerifyEmail(ctx, tokens, sender, baseURL, recipient, loc, playerID, now); err != nil {
 		logger.WarnContext(ctx, "verify email dispatch failed",
 			slog.Int64("player_id", playerID),
 			slog.String("to", recipient),
@@ -216,38 +231,28 @@ func buildVerifyLink(baseURL, rawToken string) (string, error) {
 	return u.String(), nil
 }
 
-// verifyEmailSubject returns the subject line. The register-time
-// wording stays unchanged so existing inbox filters keep matching;
-// the email-change variant ships its own subject so a recipient who
-// did not initiate the change spots it before opening the message.
-func verifyEmailSubject(pendingEmail string) string {
+// verifyEmailSubject returns the subject line for loc. The register-time
+// and email-change variants ship separate subjects so a recipient who did
+// not initiate the change spots it before opening the message.
+func verifyEmailSubject(loc, pendingEmail string) string {
 	if pendingEmail == "" {
-		return "Confirm your Top Banana! email"
+		return locale.Translate(loc, emailVerifySubjectKey)
 	}
 
-	return "Confirm your new Top Banana! email"
+	return locale.Translate(loc, emailChangeVerifySubjectKey)
 }
 
-// verifyEmailBody is the plain-text body of the verification email.
-// Plain text only - HTML alternative is out of scope for #321/#111;
-// the link is on its own line so any mail client renders it as
-// clickable. When pendingEmail is set, the body explains that
-// clicking the link switches the account's address to that value, so
-// a recipient who did not request the change can stop and ignore the
-// message instead of being surprised on their next sign-in.
-func verifyEmailBody(link, pendingEmail string) string {
+// verifyEmailBody is the plain-text body of the verification email for
+// loc. When pendingEmail is set, the body explains that clicking the link
+// switches the account's address to that value, so a recipient who did not
+// request the change can stop and ignore the message.
+func verifyEmailBody(loc, link, pendingEmail string) string {
 	if pendingEmail == "" {
-		return "Welcome to Top Banana!\n\n" +
-			"Click the link below to confirm your email address:\n\n" +
-			link + "\n\n" +
-			"This link is valid for 24 hours. If you did not sign up, you can\n" +
-			"ignore this email.\n"
+		return locale.TranslateWith(loc, emailVerifyBodyKey, map[string]string{"link": link})
 	}
 
-	return "Someone (hopefully you) asked to change a Top Banana! account email\n" +
-		"to " + pendingEmail + ".\n\n" +
-		"Click the link below to confirm the change:\n\n" +
-		link + "\n\n" +
-		"This link is valid for 24 hours. If you did not request the change,\n" +
-		"you can ignore this email and the account email will stay as it is.\n"
+	return locale.TranslateWith(loc, emailChangeVerifyBodyKey, map[string]string{
+		"pendingEmail": pendingEmail,
+		"link":         link,
+	})
 }

--- a/internal/auth/verify_gate.go
+++ b/internal/auth/verify_gate.go
@@ -182,7 +182,7 @@ func HandleVerifyResend(
 		sendCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), verifyEmailDispatchTimeout)
 		defer cancel()
 		if err := SendVerifyEmail(sendCtx, tokens, sender, baseURL,
-			p.Email, p.ID, time.Now().UTC()); err != nil {
+			p.Email, locale.Resolve(r), p.ID, time.Now().UTC()); err != nil {
 			logger.WarnContext(r.Context(), "verify resend dispatch failed",
 				slog.Int64("player_id", p.ID), slog.Any("err", err))
 			flash.SetError(w, locale.Translate(locale.Resolve(r), "verifyEmailPending.sendFailed"), 0)

--- a/internal/auth/verify_request.go
+++ b/internal/auth/verify_request.go
@@ -114,7 +114,7 @@ func HandleVerifyEmailRequestSubmit(
 
 		email := strings.ToLower(strings.TrimSpace(r.PostFormValue("email")))
 		if email != "" {
-			dispatchVerifyRequestIfMatch(r.Context(), logger, players, dispatch, email)
+			dispatchVerifyRequestIfMatch(r.Context(), logger, players, dispatch, email, locale.Resolve(r))
 		}
 
 		flash.SetNotice(w, locale.Translate(locale.Resolve(r), verifyRequestSuccessMsgKey))
@@ -133,7 +133,7 @@ func dispatchVerifyRequestIfMatch(
 	logger *slog.Logger,
 	players PlayerStore,
 	dispatch VerifyRequestDispatchDeps,
-	email string,
+	email, loc string,
 ) {
 	p, err := players.GetPlayerByEmail(ctx, email)
 	if err != nil || p.Email == "" || p.IsEmailVerified() {
@@ -148,7 +148,7 @@ func dispatchVerifyRequestIfMatch(
 	dispatch.Tasks.Go(func() {
 		defer cancel()
 		if sendErr := SendVerifyEmail(sendCtx, dispatch.Tokens, dispatch.Sender, dispatch.BaseURL,
-			p.Email, p.ID, time.Now().UTC()); sendErr != nil {
+			p.Email, loc, p.ID, time.Now().UTC()); sendErr != nil {
 			logger.WarnContext(sendCtx, "verify-email request dispatch failed",
 				slog.Int64("player_id", p.ID), slog.Any("err", sendErr))
 		}

--- a/internal/auth/verify_test.go
+++ b/internal/auth/verify_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	. "github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 )
 
@@ -111,7 +112,7 @@ func TestSendVerifyEmail_StoresHashSendsMessage(t *testing.T) {
 	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 
 	err := SendVerifyEmail(t.Context(), tokens, mailerStub,
-		"https://topbanana.example", "alice@example.test", 42, now)
+		"https://topbanana.example", "alice@example.test", locale.LocaleEN, 42, now)
 	if err != nil {
 		t.Fatalf("SendVerifyEmail err = %v, want nil", err)
 	}
@@ -140,8 +141,61 @@ func TestSendVerifyEmail_StoresHashSendsMessage(t *testing.T) {
 	if got, want := msg.Kind, mailer.KindVerify; got != want {
 		t.Errorf("msg.Kind = %q, want %q", got, want)
 	}
+	if got, want := msg.Subject, "Confirm your Top Banana! email"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
 	if !strings.Contains(msg.Body, "https://topbanana.example/verify-email?token=") {
 		t.Errorf("msg.Body missing verify link, got %q", msg.Body)
+	}
+}
+
+func TestSendVerifyEmail_Dutch(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingVerifyTokenStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendVerifyEmail(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "alice@example.test", locale.LocaleNL, 42, now)
+	if err != nil {
+		t.Fatalf("SendVerifyEmail err = %v, want nil", err)
+	}
+
+	msg := mailerStub.sent[0]
+	if got, want := msg.Subject, "Bevestig je Top Banana!-e-mailadres"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if got, want := msg.Body, "Welkom bij Top Banana!"; !strings.Contains(got, want) {
+		t.Errorf("msg.Body = %q, should contain %q", got, want)
+	}
+	if !strings.Contains(msg.Body, "https://topbanana.example/verify-email?token=") {
+		t.Errorf("msg.Body missing verify link, got %q", msg.Body)
+	}
+}
+
+func TestSendVerifyEmailWithPending_Dutch(t *testing.T) {
+	t.Parallel()
+
+	tokens := &recordingVerifyTokenStore{}
+	mailerStub := &recordingSender{}
+	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+
+	err := SendVerifyEmailWithPending(t.Context(), tokens, mailerStub,
+		"https://topbanana.example", "new@example.test", "new@example.test", locale.LocaleNL, 42, now)
+	if err != nil {
+		t.Fatalf("SendVerifyEmailWithPending err = %v, want nil", err)
+	}
+
+	msg := mailerStub.sent[0]
+	if got, want := msg.Subject, "Bevestig je nieuwe Top Banana!-e-mailadres"; got != want {
+		t.Errorf("msg.Subject = %q, want %q", got, want)
+	}
+	if got, want := msg.Body, "new@example.test"; !strings.Contains(got, want) {
+		t.Errorf("msg.Body = %q, should name the pending address %q", got, want)
+	}
+	if got, want := msg.Body, "wijzigen naar"; !strings.Contains(got, want) {
+		t.Errorf("msg.Body = %q, should contain %q", got, want)
 	}
 }
 
@@ -154,7 +208,7 @@ func TestSendVerifyEmail_StoreFailureSkipsSend(t *testing.T) {
 	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
 
 	err := SendVerifyEmail(t.Context(), tokens, mailerStub,
-		"https://topbanana.example", "alice@example.test", 1, now)
+		"https://topbanana.example", "alice@example.test", locale.LocaleEN, 1, now)
 	if got, want := err, wantErr; !errors.Is(got, want) {
 		t.Errorf("err = %v, want wrapping %v", got, want)
 	}
@@ -173,7 +227,7 @@ func TestSendVerifyEmailBestEffort_SwallowsError(t *testing.T) {
 
 	// Best-effort path must not panic or block when the store fails.
 	SendVerifyEmailBestEffort(t.Context(), logger, tokens, mailerStub,
-		"https://topbanana.example", "alice@example.test", 1, now)
+		"https://topbanana.example", "alice@example.test", locale.LocaleEN, 1, now)
 
 	if got, want := len(mailerStub.sent), 0; got != want {
 		t.Errorf("mailer.sent len = %d, want %d", got, want)

--- a/internal/locale/en.json
+++ b/internal/locale/en.json
@@ -310,5 +310,29 @@
   "join.joinError": "Couldn't join the game. Try again.",
   "join.noGameFound": "No game found with that code.",
   "join.gameStarted": "This game has already started.",
-  "join.alreadyPlayed": "You've already played this quiz."
+  "join.alreadyPlayed": "You've already played this quiz.",
+
+  "email.verify.subject": "Confirm your Top Banana! email",
+  "email.verify.body": "Welcome to Top Banana!\n\nClick the link below to confirm your email address:\n\n{link}\n\nThis link is valid for 24 hours. If you did not sign up, you can ignore this email.\n",
+
+  "email.emailChangeVerify.subject": "Confirm your new Top Banana! email",
+  "email.emailChangeVerify.body": "Someone (hopefully you) asked to change a Top Banana! account email to {pendingEmail}.\n\nClick the link below to confirm the change:\n\n{link}\n\nThis link is valid for 24 hours. If you did not request the change, you can ignore this email and the account email will stay as it is.\n",
+
+  "email.reset.subject": "Reset your Top Banana! password",
+  "email.reset.body": "We received a request to reset your Top Banana! password.\n\nClick the link below to choose a new one:\n\n{link}\n\nThis link is valid for 30 minutes. If you did not request a reset, you can ignore this email.\n",
+
+  "email.invite.subject": "You are invited to Top Banana!",
+  "email.invite.body": "You have been invited to join Top Banana!\n\nUse the link below to choose a display name and password and set up your account:\n\n{link}\n\nThis link is valid for 7 days. If you were not expecting this invite, you can ignore this email.\n",
+
+  "email.emailChangeNotice.subject": "Email change requested for your Top Banana! account",
+  "email.emailChangeNotice.body": "Someone requested to change the email on your Top Banana! account to {newEmail}.\n\nYour account email has not changed yet; it only changes when the verification link sent to the new address is clicked.\n\nIf this was you, no action is needed. If it was not you, change your password now to secure your account.\n",
+
+  "email.registerExisting.subject": "Someone tried to register with your Top Banana! email",
+  "email.registerExisting.body": "Someone tried to create a Top Banana! account with this email address.\n\nAn account already exists for this address. If it was you, sign in or reset your password instead.\n\nIf it was not you, no action is needed.\n",
+
+  "email.roleChange.subject": "Your Top Banana! account role changed",
+  "email.roleChange.body": "An administrator changed the role on your Top Banana! account to {role}.\n\nIf you have questions about this change, contact the site administrator.\n",
+  "email.roleChange.rolePlayer": "player",
+  "email.roleChange.roleHost": "host",
+  "email.roleChange.roleAdmin": "admin"
 }

--- a/internal/locale/nl.json
+++ b/internal/locale/nl.json
@@ -310,5 +310,29 @@
   "join.joinError": "Meedoen aan het spel lukte niet. Probeer het opnieuw.",
   "join.noGameFound": "Geen spel gevonden met die code.",
   "join.gameStarted": "Dit spel is al begonnen.",
-  "join.alreadyPlayed": "Je hebt deze quiz al gespeeld."
+  "join.alreadyPlayed": "Je hebt deze quiz al gespeeld.",
+
+  "email.verify.subject": "Bevestig je Top Banana!-e-mailadres",
+  "email.verify.body": "Welkom bij Top Banana!\n\nKlik op de onderstaande link om je e-mailadres te bevestigen:\n\n{link}\n\nDeze link is 24 uur geldig. Als je je niet hebt aangemeld, kun je deze e-mail negeren.\n",
+
+  "email.emailChangeVerify.subject": "Bevestig je nieuwe Top Banana!-e-mailadres",
+  "email.emailChangeVerify.body": "Iemand (hopelijk jij) heeft gevraagd om het e-mailadres van een Top Banana!-account te wijzigen naar {pendingEmail}.\n\nKlik op de onderstaande link om de wijziging te bevestigen:\n\n{link}\n\nDeze link is 24 uur geldig. Als je de wijziging niet hebt aangevraagd, kun je deze e-mail negeren en blijft het account-e-mailadres ongewijzigd.\n",
+
+  "email.reset.subject": "Stel je Top Banana!-wachtwoord opnieuw in",
+  "email.reset.body": "We hebben een verzoek ontvangen om je Top Banana!-wachtwoord opnieuw in te stellen.\n\nKlik op de onderstaande link om een nieuw wachtwoord te kiezen:\n\n{link}\n\nDeze link is 30 minuten geldig. Als je geen reset hebt aangevraagd, kun je deze e-mail negeren.\n",
+
+  "email.invite.subject": "Je bent uitgenodigd voor Top Banana!",
+  "email.invite.body": "Je bent uitgenodigd voor Top Banana!\n\nGebruik de onderstaande link om een weergavenaam en wachtwoord te kiezen en je account in te stellen:\n\n{link}\n\nDeze link is 7 dagen geldig. Als je deze uitnodiging niet verwachtte, kun je deze e-mail negeren.\n",
+
+  "email.emailChangeNotice.subject": "E-mailwijziging aangevraagd voor je Top Banana!-account",
+  "email.emailChangeNotice.body": "Iemand heeft gevraagd om het e-mailadres van je Top Banana!-account te wijzigen naar {newEmail}.\n\nJe account-e-mailadres is nog niet gewijzigd; dat gebeurt pas als op de verificatielink naar het nieuwe adres wordt geklikt.\n\nAls jij dit was, hoef je niets te doen. Was jij dit niet, wijzig dan nu je wachtwoord om je account te beveiligen.\n",
+
+  "email.registerExisting.subject": "Iemand probeerde te registreren met je Top Banana!-e-mailadres",
+  "email.registerExisting.body": "Iemand heeft geprobeerd een Top Banana!-account aan te maken met dit e-mailadres.\n\nEr bestaat al een account voor dit adres. Als jij dit was, log dan in of stel in plaats daarvan je wachtwoord opnieuw in.\n\nWas jij dit niet, dan hoef je niets te doen.\n",
+
+  "email.roleChange.subject": "De rol van je Top Banana!-account is gewijzigd",
+  "email.roleChange.body": "Een beheerder heeft de rol op je Top Banana!-account gewijzigd naar {role}.\n\nHeb je vragen over deze wijziging, neem dan contact op met de sitebeheerder.\n",
+  "email.roleChange.rolePlayer": "speler",
+  "email.roleChange.roleHost": "host",
+  "email.roleChange.roleAdmin": "beheerder"
 }

--- a/internal/profile/email.go
+++ b/internal/profile/email.go
@@ -24,6 +24,14 @@ const (
 	EmailChangeFlashCookiePath = "/profile/email"
 )
 
+// Email-change-notice catalog keys. The notice goes to the account's
+// current address (the authenticated user's own mailbox), so the
+// triggering request's locale is the right one.
+const (
+	emailChangeNoticeSubjectKey locale.MessageID = "email.emailChangeNotice.subject"
+	emailChangeNoticeBodyKey    locale.MessageID = "email.emailChangeNotice.body"
+)
+
 // emailDispatchTimeout caps the detached SMTP attempt the POST
 // handler spawns. Matches the verify-resend / forgot-password
 // timeout: above mailer.SendTimeout so the inner dial gets its own
@@ -159,7 +167,7 @@ func HandleProfileEmailChange(logger *slog.Logger, deps EmailChangeDeps) http.Ha
 			return
 		}
 
-		dispatchEmailChangeIfFree(r.Context(), logger, deps, player.ID, player.Email, newEmail)
+		dispatchEmailChangeIfFree(r.Context(), logger, deps, player.ID, player.Email, newEmail, loc)
 
 		// Always flash the same notice regardless of whether the
 		// address was free. The "if not already in use" wording is
@@ -204,7 +212,7 @@ func dispatchEmailChangeIfFree(
 	logger *slog.Logger,
 	deps EmailChangeDeps,
 	playerID int64,
-	oldEmail, newEmail string,
+	oldEmail, newEmail, loc string,
 ) {
 	existing, err := deps.Players.GetPlayerByEmail(ctx, newEmail)
 	switch {
@@ -231,12 +239,12 @@ func dispatchEmailChangeIfFree(
 		defer cancel()
 		if sendErr := auth.SendVerifyEmailWithPending(
 			sendCtx, deps.Tokens, deps.Sender, deps.BaseURL,
-			newEmail, newEmail, playerID, time.Now().UTC(),
+			newEmail, newEmail, loc, playerID, time.Now().UTC(),
 		); sendErr != nil {
 			logger.WarnContext(sendCtx, "profile email change dispatch failed",
 				slog.Int64("player_id", playerID), slog.Any("err", sendErr))
 		}
-		notifyOldAddressOfChange(sendCtx, logger, deps.Sender, playerID, oldEmail, newEmail)
+		notifyOldAddressOfChange(sendCtx, logger, deps.Sender, playerID, oldEmail, newEmail, loc)
 	})
 }
 
@@ -251,15 +259,13 @@ func notifyOldAddressOfChange(
 	logger *slog.Logger,
 	sender auth.VerifyEmailSender,
 	playerID int64,
-	oldEmail, newEmail string,
+	oldEmail, newEmail, loc string,
 ) {
 	msg := mailer.Message{
 		To:      oldEmail,
-		Subject: "Email change requested for your Top Banana! account",
-		Body: "Someone requested to change the email on your Top Banana! account to " + newEmail + ".\n\n" +
-			"Your account email has not changed yet; it only changes when the verification link sent to the new address is clicked.\n\n" +
-			"If this was you, no action is needed. If it was not you, change your password now to secure your account.\n",
-		Kind: mailer.KindEmailChangeNotice,
+		Subject: locale.Translate(loc, emailChangeNoticeSubjectKey),
+		Body:    locale.TranslateWith(loc, emailChangeNoticeBodyKey, map[string]string{"newEmail": newEmail}),
+		Kind:    mailer.KindEmailChangeNotice,
 	}
 	if err := sender.Send(ctx, msg); err != nil {
 		logger.WarnContext(ctx, "profile email change notice to old address failed",

--- a/internal/profile/email.go
+++ b/internal/profile/email.go
@@ -24,9 +24,8 @@ const (
 	EmailChangeFlashCookiePath = "/profile/email"
 )
 
-// Email-change-notice catalog keys. The notice goes to the account's
-// current address (the authenticated user's own mailbox), so the
-// triggering request's locale is the right one.
+// Email-change-notice catalog keys; the notice goes to the user's own
+// mailbox, so the triggering request's locale is the right one.
 const (
 	emailChangeNoticeSubjectKey locale.MessageID = "email.emailChangeNotice.subject"
 	emailChangeNoticeBodyKey    locale.MessageID = "email.emailChangeNotice.body"

--- a/internal/profile/email_test.go
+++ b/internal/profile/email_test.go
@@ -186,6 +186,19 @@ func postEmailChange(
 ) emailChangeResult {
 	t.Helper()
 
+	return postEmailChangeLang(t, players, player, currentPassword, "")
+}
+
+// postEmailChangeLang is postEmailChange with an explicit UI language: a
+// non-empty lang sets the lang cookie so the handler resolves that locale.
+func postEmailChangeLang(
+	t *testing.T,
+	players *store.PlayerStore,
+	player *auth.Player,
+	currentPassword, lang string,
+) emailChangeResult {
+	t.Helper()
+
 	var logs strings.Builder
 	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	sender := newEmailStubSender()
@@ -211,6 +224,9 @@ func postEmailChange(
 		t.Context(), http.MethodPost, "/profile/email", strings.NewReader(form.Encode()),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if lang != "" {
+		req.AddCookie(&http.Cookie{Name: locale.CookieName, Value: lang})
+	}
 	req = req.WithContext(auth.WithPlayer(req.Context(), player))
 
 	rec := httptest.NewRecorder()
@@ -327,6 +343,40 @@ func TestHandleProfileEmailChange_CorrectPasswordDispatchesAndNotifiesOldAddress
 	}
 	if got, want := noticeTo, emailChangeOldAddr; got != want {
 		t.Errorf("notice mail To = %q, want old address %q", got, want)
+	}
+}
+
+func TestHandleProfileEmailChange_DutchNotice(t *testing.T) {
+	t.Parallel()
+
+	players, player := seedPasswordPlayer(t)
+	res := postEmailChangeLang(t, players, player, "correct-battery-13", locale.LocaleNL)
+
+	if got, want := res.rec.Code, http.StatusSeeOther; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+
+	res.sender.waitForSends(t, 2)
+
+	for _, m := range res.sender.snapshot() {
+		if m.Kind == mailer.KindVerify {
+			if got, want := m.Subject, "Bevestig je nieuwe Top Banana!-e-mailadres"; got != want {
+				t.Errorf("verify subject = %q, want %q", got, want)
+			}
+
+			continue
+		}
+		if m.Kind == mailer.KindEmailChangeNotice {
+			if got, want := m.Subject, "E-mailwijziging aangevraagd voor je Top Banana!-account"; got != want {
+				t.Errorf("notice subject = %q, want %q", got, want)
+			}
+			if got, want := m.Body, "dat gebeurt pas als op de verificatielink"; !strings.Contains(got, want) {
+				t.Errorf("notice body = %q, should contain %q", got, want)
+			}
+
+			continue
+		}
+		t.Errorf("unexpected mail Kind %q", m.Kind)
 	}
 }
 

--- a/test/integration/verify_email_test.go
+++ b/test/integration/verify_email_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/locale"
 	"github.com/starquake/topbanana/internal/mailer"
 	"github.com/starquake/topbanana/internal/store"
 )
@@ -268,7 +269,7 @@ func TestSendVerifyEmail_RoundtripStoresAndSends(t *testing.T) {
 	tester := mailer.NewTester(mailer.NewNoop())
 	err = auth.SendVerifyEmail(
 		ctx, stores.VerifyTokens, tester,
-		"https://topbanana.example", player.Email, player.ID, time.Now(),
+		"https://topbanana.example", player.Email, locale.LocaleEN, player.ID, time.Now(),
 	)
 	if got, want := err, mailer.ErrNotConfigured; !errors.Is(got, want) {
 		t.Errorf("err = %v, want %v (no-op mailer wraps to ErrNotConfigured)", got, want)


### PR DESCRIPTION
Completes the i18n work (#1115 / #1197): the outbound emails are now sent in English or Dutch instead of always English.

## What's localized

The 7 user-facing emails — register verification, email-change verification, password reset, invite (initial + resend), the notice to your old address on an email change, the "someone tried to register with your email" notice, and the role-change notice — now render from the `internal/locale` catalog (new `email.*` keys, EN + NL) with token substitution for the link, expiry, name, and role.

## How the locale is chosen

Emails render outside a live request, so the locale is resolved from the **triggering request** (`locale.Resolve(r)`) and threaded through the mailer builders. It is captured on the request goroutine *before* the detached send goroutine spawns (`r` is never touched inside the goroutine). For the self-service flows this is exactly right — the person who registers / resets / changes their email is the recipient, so they get the email in the language they were just using.

**One honest limitation:** invite and role-change emails go to someone *other* than the person who triggered them, and there is no stored per-user locale, so those two use the **triggering admin's** UI language (noted in the code at each call site). A persisted per-player locale would fix that; it's out of scope here.

Left English on purpose:
- The **"someone tried to register with your email" notice** — it goes to the existing account owner but is triggered by an *unauthenticated* submitter who controls their own request locale, so localizing it there would let a third party choose the language of a security email sent to a victim. It stays English (its catalog keys are kept for a future per-recipient-locale fix).
- The admin SMTP **diagnostic test email** (admin-facing, like the rest of the admin UI).

Catalog now 293 keys at exact EN/NL parity, no em-dash-style dashes. Per-email Dutch subject/body tests added.

Reviewed with `/code-review` (high), `/go-style-review`, and the `comment-cleanup` skill.

Closes #1199

_— Claude Code, for @starquake_
