### PR TITLE
Add a -create-admin server command

### DIFF
--- a/cmd/server/app/commands.go
+++ b/cmd/server/app/commands.go
@@ -21,23 +21,32 @@ import (
 	"github.com/starquake/topbanana/internal/store"
 )
 
-// Sentinel errors for ResetPassword; defined at package level so err113 stays
-// quiet while keeping the failure modes typed for callers and tests. Tests
-// in the external app_test package match on these via [errors.Is]; see
-// export_test.go for the re-exports.
+// Sentinel errors for the password-prompt commands; defined at package level
+// so err113 stays quiet while keeping the failure modes typed for callers and
+// tests. Tests in the external app_test package match on these via [errors.Is];
+// see export_test.go for the re-exports. The errPassword* set is shared by
+// ResetPassword and CreateAdmin via [readNewPassword].
 var (
-	errResetEmailRequired      = errors.New("email is required")
-	errResetPasswordTooShort   = errors.New("password too short")
-	errResetPasswordTooLong    = errors.New("password too long")
-	errResetUserNotFound       = errors.New("email not found")
-	errResetEmptyInput         = errors.New("empty password input")
-	errResetPasswordsDontMatch = errors.New("passwords do not match")
+	errResetEmailRequired = errors.New("email is required")
+	errResetUserNotFound  = errors.New("email not found")
+	errPasswordTooShort   = errors.New("password too short")
+	errPasswordTooLong    = errors.New("password too long")
+	errEmptyInput         = errors.New("empty password input")
+	errPasswordsDontMatch = errors.New("passwords do not match")
 )
 
 // resetWrap is the error-wrap prefix used by every ResetPassword failure
 // path so error messages stay consistent and revive's add-constant linter
 // stays quiet.
 const resetWrap = "reset password: %w"
+
+// opWrap wraps an error under a runtime operation label; keeps revive's
+// add-constant linter quiet across its several uses.
+const opWrap = "%s: %w"
+
+// emailKey is the slog attribute key the admin commands log the target email
+// under; a shared const keeps revive's add-constant linter quiet.
+const emailKey = "email"
 
 // ResetPassword reads a new password from stdin and overwrites the
 // password_hash for the row identified by email. Operator-only tool
@@ -85,7 +94,7 @@ func ResetPassword(
 		return fmt.Errorf(resetWrap, lookupErr)
 	}
 
-	password, err := readNewPassword(stdin, stdout)
+	password, err := readNewPassword(stdin, stdout, "reset password")
 	if err != nil {
 		return err
 	}
@@ -103,7 +112,7 @@ func ResetPassword(
 		return fmt.Errorf(resetWrap, err)
 	}
 
-	logger.InfoContext(ctx, "password reset", slog.String("email", email))
+	logger.InfoContext(ctx, "password reset", slog.String(emailKey, email))
 
 	return nil
 }
@@ -191,7 +200,7 @@ func PromoteAdmin(
 	if _, err := fmt.Fprintf(stdout, "Promoted %q to admin.\n", email); err != nil {
 		return fmt.Errorf("promote admin: write confirmation: %w", err)
 	}
-	logger.InfoContext(ctx, "promoted to admin", slog.String("email", email))
+	logger.InfoContext(ctx, "promoted to admin", slog.String(emailKey, email))
 
 	return nil
 }
