### PR TITLE
Track .claude/settings.json to pin enabled plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "enabledPlugins": {
+    "github@claude-plugins-official": false,
+    "claude-md-management@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
Audit of `.claude/` found every style rule, project skill, and agent already tracked — only `.claude/settings.json` was untracked. It pins the enabled Claude Code plugins (`claude-md-management`, `playwright`, `gopls-lsp` on; `github` off) so the setup is reproducible for anyone working the repo. Contents are plugin-enablement flags only, no secrets.

If you'd rather keep plugin choices personal, move it to `.claude/settings.local.json` (gitignored) instead — let me know and I'll swap it.

_— Claude Code, for @starquake_