### PR TITLE
Bootstrap the first admin from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URL=http://localhost:8080/login/google/callback
 
+# First-admin bootstrap (#1206). On first boot with no admin present, a
+# verified admin is created from these two values; once any admin exists
+# they are ignored, so leaving them set across restarts is safe. Leave both
+# blank to disable. A malformed email or a password shorter than the
+# minimum fails startup.
+# INITIAL_ADMIN_EMAIL=
+# INITIAL_ADMIN_PASSWORD=
+
 # Trusted reverse-proxy allow-list for per-IP rate limiting (#463).
 # Comma-separated list of CIDR ranges. When a request arrives from
 # one of these CIDRs, the X-Forwarded-For header is consulted to find

--- a/cmd/server/app/app.go
+++ b/cmd/server/app/app.go
@@ -172,6 +172,10 @@ func Run(
 
 	stores := store.New(conn, logger)
 
+	if err = bootstrapInitialAdmin(signalCtx, cfg, store.NewPlayerStore(conn, logger), logger); err != nil {
+		return err
+	}
+
 	startSweeps(signalCtx, cfg, logger, stores)
 	gameService, leaderboardHub := newGameService(cfg, logger, stores)
 	// Own the runner's context so shutdown waits for its goroutine to exit

--- a/cmd/server/app/commands.go
+++ b/cmd/server/app/commands.go
@@ -390,6 +390,96 @@ func displayNameFromEmail(email string) string {
 	return local
 }
 
+// errInitialAdminInvalidEmail is wrapped by [bootstrapInitialAdmin] when
+// INITIAL_ADMIN_EMAIL fails the [auth.LooksLikeEmail] shape check, so a
+// misconfigured operator fails startup instead of minting a broken admin.
+var errInitialAdminInvalidEmail = errors.New("INITIAL_ADMIN_EMAIL is not a valid email")
+
+// errInitialAdminPasswordTooShort is wrapped by [bootstrapInitialAdmin] when
+// INITIAL_ADMIN_PASSWORD is below [auth.MinPasswordLength].
+var errInitialAdminPasswordTooShort = errors.New("INITIAL_ADMIN_PASSWORD is too short")
+
+// errInitialAdminPasswordTooLong is wrapped by [bootstrapInitialAdmin] when
+// INITIAL_ADMIN_PASSWORD exceeds [auth.MaxPasswordLength] (bcrypt's 72-byte
+// limit), so the operator sees a clear message instead of a cryptic hash error.
+var errInitialAdminPasswordTooLong = errors.New("INITIAL_ADMIN_PASSWORD is too long")
+
+// bootstrapWrap is the error-wrap prefix shared by [bootstrapInitialAdmin]
+// failure paths so revive's add-constant linter stays quiet.
+const bootstrapWrap = "bootstrap initial admin: %w"
+
+// bootstrapInitialAdmin mints a verified admin from INITIAL_ADMIN_EMAIL /
+// INITIAL_ADMIN_PASSWORD on first boot, and is a no-op once any admin exists.
+func bootstrapInitialAdmin(
+	ctx context.Context, cfg *config.Config, players *store.PlayerStore, logger *slog.Logger,
+) error {
+	email := strings.ToLower(strings.TrimSpace(cfg.InitialAdminEmail))
+	password := cfg.InitialAdminPassword
+	if email == "" || password == "" {
+		return nil
+	}
+
+	hasAdmin, err := players.HasAnyAdmin(ctx)
+	if err != nil {
+		return fmt.Errorf(bootstrapWrap, err)
+	}
+	if hasAdmin {
+		logger.InfoContext(ctx, "initial admin bootstrap skipped: an admin already exists")
+
+		return nil
+	}
+
+	if !auth.LooksLikeEmail(email) {
+		return fmt.Errorf("bootstrap initial admin: %w (%q)", errInitialAdminInvalidEmail, email)
+	}
+	if len(password) < auth.MinPasswordLength {
+		return fmt.Errorf(
+			"bootstrap initial admin: %w (need at least %d characters)",
+			errInitialAdminPasswordTooShort, auth.MinPasswordLength,
+		)
+	}
+	if len(password) > auth.MaxPasswordLength {
+		return fmt.Errorf(
+			"bootstrap initial admin: %w (bcrypt accepts at most %d bytes)",
+			errInitialAdminPasswordTooLong, auth.MaxPasswordLength,
+		)
+	}
+
+	switch _, lookupErr := players.GetPlayerByEmail(ctx, email); {
+	case lookupErr == nil:
+		logger.WarnContext(ctx, "initial admin bootstrap skipped: email already in use",
+			slog.String(emailKey, email))
+
+		return nil
+	case !errors.Is(lookupErr, auth.ErrPlayerNotFound):
+		return fmt.Errorf(bootstrapWrap, lookupErr)
+	}
+
+	hashed, err := auth.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("bootstrap initial admin: hash password: %w", err)
+	}
+
+	player, err := createVerifiedAdmin(ctx, players, email, hashed)
+	if err != nil {
+		// Another instance won the race between our HasAnyAdmin check and this
+		// insert; the admin now exists, so skip rather than fail this boot.
+		if errors.Is(err, auth.ErrEmailTaken) {
+			logger.InfoContext(ctx, "initial admin already created concurrently, skipping",
+				slog.String(emailKey, email))
+
+			return nil
+		}
+
+		return fmt.Errorf(bootstrapWrap, err)
+	}
+
+	logger.InfoContext(ctx, "initial admin created",
+		slog.String(emailKey, email), slog.String("display_name", player.DisplayName))
+
+	return nil
+}
+
 // SeedDemo seeds the demo baseline (the shared demo Host and the demo quiz set)
 // against the configured database. It exits early with an error when demo mode
 // is off (Config.DemoMode) so it cannot accidentally seed a non-demo DB. Every

