### PR TITLE
Redirect to home after logout

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -886,11 +886,11 @@ func redirectAfterLogin(w http.ResponseWriter, r *http.Request, role string) {
 }
 
 // HandleLogout returns a handler for POST /logout. It clears the session cookie and
-// redirects to /login.
+// redirects to the home page.
 func HandleLogout(sessions *session.Manager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sessions.Clear(w)
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
 	})
 }
 

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -1208,7 +1208,7 @@ func TestHandleLogout_NoCookie(t *testing.T) {
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	if got, want := rec.Header().Get("Location"), "/login"; got != want {
+	if got, want := rec.Header().Get("Location"), "/"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
 	}
 }
@@ -1225,7 +1225,7 @@ func TestHandleLogout_ClearsCookieAndRedirects(t *testing.T) {
 	if got, want := rec.Code, http.StatusSeeOther; got != want {
 		t.Errorf("status = %d, want %d", got, want)
 	}
-	if got, want := rec.Header().Get("Location"), "/login"; got != want {
+	if got, want := rec.Header().Get("Location"), "/"; got != want {
 		t.Errorf("Location = %q, want %q", got, want)
 	}
 

--- a/test/integration/auth_redirect_test.go
+++ b/test/integration/auth_redirect_test.go
@@ -101,13 +101,13 @@ func TestAuthRedirect_NextRoundTrip(t *testing.T) {
 	registerVerifyAndSignIn(ctx, t, client, baseURL, srv.DBURI, "next-admin", "next-admin-pass-123")
 
 	// Log out: the home page carries the log-out form, so POST /logout
-	// with its CSRF token. The handler 303s to /login and clears the
+	// with its CSRF token. The handler 303s to / and clears the
 	// session cookie.
 	logout := postLogoutFromHome(ctx, t, client, baseURL)
 	if got, want := logout.StatusCode, http.StatusSeeOther; got != want {
 		t.Fatalf("logout status = %d, want %d", got, want)
 	}
-	if got, want := logout.Location, "/login"; got != want {
+	if got, want := logout.Location, "/"; got != want {
 		t.Errorf("logout Location = %q, want %q", got, want)
 	}
 

--- a/test/integration/home_test.go
+++ b/test/integration/home_test.go
@@ -390,12 +390,12 @@ func TestHome_Integration_FooterAffordance(t *testing.T) {
 
 	t.Run("log-out form actually clears the session", func(t *testing.T) {
 		// Submit the form the home page rendered. The handler returns
-		// 303 to /login on success and clears the session cookie.
+		// 303 to / on success and clears the session cookie.
 		logoutSnap := postLogoutFromHome(ctx, t, regClient, srv.BaseURL)
 		if got, want := logoutSnap.StatusCode, http.StatusSeeOther; got != want {
 			t.Fatalf("logout status = %d, want %d", got, want)
 		}
-		if got, want := logoutSnap.Location, "/login"; got != want {
+		if got, want := logoutSnap.Location, "/"; got != want {
 			t.Errorf("logout Location = %q, want %q", got, want)
 		}
 


### PR DESCRIPTION
Logout redirected to `/login`, which is a dead end for a signed-out visitor (and confusing on the demo). It now 303s to `/` instead.

- `HandleLogout` redirects to `/`; doc comment and the two handler tests updated.
- Integration tests `auth_redirect_test.go` and `home_test.go` updated to assert the new target.

Closes #1217

_— Claude Code, for @starquake_