### PR TITLE
Retire the standalone question page in favour of the editor

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1811,14 +1811,27 @@ func HandleQuestionCreate(
 			return
 		}
 
-		renderer.Render(w, r, http.StatusOK, questionFormData{
+		createData := questionFormData{
 			Title:        "Admin Dashboard - Question Create",
 			Quiz:         quizDataFromQuiz(qz),
 			Question:     &QuestionData{},
 			Round:        roundDataFromRound(rnd),
 			Library:      library,
 			AudioLibrary: audioLibrary,
-		})
+		}
+
+		// "Add question" in the editor rail opens the blank form in the pane;
+		// the quiz view's link still navigates to the standalone page, which
+		// is why that page survives slice 6 even though the edit route no
+		// longer uses it.
+		if htmx.IsRequest(r) {
+			createData.InEditor = true
+			renderer.RenderPartial(w, r, "question_form", createData)
+
+			return
+		}
+
+		renderer.Render(w, r, http.StatusOK, createData)
 	})
 }
 
@@ -1925,17 +1938,49 @@ func HandleQuestionEdit(
 			AudioLibrary: audioLibrary,
 		}
 
-		// The two-pane editor (#1244) asks for the form alone; a direct visit
-		// still gets the full page, which is also the no-JS path.
-		if htmx.IsRequest(r) {
-			data.InEditor = true
-			renderer.RenderPartial(w, r, "question_form", data)
-
-			return
-		}
-
-		renderer.Render(w, r, http.StatusOK, data)
+		respondQuestionEdit(w, r, renderer, data, quizID, questionID)
 	})
+}
+
+// respondQuestionEdit writes the question-edit response: the bare form for the
+// editor pane, or a redirect into the editor for a direct visit (#1244 slice
+// 6). One way to edit a question instead of two; the deliberate cost is that
+// editing now needs JavaScript.
+//
+// The redirect is 303, NOT 301: this URL still serves the form itself to htmx,
+// and a permanent redirect is cacheable. The browser would cache it and then
+// serve it for the editor pane's own fetch, swapping a whole HTML document
+// into the pane instead of the form.
+func respondQuestionEdit(
+	w http.ResponseWriter,
+	r *http.Request,
+	renderer *render.Renderer,
+	data questionFormData,
+	quizID, questionID int64,
+) {
+	if htmx.IsRequest(r) {
+		data.InEditor = true
+		renderer.RenderPartial(w, r, "question_form", data)
+
+		return
+	}
+
+	// questionID 0 is the defensive blank-question branch, which has no editor
+	// URL to point at - it keeps rendering the page.
+	if questionID == 0 {
+		renderer.Render(w, r, http.StatusOK, data)
+
+		return
+	}
+
+	// strconv.FormatInt rather than fmt.Sprintf: both ids came off the request
+	// path, and %d taints the redirect for gosec G710.
+	http.Redirect(
+		w, r,
+		"/admin/quizzes/"+strconv.FormatInt(quizID, 10)+
+			"/questions?q="+strconv.FormatInt(questionID, 10),
+		http.StatusSeeOther,
+	)
 }
 
 // HandleQuizSetMode flips a quiz between solo and live without going through

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1393,6 +1393,7 @@ func TestHandleQuestionEdit(t *testing.T) {
 			fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", qz.ID, question.ID),
 			nil,
 		)
+		req.Header.Set("Hx-Request", "true")
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		req.SetPathValue("questionID", strconv.FormatInt(question.ID, 10))
 		rr := httptest.NewRecorder()
@@ -1511,6 +1512,7 @@ func TestQuestionEditSave_OptionIDsRoundTrip(t *testing.T) {
 		fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", qz.ID, original.ID),
 		nil,
 	)
+	editReq.Header.Set("Hx-Request", "true")
 	editReq.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 	editReq.SetPathValue("questionID", strconv.FormatInt(original.ID, 10))
 	editRec := httptest.NewRecorder()
@@ -1641,6 +1643,7 @@ func TestHandleQuestionEdit_HandleError(t *testing.T) {
 			fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", qz.ID, question.ID),
 			nil,
 		)
+		req.Header.Set("Hx-Request", "true")
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		req.SetPathValue("questionID", strconv.FormatInt(question.ID, 10))
 		rr := httptest.NewRecorder()