--- a/cmd/server/app/commands_test.go
+++ b/cmd/server/app/commands_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/starquake/topbanana/cmd/server/app"
 	"github.com/starquake/topbanana/internal/auth"
+	"github.com/starquake/topbanana/internal/config"
 	"github.com/starquake/topbanana/internal/database"
 	"github.com/starquake/topbanana/internal/dbtest"
 	"github.com/starquake/topbanana/internal/demo"
@@ -590,6 +591,218 @@ func TestSeedDemo_EmptyArchiveDir_ReturnsError(t *testing.T) {
 	err := SeedDemo(t.Context(), getenv, &stderr)
 	if got, want := err, demo.ErrNoArchives; !errors.Is(got, want) {
 		t.Errorf("SeedDemo err = %v, want %v", got, want)
+	}
+}
+
+// openMigratedPlayerStore opens a fresh connection to the migrated DB at dbURI
+// and returns a concrete PlayerStore, the type bootstrapInitialAdmin takes.
+func openMigratedPlayerStore(t *testing.T, dbURI string) *store.PlayerStore {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := conn.Close(); cerr != nil {
+			t.Errorf("conn.Close err = %v, want nil", cerr)
+		}
+	})
+	if err := database.Migrate(conn); err != nil {
+		t.Fatalf("Migrate err = %v, want nil", err)
+	}
+
+	return store.NewPlayerStore(conn, slog.Default())
+}
+
+// countPlayers returns the total number of rows in the players table, used to
+// assert bootstrapInitialAdmin did not insert when it should have skipped.
+func countPlayers(t *testing.T, dbURI string) int {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := conn.Close(); cerr != nil {
+			t.Errorf("conn.Close err = %v, want nil", cerr)
+		}
+	})
+	var n int
+	if err := conn.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM players").Scan(&n); err != nil {
+		t.Fatalf("count players err = %v, want nil", err)
+	}
+
+	return n
+}
+
+// discardLogger is a slog logger that drops output, for bootstrap tests that
+// assert on state and return values rather than log output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func TestBootstrapInitialAdmin_NoAdmin_CreatesVerifiedAdmin(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	const (
+		email    = "founder@example.test"
+		password = "correct-horse-battery"
+	)
+	cfg := &config.Config{InitialAdminEmail: email, InitialAdminPassword: password}
+	if err := BootstrapInitialAdmin(t.Context(), cfg, openMigratedPlayerStore(t, dbURI), discardLogger()); err != nil {
+		t.Fatalf("BootstrapInitialAdmin err = %v, want nil", err)
+	}
+
+	p := fetchPlayerByEmail(t, dbURI, email)
+	if got, want := p.Role, auth.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if !p.IsEmailVerified() {
+		t.Error("IsEmailVerified() = false, want true")
+	}
+	if err := auth.CheckPassword(p.PasswordHash, password); err != nil {
+		t.Errorf("CheckPassword(password) err = %v, want nil", err)
+	}
+}
+
+func TestBootstrapInitialAdmin_AdminPresent_NoNewAdmin(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+	// The first credentialled registrant becomes admin automatically, so the DB
+	// now holds one admin; bootstrap must be a no-op against it.
+	seedPlayer(t, dbURI, "alice")
+
+	before := countPlayers(t, dbURI)
+	cfg := &config.Config{InitialAdminEmail: "founder@example.test", InitialAdminPassword: "correct-horse-battery"}
+	if err := BootstrapInitialAdmin(t.Context(), cfg, openMigratedPlayerStore(t, dbURI), discardLogger()); err != nil {
+		t.Fatalf("BootstrapInitialAdmin err = %v, want nil", err)
+	}
+
+	if got, want := countPlayers(t, dbURI), before; got != want {
+		t.Errorf("player count after bootstrap = %d, want %d (no new row)", got, want)
+	}
+}
+
+func TestBootstrapInitialAdmin_EmailInUse_SkipsWithoutError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	// Insert a non-admin owning the target email while no admin exists, so the
+	// bootstrap reaches the "email already in use" skip branch.
+	const email = "founder@example.test"
+	seedNonAdminWithEmail(t, dbURI, "founder", email)
+
+	before := countPlayers(t, dbURI)
+	cfg := &config.Config{InitialAdminEmail: email, InitialAdminPassword: "correct-horse-battery"}
+	players := openMigratedPlayerStore(t, dbURI)
+	if err := BootstrapInitialAdmin(t.Context(), cfg, players, discardLogger()); err != nil {
+		t.Fatalf("BootstrapInitialAdmin err = %v, want nil", err)
+	}
+
+	if got, want := countPlayers(t, dbURI), before; got != want {
+		t.Errorf("player count after bootstrap = %d, want %d (no new row)", got, want)
+	}
+	hasAdmin, err := players.HasAnyAdmin(t.Context())
+	if err != nil {
+		t.Fatalf("HasAnyAdmin err = %v, want nil", err)
+	}
+	if hasAdmin {
+		t.Error("HasAnyAdmin() = true, want false (bootstrap should not have promoted)")
+	}
+}
+
+func TestBootstrapInitialAdmin_PasswordTooShort_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	cfg := &config.Config{InitialAdminEmail: "founder@example.test", InitialAdminPassword: "short"}
+	err := BootstrapInitialAdmin(t.Context(), cfg, openMigratedPlayerStore(t, dbURI), discardLogger())
+	if got, want := err, ErrInitialAdminPasswordTooShort; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestBootstrapInitialAdmin_PasswordTooLong_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	tooLong := strings.Repeat("a", auth.MaxPasswordLength+1)
+	cfg := &config.Config{InitialAdminEmail: "founder@example.test", InitialAdminPassword: tooLong}
+	err := BootstrapInitialAdmin(t.Context(), cfg, openMigratedPlayerStore(t, dbURI), discardLogger())
+	if got, want := err, ErrInitialAdminPasswordTooLong; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestBootstrapInitialAdmin_MalformedEmail_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	cfg := &config.Config{InitialAdminEmail: "admin@localhost", InitialAdminPassword: "correct-horse-battery"}
+	err := BootstrapInitialAdmin(t.Context(), cfg, openMigratedPlayerStore(t, dbURI), discardLogger())
+	if got, want := err, ErrInitialAdminInvalidEmail; !errors.Is(got, want) {
+		t.Errorf("err = %v, want %v", got, want)
+	}
+}
+
+func TestBootstrapInitialAdmin_EmptyEnv_NoOp(t *testing.T) {
+	t.Parallel()
+
+	dbURI, cleanup := dbtest.SetupTestDB(t)
+	t.Cleanup(cleanup)
+
+	before := countPlayers(t, dbURI)
+	players := openMigratedPlayerStore(t, dbURI)
+	cfg := &config.Config{}
+	if err := BootstrapInitialAdmin(t.Context(), cfg, players, discardLogger()); err != nil {
+		t.Fatalf("BootstrapInitialAdmin err = %v, want nil", err)
+	}
+
+	if got, want := countPlayers(t, dbURI), before; got != want {
+		t.Errorf("player count after empty-env bootstrap = %d, want %d (no new row)", got, want)
+	}
+}
+
+// seedNonAdminWithEmail inserts a player row holding the given email at the
+// player tier without any admin present, the state the "email already in use"
+// skip branch needs. A normal registration would auto-promote the first
+// credentialled row to admin, which would short-circuit before that branch.
+func seedNonAdminWithEmail(t *testing.T, dbURI, displayName, email string) {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", dbURI)
+	if err != nil {
+		t.Fatalf("sql.Open err = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		if cerr := conn.Close(); cerr != nil {
+			t.Errorf("conn.Close err = %v, want nil", cerr)
+		}
+	})
+	if err := database.Migrate(conn); err != nil {
+		t.Fatalf("Migrate err = %v, want nil", err)
+	}
+	if _, err := conn.ExecContext(
+		t.Context(),
+		"INSERT INTO players (display_name, email, role) VALUES (?, ?, ?)",
+		displayName, email, auth.RolePlayer,
+	); err != nil {
+		t.Fatalf("insert non-admin err = %v, want nil", err)
 	}
 }
 