@@ -245,9 +254,145 @@ func VerifyEmail(
 	if _, err := fmt.Fprintf(stdout, "Verified email for %q.\n", email); err != nil {
 		return fmt.Errorf("verify email: write confirmation: %w", err)
 	}
-	logger.InfoContext(ctx, "email verified", slog.String("email", email))
+	logger.InfoContext(ctx, "email verified", slog.String(emailKey, email))
 
 	return nil
+}
+
+// errCreateAdminEmailRequired is wrapped by [CreateAdmin] when the supplied
+// email trims to empty.
+var errCreateAdminEmailRequired = errors.New("email is required")
+
+// errCreateAdminEmailExists is wrapped by [CreateAdmin] when a player already
+// owns the email; the operator should use -promote-admin / -verify-email
+// instead.
+var errCreateAdminEmailExists = errors.New("email already exists")
+
+// errCreateAdminInvalidEmail is wrapped by [CreateAdmin] when the supplied
+// email fails the [auth.LooksLikeEmail] shape check, so a malformed address
+// never becomes a verified admin that later breaks the email-change flows.
+var errCreateAdminInvalidEmail = errors.New("invalid email")
+
+// createAdminWrap is the error-wrap prefix shared by [CreateAdmin] failure
+// paths so revive's add-constant linter stays quiet.
+const createAdminWrap = "create admin: %w"
+
+// CreateAdmin creates a verified admin account whose password is read from stdin.
+func CreateAdmin(
+	ctx context.Context,
+	getenv func(string) string,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+	email string,
+) error {
+	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return fmt.Errorf(createAdminWrap, errCreateAdminEmailRequired)
+	}
+	if !auth.LooksLikeEmail(email) {
+		return fmt.Errorf("create admin: %w (%q)", errCreateAdminInvalidEmail, email)
+	}
+
+	dbc, err := config.ParseDatabase(getenv)
+	if err != nil {
+		return fmt.Errorf("create admin: parse config: %w", err)
+	}
+
+	conn, err := setupDB(ctx, dbc, logger)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			logger.ErrorContext(ctx, "error closing database connection", slog.Any("err", cerr))
+		}
+	}()
+
+	players := store.NewPlayerStore(conn, logger)
+	switch _, lookupErr := players.GetPlayerByEmail(ctx, email); {
+	case lookupErr == nil:
+		return errCreateAdminEmailExistsFor(email)
+	case !errors.Is(lookupErr, auth.ErrPlayerNotFound):
+		return fmt.Errorf(createAdminWrap, lookupErr)
+	}
+
+	password, err := readNewPassword(stdin, stdout, "create admin")
+	if err != nil {
+		return err
+	}
+
+	hashed, err := auth.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("create admin: hash password: %w", err)
+	}
+
+	player, err := createVerifiedAdmin(ctx, players, email, hashed)
+	if err != nil {
+		if errors.Is(err, auth.ErrEmailTaken) {
+			return errCreateAdminEmailExistsFor(email)
+		}
+
+		return err
+	}
+
+	if _, err := fmt.Fprintf(stdout, "Created admin %q (display name %q).\n", email, player.DisplayName); err != nil {
+		return fmt.Errorf("create admin: write confirmation: %w", err)
+	}
+	logger.InfoContext(ctx, "created admin",
+		slog.String(emailKey, email), slog.String("display_name", player.DisplayName))
+
+	return nil
+}
+
+// createVerifiedAdmin inserts a verified admin row in one write. It first tries
+// the email's local-part display name, then falls back to petnames for a bounded
+// number of attempts when the name is already taken.
+func createVerifiedAdmin(
+	ctx context.Context, players *store.PlayerStore, email, passwordHash string,
+) (*auth.Player, error) {
+	const maxPetnameAttempts = 5
+	displayName := displayNameFromEmail(email)
+	var err error
+	for attempt := 0; attempt <= maxPetnameAttempts; attempt++ {
+		var player *auth.Player
+		player, err = players.CreatePlayerByAdmin(ctx, displayName, email, passwordHash, auth.RoleAdmin)
+		if err == nil {
+			return player, nil
+		}
+		if !errors.Is(err, auth.ErrDisplayNameTaken) {
+			break
+		}
+		displayName = auth.GeneratePetname()
+	}
+
+	return nil, fmt.Errorf(createAdminWrap, err)
+}
+
+// errCreateAdminEmailExistsFor wraps errCreateAdminEmailExists with the offending
+// email and the recovery guidance, shared by the pre-check and the insert race.
+func errCreateAdminEmailExistsFor(email string) error {
+	return fmt.Errorf(
+		"create admin: %w (%q); use -promote-admin or -verify-email instead",
+		errCreateAdminEmailExists, email,
+	)
+}
+
+// displayNameFromEmail derives a display name from an email's local part,
+// capping it at [auth.MaxDisplayNameLength] runes and falling back to a
+// [auth.GeneratePetname] when the local part is empty.
+func displayNameFromEmail(email string) string {
+	local, _, _ := strings.Cut(email, "@")
+	local = strings.TrimSpace(local)
+	if runes := []rune(local); len(runes) > auth.MaxDisplayNameLength {
+		local = string(runes[:auth.MaxDisplayNameLength])
+	}
+	if local == "" {
+		return auth.GeneratePetname()
+	}
+
+	return local
 }
 
 // SeedDemo seeds the demo baseline (the shared demo Host and the demo quiz set)
