### PR TITLE
Add a -verify-email server command

### DIFF
--- a/cmd/server/app/commands.go
+++ b/cmd/server/app/commands.go
@@ -117,6 +117,15 @@ var errPromoteEmailRequired = errors.New("email is required")
 // matches the supplied email.
 var errPromoteEmailNotFound = errors.New("email not found")
 
+// errVerifyEmailRequired is wrapped by [VerifyEmail] when the supplied email
+// trims to empty; defined at package scope so callers and tests can match it
+// via [errors.Is].
+var errVerifyEmailRequired = errors.New("email is required")
+
+// errVerifyEmailNotFound is wrapped by [VerifyEmail] when no player row
+// matches the supplied email.
+var errVerifyEmailNotFound = errors.New("email not found")
+
 // errSeedDemoDisabled is returned by SeedDemo when demo mode (Config.DemoMode,
 // from DEMO_MODE_ENABLED) is off; defined at package scope so callers can match
 // it via [errors.Is].
@@ -183,6 +192,60 @@ func PromoteAdmin(
 		return fmt.Errorf("promote admin: write confirmation: %w", err)
 	}
 	logger.InfoContext(ctx, "promoted to admin", slog.String("email", email))
+
+	return nil
+}
+
+// VerifyEmail stamps email_verified_at for the player with the given email, the
+// break-glass path to verify an account when no SMTP is configured to send the
+// mailed link. The server should not be running concurrently against the same
+// database.
+func VerifyEmail(
+	ctx context.Context,
+	getenv func(string) string,
+	stdout, stderr io.Writer,
+	email string,
+) error {
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return fmt.Errorf("verify email: %w", errVerifyEmailRequired)
+	}
+
+	dbc, err := config.ParseDatabase(getenv)
+	if err != nil {
+		return fmt.Errorf("verify email: parse config: %w", err)
+	}
+
+	conn, err := setupDB(ctx, dbc, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			logger.ErrorContext(ctx, "error closing database connection", slog.Any("err", cerr))
+		}
+	}()
+
+	players := store.NewPlayerStore(conn, logger)
+	player, err := players.GetPlayerByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, auth.ErrPlayerNotFound) {
+			return fmt.Errorf("verify email: %w (%q)", errVerifyEmailNotFound, email)
+		}
+
+		return fmt.Errorf("verify email: %w", err)
+	}
+
+	if err := players.SetPlayerEmailVerifiedNow(ctx, player.ID); err != nil {
+		return fmt.Errorf("verify email: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(stdout, "Verified email for %q.\n", email); err != nil {
+		return fmt.Errorf("verify email: write confirmation: %w", err)
+	}
+	logger.InfoContext(ctx, "email verified", slog.String("email", email))
 
 	return nil
 }

--- a/cmd/server/app/commands_test.go
+++ b/cmd/server/app/commands_test.go
@@ -322,6 +322,61 @@ func TestPromoteAdmin_BlankEmail_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestVerifyEmail_HappyPath_MarksVerified(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		displayName = "alice"
+		email       = "alice@example.test"
+	)
+	seedPlayer(t, dbURI, displayName)
+
+	if got := fetchSeededPlayer(t, dbURI).IsEmailVerified(); got {
+		t.Fatalf("IsEmailVerified before VerifyEmail = %v, want false", got)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := VerifyEmail(t.Context(), envFor(dbURI), &stdout, &stderr, email); err != nil {
+		t.Fatalf("VerifyEmail err = %v, want nil", err)
+	}
+
+	if got, want := fetchSeededPlayer(t, dbURI).IsEmailVerified(), true; got != want {
+		t.Errorf("IsEmailVerified after VerifyEmail = %v, want %v", got, want)
+	}
+	if got, want := stdout.String(), "Verified"; !strings.Contains(got, want) {
+		t.Errorf("stdout = %q, want substring %q", got, want)
+	}
+}
+
+func TestVerifyEmail_UnknownEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	var stdout, stderr bytes.Buffer
+	err := VerifyEmail(t.Context(), envFor(dbURI), &stdout, &stderr, "nobody@example.test")
+	if got, want := err, ErrVerifyEmailNotFound; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestVerifyEmail_BlankEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	var stdout, stderr bytes.Buffer
+	err := VerifyEmail(t.Context(), envFor(dbURI), &stdout, &stderr, "   ")
+	if got, want := err, ErrVerifyEmailRequired; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
 // TestSeedDemo_DisabledMode_ReturnsError pins the guard: SeedDemo refuses to
 // seed when demo mode is off, so it can never populate a non-demo DB. The guard
 // runs before any DB or archive access, so neither is needed. APP_ENV=development