--- a/cmd/server/app/export_test.go
+++ b/cmd/server/app/export_test.go
@@ -32,6 +32,12 @@ var (
 	ErrCreateAdminEmailExists = errCreateAdminEmailExists
 	// ErrCreateAdminInvalidEmail re-exports errCreateAdminInvalidEmail for tests.
 	ErrCreateAdminInvalidEmail = errCreateAdminInvalidEmail
+	// ErrInitialAdminInvalidEmail re-exports errInitialAdminInvalidEmail for tests.
+	ErrInitialAdminInvalidEmail = errInitialAdminInvalidEmail
+	// ErrInitialAdminPasswordTooShort re-exports errInitialAdminPasswordTooShort for tests.
+	ErrInitialAdminPasswordTooShort = errInitialAdminPasswordTooShort
+	// ErrInitialAdminPasswordTooLong re-exports errInitialAdminPasswordTooLong for tests.
+	ErrInitialAdminPasswordTooLong = errInitialAdminPasswordTooLong
 	// ErrSeedDemoDisabled re-exports errSeedDemoDisabled for tests.
 	ErrSeedDemoDisabled = errSeedDemoDisabled
 	// ErrSeedDemoArchiveNotSet re-exports errSeedDemoArchiveNotSet for tests.
@@ -39,6 +45,11 @@ var (
 	// ErrEmptyMediaDir re-exports errEmptyMediaDir for tests.
 	ErrEmptyMediaDir = errEmptyMediaDir
 )
+
+// BootstrapInitialAdmin exposes the unexported first-boot admin bootstrap so
+// the external app_test package can pin its create / skip / validate behaviour
+// (#1206) without standing up the full server.
+var BootstrapInitialAdmin = bootstrapInitialAdmin
 
 // MkMediaDir exposes the pure media-directory creation helper so the external
 // app_test package can pin that it creates the directory and rejects an empty

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -294,6 +294,11 @@ type Config struct {
 	// SeedDemo, which gates on DemoMode.
 	DemoSeedArchiveDir string
 
+	// InitialAdminEmail and InitialAdminPassword bootstrap the first admin on
+	// first boot; empty disables it. See .env.example for the full behaviour.
+	InitialAdminEmail    string
+	InitialAdminPassword string
+
 	// RevealDelay overrides the per-question reveal beat (#247). Zero means
 	// "use the built-in default" (3 s). Parsed from the REVEAL_DELAY env var
 	// via time.ParseDuration; e2e and load-test deployments shrink this to a
@@ -660,6 +665,9 @@ func Parse(getenv func(string) string) (*Config, error) {
 	c.GoogleIssuerURL = getenv("GOOGLE_ISSUER_URL")
 
 	c.DemoSeedArchiveDir = getenv("DEMO_SEED_ARCHIVE_DIR")
+
+	c.InitialAdminEmail = getenv("INITIAL_ADMIN_EMAIL")
+	c.InitialAdminPassword = getenv("INITIAL_ADMIN_PASSWORD")
 
 	applyDemoMode(&c)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -597,6 +597,57 @@ func TestParse_DemoMode(t *testing.T) {
 	})
 }
 
+func TestParse_InitialAdmin(t *testing.T) {
+	t.Parallel()
+
+	getenv := func(key string) string {
+		switch key {
+		case "INITIAL_ADMIN_EMAIL":
+			return "founder@example.test"
+		case "INITIAL_ADMIN_PASSWORD":
+			return "correct-horse-battery"
+		case "APP_ENV":
+			return "development"
+		}
+
+		return ""
+	}
+
+	c, err := Parse(getenv)
+	if err != nil {
+		t.Fatalf("Parse() err = %v, want nil", err)
+	}
+	if got, want := c.InitialAdminEmail, "founder@example.test"; got != want {
+		t.Errorf("InitialAdminEmail = %q, want %q", got, want)
+	}
+	if got, want := c.InitialAdminPassword, "correct-horse-battery"; got != want {
+		t.Errorf("InitialAdminPassword = %q, want %q", got, want)
+	}
+}
+
+func TestParse_InitialAdmin_UnsetDefaultsEmpty(t *testing.T) {
+	t.Parallel()
+
+	getenv := func(key string) string {
+		if key == "APP_ENV" {
+			return "development"
+		}
+
+		return ""
+	}
+
+	c, err := Parse(getenv)
+	if err != nil {
+		t.Fatalf("Parse() err = %v, want nil", err)
+	}
+	if got, want := c.InitialAdminEmail, ""; got != want {
+		t.Errorf("InitialAdminEmail = %q, want %q", got, want)
+	}
+	if got, want := c.InitialAdminPassword, ""; got != want {
+		t.Errorf("InitialAdminPassword = %q, want %q", got, want)
+	}
+}
+
 func TestParse_DemoSeedArchiveDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -701,6 +701,20 @@ func (q *Queries) GetPlayerByProviderSubject(ctx context.Context, arg GetPlayerB
 	return i, err
 }
 
+const hasAnyAdmin = `-- name: HasAnyAdmin :one
+SELECT EXISTS(SELECT 1 FROM players WHERE role = 'admin') AS has_admin
+`
+
+// Reports whether any player currently holds the admin role. Backs the
+// first-boot bootstrap that mints an admin from env vars only when none
+// exists yet, so a populated deployment ignores the bootstrap vars.
+func (q *Queries) HasAnyAdmin(ctx context.Context) (bool, error) {
+	row := q.db.QueryRowContext(ctx, hasAnyAdmin)
+	var has_admin bool
+	err := row.Scan(&has_admin)
+	return has_admin, err
+}
+
 const linkProviderIdentity = `-- name: LinkProviderIdentity :exec
 INSERT INTO player_identities (player_id, provider, subject)
 VALUES (?, ?, ?)

--- a/internal/queries/players.sql
+++ b/internal/queries/players.sql
@@ -487,6 +487,12 @@ WHERE players.id = sqlc.arg('id')
   AND players.role = 'admin'
   AND (SELECT COUNT(*) FROM players AS admins WHERE admins.role = 'admin') > 1;
 
+-- name: HasAnyAdmin :one
+-- Reports whether any player currently holds the admin role. Backs the
+-- first-boot bootstrap that mints an admin from env vars only when none
+-- exists yet, so a populated deployment ignores the bootstrap vars.
+SELECT EXISTS(SELECT 1 FROM players WHERE role = 'admin') AS has_admin;
+
 -- name: ListAdmins :many
 -- Every current Admin, ordered by display_name so the admin settings page
 -- (#320/#538) renders a stable list. Only the columns the list needs are

--- a/internal/store/player.go
+++ b/internal/store/player.go
@@ -1010,6 +1010,18 @@ func classifyDemoteRefusal(ctx context.Context, q *db.Queries, playerID int64) e
 	return auth.ErrPlayerNotFound
 }
 
+// HasAnyAdmin reports whether any player currently holds the admin role.
+// Backs the first-boot bootstrap that mints an admin from env vars only when
+// none exists yet.
+func (s *PlayerStore) HasAnyAdmin(ctx context.Context) (bool, error) {
+	exists, err := s.q.HasAnyAdmin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check for any admin: %w", err)
+	}
+
+	return exists, nil
+}
+
 // ListAdmins returns every current Admin ordered by displayName (#320/#538).
 // Empty slice when no Admin exists yet.
 func (s *PlayerStore) ListAdmins(ctx context.Context) ([]*auth.AdminEntry, error) {


### PR DESCRIPTION
On first boot with no admin present, create a verified admin from `INITIAL_ADMIN_EMAIL` + `INITIAL_ADMIN_PASSWORD`, then continue booting. Once any admin exists the vars are ignored, so a restart with them still set is a no-op.

- Config: new `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD` (both default empty, which disables the bootstrap); documented in `.env.example`.
- Store: `HasAnyAdmin` query + `PlayerStore` method (`SELECT EXISTS(... role = 'admin')`).
- Startup: `bootstrapInitialAdmin` runs in `Run` right after migrations, reusing the existing `createVerifiedAdmin` helper. A malformed email or too-short password fails startup; an email already taken by a non-admin is a skip, not a failure.
- Tests: layer tests for create / admin-present skip / email-in-use skip / too-short password / malformed email / empty-env no-op, plus config parse tests.

Note: `bootstrapInitialAdmin` takes the concrete `*store.PlayerStore` (matching the other `cmd/server/app` commands and reusing `createVerifiedAdmin`), so `HasAnyAdmin` was added to the concrete store rather than the `auth.PlayerStore` interface. Adding it to that interface would break several test stubs for no functional gain, since no interface-typed caller needs it.

Closes #1206

_— Claude Code, for @starquake_