### PR TITLE
Duplicate a question from the editor

### DIFF
--- a/internal/admin/questionduplicate.go
+++ b/internal/admin/questionduplicate.go
@@ -1,0 +1,208 @@
+package admin
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/starquake/topbanana/internal/csrf"
+	"github.com/starquake/topbanana/internal/handlers"
+	"github.com/starquake/topbanana/internal/htmx"
+	"github.com/starquake/topbanana/internal/quiz"
+	"github.com/starquake/topbanana/internal/render"
+)
+
+// HandleQuestionDuplicate copies a question and drops the copy directly after
+// the original (#1246). Authoring several near-identical questions otherwise
+// means retyping four options with one word changed.
+//
+// The copy is created at the end and then moved, rather than inserted mid-list:
+// [quiz.Store.CreateQuestionAtNextPosition] already owns the max+1 race and its
+// retry budget, and MoveQuestionToPosition already owns the renumbering. Two
+// tested primitives beat a third transaction that has to get both right.
+func HandleQuestionDuplicate(
+	logger *slog.Logger,
+	csrfMgr *csrf.Manager,
+	quizStore quiz.Store,
+	mediaStore QuestionMediaStore,
+) http.Handler {
+	renderer := NewTemplateRenderer(logger, csrfMgr, "admin/pages/questionform.gohtml")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		quizID, ok := handlers.ParseIDFromPath(w, r, logger, "quizID")
+		if !ok {
+			return
+		}
+
+		questionID, ok := handlers.ParseIDFromPath(w, r, logger, "questionID")
+		if !ok {
+			return
+		}
+
+		// Editable-owner, not just owner: duplicating is a content edit, so it
+		// is refused on a published quiz like every other one (#1192).
+		qz, ok := requireEditableQuizOwner(w, r, logger, csrfMgr, quizStore, quizID)
+		if !ok {
+			return
+		}
+
+		source, ok := questionByID(w, r, logger, csrfMgr, quizStore, qz.ID, questionID)
+		if !ok {
+			return
+		}
+
+		copied := copyQuestion(source)
+		if err := quizStore.CreateQuestionAtNextPosition(r.Context(), copied); err != nil {
+			logger.ErrorContext(r.Context(), "error duplicating question", slog.Any("err", err))
+			render500(w, r, logger, csrfMgr)
+
+			return
+		}
+
+		// Slot it in behind its source. A failure here leaves a valid question
+		// at the end of the quiz rather than a broken one, so it is logged and
+		// the admin still gets their copy.
+		if err := quizStore.MoveQuestionToPosition(
+			r.Context(), qz.ID, copied.ID, copied.RoundID, source.Position+1,
+		); err != nil {
+			logger.ErrorContext(r.Context(), "error positioning duplicated question", slog.Any("err", err))
+		}
+
+		if htmx.IsRequest(r) {
+			renderDuplicatedQuestion(w, r, duplicateDeps{
+				logger:   logger,
+				csrfMgr:  csrfMgr,
+				renderer: renderer,
+				quizzes:  quizStore,
+				media:    mediaStore,
+			}, qz, copied.ID)
+
+			return
+		}
+
+		http.Redirect(
+			w, r,
+			"/admin/quizzes/"+strconv.FormatInt(qz.ID, 10)+
+				"/questions?q="+strconv.FormatInt(copied.ID, 10),
+			http.StatusSeeOther,
+		)
+	})
+}
+
+// copyQuestion returns an unsaved duplicate of qs: same text, options, media,
+// repeat flag and time limit, with the identity fields left for the store to
+// assign. Media is referenced by id, so the copy points at the same library
+// entries rather than duplicating the uploads.
+func copyQuestion(qs *quiz.Question) *quiz.Question {
+	copied := &quiz.Question{
+		QuizID:           qs.QuizID,
+		RoundID:          qs.RoundID,
+		Text:             qs.Text,
+		AudioRepeat:      qs.AudioRepeat,
+		ImageMediaID:     copyInt64Ptr(qs.ImageMediaID),
+		AudioMediaID:     copyInt64Ptr(qs.AudioMediaID),
+		TimeLimitSeconds: copyIntPtr(qs.TimeLimitSeconds),
+		Options:          make([]*quiz.Option, 0, len(qs.Options)),
+	}
+
+	for _, o := range qs.Options {
+		copied.Options = append(copied.Options, &quiz.Option{
+			Text:    o.Text,
+			Correct: o.Correct,
+		})
+	}
+
+	return copied
+}
+
+// copyInt64Ptr returns a fresh pointer to the same value, so the copy never
+// shares a nullable field with its source.
+func copyInt64Ptr(v *int64) *int64 {
+	if v == nil {
+		return nil
+	}
+	out := *v
+
+	return &out
+}
+
+// copyIntPtr is [copyInt64Ptr] for the per-question time limit.
+func copyIntPtr(v *int) *int {
+	if v == nil {
+		return nil
+	}
+	out := *v
+
+	return &out
+}
+
+// renderDuplicatedQuestion answers the editor: the copy's own form for the
+// pane, and the whole rail out of band. The rail re-renders wholesale because a
+// brand new row has no element for htmx to graft onto - the same reason adding
+// a round does (#1257). quiz-reorder.js rebinds SortableJS on the swap.
+// duplicateDeps bundles the request-scoped plumbing renderDuplicatedQuestion
+// needs. They always travel together, and passing them individually pushed the
+// function past revive's argument limit.
+type duplicateDeps struct {
+	logger   *slog.Logger
+	csrfMgr  *csrf.Manager
+	renderer *render.Renderer
+	quizzes  quiz.Store
+	media    QuestionMediaStore
+}
+
+func renderDuplicatedQuestion(
+	w http.ResponseWriter,
+	r *http.Request,
+	deps duplicateDeps,
+	qz *quiz.Quiz,
+	copiedID int64,
+) {
+	logger, csrfMgr, renderer := deps.logger, deps.csrfMgr, deps.renderer
+	quizStore, mediaStore := deps.quizzes, deps.media
+
+	// Re-read the copy rather than trusting the struct we just inserted: the
+	// position move renumbered it, and its options came back with fresh ids.
+	fresh, ok := questionByID(w, r, logger, csrfMgr, quizStore, qz.ID, copiedID)
+	if !ok {
+		return
+	}
+
+	library, audioLibrary, ok := loadQuestionLibrary(w, r, logger, csrfMgr, mediaStore, qz.ID)
+	if !ok {
+		return
+	}
+
+	rounds, ok := loadRounds(w, r, logger, csrfMgr, quizStore, qz.ID)
+	if !ok {
+		return
+	}
+
+	// Re-read the quiz: the one the owner gate loaded predates the copy, so
+	// building the rail from it renders a list without the new row - the swap
+	// lands correctly and changes nothing visible.
+	refreshed, ok := quizByID(w, r, logger, csrfMgr, quizStore, qz.ID)
+	if !ok {
+		return
+	}
+
+	quizData := quizDataFromQuiz(refreshed)
+	attachCanEdit(r, quizData)
+
+	renderer.RenderPartials(w, r,
+		render.Fragment{Name: "question_form", Data: questionFormData{
+			Title:        "Admin Dashboard - Question Edit",
+			Quiz:         quizData,
+			Question:     questionDataFromQuestion(fresh),
+			Library:      library,
+			AudioLibrary: audioLibrary,
+			InEditor:     true,
+		}},
+		render.Fragment{Name: "questions_list", Data: roundsPartialData{
+			Quiz:     quizData,
+			Rounds:   buildRoundView(rounds, quizData.Questions),
+			InEditor: true,
+			OOB:      true,
+		}},
+	)
+}