@@ -323,34 +468,37 @@ func readDemoArchives(dir string) ([][]byte, error) {
 // and returns the password if the two reads match and the value falls within
 // the [auth.MinPasswordLength] / [auth.MaxPasswordLength] range. Length is
 // validated *before* the second prompt so a too-short or too-long password
-// fails fast with a single typed line - same UX as `passwd(1)`.
-func readNewPassword(stdin io.Reader, stdout io.Writer) (string, error) {
+// fails fast with a single typed line - same UX as `passwd(1)`. op labels
+// the wrapping error prefix so both -reset-password and -create-admin reuse it.
+func readNewPassword(stdin io.Reader, stdout io.Writer, op string) (string, error) {
 	readPassword := newPasswordReader(stdin, stdout)
 
 	password, err := readPassword("New password: ")
 	if err != nil {
-		return "", fmt.Errorf(resetWrap, err)
+		return "", fmt.Errorf(opWrap, op, err)
 	}
 	if len(password) < auth.MinPasswordLength {
 		return "", fmt.Errorf(
-			"reset password: %w (need at least %d characters)",
-			errResetPasswordTooShort,
+			"%s: %w (need at least %d characters)",
+			op,
+			errPasswordTooShort,
 			auth.MinPasswordLength,
 		)
 	}
 	if len(password) > auth.MaxPasswordLength {
 		return "", fmt.Errorf(
-			"reset password: %w (bcrypt accepts at most %d bytes)",
-			errResetPasswordTooLong,
+			"%s: %w (bcrypt accepts at most %d bytes)",
+			op,
+			errPasswordTooLong,
 			auth.MaxPasswordLength,
 		)
 	}
 	confirm, err := readPassword("Confirm password: ")
 	if err != nil {
-		return "", fmt.Errorf(resetWrap, err)
+		return "", fmt.Errorf(opWrap, op, err)
 	}
 	if confirm != password {
-		return "", fmt.Errorf(resetWrap, errResetPasswordsDontMatch)
+		return "", fmt.Errorf(opWrap, op, errPasswordsDontMatch)
 	}
 
 	return password, nil
@@ -392,7 +540,7 @@ func newPasswordReader(stdin io.Reader, stdout io.Writer) func(prompt string) (s
 				return "", fmt.Errorf("read password: %w", err)
 			}
 
-			return "", fmt.Errorf("read password: %w", errResetEmptyInput)
+			return "", fmt.Errorf("read password: %w", errEmptyInput)
 		}
 
 		return scanner.Text(), nil
@@ -458,7 +606,7 @@ func Check(ctx context.Context, getenv func(string) string, stdout io.Writer) er
 		msg := "error parsing config"
 		logger.ErrorContext(ctx, msg, slog.Any("err", err))
 
-		return fmt.Errorf("%s: %w", msg, err)
+		return fmt.Errorf(opWrap, msg, err)
 	}
 	logConfigSummary(ctx, logger, cfg)
 

--- a/cmd/server/app/commands_test.go
+++ b/cmd/server/app/commands_test.go
@@ -377,6 +377,151 @@ func TestVerifyEmail_BlankEmail_ReturnsError(t *testing.T) {
 	}
 }
 
