### PR TITLE
Prune admin_audit rows older than 6 months

### DIFF
--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -337,6 +337,7 @@ type inviteSweeper interface {
 type retentionSweeper interface {
 	SweepStaleAnonymousPlayers(ctx context.Context, days int) error
 	SweepAbandonedGames(ctx context.Context, days int) error
+	SweepStaleAuditLog(ctx context.Context, days int) error
 }
 
 // mediaSweeper is the slice of the media service the sweep calls: drop the
@@ -354,15 +355,18 @@ func runMediaSweep(ctx context.Context, logger *slog.Logger, mediaSweep mediaSwe
 	}
 }
 
-// runRetentionSweep runs both data-retention sweeps once with the configured
+// runRetentionSweep runs the data-retention sweeps once with the configured
 // retention windows, logging each failure at warn so a transient error in one
-// does not skip the other or abort the surrounding token sweep.
+// does not skip the others or abort the surrounding token sweep.
 func runRetentionSweep(ctx context.Context, logger *slog.Logger, retention retentionSweeper) {
 	if err := retention.SweepStaleAnonymousPlayers(ctx, store.AnonymousRetentionDays); err != nil {
 		logger.WarnContext(ctx, "anonymous-player retention sweep failed", slog.Any("err", err))
 	}
 	if err := retention.SweepAbandonedGames(ctx, store.AbandonedGameDays); err != nil {
 		logger.WarnContext(ctx, "abandoned-game retention sweep failed", slog.Any("err", err))
+	}
+	if err := retention.SweepStaleAuditLog(ctx, store.AdminAuditRetentionDays); err != nil {
+		logger.WarnContext(ctx, "admin-audit retention sweep failed", slog.Any("err", err))
 	}
 }
 