--- a/internal/admin/questionduplicate_test.go
+++ b/internal/admin/questionduplicate_test.go
@@ -1,0 +1,125 @@
+package admin_test
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/starquake/topbanana/internal/admin"
+)
+
+func TestHandleQuestionDuplicate(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+
+	newRequest := func(t *testing.T, quizID, questionID int64, htmxReq bool) *http.Request {
+		t.Helper()
+
+		target := "/admin/quizzes/" + strconv.FormatInt(quizID, 10) +
+			"/questions/" + strconv.FormatInt(questionID, 10) + "/duplicate"
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, target, nil)
+		r.SetPathValue("quizID", strconv.FormatInt(quizID, 10))
+		r.SetPathValue("questionID", strconv.FormatInt(questionID, 10))
+		if htmxReq {
+			r.Header.Set("Hx-Request", "true")
+		}
+
+		return withTestAdmin(r)
+	}
+
+	t.Run("copies the question directly after its source", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		qz := env.seedQuiz(t, twoQuestionQuiz("Dupe Quiz", "dupe-quiz"))
+		source := qz.Questions[0]
+
+		rr := httptest.NewRecorder()
+		HandleQuestionDuplicate(logger, nil, env.quizzes, env.media).
+			ServeHTTP(rr, newRequest(t, qz.ID, source.ID, false))
+
+		if got, want := rr.Code, http.StatusSeeOther; got != want {
+			t.Fatalf("duplicate status = %d, want %d", got, want)
+		}
+
+		full, err := env.quizzes.GetQuiz(t.Context(), qz.ID)
+		if err != nil {
+			t.Fatalf("GetQuiz err = %v, want nil", err)
+		}
+		if got, want := len(full.Questions), len(qz.Questions)+1; got != want {
+			t.Fatalf("question count = %d, want %d", got, want)
+		}
+
+		// The copy sits immediately behind its source, not at the end.
+		var copied *struct {
+			Text     string
+			Position int
+			Options  int
+		}
+		for _, q := range full.Questions {
+			if q.ID != source.ID && q.Text == source.Text {
+				copied = &struct {
+					Text     string
+					Position int
+					Options  int
+				}{q.Text, q.Position, len(q.Options)}
+			}
+		}
+		if copied == nil {
+			t.Fatal("no duplicate found in the quiz")
+		}
+		if got, want := copied.Position, source.Position+1; got != want {
+			t.Errorf("duplicate position = %d, want %d (directly after its source)", got, want)
+		}
+		if got, want := copied.Options, len(source.Options); got != want {
+			t.Errorf("duplicate carried %d options, want %d", got, want)
+		}
+	})
+
+	// Duplicating is a content edit, so the publish lock applies (#1192).
+	t.Run("refuses a published quiz", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		qz := env.seedQuiz(t, twoQuestionQuiz("Locked Dupe", "locked-dupe"))
+		if err := env.quizzes.SetQuizPublished(t.Context(), qz.ID, true); err != nil {
+			t.Fatalf("SetQuizPublished err = %v, want nil", err)
+		}
+
+		rr := httptest.NewRecorder()
+		HandleQuestionDuplicate(logger, nil, env.quizzes, env.media).
+			ServeHTTP(rr, newRequest(t, qz.ID, qz.Questions[0].ID, false))
+
+		if got, want := rr.Code, http.StatusConflict; got != want {
+			t.Errorf("published duplicate status = %d, want %d", got, want)
+		}
+	})
+
+	// From the editor the response fills the pane with the copy and refreshes
+	// the rail out of band, since a brand new row has nothing to graft onto.
+	t.Run("htmx gets the copy's form plus the rail", func(t *testing.T) {
+		t.Parallel()
+
+		env := newAdminEnv(t)
+		qz := env.seedQuiz(t, twoQuestionQuiz("Dupe Pane", "dupe-pane"))
+
+		rr := httptest.NewRecorder()
+		HandleQuestionDuplicate(logger, nil, env.quizzes, env.media).
+			ServeHTTP(rr, newRequest(t, qz.ID, qz.Questions[0].ID, true))
+
+		if got, want := rr.Code, http.StatusOK; got != want {
+			t.Fatalf("htmx duplicate status = %d, want %d", got, want)
+		}
+
+		body := rr.Body.String()
+		for _, want := range []string{"<form", `id="questions-list"`, `hx-swap-oob="true"`} {
+			if !strings.Contains(body, want) {
+				t.Errorf("htmx duplicate response should contain %q", want)
+			}
+		}
+	})
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -770,6 +770,10 @@ func addAdminQuestionRoutes(
 	requireGameHost func(http.Handler) http.Handler,
 	csrfMgr *csrf.Manager,
 ) {
+	mux.Handle(
+		"POST /admin/quizzes/{quizID}/questions/{questionID}/duplicate",
+		csrfMW(requireGameHost(admin.HandleQuestionDuplicate(logger, csrfMgr, stores.Quizzes, stores.Media))),
+	)
 	// The two-pane question editor (#1244). Note the sibling path
 	// /admin/quizzes/{quizID}/edit is already the quiz metadata form, so the
 	// editor lives under /questions instead.

--- a/internal/web/tmpl/admin/partials/question_form.gohtml
+++ b/internal/web/tmpl/admin/partials/question_form.gohtml
@@ -312,6 +312,18 @@
             <div class="editor-actions">
                 <button type="submit" name="action" value="Save" class="btn-primary btn-compact">Save</button>
                 <button type="button" class="btn-ghost btn-compact" data-editor-save-next>Save and next</button>
+                {{/* Duplicate lands a copy right after this question and opens
+                     it, so a near-identical question is one click plus an edit
+                     (#1246). Only for a saved question - there is nothing to
+                     copy until it exists. */}}
+                {{if .Question.ID}}
+                <button type="button" class="btn-ghost btn-compact"
+                        data-testid="editor-duplicate"
+                        hx-post="/admin/quizzes/{{.Question.QuizID}}/questions/{{.Question.ID}}/duplicate"
+                        hx-target="#question-editor"
+                        hx-swap="innerHTML"
+                        hx-vals='{"csrf_token": "{{csrfToken}}"}'>Duplicate</button>
+                {{end}}
                 <button type="button"
                         class="btn-ghost btn-compact"
                         data-testid="editor-discard"

--- a/test/e2e/tests/admin-app-shell.spec.ts
+++ b/test/e2e/tests/admin-app-shell.spec.ts
@@ -327,3 +327,41 @@ test('a round can be added from the editor rail', async ({ page, browserName }) 
     }
   }
 });