+// fetchPlayerByEmail re-opens dbURI and returns the player row for email.
+func fetchPlayerByEmail(t *testing.T, dbURI, email string) *auth.Player {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := conn.Close(); cerr != nil {
+			t.Errorf("conn.Close err = %v, want nil", cerr)
+		}
+	})
+	players := store.NewPlayerStore(conn, slog.Default())
+	p, err := players.GetPlayerByEmail(t.Context(), email)
+	if err != nil {
+		t.Fatalf("GetPlayerByEmail err = %v, want nil", err)
+	}
+
+	return p
+}
+
+func TestCreateAdmin_HappyPath_CreatesVerifiedAdmin(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		email    = "founder@example.test"
+		password = "correct-horse-battery"
+	)
+	stdin := strings.NewReader(password + "\n" + password + "\n")
+	var stdout, stderr bytes.Buffer
+	if err := CreateAdmin(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, email); err != nil {
+		t.Fatalf("CreateAdmin err = %v, want nil", err)
+	}
+
+	p := fetchPlayerByEmail(t, dbURI, email)
+	if got, want := p.Role, auth.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if !p.IsAdmin() {
+		t.Error("IsAdmin() = false, want true")
+	}
+	if !p.IsEmailVerified() {
+		t.Error("IsEmailVerified() = false, want true")
+	}
+	if err := auth.CheckPassword(p.PasswordHash, password); err != nil {
+		t.Errorf("CheckPassword(password) err = %v, want nil", err)
+	}
+	if got, want := p.DisplayName, "founder"; got != want {
+		t.Errorf("DisplayName = %q, want %q", got, want)
+	}
+	if got, want := stdout.String(), "Created admin"; !strings.Contains(got, want) {
+		t.Errorf("stdout = %q, want substring %q", got, want)
+	}
+}
+
+func TestCreateAdmin_ExistingEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+	seedPlayer(t, dbURI, "alice")
+
+	stdin := strings.NewReader("correct-horse-battery\ncorrect-horse-battery\n")
+	var stdout, stderr bytes.Buffer
+	err := CreateAdmin(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "alice@example.test")
+	if got, want := err, ErrCreateAdminEmailExists; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestCreateAdmin_BlankEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	var stdout, stderr bytes.Buffer
+	err := CreateAdmin(t.Context(), envFor(dbURI), strings.NewReader(""), &stdout, &stderr, "   ")
+	if got, want := err, ErrCreateAdminEmailRequired; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestCreateAdmin_MalformedEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	var stdout, stderr bytes.Buffer
+	err := CreateAdmin(t.Context(), envFor(dbURI), strings.NewReader(""), &stdout, &stderr, "admin@localhost")
+	if got, want := err, ErrCreateAdminInvalidEmail; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestCreateAdmin_PasswordTooShort_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	stdin := strings.NewReader("short\n")
+	var stdout, stderr bytes.Buffer
+	err := CreateAdmin(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, "founder@example.test")
+	if got, want := err, ErrPasswordTooShort; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestCreateAdmin_DisplayNameCollision_FallsBackToPetname(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+	// seedPlayer claims display name "founder"; the new admin's email local
+	// part is also "founder", forcing the petname fallback.
+	seedPlayer(t, dbURI, "founder")
+
+	const (
+		email    = "founder@other.test"
+		password = "correct-horse-battery"
+	)
+	stdin := strings.NewReader(password + "\n" + password + "\n")
+	var stdout, stderr bytes.Buffer
+	if err := CreateAdmin(t.Context(), envFor(dbURI), stdin, &stdout, &stderr, email); err != nil {
+		t.Fatalf("CreateAdmin err = %v, want nil", err)
+	}
+
+	p := fetchPlayerByEmail(t, dbURI, email)
+	if got, want := p.Role, auth.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if !p.IsEmailVerified() {
+		t.Error("IsEmailVerified() = false, want true")
+	}
+	if got := p.DisplayName; got == "founder" {
+		t.Errorf("DisplayName = %q, want a petname fallback distinct from the taken name", got)
+	}
+}
+
 // TestSeedDemo_DisabledMode_ReturnsError pins the guard: SeedDemo refuses to
 // seed when demo mode is off, so it can never populate a non-demo DB. The guard
 // runs before any DB or archive access, so neither is needed. APP_ENV=development
@@ -508,7 +653,7 @@ func TestResetPassword_PasswordTooShort_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for too-short password")
 	}
-	if got, want := err, ErrResetPasswordTooShort; !errors.Is(got, want) {
+	if got, want := err, ErrPasswordTooShort; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -537,7 +682,7 @@ func TestResetPassword_PasswordTooLong_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for too-long password")
 	}
-	if got, want := err, ErrResetPasswordTooLong; !errors.Is(got, want) {
+	if got, want := err, ErrPasswordTooLong; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -561,7 +706,7 @@ func TestResetPassword_ConfirmationMismatch_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for mismatching confirmation")
 	}
