### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      # Safe under the signed-commit ruleset: Dependabot signs its own rebases and GitHub signs the squash-merge.
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,8 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Skip /tools: those pins are tracking-only, and the version that is
+      # actually used has to be mirrored into the Makefile + ci.yml by hand.
       # Safe under the signed-commit ruleset: Dependabot signs its own rebases and GitHub signs the squash-merge.
       - name: Enable auto-merge
+        if: steps.meta.outputs.directory != '/tools'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds a workflow that enables auto-merge (squash) on Dependabot PRs, so a dependency bump merges on its own once the required checks are green.

- `.github/workflows/dependabot-auto-merge.yml` runs only when the PR actor is `dependabot[bot]` and calls `gh pr merge --auto --squash`.
- Scope: every ecosystem and every bump size (patch, minor, major) **except** the `/tools` directory. Those pins are tracking-only: the version actually used lives in the Makefile (`GOLANGCI_VERSION`, `SQLC_VERSION`, ...) and in the `lint` job of `ci.yml`, mirrored by hand. A `/tools` PR goes green without changing anything that runs, so it stays manual. Detected via `dependabot/fetch-metadata`'s `directory` output.
- The other ecosystems are self-checking: npm bumps of the vendored libs and esbuild are drift-checked by `make js-check`, and `github-actions` bumps edit the workflow file itself.
- Safe under the signed-commit ruleset: Dependabot signs its own rebases and GitHub signs the final squash-merge.
- Repo `Allow auto-merge` is already enabled, and no required-check changes, so the ruleset is untouched.

_— Claude Code, for @starquake_
