### PR TITLE
Honour the publish lock on the question editor route

### DIFF
--- a/internal/admin/quizeditor.go
+++ b/internal/admin/quizeditor.go
@@ -54,6 +54,16 @@ func HandleQuizEditor(
 			return
 		}
 
+		// Content edits lock on publish (#1192), and the editor is an editing
+		// surface: the quiz view hides its entry point for a published quiz, so
+		// a hand-typed URL would otherwise open a form whose every save 409s.
+		// Send it to the quiz view instead, where the lock notice says why.
+		if qz.Published {
+			http.Redirect(w, r, "/admin/quizzes/"+strconv.FormatInt(id, 10), http.StatusSeeOther)
+
+			return
+		}
+
 		rounds, ok := loadRounds(w, r, logger, csrfMgr, quizStore, id)
 		if !ok {
 			return

--- a/internal/admin/quizeditor_test.go
+++ b/internal/admin/quizeditor_test.go
@@ -376,3 +376,35 @@ func TestQuestionFormMediaPickersCollapse(t *testing.T) {
 		t.Errorf("image picker should start collapsed, found %q", notWant)
 	}
 }
+
+// The quiz view hides the editor's entry point once a quiz is published
+// (content edits lock, #1192). The route has to agree: otherwise a hand-typed
+// URL opens a form whose every save 409s.
+func TestHandleQuizEditorPublishedRedirects(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	env := newAdminEnv(t)
+	qz := env.seedQuiz(t, twoQuestionQuiz("Locked Quiz", "locked-quiz"))
+	if err := env.quizzes.SetQuizPublished(t.Context(), qz.ID, true); err != nil {
+		t.Fatalf("SetQuizPublished err = %v, want nil", err)
+	}
+
+	req := httptest.NewRequestWithContext(
+		t.Context(), http.MethodGet,
+		"/admin/quizzes/"+strconv.FormatInt(qz.ID, 10)+"/questions", nil,
+	)
+	req.SetPathValue("quizID", strconv.FormatInt(qz.ID, 10))
+
+	rr := httptest.NewRecorder()
+	HandleQuizEditor(logger, nil, env.quizzes).ServeHTTP(rr, withTestAdmin(req))
+
+	if got, want := rr.Code, http.StatusSeeOther; got != want {
+		t.Fatalf("published editor status = %d, want %d", got, want)
+	}
+	if got, want := rr.Header().Get("Location"),
+		"/admin/quizzes/"+strconv.FormatInt(qz.ID, 10); got != want {
+		t.Errorf("redirect Location = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
The quiz view hides "Open question editor" once a quiz is published, because content edits lock then (#1192). The editor route did not agree: a hand-typed URL opened it on a locked quiz, rendered the form, and every save 409'd at `requireEditableQuizOwner`. The door was hidden but unlocked, and the room did not work.

It now redirects to the quiz view, where the lock notice already explains why editing is unavailable.

## Not the fix I first proposed

I initially read the hidden button as the bug and offered to un-gate it. That was wrong: `admin.go:487` refuses every content write on a published quiz, so hiding an editing surface when editing is locked is correct - and it is the same gate the old per-question Edit links always carried, so it is not even a change from before #1244. The inconsistency ran the other way.

`make check` green, full `make test-e2e` 336 passed / 5 skipped / 0 failed.

Related: #1260 covers the larger question of the quiz view and the editor both rendering the play sequence.

_— Claude Code, for @starquake_
