### PR TITLE
Serialize deploys on the shared host to avoid the pull-prune lease race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,6 +176,10 @@ jobs:
             EOF
             mv -f docker-compose.staging.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
+            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
+            exec 9>/tmp/topbanana-deploy.lock
+            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
             docker image prune -af
@@ -361,6 +365,10 @@ jobs:
             EOF
             mv -f docker-compose.production.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
+            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
+            exec 9>/tmp/topbanana-deploy.lock
+            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
             docker image prune -af
@@ -527,6 +535,10 @@ jobs:
             EOF
             mv -f docker-compose.demo.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
+            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
+            exec 9>/tmp/topbanana-deploy.lock
+            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
             docker image prune -af


### PR DESCRIPTION
Staging, demo, and production all deploy to the same host/daemon (each `deploy-*` job SSHes in with its per-environment `SSH_HOST`, which resolves to the same box). On every merge to `main`, `deploy-staging` and `deploy-demo` run in parallel and each runs `docker compose pull` then `docker image prune -af`. Because `-af` prunes across the whole daemon, one job's prune can collect the other's in-flight pull lease, failing the deploy with `unable to lease content: lease does not exist: not found`. That took down `deploy-demo` after the last merge; a plain re-run succeeded, confirming the race.

This wraps the daemon-touching steps (`pull` / `up -d` / `prune -af`) in a host-side `flock` on `/tmp/topbanana-deploy.lock`, so concurrent deploys wait for the lock instead of pruning across each other's pulls. The lock is held via fd 9 for the whole critical section and released when the script exits. `flock -w 300` bounds the wait and fails the deploy with a clear message rather than hanging.

## Why not a job-level `concurrency` group

The first version of this PR used a shared `concurrency: { group: deploy-shared-host, cancel-in-progress: false }` across the three jobs. A high-effort review (and a second look at GitHub's semantics) found it unsafe: a group keeps at most one running + one pending job, and a newly queued job **cancels the previously pending one** — `cancel-in-progress: false` only protects the running job, not the pending one. So a tagged **production** deploy sitting pending behind a running staging deploy could be silently cancelled by a second staging deploy queued behind it, dropping the release with no failure surfaced. A host-side lock serializes at the actual point of contention (the daemon), across all runs and environments, with no cancellation and no dropped deploys.

Deploy scripts otherwise unchanged; validated with `yq`.

_— Claude Code, for @starquake_