@@ -383,8 +387,9 @@ func startSweeps(ctx context.Context, cfg *config.Config, logger *slog.Logger, s
 
 // sweepExpiredAtStartup runs the one-shot expiry sweep across the verify,
 // reset, and invite token tables plus the data-retention sweeps (stale
-// anonymous players and abandoned games) and the stale not-ready media sweep
-// at boot, before the periodic sweep goroutine takes over. Each failure is
+// anonymous players, abandoned games, and the admin-audit log) and the stale
+// not-ready media sweep at boot, before the periodic sweep goroutine takes
+// over. Each failure is
 // logged at warn and the others still run; a single table's transient error
 // must not skip the rest.
 func sweepExpiredAtStartup(
@@ -405,8 +410,9 @@ func sweepExpiredAtStartup(
 
 // runTokenSweep ticks at interval and on each iteration runs the verify,
 // reset, and invite token expiry sweeps plus the data-retention sweeps
-// (stale anonymous players and abandoned games) and the stale not-ready
-// media sweep. Returns when ctx is cancelled (which is the signal-driven
+// (stale anonymous players, abandoned games, and the admin-audit log) and the
+// stale not-ready media sweep. Returns when ctx is cancelled (which is the
+// signal-driven
 // shutdown context, so a graceful shutdown stops the sweep before the DB is
 // closed). A sweep failure is logged at warn and the loop continues; one bad
 // tick should not silence the next hour's pass.

--- a/cmd/server/app/app_test.go
+++ b/cmd/server/app/app_test.go
@@ -138,12 +138,14 @@ func (s *stubInviteSweep) Calls() int {
 // called and optionally returns an error. Concurrent-safe so the sweep
 // goroutine and the test can touch it from different goroutines.
 type stubRetentionSweep struct {
-	mu               sync.Mutex
-	anonCalls        int
-	gameCalls        int
-	lastAnonDays     int
-	lastGameDays     int
-	anonErr, gameErr error
+	mu                         sync.Mutex
+	anonCalls                  int
+	gameCalls                  int
+	auditCalls                 int
+	lastAnonDays               int
+	lastGameDays               int
+	lastAuditDays              int
+	anonErr, gameErr, auditErr error
 }
 
 func (s *stubRetentionSweep) SweepStaleAnonymousPlayers(_ context.Context, days int) error {
@@ -164,6 +166,16 @@ func (s *stubRetentionSweep) SweepAbandonedGames(_ context.Context, days int) er
 	s.lastGameDays = days
 
 	return s.gameErr
+}
+
+func (s *stubRetentionSweep) SweepStaleAuditLog(_ context.Context, days int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.auditCalls++
+	s.lastAuditDays = days
+
+	return s.auditErr
 }
 
 func (s *stubRetentionSweep) AnonCalls() int {
@@ -192,6 +204,20 @@ func (s *stubRetentionSweep) LastGameDays() int {
 	defer s.mu.Unlock()
 
 	return s.lastGameDays
+}
+
+func (s *stubRetentionSweep) AuditCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.auditCalls
+}
+
+func (s *stubRetentionSweep) LastAuditDays() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.lastAuditDays
 }
 
 // stubMediaSweep counts how many times the media sweep ran. Concurrent-safe
@@ -243,12 +269,13 @@ func TestRunTokenSweep_TicksUntilCancel(t *testing.T) {
 	// Wait until at least one tick lands on each store before cancelling.
 	deadline := time.After(time.Second)
 	for verify.Calls() <= 0 || reset.Calls() <= 0 || invites.Calls() <= 0 ||
-		retention.AnonCalls() <= 0 || retention.GameCalls() <= 0 || mediaSweep.Calls() <= 0 {
+		retention.AnonCalls() <= 0 || retention.GameCalls() <= 0 || retention.AuditCalls() <= 0 ||
+		mediaSweep.Calls() <= 0 {
 		select {
 		case <-deadline:
-			t.Fatalf("sweep did not tick; verify=%d reset=%d invites=%d anon=%d game=%d media=%d",
+			t.Fatalf("sweep did not tick; verify=%d reset=%d invites=%d anon=%d game=%d audit=%d media=%d",
 				verify.Calls(), reset.Calls(), invites.Calls(),
-				retention.AnonCalls(), retention.GameCalls(), mediaSweep.Calls())
+				retention.AnonCalls(), retention.GameCalls(), retention.AuditCalls(), mediaSweep.Calls())
 		case <-time.After(time.Millisecond):
 		}
 	}
@@ -272,8 +299,9 @@ func TestRunTokenSweep_ContinuesAfterError(t *testing.T) {
 	reset := &stubResetSweep{err: errors.New("reset sweep failed")}
 	invites := &stubInviteSweep{err: errors.New("invite sweep failed")}
 	retention := &stubRetentionSweep{
-		anonErr: errors.New("anon sweep failed"),
-		gameErr: errors.New("game sweep failed"),
+		anonErr:  errors.New("anon sweep failed"),
+		gameErr:  errors.New("game sweep failed"),
+		auditErr: errors.New("audit sweep failed"),
 	}
 	mediaSweep := &stubMediaSweep{}
 
@@ -291,12 +319,12 @@ func TestRunTokenSweep_ContinuesAfterError(t *testing.T) {
 	// invariant is observable.
 	deadline := time.After(time.Second)
 	for verify.Calls() < 2 || reset.Calls() < 2 || invites.Calls() < 2 ||
-		retention.AnonCalls() < 2 || retention.GameCalls() < 2 {
+		retention.AnonCalls() < 2 || retention.GameCalls() < 2 || retention.AuditCalls() < 2 {
 		select {
 		case <-deadline:
-			t.Fatalf("sweep did not tick twice; verify=%d reset=%d invites=%d anon=%d game=%d",
+			t.Fatalf("sweep did not tick twice; verify=%d reset=%d invites=%d anon=%d game=%d audit=%d",
 				verify.Calls(), reset.Calls(), invites.Calls(),
-				retention.AnonCalls(), retention.GameCalls())
+				retention.AnonCalls(), retention.GameCalls(), retention.AuditCalls())
 		case <-time.After(time.Millisecond):
 		}
 	}
@@ -321,15 +349,21 @@ func TestRunRetentionSweep_PassesConfiguredWindows(t *testing.T) {
 	if got, want := retention.LastGameDays(), store.AbandonedGameDays; got != want {
 		t.Errorf("game sweep days = %d, want %d", got, want)
 	}
+	if got, want := retention.LastAuditDays(), store.AdminAuditRetentionDays; got != want {
+		t.Errorf("audit sweep days = %d, want %d", got, want)
+	}
 }
 
-// TestRunRetentionSweep_RunsGameSweepAfterAnonError pins that a failure in
-// the anonymous-player sweep does not skip the abandoned-game sweep: both
-// run on every pass regardless of the other's outcome.
-func TestRunRetentionSweep_RunsGameSweepAfterAnonError(t *testing.T) {
+// TestRunRetentionSweep_RunsRemainingSweepsAfterEarlierError pins that a failure
+// in an earlier sweep does not skip the later ones: every sweep runs on each
+// pass regardless of the others' outcomes.
+func TestRunRetentionSweep_RunsRemainingSweepsAfterEarlierError(t *testing.T) {
 	t.Parallel()
 
-	retention := &stubRetentionSweep{anonErr: errors.New("anon sweep failed")}
+	retention := &stubRetentionSweep{
+		anonErr: errors.New("anon sweep failed"),
+		gameErr: errors.New("game sweep failed"),
+	}
 
 	RunRetentionSweep(t.Context(), slog.New(slog.DiscardHandler), retention)
 
@@ -338,6 +372,9 @@ func TestRunRetentionSweep_RunsGameSweepAfterAnonError(t *testing.T) {
 	}
 	if got, want := retention.GameCalls(), 1; got != want {
 		t.Errorf("game sweep calls = %d, want %d", got, want)
+	}
+	if got, want := retention.AuditCalls(), 1; got != want {
+		t.Errorf("audit sweep calls = %d, want %d", got, want)
 	}
 }
 

--- a/internal/db/retention.sql.go
+++ b/internal/db/retention.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 )
 
@@ -36,6 +37,23 @@ func (q *Queries) DeletePlayersByIDs(ctx context.Context, ids []int64) error {
 	}
 	_, err := q.db.ExecContext(ctx, query, queryParams...)
 	return err
+}
+
+const deleteStaleAuditLog = `-- name: DeleteStaleAuditLog :execresult
+DELETE
+FROM admin_audit
+WHERE created_at < datetime('now', '-' || CAST(?1 AS INTEGER) || ' days')
+`
+
+// Prunes admin_audit rows created more than the retention window ago (#628).
+// admin_audit is a low-volume, self-contained table (no rows FK-reference it),
+// so a single date-range DELETE suffices with no id-list batching. The window
+// in days is a caller-supplied integer, but the cutoff is computed in SQL
+// (datetime('now', '-<days> days')) so both sides of the comparison are SQLite
+// text in the CURRENT_TIMESTAMP encoding rows are minted with, not a
+// cross-format Go time.Time comparison.
+func (q *Queries) DeleteStaleAuditLog(ctx context.Context, days int64) (sql.Result, error) {
+	return q.db.ExecContext(ctx, deleteStaleAuditLog, days)
 }
 
 const filterAnonymousPlayerIDs = `-- name: FilterAnonymousPlayerIDs :many

--- a/internal/queries/retention.sql
+++ b/internal/queries/retention.sql
@@ -81,3 +81,15 @@ WHERE g.created_at < datetime('now', '-' || CAST(sqlc.arg('days') AS INTEGER) ||
     AND (SELECT COUNT(*) FROM game_questions gqc WHERE gqc.game_id = g.id) >=
         (SELECT COUNT(*) FROM questions qc WHERE qc.quiz_id = g.quiz_id)
   );
+
+-- name: DeleteStaleAuditLog :execresult
+-- Prunes admin_audit rows created more than the retention window ago (#628).
+-- admin_audit is a low-volume, self-contained table (no rows FK-reference it),
+-- so a single date-range DELETE suffices with no id-list batching. The window
+-- in days is a caller-supplied integer, but the cutoff is computed in SQL
+-- (datetime('now', '-<days> days')) so both sides of the comparison are SQLite
+-- text in the CURRENT_TIMESTAMP encoding rows are minted with, not a
+-- cross-format Go time.Time comparison.
+DELETE
+FROM admin_audit
+WHERE created_at < datetime('now', '-' || CAST(sqlc.arg('days') AS INTEGER) || ' days');

--- a/internal/store/retention.go
+++ b/internal/store/retention.go
@@ -30,12 +30,16 @@ const (
 	// AbandonedGameDays is how long after creation a never-finished game is
 	// kept before the sweep prunes it (#627).
 	AbandonedGameDays = 30
+	// AdminAuditRetentionDays is how long an admin_audit row is kept before the
+	// sweep prunes it (#628).
+	AdminAuditRetentionDays = 180
 )
 
 // RetentionStore runs the periodic data-retention sweeps: it prunes stale
-// anonymous players together with all their game data (#626) and abandoned,
-// never-finished games regardless of player (#627). Each sweep takes its
-// retention window in days and computes the cutoff date in SQL.
+// anonymous players together with all their game data (#626), abandoned,
+// never-finished games regardless of player (#627), and admin_audit rows past
+// their retention window (#628). Each sweep takes its retention window in days
+// and computes the cutoff date in SQL.
 type RetentionStore struct {
 	q      *db.Queries
 	db     *sql.DB
@@ -100,6 +104,17 @@ func (s *RetentionStore) SweepAbandonedGames(ctx context.Context, days int) erro
 		if err != nil {
 			return fmt.Errorf("failed to sweep abandoned games: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// SweepStaleAuditLog hard-deletes admin_audit rows created more than days ago
+// (#628). One date-range DELETE with no id-list batching: admin_audit is
+// low-volume and nothing FK-references it, so there is no chunking concern.
+func (s *RetentionStore) SweepStaleAuditLog(ctx context.Context, days int) error {
+	if _, err := s.q.DeleteStaleAuditLog(ctx, int64(days)); err != nil {
+		return fmt.Errorf("failed to sweep stale audit log: %w", err)
 	}
 
 	return nil

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -72,6 +72,36 @@ func TestRetentionSweep(t *testing.T) {
 	assertRetention(ctx, t, db, seed)
 }
 
+// TestSweepStaleAuditLog prunes admin_audit rows older than the 180-day
+// retention window while keeping rows inside it, including the rows straddling
+// the cutoff boundary (#628). created_at is stamped via SQLite datetime
+// expressions so the cutoff comparison runs against production-shaped
+// timestamps.
+func TestSweepStaleAuditLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	db := dbtest.Open(t)
+
+	actorID := insertSignedInPlayer(ctx, t, db, "audit-actor", seedRecent)
+	targetID := insertAnonPlayer(ctx, t, db, "audit-target", seedRecent)
+
+	oldID := insertAuditLog(ctx, t, db, actorID, targetID, "datetime('now', '-200 days')")
+	justOverID := insertAuditLog(ctx, t, db, actorID, targetID, "datetime('now', '-181 days')")
+	justUnderID := insertAuditLog(ctx, t, db, actorID, targetID, "datetime('now', '-179 days')")
+	recentID := insertAuditLog(ctx, t, db, actorID, targetID, seedRecent)
+
+	retention := NewRetentionStore(db, slog.Default())
+	if err := retention.SweepStaleAuditLog(ctx, AdminAuditRetentionDays); err != nil {
+		t.Fatalf("SweepStaleAuditLog err = %v, want nil", err)
+	}
+
+	assertAuditAbsent(ctx, t, db, oldID)
+	assertAuditAbsent(ctx, t, db, justOverID)
+	assertAuditPresent(ctx, t, db, justUnderID)
+	assertAuditPresent(ctx, t, db, recentID)
+}
+
 // TestDeletePlayersByIDs_SkipsClaimedPlayer: DeletePlayersByIDs deletes a still-
 // anonymous id but spares a since-claimed one in the same call (#1175).
 func TestDeletePlayersByIDs_SkipsClaimedPlayer(t *testing.T) {
@@ -528,6 +558,26 @@ func insertSeenRound(
 	}
 }
 
+func insertAuditLog(
+	ctx context.Context,
+	t *testing.T,
+	db *sql.DB,
+	actorID, targetID int64,
+	at string,
+) int64 {
+	t.Helper()
+	res, err := db.ExecContext(ctx,
+		`INSERT INTO admin_audit (actor_player_id, target_player_id, action, payload, created_at)
+		 VALUES (?, ?, 'verify', '{}', `+at+`)`,
+		actorID, targetID,
+	)
+	if err != nil {
+		t.Fatalf("insert admin_audit err = %v, want nil", err)
+	}
+
+	return lastID(t, res)
+}
+
 func lastID(t *testing.T, res sql.Result) int64 {
 	t.Helper()
 	id, err := res.LastInsertId()
@@ -573,6 +623,20 @@ func assertGamePresent(ctx context.Context, t *testing.T, db *sql.DB, id string)
 	t.Helper()
 	if got := countRows(ctx, t, db, `SELECT COUNT(*) FROM games WHERE id = ?`, id); got != 1 {
 		t.Errorf("game %q rows = %d, want 1 (should survive)", id, got)
+	}
+}
+
+func assertAuditAbsent(ctx context.Context, t *testing.T, db *sql.DB, id int64) {
+	t.Helper()
+	if got := countRows(ctx, t, db, `SELECT COUNT(*) FROM admin_audit WHERE id = ?`, id); got != 0 {
+		t.Errorf("admin_audit %d rows = %d, want 0 (should be swept)", id, got)
+	}
+}
+
+func assertAuditPresent(ctx context.Context, t *testing.T, db *sql.DB, id int64) {
+	t.Helper()
+	if got := countRows(ctx, t, db, `SELECT COUNT(*) FROM admin_audit WHERE id = ?`, id); got != 1 {
+		t.Errorf("admin_audit %d rows = %d, want 1 (should survive)", id, got)
 	}
 }
 


### PR DESCRIPTION
Prunes `admin_audit` rows older than 6 months, so the audit log no longer grows without bound.

## What changed

- New `AdminAuditRetentionDays = 180` window constant next to the existing `AnonymousRetentionDays` / `AbandonedGameDays`, and a `RetentionStore.SweepStaleAuditLog` method backed by a single date-range `DELETE` (the table is low-volume and nothing FK-references it, so no id-list batching is needed).
- Wired into `runRetentionSweep` alongside the other two sweeps, so it rides the existing startup + hourly pass — no new goroutine or schedule. A failure is warn-logged without skipping the others.
- Layer test backdating `admin_audit` rows around the cutoff (200d/181d pruned, 179d/1h kept) plus loop-test coverage that the sweep is invoked with the configured window.

## Note on the retention decision

The ticket floated an env-configurable, default-off knob, but the two existing retention sweeps are always-on day constants (no env), so this follows that convention: a fixed 180-day always-on prune. If you'd rather it be operator-configurable or default-off, say so and I'll switch it. The actor FK is already `ON DELETE SET NULL`, so this only prunes by age.

Closes #628

_— Claude Code, for @starquake_