@@ -1956,6 +1959,7 @@ func TestHandleQuestionEdit_Picker(t *testing.T) {
 			t.Context(), http.MethodGet,
 			fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", qz.ID, question.ID), nil,
 		)
+		req.Header.Set("Hx-Request", "true")
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		req.SetPathValue("questionID", strconv.FormatInt(question.ID, 10))
 		rr := httptest.NewRecorder()
@@ -1992,6 +1996,7 @@ func TestHandleQuestionEdit_Picker(t *testing.T) {
 			t.Context(), http.MethodGet,
 			fmt.Sprintf("/admin/quizzes/%d/questions/%d/edit", qz.ID, question.ID), nil,
 		)
+		req.Header.Set("Hx-Request", "true")
 		req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 		req.SetPathValue("questionID", strconv.FormatInt(question.ID, 10))
 		rr := httptest.NewRecorder()

--- a/internal/admin/quizeditor_test.go
+++ b/internal/admin/quizeditor_test.go
@@ -246,17 +246,23 @@ func TestHandleQuestionEditPartial(t *testing.T) {
 		}
 	})
 
-	t.Run("a direct visit still returns the full page", func(t *testing.T) {
+	// Slice 6 retired the standalone page: a direct visit redirects into the
+	// editor. 303 not 301: see the handler - a cacheable redirect poisons the
+	// pane fetch that shares this URL.
+	t.Run("a direct visit redirects into the editor", func(t *testing.T) {
 		t.Parallel()
 
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, newRequest(t, qz.ID, questionID, false))
 
-		if got, want := rr.Code, http.StatusOK; got != want {
-			t.Fatalf("page status = %d, want %d", got, want)
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("direct visit status = %d, want %d", got, want)
 		}
-		if want := "<html"; !strings.Contains(rr.Body.String(), want) {
-			t.Errorf("direct visit should return the full page containing %q", want)
+
+		wantLocation := "/admin/quizzes/" + strconv.FormatInt(qz.ID, 10) +
+			"/questions?q=" + strconv.FormatInt(questionID, 10)
+		if got := rr.Header().Get("Location"); got != wantLocation {
+			t.Errorf("redirect Location = %q, want %q", got, wantLocation)
 		}
 	})
 }
@@ -344,6 +350,8 @@ func TestQuestionFormMediaPickersCollapse(t *testing.T) {
 	)
 	req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
 	req.SetPathValue("questionID", strconv.FormatInt(questionID, 10))
+	// The form only renders for the editor pane now; a plain visit redirects.
+	req.Header.Set("Hx-Request", "true")
 
 	rr := httptest.NewRecorder()
 	HandleQuestionEdit(logger, nil, env.quizzes, env.media).ServeHTTP(rr, withTestAdmin(req))

--- a/internal/web/tmpl/admin/partials/question_row.gohtml
+++ b/internal/web/tmpl/admin/partials/question_row.gohtml
@@ -85,7 +85,10 @@
     </div>
     {{if and $canEdit (not $inEditor)}}
     <div class="q-actions">
-        <a href="/admin/quizzes/{{$q.QuizID}}/questions/{{$q.ID}}/edit"
+        {{/* Points straight at the editor: the old per-question edit URL is a
+             permanent redirect there now (#1244 slice 6), and following it
+             would just cost a round trip. */}}
+        <a href="/admin/quizzes/{{$q.QuizID}}/questions?q={{$q.ID}}"
            aria-label="Edit question" title="Edit question" class="icon-btn">
             <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4" aria-hidden="true"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"/></svg>
         </a>

--- a/internal/web/tmpl/admin/partials/questions_list.gohtml
+++ b/internal/web/tmpl/admin/partials/questions_list.gohtml
@@ -54,7 +54,15 @@
             </div>
             {{if $canEdit}}
             <div class="mt-3">
+                {{/* In the editor the blank form opens in the pane; on the quiz
+                     view the link still navigates to the standalone page. */}}
                 <a href="/admin/quizzes/{{$quizID}}/questions/new?round_id={{$round.ID}}"
+                   {{if $inEditor}}
+                   hx-get="/admin/quizzes/{{$quizID}}/questions/new?round_id={{$round.ID}}"
+                   hx-target="#question-editor"
+                   hx-swap="innerHTML"
+                   data-editor-add-question
+                   {{end}}
                    class="btn-ghost gap-2">
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a.5.5 0 0 1 .5.5v5.5H14a.5.5 0 0 1 0 1H8.5V14a.5.5 0 0 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 .5-.5z"/></svg>
                     <span>Add question</span>

--- a/test/e2e/tests/admin-app-shell.spec.ts
+++ b/test/e2e/tests/admin-app-shell.spec.ts
@@ -257,3 +257,31 @@ test('a round can be edited in the pane and its header updates in place', async 
     await expect.poll(async () => (await texts())[0]).toBe(before[before.length - 1]);
   }
 });
