### PR TITLE
Rebase stale Dependabot pull requests and narrow the tools skip

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,9 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 permissions:
   contents: write
@@ -9,7 +12,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: meta
@@ -17,12 +20,49 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Skip /tools: those pins are tracking-only, and the version that is
-      # actually used has to be mirrored into the Makefile + ci.yml by hand.
+      # Skip only /tools direct requires: those versions have to be mirrored into
+      # the Makefile + ci.yml by hand. Indirect bumps there are mirrored nowhere.
       # Safe under the signed-commit ruleset: Dependabot signs its own rebases and GitHub signs the squash-merge.
       - name: Enable auto-merge
-        if: steps.meta.outputs.directory != '/tools'
+        if: steps.meta.outputs.directory != '/tools' || !startsWith(steps.meta.outputs.dependency-type, 'direct')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rebase-stale:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      # Auto-merge alone never lands a PR that main has moved past: the ruleset is
+      # strict, and only Dependabot can bring its branch forward while keeping the
+      # commits signed. One PR per push, so the queue drains as a train rather than
+      # rebuilding every branch to land a single merge.
+      - name: Rebase the oldest stale Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.ref_name }}
+        run: |
+          candidates=$(gh pr list --repo "$REPO" --state open --limit 100 \
+            --json number,headRefName,author,autoMergeRequest \
+            --jq '[.[] | select(.author.login == "app/dependabot" and .autoMergeRequest != null)]
+                  | sort_by(.number)[] | "\(.number) \(.headRefName)"')
+
+          if [ -z "$candidates" ]; then
+            echo "No open Dependabot PR has auto-merge enabled."
+            exit 0
+          fi
+
+          while read -r number head; do
+            behind=$(gh api "repos/$REPO/compare/$BASE...$head" --jq '.behind_by' 2>/dev/null || true)
+            case "$behind" in ''|*[!0-9]*) behind=0 ;; esac
+            if [ "$behind" -gt 0 ]; then
+              echo "PR #$number is $behind commit(s) behind $BASE; asking Dependabot to rebase."
+              gh pr comment "$number" --repo "$REPO" --body '@dependabot rebase'
+              exit 0
+            fi
+            echo "PR #$number is up to date with $BASE."
+          done <<< "$candidates"
+
+          echo "No stale Dependabot PR to rebase."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,14 +5,13 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: meta
@@ -33,6 +32,9 @@ jobs:
   rebase-stale:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       # Auto-merge alone never lands a PR that main has moved past: the ruleset is
       # strict, and only Dependabot can bring its branch forward while keeping the


### PR DESCRIPTION
I opened this PR. It came out of unsticking #1273 and #1274, which were both green, both labeled `ready to merge`, and both parked at `BEHIND` with nothing able to move them.

## Why they stalled

The `Default` ruleset is strict, so a PR must be up to date with `main` to merge. Nothing brings a Dependabot branch forward on its own: GitHub's auto-merge does not update Dependabot branches, and a server-side update would re-create the commits unsigned and trip `required_signatures`. #1274 sat with auto-merge armed since Aug 4 waiting on an update that was never coming.

#1273 had no auto-merge at all, because this workflow skipped the whole `/tools` directory. That skip exists so a tool version the Makefile installs by release binary gets mirrored into the Makefile and `ci.yml` by hand — true for the module's two direct requires (`golangci-lint`, `sqlc`), but `cel-go` is an `// indirect` line in `tools/go.mod`, mirrored nowhere.

## What changed

**Narrow the `/tools` skip to direct dependencies.** `dependabot/fetch-metadata@v3` already exposes `dependency-type` (`direct:production` / `direct:development` / `indirect`) next to the `directory` output the step reads. Indirect `/tools` bumps now auto-merge like any other; `golangci-lint` and `sqlc` still stop for the hand-mirroring step.

**Rebase the oldest stale Dependabot PR on every push to `main`.** A new `rebase-stale` job picks the lowest-numbered open Dependabot PR that has auto-merge armed and is genuinely behind, and comments `@dependabot rebase` on it.

Choices worth flagging for review:

- **`@dependabot rebase`, not `gh pr update-branch`.** Keeps the branch's commits Dependabot-signed, and keeps Dependabot willing to manage the branch — a foreign commit makes it treat the PR as modified and stop rebasing.
- **One PR per push, not all of them.** A merge train: the nudged PR rebases, goes green, merges, and its own merge push nudges the next. Nudging all N would rebase N branches and burn N full CI runs to land one merge.
- **Only PRs with auto-merge armed.** A PR the workflow deliberately skipped (a direct `/tools` bump) can never merge, so it must never head the train and stall it.
- **`compare`'s `behind_by`, not `mergeStateStatus`.** GitHub computes mergeability asynchronously, so it reads `UNKNOWN` moments after a push. Rebasing a PR that is already current would only reset its CI and delay it, so the job skips to the next candidate instead.

## Testing

No test layer covers workflow YAML here — there is no `actionlint` target, and `make check` covers Go/SQL/frontend. This is CI configuration, so I verified it the only ways that mean anything short of a live run:

- Ran the `rebase-stale` script verbatim against the live repo with the comment replaced by an echo. It selected #1274, correctly reported it 1 commit behind `main`, and stopped there.
- Confirmed `dependency-type` is a real `fetch-metadata@v3` output with the three documented values, rather than assuming it.
- Parsed the file and checked every `if:` expression resolves as written.

The job's first real exercise is this PR's own merge push. `make check` is green on the branch.

_— Claude Code, for @starquake_