+
+// Duplicating a question from the editor (#1246). The copy lands directly after
+// its source and opens in the pane. Like adding a round, the rail re-renders
+// wholesale because the new row has nothing to graft onto - hence the drag
+// check, which is what catches a Sortable that failed to rebind.
+test('a question can be duplicated from the editor', async ({ page, browserName }) => {
+  const title = `E2E Duplicate ${browserName} ${Date.now()}`;
+  await seedQuiz(page, title, QUIZ_QUESTIONS, { publish: false });
+  await page.goto('/admin/quizzes');
+  await page.getByRole('link', { name: title }).click();
+  await page.getByTestId('open-question-editor').click();
+
+  const rows = page.locator('article.q-row');
+  const texts = async () => rows.locator('.q-text').allTextContents();
+  const before = await texts();
+
+  await rows.first().click();
+  await expect(page.locator('#question-editor textarea[name="text"]')).toBeVisible();
+  const sourceText = before[0];
+
+  await page.getByTestId('editor-duplicate').click();
+
+  // One more row, and the copy sits immediately behind its source.
+  await expect.poll(async () => (await texts()).length).toBe(before.length + 1);
+  const after = await texts();
+  expect(after[0]).toBe(sourceText);
+  expect(after[1]).toBe(sourceText);
+
+  // The pane holds the copy, ready to edit.
+  await expect(page.locator('#question-editor textarea[name="text"]')).toHaveValue(sourceText);
+
+  // The rail was replaced wholesale, so Sortable had to rebind.
+  if (browserName !== 'chromium') {
+    await rows.last().locator('[data-question-handle]')
+      .dragTo(rows.first(), { force: true });
+    await expect.poll(async () => (await texts())[0]).toBe(after[after.length - 1]);
+  }
+});