+
+// Slice 6 retires the standalone question page: the old URL is a permanent
+// redirect into the editor, and "Add question" opens the blank form in the
+// pane rather than navigating away mid-session.
+test('the old question edit URL redirects into the editor', async ({ page, browserName }) => {
+  const title = `E2E Editor Retire ${browserName} ${Date.now()}`;
+  await seedQuiz(page, title, QUIZ_QUESTIONS, { publish: false });
+  await page.goto('/admin/quizzes');
+  await page.getByRole('link', { name: title }).click();
+  const quizUrl = page.url();
+  const quizId = quizUrl.match(/\/admin\/quizzes\/(\d+)/)?.[1];
+  expect(quizId, 'quiz id from the URL').toBeTruthy();
+
+  await page.getByTestId('open-question-editor').click();
+  const firstRow = page.locator('article.q-row').first();
+  const questionId = await firstRow.getAttribute('data-question-id');
+
+  // Visiting the retired URL directly lands in the editor with that question
+  // already open.
+  await page.goto(`/admin/quizzes/${quizId}/questions/${questionId}/edit`);
+  await expect(page).toHaveURL(new RegExp(`/admin/quizzes/${quizId}/questions\\?q=${questionId}$`));
+  await expect(page.locator('#question-editor textarea[name="text"]')).toBeVisible();
+
+  // Add question fills the pane instead of navigating.
+  await page.locator('[data-editor-add-question]').first().click();
+  await expect(page).toHaveURL(/\/questions(\?|$)/);
+  await expect(page.locator('#question-editor textarea[name="text"]')).toHaveValue('');
+});

--- a/test/e2e/tests/question-image.spec.ts
+++ b/test/e2e/tests/question-image.spec.ts
@@ -48,7 +48,10 @@ async function authorQuizWithImageQuestion(page: Page, quizTitle: string): Promi
   await expect(libraryThumb).toBeVisible({ timeout: 30_000 });
 
   await page.getByRole('link', { name: 'Edit question' }).first().click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/\d+\/edit$/);
+  // The standalone question page is retired (#1244 slice 6): editing now
+  // happens in the two-pane editor.
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\?q=\d+$/);
+  await expect(page.locator('#question-editor form')).toBeVisible();
   // The picker is collapsed in the form now (#1244); open it before clicking.
   await openMediaPicker(page, 'image');
   const pickerThumb = page
@@ -57,7 +60,7 @@ async function authorQuizWithImageQuestion(page: Page, quizTitle: string): Promi
     .first();
   await expect(pickerThumb).toBeVisible();
   await pickerThumb.click();
-  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect(page.locator('.q-text', { hasText: SINGLE_QUESTION[0].text })).toBeVisible({ timeout: 15_000 });
 }
 

--- a/test/e2e/tests/quiz-audio-upload.spec.ts
+++ b/test/e2e/tests/quiz-audio-upload.spec.ts
@@ -114,7 +114,10 @@ test('an edited sound description shows in the question editor audio picker', as
   await expect(page.getByTestId('audio-description-input').first()).toHaveValue('Theme tune');
 
   await page.getByRole('link', { name: 'Edit question' }).first().click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/\d+\/edit$/);
+  // The standalone question page is retired (#1244 slice 6): editing now
+  // happens in the two-pane editor.
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\?q=\d+$/);
+  await expect(page.locator('#question-editor form')).toBeVisible();
 
   await openMediaPicker(page, 'audio');
   const picker = page.getByTestId('question-audio-picker');