--- a/cmd/server/app/export_test.go
+++ b/cmd/server/app/export_test.go
@@ -22,6 +22,10 @@ var (
 	ErrPromoteEmailRequired = errPromoteEmailRequired
 	// ErrPromoteEmailNotFound re-exports errPromoteEmailNotFound for tests.
 	ErrPromoteEmailNotFound = errPromoteEmailNotFound
+	// ErrVerifyEmailRequired re-exports errVerifyEmailRequired for tests.
+	ErrVerifyEmailRequired = errVerifyEmailRequired
+	// ErrVerifyEmailNotFound re-exports errVerifyEmailNotFound for tests.
+	ErrVerifyEmailNotFound = errVerifyEmailNotFound
 	// ErrSeedDemoDisabled re-exports errSeedDemoDisabled for tests.
 	ErrSeedDemoDisabled = errSeedDemoDisabled
 	// ErrSeedDemoArchiveNotSet re-exports errSeedDemoArchiveNotSet for tests.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,50 +13,35 @@ import (
 	"github.com/starquake/topbanana/internal/database"
 )
 
+// modeFlags holds the parsed mode-flag pointers. At most one may be set; more
+// than one is a usage error rejected before dispatch.
+type modeFlags struct {
+	resetPasswordFor *string
+	promoteAdminFor  *string
+	verifyEmailFor   *string
+	checkOnly        *bool
+	healthcheckOnly  *bool
+	seedDemo         *bool
+}
+
 func main() {
-	checkOnly := flag.Bool(
-		"check",
-		false,
-		"validate startup (parse config, open DB, run migrations) and exit without serving HTTP",
-	)
-	resetPasswordFor := flag.String(
-		"reset-password",
-		"",
-		"reset the password for the given email; reads the new password from stdin and exits."+
-			" The server should not be running concurrently against the same database."+
-			" Mutually exclusive with the other mode flags",
-	)
-	promoteAdminFor := flag.String(
-		"promote-admin",
-		"",
-		"promote the player with the given email to admin (sets role=admin) and exits."+
-			" Break-glass recovery tool for when every admin is locked out; the first admin"+
-			" normally comes from the first registration. The server should not be running"+
-			" concurrently against the same database",
-	)
-	healthcheckOnly := flag.Bool(
-		"healthcheck",
-		false,
-		"probe http://127.0.0.1:$PORT/healthz and exit 0/1 based on the response."+
-			" Designed for Dockerfile HEALTHCHECK on distroless images (#344) so the image"+
-			" doesn't need a separate wget/curl binary",
-	)
-	seedDemo := flag.Bool(
-		"seed-demo",
-		false,
-		"seed the demo baseline (requires DEMO_MODE_ENABLED) and exit."+
-			" The server should not be running concurrently against the same database."+
-			" Mutually exclusive with the other mode flags",
-	)
+	f := registerModeFlags()
 	flag.Parse()
 
 	ctx := context.Background()
 
 	// Reject more than one mode flag: resolving by switch order would silently
 	// run a different recovery action than the operator asked for.
-	if tooManyModes(*resetPasswordFor != "", *promoteAdminFor != "", *checkOnly, *healthcheckOnly, *seedDemo) {
+	if tooManyModes(
+		*f.resetPasswordFor != "",
+		*f.promoteAdminFor != "",
+		*f.verifyEmailFor != "",
+		*f.checkOnly,
+		*f.healthcheckOnly,
+		*f.seedDemo,
+	) {
 		if _, err := fmt.Fprintln(os.Stderr,
-			"error: -reset-password, -promote-admin, -check, -healthcheck, and"+
+			"error: -reset-password, -promote-admin, -verify-email, -check, -healthcheck, and"+
 				" -seed-demo are mutually exclusive"); err != nil {
 			panic(err)
 		}
@@ -68,15 +53,17 @@ func main() {
 
 	var err error
 	switch {
-	case *resetPasswordFor != "":
-		err = app.ResetPassword(ctx, os.Getenv, os.Stdin, os.Stdout, os.Stderr, *resetPasswordFor)
-	case *promoteAdminFor != "":
-		err = app.PromoteAdmin(ctx, os.Getenv, os.Stdout, os.Stderr, *promoteAdminFor)
-	case *checkOnly:
+	case *f.resetPasswordFor != "":
+		err = app.ResetPassword(ctx, os.Getenv, os.Stdin, os.Stdout, os.Stderr, *f.resetPasswordFor)
+	case *f.promoteAdminFor != "":
+		err = app.PromoteAdmin(ctx, os.Getenv, os.Stdout, os.Stderr, *f.promoteAdminFor)
+	case *f.verifyEmailFor != "":
+		err = app.VerifyEmail(ctx, os.Getenv, os.Stdout, os.Stderr, *f.verifyEmailFor)
+	case *f.checkOnly:
 		err = app.Check(ctx, os.Getenv, os.Stdout)
-	case *healthcheckOnly:
+	case *f.healthcheckOnly:
 		err = app.Healthcheck(ctx, os.Getenv)
-	case *seedDemo:
+	case *f.seedDemo:
 		err = app.SeedDemo(ctx, os.Getenv, os.Stderr)
 	default:
 		err = app.Run(ctx, os.Getenv, os.Stdout, nil)
@@ -88,6 +75,55 @@ func main() {
 		}
 
 		os.Exit(1)
+	}
+}
+
+// registerModeFlags registers the mode flags and returns their pointers. The
+// caller runs [flag.Parse] before reading them.
+func registerModeFlags() modeFlags {
+	return modeFlags{
+		checkOnly: flag.Bool(
+			"check",
+			false,
+			"validate startup (parse config, open DB, run migrations) and exit without serving HTTP",
+		),
+		resetPasswordFor: flag.String(
+			"reset-password",
+			"",
+			"reset the password for the given email; reads the new password from stdin and exits."+
+				" The server should not be running concurrently against the same database."+
+				" Mutually exclusive with the other mode flags",
+		),
+		promoteAdminFor: flag.String(
+			"promote-admin",
+			"",
+			"promote the player with the given email to admin (sets role=admin) and exits."+
+				" Break-glass recovery tool for when every admin is locked out; the first admin"+
+				" normally comes from the first registration. The server should not be running"+
+				" concurrently against the same database",
+		),
+		verifyEmailFor: flag.String(
+			"verify-email",
+			"",
+			"mark the player with the given email as verified (stamps email_verified_at) and exits."+
+				" Break-glass path for a self-hoster with no SMTP configured, where the mailed"+
+				" verification link is a no-op. The server should not be running concurrently"+
+				" against the same database. Mutually exclusive with the other mode flags",
+		),
+		healthcheckOnly: flag.Bool(
+			"healthcheck",
+			false,
+			"probe http://127.0.0.1:$PORT/healthz and exit 0/1 based on the response."+
+				" Designed for Dockerfile HEALTHCHECK on distroless images (#344) so the image"+
+				" doesn't need a separate wget/curl binary",
+		),
+		seedDemo: flag.Bool(
+			"seed-demo",
+			false,
+			"seed the demo baseline (requires DEMO_MODE_ENABLED) and exit."+
+				" The server should not be running concurrently against the same database."+
+				" Mutually exclusive with the other mode flags",
+		),
 	}
 }
 


### PR DESCRIPTION
Adds a `-verify-email <email>` server command that marks a player's email verified from the CLI, mirroring `-promote-admin` / `-reset-password`.

- Looks the player up by email and calls the existing `SetPlayerEmailVerifiedNow`; empty-email and unknown-email errors mirror the promote command's sentinels.
- Runs on the distroless image the same way `-seed-demo` does: `docker compose run --rm app -verify-email you@example.com`.
- Why: with no SMTP configured the mailed verification link is a no-op, so a self-hosted account otherwise can never be verified through the UI.
- Extracts the mode-flag registration into `registerModeFlags` to keep `main` under revive's function-length limit.

Tests: happy path (account ends up verified), empty-email, and unknown-email.

Closes #1204

_— Claude Code, for @starquake_