### PR TITLE
Remove the per-deploy image prune from the shared host

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,13 +176,8 @@ jobs:
             EOF
             mv -f docker-compose.staging.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
-            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
-            exec 9>/tmp/topbanana-deploy.lock
-            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
-            docker image prune -af
             docker logout ghcr.io
 
       - name: Verify staging deployment
@@ -365,13 +360,8 @@ jobs:
             EOF
             mv -f docker-compose.production.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
-            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
-            exec 9>/tmp/topbanana-deploy.lock
-            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
-            docker image prune -af
             docker logout ghcr.io
 
       - name: Verify production deployment
@@ -535,13 +525,8 @@ jobs:
             EOF
             mv -f docker-compose.demo.yml docker-compose.yml
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-            # Shared host: serialize the daemon-touching steps so a concurrent deploy's
-            # `docker image prune -af` cannot collect this deploy's in-flight pull lease.
-            exec 9>/tmp/topbanana-deploy.lock
-            flock -w 300 9 || { echo "another deploy holds the host lock; retry this deploy" >&2; exit 1; }
             docker compose pull
             docker compose up -d
-            docker image prune -af
             docker logout ghcr.io
 
       - name: Verify demo deployment


### PR DESCRIPTION
Follow-up to #1221. That PR serialized deploys with a `flock`, but the shared host uses different SSH users, so the `umask 077` lock file was unopenable by the second user and demo failed every deploy.

Root cause of the original lease race: `docker image prune -af` ran after every deploy, and on this shared daemon its content GC can collect a concurrent deploy's in-flight pull lease (`unable to lease content: lease does not exist`). The prune is the only thing that triggers that GC — two concurrent pulls alone don't race.

This removes the prune (and the flock) from all three deploy jobs, leaving each as just `pull` + `up -d`. With no GC during deploys, concurrent staging/demo deploys can't hit the race. Image cleanup is handled out-of-band on the host.

_— Claude Code, for @starquake_