@@ -138,7 +141,10 @@ test('the question editor audio picker lists a sound and attaches it', async ({ 
 
   // Open the question editor for the one seeded question.
   await page.getByRole('link', { name: 'Edit question' }).first().click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/\d+\/edit$/);
+  // The standalone question page is retired (#1244 slice 6): editing now
+  // happens in the two-pane editor.
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\?q=\d+$/);
+  await expect(page.locator('#question-editor form')).toBeVisible();
 
   await openMediaPicker(page, 'audio');
   const picker = page.getByTestId('question-audio-picker');
@@ -153,12 +159,16 @@ test('the question editor audio picker lists a sound and attaches it', async ({ 
     .first()
     .locator('input[name="audio_media_id"]')
     .check({ force: true });
-  await page.getByRole('button', { name: 'Save' }).click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+$/);
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  // Saving from the pane stays on the page now (#1244 slice 2) rather than
+  // redirecting to the quiz view; the rail row picks up the audio flag.
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions/);
+  await expect(page.getByTestId('q-badge-audio').first()).toBeVisible();
 
-  // Re-open the editor; the audio's radio is now checked.
-  await page.getByRole('link', { name: 'Edit question' }).first().click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/\d+\/edit$/);
+  // Reload from the deep link; the audio's radio is still checked.
+  await page.reload();
+  await expect(page.locator('#question-editor form')).toBeVisible();
+  await openMediaPicker(page, 'audio');
   const chosen = page
     .getByTestId('question-audio-picker')
     .getByTestId('audio-library-item')

--- a/test/e2e/tests/solo-options-fit.spec.ts
+++ b/test/e2e/tests/solo-options-fit.spec.ts
@@ -51,7 +51,10 @@ async function authorQuizWithImageQuestion(page: Page, quizTitle: string): Promi
   await expect(libraryThumb).toBeVisible({ timeout: 30_000 });
 
   await page.getByRole('link', { name: 'Edit question' }).first().click();
-  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\/\d+\/edit$/);
+  // The standalone question page is retired (#1244 slice 6): editing now
+  // happens in the two-pane editor.
+  await expect(page).toHaveURL(/\/admin\/quizzes\/\d+\/questions\?q=\d+$/);
+  await expect(page.locator('#question-editor form')).toBeVisible();
   await openMediaPicker(page, 'image');
   const pickerThumb = page
     .getByTestId('question-image-picker')
@@ -59,7 +62,7 @@ async function authorQuizWithImageQuestion(page: Page, quizTitle: string): Promi
     .first();
   await expect(pickerThumb).toBeVisible();
   await pickerThumb.click();
-  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect(page.locator('.q-text', { hasText: REALISTIC[0].text })).toBeVisible({ timeout: 15_000 });
 }
 