-	if got, want := err, ErrResetPasswordsDontMatch; !errors.Is(got, want) {
+	if got, want := err, ErrPasswordsDontMatch; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 
@@ -587,7 +732,7 @@ func TestResetPassword_ClosedStdin_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ResetPassword err = nil, want non-nil for empty stdin")
 	}
-	if got, want := err, ErrResetEmptyInput; !errors.Is(got, want) {
+	if got, want := err, ErrEmptyInput; !errors.Is(got, want) {
 		t.Errorf("err = %v, want errors.Is(%v)", got, want)
 	}
 

--- a/cmd/server/app/export_test.go
+++ b/cmd/server/app/export_test.go
@@ -8,16 +8,16 @@ package app
 var (
 	// ErrResetEmailRequired re-exports errResetEmailRequired for tests.
 	ErrResetEmailRequired = errResetEmailRequired
-	// ErrResetPasswordTooShort re-exports errResetPasswordTooShort for tests.
-	ErrResetPasswordTooShort = errResetPasswordTooShort
-	// ErrResetPasswordTooLong re-exports errResetPasswordTooLong for tests.
-	ErrResetPasswordTooLong = errResetPasswordTooLong
+	// ErrPasswordTooShort re-exports errPasswordTooShort for tests.
+	ErrPasswordTooShort = errPasswordTooShort
+	// ErrPasswordTooLong re-exports errPasswordTooLong for tests.
+	ErrPasswordTooLong = errPasswordTooLong
 	// ErrResetUserNotFound re-exports errResetUserNotFound for tests.
 	ErrResetUserNotFound = errResetUserNotFound
-	// ErrResetEmptyInput re-exports errResetEmptyInput for tests.
-	ErrResetEmptyInput = errResetEmptyInput
-	// ErrResetPasswordsDontMatch re-exports errResetPasswordsDontMatch for tests.
-	ErrResetPasswordsDontMatch = errResetPasswordsDontMatch
+	// ErrEmptyInput re-exports errEmptyInput for tests.
+	ErrEmptyInput = errEmptyInput
+	// ErrPasswordsDontMatch re-exports errPasswordsDontMatch for tests.
+	ErrPasswordsDontMatch = errPasswordsDontMatch
 	// ErrPromoteEmailRequired re-exports errPromoteEmailRequired for tests.
 	ErrPromoteEmailRequired = errPromoteEmailRequired
 	// ErrPromoteEmailNotFound re-exports errPromoteEmailNotFound for tests.
@@ -26,6 +26,12 @@ var (
 	ErrVerifyEmailRequired = errVerifyEmailRequired
 	// ErrVerifyEmailNotFound re-exports errVerifyEmailNotFound for tests.
 	ErrVerifyEmailNotFound = errVerifyEmailNotFound
+	// ErrCreateAdminEmailRequired re-exports errCreateAdminEmailRequired for tests.
+	ErrCreateAdminEmailRequired = errCreateAdminEmailRequired
+	// ErrCreateAdminEmailExists re-exports errCreateAdminEmailExists for tests.
+	ErrCreateAdminEmailExists = errCreateAdminEmailExists
+	// ErrCreateAdminInvalidEmail re-exports errCreateAdminInvalidEmail for tests.
+	ErrCreateAdminInvalidEmail = errCreateAdminInvalidEmail
 	// ErrSeedDemoDisabled re-exports errSeedDemoDisabled for tests.
 	ErrSeedDemoDisabled = errSeedDemoDisabled
 	// ErrSeedDemoArchiveNotSet re-exports errSeedDemoArchiveNotSet for tests.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ type modeFlags struct {
 	resetPasswordFor *string
 	promoteAdminFor  *string
 	verifyEmailFor   *string
+	createAdminFor   *string
 	checkOnly        *bool
 	healthcheckOnly  *bool
 	seedDemo         *bool
@@ -36,13 +37,14 @@ func main() {
 		*f.resetPasswordFor != "",
 		*f.promoteAdminFor != "",
 		*f.verifyEmailFor != "",
+		*f.createAdminFor != "",
 		*f.checkOnly,
 		*f.healthcheckOnly,
 		*f.seedDemo,
 	) {
 		if _, err := fmt.Fprintln(os.Stderr,
-			"error: -reset-password, -promote-admin, -verify-email, -check, -healthcheck, and"+
-				" -seed-demo are mutually exclusive"); err != nil {
+			"error: -reset-password, -promote-admin, -verify-email, -create-admin, -check,"+
+				" -healthcheck, and -seed-demo are mutually exclusive"); err != nil {
 			panic(err)
 		}
 
@@ -59,6 +61,8 @@ func main() {
 		err = app.PromoteAdmin(ctx, os.Getenv, os.Stdout, os.Stderr, *f.promoteAdminFor)
 	case *f.verifyEmailFor != "":
 		err = app.VerifyEmail(ctx, os.Getenv, os.Stdout, os.Stderr, *f.verifyEmailFor)
+	case *f.createAdminFor != "":
+		err = app.CreateAdmin(ctx, os.Getenv, os.Stdin, os.Stdout, os.Stderr, *f.createAdminFor)
 	case *f.checkOnly:
 		err = app.Check(ctx, os.Getenv, os.Stdout)
 	case *f.healthcheckOnly:
@@ -109,6 +113,15 @@ func registerModeFlags() modeFlags {
 				" Break-glass path for a self-hoster with no SMTP configured, where the mailed"+
 				" verification link is a no-op. The server should not be running concurrently"+
 				" against the same database. Mutually exclusive with the other mode flags",
+		),
+		createAdminFor: flag.String(
+			"create-admin",
+			"",
+			"create a verified admin account for the given email; reads the new password from"+
+				" stdin and exits. Bootstraps the first admin without opening registration or"+
+				" configuring SMTP. Refuses an email that already exists (use -promote-admin /"+
+				" -verify-email for that). The server should not be running concurrently against"+
+				" the same database",
 		),
 		healthcheckOnly: flag.Bool(
 			"healthcheck",

--- a/internal/admin/playeractions_credentials.go
+++ b/internal/admin/playeractions_credentials.go
@@ -238,7 +238,7 @@ func HandlePlayerCreateSubmit(
 			return
 		}
 
-		player, err := store.CreatePlayerByAdmin(r.Context(), input.DisplayName, input.Email, hash)
+		player, err := store.CreatePlayerByAdmin(r.Context(), input.DisplayName, input.Email, hash, auth.RolePlayer)
 		if err != nil {
 			renderCreatePlayerError(w, r, renderer, input, err)
 

--- a/internal/auth/player.go
+++ b/internal/auth/player.go
@@ -349,10 +349,10 @@ type AdminPlayerStore interface {
 	// a UNIQUE collision, ErrPlayerNotFound when the id matches no row.
 	SetPlayerEmail(ctx context.Context, playerID int64, email string) error
 	// CreatePlayerByAdmin inserts a fresh credentialled row with
-	// email_verified_at stamped. role is fixed to 'player'. Returns
+	// email_verified_at stamped. role sets the new row's tier. Returns
 	// ErrDisplayNameTaken / ErrEmailTaken on UNIQUE collisions.
 	CreatePlayerByAdmin(
-		ctx context.Context, displayName, email, passwordHash string,
+		ctx context.Context, displayName, email, passwordHash, role string,
 	) (*Player, error)
 	// SetPlayerRole sets the role on the row identified by id (#538), so the
 	// id-based role selector can move a player to any tier. role is one of

--- a/internal/db/admin.sql.go
+++ b/internal/db/admin.sql.go
@@ -87,7 +87,7 @@ VALUES (
     ?2,
     ?3,
     CURRENT_TIMESTAMP,
-    'player',
+    ?4,
     1
 )
 RETURNING id, display_name, email, password_hash, role, created_at, display_name_claimed, email_verified_at, session_version, role_changed_at
@@ -97,16 +97,22 @@ type CreatePlayerByAdminParams struct {
 	DisplayName  string
 	Email        sql.NullString
 	PasswordHash sql.NullString
+	Role         string
 }
 
 // Admin-initiated player creation (#450). Stamps email_verified_at at
 // CURRENT_TIMESTAMP so the new row bypasses the email loop entirely; the
 // admin hands the credentials to the recipient out-of-band. password_hash
 // is nullable on the column but the handler enforces a non-empty hash so
-// the row can log in immediately. role is fixed to 'player' - the admin
-// promotion CASE only fires on the public register/oauth paths.
+// the row can log in immediately. role is passed explicitly so callers can
+// create a verified account at any tier in one write.
 func (q *Queries) CreatePlayerByAdmin(ctx context.Context, arg CreatePlayerByAdminParams) (Player, error) {
-	row := q.db.QueryRowContext(ctx, createPlayerByAdmin, arg.DisplayName, arg.Email, arg.PasswordHash)
+	row := q.db.QueryRowContext(ctx, createPlayerByAdmin,
+		arg.DisplayName,
+		arg.Email,
+		arg.PasswordHash,
+		arg.Role,
+	)
 	var i Player
 	err := row.Scan(
 		&i.ID,

--- a/internal/queries/admin.sql
+++ b/internal/queries/admin.sql
@@ -178,15 +178,15 @@ WHERE id = sqlc.arg('id');
 -- CURRENT_TIMESTAMP so the new row bypasses the email loop entirely; the
 -- admin hands the credentials to the recipient out-of-band. password_hash
 -- is nullable on the column but the handler enforces a non-empty hash so
--- the row can log in immediately. role is fixed to 'player' - the admin
--- promotion CASE only fires on the public register/oauth paths.
+-- the row can log in immediately. role is passed explicitly so callers can
+-- create a verified account at any tier in one write.
 INSERT INTO players (display_name, email, password_hash, email_verified_at, role, display_name_claimed)
 VALUES (
     sqlc.arg('display_name'),
     sqlc.arg('email'),
     sqlc.arg('password_hash'),
     CURRENT_TIMESTAMP,
-    'player',
+    sqlc.arg('role'),
     1
 )
 RETURNING *;

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -897,10 +897,10 @@ func (s *PlayerStore) SetPlayerEmail(ctx context.Context, playerID int64, email 
 // CreatePlayerByAdmin inserts a fresh credentialled row with
 // email_verified_at stamped (#450). Email is trimmed + lowercased;
 // passwordHash must be non-empty (the handler enforces it before
-// reaching the store). Returns auth.ErrDisplayNameTaken / auth.ErrEmailTaken
-// on UNIQUE collisions.
+// reaching the store). role sets the new row's tier. Returns
+// auth.ErrDisplayNameTaken / auth.ErrEmailTaken on UNIQUE collisions.
 func (s *PlayerStore) CreatePlayerByAdmin(
-	ctx context.Context, displayName, email, passwordHash string,
+	ctx context.Context, displayName, email, passwordHash, role string,
 ) (*auth.Player, error) {
 	cleanedDisplayName := strings.TrimSpace(displayName)
 	cleanedEmail := strings.ToLower(strings.TrimSpace(email))
@@ -908,6 +908,7 @@ func (s *PlayerStore) CreatePlayerByAdmin(
 		DisplayName:  cleanedDisplayName,
 		Email:        sql.NullString{String: cleanedEmail, Valid: cleanedEmail != ""},
 		PasswordHash: sql.NullString{String: passwordHash, Valid: passwordHash != ""},
+		Role:         role,
 	})
 	if err != nil {
 		return nil, s.classifyCredentialConflict(ctx, cleanedDisplayName, cleanedEmail, err)

--- a/internal/store/player_test.go
+++ b/internal/store/player_test.go
@@ -1030,7 +1030,7 @@ func TestPlayerStore_SetPlayerEmail_ClearsVerification(t *testing.T) {
 	// CreatePlayerByAdmin stamps email_verified_at, so the row starts
 	// in the verified bucket.
 	created, err := ps.CreatePlayerByAdmin(
-		t.Context(), "verified-then-changed", "before@example.test", "hashed-secret",
+		t.Context(), "verified-then-changed", "before@example.test", "hashed-secret", auth.RolePlayer,
 	)
 	if err != nil {
 		t.Fatalf("CreatePlayerByAdmin err = %v, want nil", err)
@@ -1245,7 +1245,7 @@ func TestPlayerStore_GetPlayerDetail_ExposesRole(t *testing.T) {
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	created, err := ps.CreatePlayerByAdmin(t.Context(), "detail-role", "detail-role@example.test", "h")
+	created, err := ps.CreatePlayerByAdmin(t.Context(), "detail-role", "detail-role@example.test", "h", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayerByAdmin err = %v, want nil", err)
 	}
@@ -1297,11 +1297,11 @@ func TestPlayerStore_ListAdminAuditForTarget_SurvivesActorDeletion(t *testing.T)
 	db := dbtest.Open(t)
 	ps := NewPlayerStore(db, slog.Default())
 
-	actor, err := ps.CreatePlayerByAdmin(t.Context(), "audit-actor", "actor@example.test", "h")
+	actor, err := ps.CreatePlayerByAdmin(t.Context(), "audit-actor", "actor@example.test", "h", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayerByAdmin actor err = %v, want nil", err)
 	}
-	target, err := ps.CreatePlayerByAdmin(t.Context(), "audit-target", "target@example.test", "h")
+	target, err := ps.CreatePlayerByAdmin(t.Context(), "audit-target", "target@example.test", "h", auth.RolePlayer)
 	if err != nil {
 		t.Fatalf("CreatePlayerByAdmin target err = %v, want nil", err)
 	}
@@ -1536,7 +1536,9 @@ func TestPlayerStore_SetPlayerEmail(t *testing.T) {
 		db := dbtest.Open(t)
 		ps := NewPlayerStore(db, slog.Default())
 
-		created, err := ps.CreatePlayerByAdmin(t.Context(), "set-email-happy", "before@example.test", "hashed-secret")
+		created, err := ps.CreatePlayerByAdmin(
+			t.Context(), "set-email-happy", "before@example.test", "hashed-secret", auth.RolePlayer,
+		)
 		if err != nil {
 			t.Fatalf("CreatePlayerByAdmin err = %v, want nil", err)
 		}
@@ -1560,11 +1562,13 @@ func TestPlayerStore_SetPlayerEmail(t *testing.T) {
 		ps := NewPlayerStore(db, slog.Default())
 
 		if _, err := ps.CreatePlayerByAdmin(
-			t.Context(), "set-email-owner", "taken@example.test", "hashed-secret",
+			t.Context(), "set-email-owner", "taken@example.test", "hashed-secret", auth.RolePlayer,
 		); err != nil {
 			t.Fatalf("CreatePlayerByAdmin (owner) err = %v, want nil", err)
 		}
-		other, err := ps.CreatePlayerByAdmin(t.Context(), "set-email-other", "other@example.test", "hashed-secret")
+		other, err := ps.CreatePlayerByAdmin(
+			t.Context(), "set-email-other", "other@example.test", "hashed-secret", auth.RolePlayer,
+		)
 		if err != nil {
 			t.Fatalf("CreatePlayerByAdmin (other) err = %v, want nil", err)
 		}


### PR DESCRIPTION
Adds a `-create-admin <email>` server command that creates a verified admin in one shot, mirroring `-reset-password` / `-promote-admin` / `-verify-email`.

- Reads + confirms the password from **stdin** (like `-reset-password`), not an argv `<password>` — keeps it out of shell history / process args. The flag takes the email only.
- Refuses an email that already exists (use `-promote-admin` / `-verify-email` for an existing account); enforces the same min-password length as registration.
- Creates the verified admin in a **single atomic write**: `CreatePlayerByAdmin` (generalized to take a role; its INSERT stamps `email_verified_at`) — no half-created-admin window.
- Display name is derived from the email local-part, retrying once with a petname if that name is already taken.
- Bootstraps a self-host: `docker compose run --rm app -create-admin you@example.com`.
- Also generalizes the shared `readNewPassword` to take the operation label and adds a shared `emailKey` slog const — fallout from sitting alongside the existing commands.

Tests: happy path (verified admin, password verifies, role=admin), existing-email, blank-email, too-short-password, and display-name-collision -> petname fallback.

A high-effort `/code-review` found 3 issues (atomicity, collision, race-error-message); all are fixed here — see the PR comment for detail.

Closes #1205

_— Claude Code, for @starquake_