### PR DESCRIPTION
Duplicate sits in the editor's action bar beside Save. The copy lands directly after its source and opens in the pane, so a near-identical question is one click plus an edit.

## Built from two existing primitives

The copy is created at the end and then moved, rather than inserted mid-list: `CreateQuestionAtNextPosition` already owns the max+1 race and its retry budget, and `MoveQuestionToPosition` already owns the renumbering. Two tested primitives beat a third transaction that has to get both right.

If the move fails the copy still exists at the end of the quiz - a valid question in the wrong place beats a lost one - so that error is logged rather than surfaced.

Media is referenced by id, so the copy points at the same library entries rather than duplicating uploads. Nullable fields are copied through fresh pointers so the two questions never share one.

## Two corrections to the ticket, which I wrote

**No audit entry.** #1246 said it should write one "like the other question mutations". They do not: the audit log is player-admin only - every `writeAudit` caller targets a player id, and no quiz, round or question mutation writes one. Adding it would have invented a pattern the table's shape does not fit.

**Duplicating respects the publish lock.** Not in the ticket, but it is a content edit, so it goes through `requireEditableQuizOwner` and 409s on a published quiz like every other one (#1192). Pinned by a test.

## The bug the e2e caught

First run: the POST returned 200, the response carried the out-of-band rail, the swap fired - and the rail showed no new row.

The htmx events were what pinned it (`oobAfterSwap`, then `afterSwap target=questions-list`): the swap was landing correctly and rendering nothing new, because the handler built the rail from the quiz `requireEditableQuizOwner` had loaded *before* the copy existed. It now re-reads. Every other signal - status, markup, swap event - looked right.

`make check` green, full `make test-e2e` 340 passed / 5 skipped / 0 failed.

Closes #1246

_— Claude Code, for @starquake_