--- a/test/integration/media_audio_test.go
+++ b/test/integration/media_audio_test.go
@@ -254,7 +254,7 @@ func TestMediaAudioLibraryAndPicker_Integration(t *testing.T) {
 	t.Run("question editor shows the audio picker and attaches the audio", func(t *testing.T) {
 		t.Parallel()
 		editURL := fmt.Sprintf("%s/admin/quizzes/%d/questions/%d/edit", baseURL, quizID, questionID)
-		page := getPageBody(ctx, t, owner, editURL)
+		page := getPartialBody(ctx, t, owner, editURL)
 		for _, want := range []string{`data-testid="question-audio-picker"`, `name="audio_media_id"`} {
 			if !strings.Contains(page, want) {
 				t.Errorf("question editor missing %q", want)
@@ -344,7 +344,7 @@ func TestMediaAudioDescription_Integration(t *testing.T) {
 		}
 
 		editURL := fmt.Sprintf("%s/admin/quizzes/%d/questions/%d/edit", baseURL, quizID, questionID)
-		picker := getPageBody(ctx, t, owner, editURL)
+		picker := getPartialBody(ctx, t, owner, editURL)
 		if !strings.Contains(picker, "Round one intro") {
 			t.Errorf("question picker missing the edited description %q", "Round one intro")
 		}
@@ -451,14 +451,29 @@ func addQuestionToQuiz(ctx context.Context, t *testing.T, stores *store.Stores, 
 }
 
 // getPageBody fetches a page and returns its body, asserting a 200. Used to
-// probe the question editor's rendered HTML for the audio picker.
-func getPageBody(ctx context.Context, t *testing.T, client *http.Client, target string) string {
+
+// getPartialBody fetches a URL the way the two-pane editor does, with the
+// HX-Request header, and returns the fragment. The question edit route serves
+// the bare form to htmx and redirects a plain visit into the editor (#1244).
+func getPartialBody(ctx context.Context, t *testing.T, client *http.Client, target string) string {
 	t.Helper()
-	resp := httpGet(ctx, t, client, target)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		t.Fatalf("new request err = %v, want nil", err)
+	}
+	req.Header.Set("Hx-Request", "true")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s err = %v, want nil", target, err)
+	}
 	defer closeBody(t, resp.Body)
+
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
 		t.Fatalf("GET %s status = %d, want %d", target, got, want)
 	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read body err = %v, want nil", err)
@@ -568,9 +583,14 @@ func saveQuestionWithAudio(
 ) {
 	t.Helper()
 	saveURL := baseURL + fmt.Sprintf("/admin/quizzes/%d/questions/%d", quizID, questionID)
-	token := fetchCSRFToken(ctx, t, client, saveURL+"/edit")
+	// The edit route only serves its form to htmx now: a plain visit redirects
+	// into the two-pane editor (#1244), so the token comes from the fragment.
+	token := csrfTokenPattern.FindStringSubmatch(getPartialBody(ctx, t, client, saveURL+"/edit"))
+	if token == nil {
+		t.Fatalf("no csrf_token in the question form fragment for %s", saveURL)
+	}
 	form := url.Values{
-		"csrf_token":        {token},
+		"csrf_token":        {token[1]},
 		"id":                {strconv.FormatInt(questionID, 10)},
 		"text":              {"Name that tune"},
 		"audio_media_id":    {strconv.FormatInt(audioID, 10)},


### PR DESCRIPTION
Slice 6, the last of #1244. `GET .../questions/{id}/edit` now redirects into the two-pane editor, so there is one way to edit a question. As decided when the ticket's open questions were settled, **this drops the no-JS editing path**.

## 303, not the 301 the plan specified

The plan said 301. A 301 is actively wrong here, and the e2e caught it: the pane filled with 951KB of HTML starting `<nav class="sticky top-0 z-30...">` - the whole page nested inside itself.

That URL serves *two different things*: a redirect to a browser, and the bare form to htmx. A permanent redirect is cacheable, so the browser cached it and then served that cached redirect for the editor pane's own fetch. 303 keeps the redirect out of the cache. The reasoning is in the handler so it does not get "simplified" back.

I only found it by dumping the swapped content. The URL assertion passed, the redirect worked, the server log looked right; the only symptom was a missing textarea.

## The page shell survives, deliberately

The plan said to delete `questionform.gohtml`. That would have broken question creation outright: `HandleQuestionCreate` renders the same shell, and the rail's "Add question" links to `/questions/new`.

So the page stays for the create path. "Add question" in the editor rail now opens the blank form in the pane; on the quiz view it still navigates. The quiz view's per-row edit icon points straight at the editor rather than through the redirect.

## Test churn, in three waves

Ten failures across five specs. Only the first wave was expected:

1. **Expected**: specs clicked "Edit question" and asserted the standalone URL. They now expect `/questions?q=N` with the form scoped to `#question-editor`.
2. **My regression, from slice 7**: `getByRole('button', { name: 'Save' })` became ambiguous once the editor grew a **"Save and next"**. Same substring trap as "Edit question" / "Edit questions" earlier in this ticket.
3. **My over-correction**: I made every `name: 'Save'` exact, which broke the new-quiz helper - that form's button says **"Save quiz"**, so substring matching was load-bearing there. Now exact only where the editor's two buttons genuinely coexist.

One spec also expected the post-save redirect to the quiz view. Saving from the pane stays put, which is slice 2's behaviour that spec had never actually exercised.

Integration coverage moved too: the question edit route only serves its form to htmx, so `media_audio_test.go` fetches it with the header and reads its CSRF token from the fragment.

`make check` green, full `make test-e2e` 336 passed / 5 skipped / 0 failed.

Closes #1244

_— Claude Code, for @starquake_
