### PR TITLE
Group Dependabot minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
+
+# Minor/patch bumps ride together in one PR per ecosystem so a weekly batch
+# drains in one CI run; majors stay solo and cannot block the rest.
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gomod:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Tracking-only module for tools we install via release binaries (see
   # GOLANGCI_VERSION in the Makefile). The main module does not import
@@ -14,6 +21,10 @@ updates:
     directory: "/tools"
     schedule:
       interval: "weekly"
+    groups:
+      gomod-tools:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Action versions pinned in .github/workflows/*.yml. Without this entry the
   # pins drift silently — actions/checkout, actions/setup-go, etc. age out
@@ -22,6 +33,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # esbuild under the root package.json - the dev-only build tooling for the
   # player client + admin JS bundles (#721). Without this entry only security
@@ -31,6 +46,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Playwright + @types/node under test/e2e/. Keeps the browser deps moving
   # forward in step with upstream releases (relevant for security advisories
@@ -39,3 +58,7 @@ updates:
     directory: "/test/e2e"
     schedule:
       interval: "weekly"
+    groups:
+      npm-e2e:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Groups routine Dependabot version updates so a weekly batch arrives as one PR per ecosystem instead of one per dependency. With the strict up-to-date-before-merge ruleset, N separate bump PRs cost O(N^2) CI runs to drain -- each merge puts the rest behind, and the full suite re-runs on every rebase.

- `groups` added to all five update entries (`gomod /`, `gomod /tools`, `github-actions`, `npm /`, `npm /test/e2e`).
- Scoped to `minor` + `patch`. A major bump still opens on its own, so a breaking one is readable in isolation and cannot hold back the harmless patches beside it.
- Security updates are unaffected: `groups` applies to version updates only, so an advisory fix still arrives as its own PR.
- The `/tools` auto-merge exclusion still holds -- that workflow keys on `dependabot/fetch-metadata`'s `directory` output, not the branch name, and grouping is per-ecosystem-per-directory.

Trade-off, stated plainly: a grouped bump lands as one squash commit, so you can no longer revert a single dependency out of the batch without hand-editing the manifest.

No code or test changes; nothing in `make check` covers `dependabot.yml`. Config validated by parsing it and confirming all five entries carry a group scoped to minor+patch.

_— Claude Code, for @starquake_
